### PR TITLE
Fix bad parameter when calling nmcli to get DNS

### DIFF
--- a/Pcap++/src/PcapLiveDeviceList.cpp
+++ b/Pcap++/src/PcapLiveDeviceList.cpp
@@ -91,7 +91,7 @@ void PcapLiveDeviceList::setDnsServers()
 		}
 	}
 #elif LINUX
-	std::string command = "nmcli dev list | grep IP4.DNS";
+	std::string command = "nmcli dev show | grep IP4.DNS";
 	std::string dnsServersInfo = executeShellCommand(command);
 	if (dnsServersInfo == "")
 	{


### PR DESCRIPTION
With nmcli version 1.2.2 i got this error

![nmcli_dev_list_error](https://cloud.githubusercontent.com/assets/1073706/20396205/dfc157fa-acfe-11e6-8617-8cfc9758c4fe.png)
