### PR TITLE
Fixed PcapLiveDevice timeout causing high CPU usage

### DIFF
--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -29,14 +29,7 @@
 #include <net/if_dl.h>
 #endif
 
-// On Mac OS X timeout of -1 causes pcap_open_live to fail so value of 1ms is set here.
-// On Linux and Windows this is not the case so we keep the -1 value
-#ifdef MAC_OS_X
-#define LIBPCAP_OPEN_LIVE_TIMEOUT 1
-#else
-#define LIBPCAP_OPEN_LIVE_TIMEOUT -1
-#endif
-
+static const int DEFAULT_OPEN_LIVE_TIMEOUT = 1000;
 static const int DEFAULT_SNAPLEN = 9000;
 
 namespace pcpp
@@ -231,7 +224,7 @@ pcap_t* PcapLiveDevice::doOpen(DeviceMode mode)
 	{
 		LOG_ERROR("%s", pcap_geterr(pcap));
 	}
-	ret = pcap_set_timeout(pcap, LIBPCAP_OPEN_LIVE_TIMEOUT);
+	ret = pcap_set_timeout(pcap, DEFAULT_OPEN_LIVE_TIMEOUT);
 	if (ret != 0)
 	{
 		LOG_ERROR("%s", pcap_geterr(pcap));

--- a/mk/vs2015/GitInfoPropertySheet.props
+++ b/mk/vs2015/GitInfoPropertySheet.props
@@ -2,8 +2,8 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros">
-    <GitCommit>unavailable</GitCommit>
-    <GitBranch>unavailable</GitBranch>
+    <GitCommit>4b5e72ed882d76b804ccbd8c6b6e2800f100662e</GitCommit>
+    <GitBranch>master</GitBranch>
   </PropertyGroup>
   <PropertyGroup />
   <ItemDefinitionGroup />


### PR DESCRIPTION
Fixes #85 

Before the fix:
![image](https://user-images.githubusercontent.com/5243906/34820048-2bd60384-f6c8-11e7-8fc2-d78d5480d1a6.png)

After the fix:
![image](https://user-images.githubusercontent.com/5243906/34820569-984955c4-f6c9-11e7-8428-0dc5b0f88647.png)
