### PR TITLE
Remove extra semi-colons (try 2)

### DIFF
--- a/Packet++/header/DhcpLayer.h
+++ b/Packet++/header/DhcpLayer.h
@@ -604,7 +604,7 @@ namespace pcpp
 		 * Get a pointer to the DHCP header. Notice this points directly to the data, so every change will change the actual packet data
 		 * @return A pointer to the @ref dhcp_header
 		 */
-		inline dhcp_header* getDhcpHeader() { return (dhcp_header*)m_Data; };
+		inline dhcp_header* getDhcpHeader() { return (dhcp_header*)m_Data; }
 
 		/**
 		 * @return The BootP opcode of this message

--- a/Packet++/header/GreLayer.h
+++ b/Packet++/header/GreLayer.h
@@ -393,7 +393,7 @@ namespace pcpp
 		 * Get a pointer to the PPP-PPTP header. Notice this points directly to the data, so every change will change the actual packet data
 		 * @return A pointer to the @ref ppp_pptp_header
 		 */
-		inline ppp_pptp_header* getPPP_PPTPHeader() { return (ppp_pptp_header*)m_Data; };
+		inline ppp_pptp_header* getPPP_PPTPHeader() { return (ppp_pptp_header*)m_Data; }
 
 
 		// implement abstract methods

--- a/Packet++/header/IPv4Layer.h
+++ b/Packet++/header/IPv4Layer.h
@@ -402,7 +402,7 @@ namespace pcpp
 		 * Get a pointer to the IPv4 header. Notice this points directly to the data, so every change will change the actual packet data
 		 * @return A pointer to the @ref iphdr
 		 */
-		inline iphdr* getIPv4Header() { return (iphdr*)m_Data; };
+		inline iphdr* getIPv4Header() { return (iphdr*)m_Data; }
 
 		/**
 		 * Get the source IP address in the form of IPv4Address

--- a/Packet++/header/IPv6Layer.h
+++ b/Packet++/header/IPv6Layer.h
@@ -94,7 +94,7 @@ namespace pcpp
 		 * Get a pointer to the IPv6 header. Notice this points directly to the data, so every change will change the actual packet data
 		 * @return A pointer to the @ref ip6_hdr
 		 */
-		inline ip6_hdr* getIPv6Header() { return (ip6_hdr*)m_Data; };
+		inline ip6_hdr* getIPv6Header() { return (ip6_hdr*)m_Data; }
 
 		/**
 		 * Get the source IP address in the form of IPv6Address

--- a/Packet++/header/IcmpLayer.h
+++ b/Packet++/header/IcmpLayer.h
@@ -410,7 +410,7 @@ namespace pcpp
 		 * Get a pointer to the basic ICMP header. Notice this points directly to the data, so every change will change the actual packet data
 		 * @return A pointer to the @ref icmphdr
 		 */
-		inline icmphdr* getIcmpHeader() { return (icmphdr*)m_Data; };
+		inline icmphdr* getIcmpHeader() { return (icmphdr*)m_Data; }
 
 		/**
 		 * @return The ICMP message type

--- a/Packet++/header/MplsLayer.h
+++ b/Packet++/header/MplsLayer.h
@@ -29,7 +29,7 @@ namespace pcpp
 		};
 		#pragma pack(pop)
 
-		inline mpls_header* getMplsHeader() { return (mpls_header*)m_Data; };
+		inline mpls_header* getMplsHeader() { return (mpls_header*)m_Data; }
 
 	public:
 		 /** A constructor that creates the layer from an existing packet raw data

--- a/Packet++/header/PPPoELayer.h
+++ b/Packet++/header/PPPoELayer.h
@@ -86,7 +86,7 @@ namespace pcpp
 		 * Get a pointer to the PPPoE header. Notice this points directly to the data, so every change will change the actual packet data
 		 * @return A pointer to the pppoe_header
 		 */
-		inline pppoe_header* getPPPoEHeader() { return (pppoe_header*)m_Data; };
+		inline pppoe_header* getPPPoEHeader() { return (pppoe_header*)m_Data; }
 
 		// abstract methods implementation
 
@@ -367,7 +367,7 @@ namespace pcpp
 		/**
 		 * Does nothing for this layer (PPPoE discovery is always the last layer)
 		 */
-		virtual void parseNextLayer() {};
+		virtual void parseNextLayer() {}
 
 		/**
 		 * @return The header length which is size of strcut pppoe_header plus the total size of tags

--- a/Packet++/header/RadiusLayer.h
+++ b/Packet++/header/RadiusLayer.h
@@ -203,7 +203,7 @@ namespace pcpp
 		 * Get a pointer to the RADIUS header. Notice this points directly to the data, so every change will change the actual packet data
 		 * @return A pointer to the radius_header object
 		 */
-		inline radius_header* getRadiusHeader() { return (radius_header*)m_Data; };
+		inline radius_header* getRadiusHeader() { return (radius_header*)m_Data; }
 
 		/**
 		 * @return A hex string representation of the radius_header#authenticator byte array value

--- a/Packet++/header/TcpLayer.h
+++ b/Packet++/header/TcpLayer.h
@@ -300,7 +300,7 @@ namespace pcpp
 		 * Get a pointer to the TCP header. Notice this points directly to the data, so every change will change the actual packet data
 		 * @return A pointer to the @ref tcphdr
 		 */
-		inline tcphdr* getTcpHeader() { return (tcphdr*)m_Data; };
+		inline tcphdr* getTcpHeader() { return (tcphdr*)m_Data; }
 
 		/**
 		 * Get a pointer to a TCP option. Notice this points directly to the data, so every change will change the actual packet data

--- a/Packet++/header/UdpLayer.h
+++ b/Packet++/header/UdpLayer.h
@@ -57,7 +57,7 @@ namespace pcpp
 		 * Get a pointer to the UDP header. Notice this points directly to the data, so every change will change the actual packet data
 		 * @return A pointer to the @ref udphdr
 		 */
-		inline udphdr* getUdpHeader() { return (udphdr*)m_Data; };
+		inline udphdr* getUdpHeader() { return (udphdr*)m_Data; }
 
 		/**
 		 * Calculate the checksum from header and data and possibly write the result to @ref udphdr#headerChecksum

--- a/Pcap++/header/PcapRemoteDeviceList.h
+++ b/Pcap++/header/PcapRemoteDeviceList.h
@@ -34,7 +34,7 @@ namespace pcpp
 		PcapRemoteAuthentication* m_RemoteAuthentication;
 
 		// private c'tor. User should create the list via static methods PcapRemoteDeviceList::getRemoteDeviceList()
-		PcapRemoteDeviceList() : m_RemoteMachineIpAddress(NULL), m_RemoteMachinePort(0), m_RemoteAuthentication(NULL) {};
+		PcapRemoteDeviceList() : m_RemoteMachineIpAddress(NULL), m_RemoteMachinePort(0), m_RemoteAuthentication(NULL) {}
 		// private copy c'tor
 		PcapRemoteDeviceList(const PcapRemoteDeviceList& other);
 		PcapRemoteDeviceList& operator=(const PcapRemoteDeviceList& other);


### PR DESCRIPTION
Remove extra semi-colons in several .h-files.

And a white-space patch sneaked in for "Pcap++/header/DpdkDevice.h";
lots of trailing white-space removed (what editor did that?).