### PR TITLE
Add filter capabilities to PcapNgFileWriterDevice

### DIFF
--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -388,12 +388,17 @@ namespace pcpp
 	class PcapNgFileWriterDevice : public IFileWriterDevice
 	{
 	private:
-
 		void* m_LightPcapNg;
+		struct bpf_program m_Bpf;
+		bool m_BpfInitialized;
+		int m_BpfLinkType;
+		std::string m_CurFilter;
 
 		// private copy c'tor
 		PcapNgFileWriterDevice(const PcapFileWriterDevice& other);
 		PcapNgFileWriterDevice& operator=(const PcapNgFileWriterDevice& other);
+
+		bool matchPacketWithFilter(const uint8_t* packetData, size_t packetLen, timeval packetTimestamp, uint16_t linkType);
 
 	public:
 
@@ -484,6 +489,14 @@ namespace pcpp
 		 * @param[out] stats The stats struct where stats are returned
 		 */
 		void getStatistics(pcap_stat& stats);
+
+		/**
+		 * Set a filter for PcapNG writer device. Only packets that match the filter will be persisted
+		 * @param[in] filterAsString The filter to be set in Berkeley Packet Filter (BPF) syntax (http://biot.com/capstats/bpf.html)
+		 * @return True if filter set successfully, false otherwise
+		 */
+		bool setFilter(std::string filterAsString);
+
 	};
 
 }// namespace pcpp

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -671,6 +671,38 @@ bool PcapFileWriterDevice::open(bool appendMode)
 PcapNgFileWriterDevice::PcapNgFileWriterDevice(const char* fileName) : IFileWriterDevice(fileName)
 {
 	m_LightPcapNg = NULL;
+	m_CurFilter = "";
+	m_BpfLinkType = -1;
+	m_BpfInitialized = false;
+}
+
+bool PcapNgFileWriterDevice::matchPacketWithFilter(const uint8_t* packetData, size_t packetLen, timeval packetTimestamp, uint16_t linkType)
+{
+	if (m_CurFilter == "")
+		return true;
+
+	int linkTypeAsInt = (int)linkType;
+
+	if (m_BpfLinkType != linkTypeAsInt)
+	{
+		LOG_DEBUG("Compiling the filter '%s' for link type %d", m_CurFilter.c_str(), linkTypeAsInt);
+		if (m_BpfInitialized)
+			pcap_freecode(&m_Bpf);
+		if (pcap_compile_nopcap(9000, linkTypeAsInt, &m_Bpf, m_CurFilter.c_str(), 1, 0) < 0)
+		{
+			m_BpfInitialized = false;
+			return false;
+		}
+
+		m_BpfLinkType = linkTypeAsInt;
+		m_BpfInitialized = true;
+	}
+
+	struct pcap_pkthdr pktHdr;
+	pktHdr.caplen = packetLen;
+	pktHdr.len = packetLen;
+	pktHdr.ts = packetTimestamp;
+	return (pcap_offline_filter(&m_Bpf, &pktHdr, packetData) != 0);
 }
 
 bool PcapNgFileWriterDevice::open(const char* os, const char* hardware, const char* captureApp, const char* fileComment)
@@ -728,10 +760,14 @@ bool PcapNgFileWriterDevice::writePacket(RawPacket const& packet, const char* co
 		pktHeader.comment_length = 0;
 	}
 
-	light_write_packet((light_pcapng_t*)m_LightPcapNg, &pktHeader, ((RawPacket&)packet).getRawData());
+	const uint8_t* pktData = ((RawPacket&)packet).getRawData();
+	if(!matchPacketWithFilter(pktData, pktHeader.captured_length, pktHeader.timestamp, pktHeader.data_link))
+	{
+		return false;
+	}
 
+	light_write_packet((light_pcapng_t*)m_LightPcapNg, &pktHeader, pktData);
 	m_NumOfPacketsWritten++;
-
 	return true;
 }
 
@@ -819,6 +855,20 @@ void PcapNgFileWriterDevice::getStatistics(pcap_stat& stats)
 	stats.ps_drop = m_NumOfPacketsNotWritten;
 	stats.ps_ifdrop = 0;
 	LOG_DEBUG("Statistics received for pcap-ng writer device for filename '%s'", m_FileName);
+}
+
+bool PcapNgFileWriterDevice::setFilter(std::string filterAsString)
+{
+	struct bpf_program prog;
+	if (pcap_compile_nopcap(9000, 1, &prog, filterAsString.c_str(), 1, 0) < 0)
+	{
+		return false;
+	}
+	pcap_freecode(&prog);
+
+	m_CurFilter = filterAsString;
+	m_BpfLinkType = -1;
+	return true;
 }
 
 

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -1195,18 +1195,31 @@ PCAPP_TEST(TestPcapNgFileReadWriteAdv)
     // -------
 
     PcapNgFileReaderDevice readerDev5(EXAMPLE2_PCAPNG_PATH);
-    PCAPP_ASSERT(readerDev5.open(), "cannot open reader device 5");
-    PCAPP_ASSERT(readerDev5.setFilter("bla bla bla") == false, "Managed to set illegal filter");
-    PCAPP_ASSERT(readerDev5.setFilter("src net 130.217.250.129") == true, "Couldn't set filter");
+	PCAPP_ASSERT(readerDev5.open(), "cannot open reader device 5");
+    PCAPP_ASSERT(readerDev5.setFilter("bla bla bla") == false, "Managed to set illegal filter to reader device");
+    PCAPP_ASSERT(readerDev5.setFilter("src net 130.217.250.129") == true, "Couldn't set filter to reader device");
 
-    packetCount = 0;
+	PcapNgFileWriterDevice writerDev2(EXAMPLE2_PCAPNG_WRITE_PATH);
+    PCAPP_ASSERT(writerDev2.open(true) == true, "Couldn't writer dev 2 in append mode");
+    PCAPP_ASSERT(writerDev2.setFilter("bla bla bla") == false, "Managed to set illegal filter to writer device");
+    PCAPP_ASSERT(writerDev2.setFilter("dst port 35938") == true, "Couldn't set filter to writer device");
+
+    int filteredReadPacketCount = 0;
+    int filteredWritePacketCount = 0;
 
     while (readerDev5.getNextPacket(rawPacket, pktComment))
     {
-        packetCount++;
+		cout << Packet(&rawPacket).toString() << endl;
+        filteredReadPacketCount++;
+    	if(writerDev2.writePacket(rawPacket))
+			filteredWritePacketCount++;
     }
 
-    PCAPP_ASSERT(packetCount == 14, "Number of packets matched to filter != 14, it's %d", packetCount);
+    PCAPP_ASSERT(filteredReadPacketCount == 14, "Number of packets matched to reader filter != 14, it's %d", filteredReadPacketCount);
+    PCAPP_ASSERT(filteredWritePacketCount == 3, "Number of packets matched to writer filter != 3, it's %d", filteredWritePacketCount);
+
+	readerDev5.close();
+	writerDev2.close();
 
     PCAPP_TEST_PASSED;
 }


### PR DESCRIPTION
This patch adds support to specify BPF filters to in a PcapNgFileWriterDevice instance, in order to control what packets are written or not to the capture file.