### PR TITLE
modify for PcapSpliter

### DIFF
--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -218,6 +218,7 @@ namespace pcpp
 	protected:
 		uint8_t* m_pRawData;
 		int m_RawDataLen;
+		int m_FrameLength;
 		timeval m_TimeStamp;
 		bool m_DeleteRawDataAtDestructor;
 		bool m_RawPacketSet;
@@ -275,7 +276,7 @@ namespace pcpp
 		 * @param[in] layerType The link layer type for this raw data
 		 * @return True if raw data was set successfully, false otherwise
 		 */
-		virtual bool setRawData(const uint8_t* pRawData, int rawDataLen, timeval timestamp, LinkLayerType layerType = LINKTYPE_ETHERNET);
+		virtual bool setRawData(const uint8_t* pRawData, int rawDataLen, timeval timestamp, LinkLayerType layerType = LINKTYPE_ETHERNET, int frameLength = -1);
 
 		/**
 		 * Get raw data pointer
@@ -301,6 +302,11 @@ namespace pcpp
 		 */
 		int getRawDataLen() const;
 
+		/**
+		 * Get frame length in bytes
+		 * @return frame length in bytes
+		 */
+		int getFrameLength() const;
 		/**
 		 * Get raw data timestamp
 		 * @return Raw data timestamp

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -72,8 +72,11 @@ void RawPacket::copyDataFrom(const RawPacket& other, bool allocateData)
 	m_RawPacketSet = true;
 }
 
-bool RawPacket::setRawData(const uint8_t* pRawData, int rawDataLen, timeval timestamp, LinkLayerType layerType)
+bool RawPacket::setRawData(const uint8_t* pRawData, int rawDataLen, timeval timestamp, LinkLayerType layerType, int frameLength)
 {
+	if(frameLength == -1)
+		frameLength = rawDataLen;
+	m_FrameLength = frameLength;
 	if (m_pRawData != 0 && m_DeleteRawDataAtDestructor)
 	{
 		delete[] m_pRawData;
@@ -105,6 +108,11 @@ LinkLayerType RawPacket::getLinkLayerType() const
 int RawPacket::getRawDataLen() const
 {
 	return m_RawDataLen;
+}
+
+int RawPacket::getFrameLength() const
+{
+	return m_FrameLength;
 }
 
 timeval RawPacket::getPacketTimeStamp()

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -169,7 +169,7 @@ bool PcapFileReaderDevice::getNextPacket(RawPacket& rawPacket)
 
 	uint8_t* pMyPacketData = new uint8_t[pkthdr.caplen];
 	memcpy(pMyPacketData, pPacketData, pkthdr.caplen);
-	if (!rawPacket.setRawData(pMyPacketData, pkthdr.caplen, pkthdr.ts, static_cast<LinkLayerType>(m_PcapLinkLayerType)))
+	if (!rawPacket.setRawData(pMyPacketData, pkthdr.caplen, pkthdr.ts, static_cast<LinkLayerType>(m_PcapLinkLayerType), pkthdr.len))
 	{
 		LOG_ERROR("Couldn't set data to raw packet");
 		return false;
@@ -456,7 +456,7 @@ bool PcapFileWriterDevice::writePacket(RawPacket const& packet)
 
 	pcap_pkthdr pktHdr;
 	pktHdr.caplen = ((RawPacket&)packet).getRawDataLen();
-	pktHdr.len = ((RawPacket&)packet).getRawDataLen();
+	pktHdr.len = ((RawPacket&)packet).getFrameLength();
 	pktHdr.ts = ((RawPacket&)packet).getPacketTimeStamp();
 	if (!m_AppendMode)
 		pcap_dump((uint8_t*)m_PcapDumpHandler, &pktHdr, ((RawPacket&)packet).getRawData());


### PR DESCRIPTION
An example file is univ1_trace.tgz/univ1_pt20
### This is the source pcap file, The capture length is smaller than frame length
![source pcap](https://cloud.githubusercontent.com/assets/7352092/23576888/dcec28b6-00eb-11e7-80be-e0720a18a66d.png)
### Result using current PcapSpliter, losing frame length
![current pcap spliter](https://cloud.githubusercontent.com/assets/7352092/23576890/e1c31b7e-00eb-11e7-9379-ecd82765ac5f.png)
### Fixed Result 
![modified pcap spliter](https://cloud.githubusercontent.com/assets/7352092/23576891/e65a7de4-00eb-11e7-990d-71e290556454.png)
