### PR TITLE
Resolving issues 'in.h" file not found for MacOS

### DIFF
--- a/Examples/ArpSpoofing/main.cpp
+++ b/Examples/ArpSpoofing/main.cpp
@@ -2,6 +2,13 @@
 #include <stdlib.h>
 #include <fstream>
 #include <memory>
+#if defined(WIN32) || defined(WINx64) // for using ntohl, ntohs, etc.
+#include <winsock2.h>
+#elif LINUX
+#include <in.h>
+#elif MAC_OS_X
+#include <arpa/inet.h>
+#endif
 #include <MacAddress.h>
 #include <IpAddress.h>
 #include <PcapPlusPlusVersion.h>
@@ -12,13 +19,6 @@
 #include <EthLayer.h>
 #include <ArpLayer.h>
 #include <Logger.h>
-#ifdef WIN32 // for using ntohl, ntohs, etc.
-#include <winsock2.h>
-#elif LINUX
-#include <in.h>
-#elif MAC_OS_X
-#include <arpa/inet.h>
-#endif
 #include <getopt.h>
 
 using namespace std;

--- a/Examples/ArpSpoofing/main.cpp
+++ b/Examples/ArpSpoofing/main.cpp
@@ -2,9 +2,6 @@
 #include <stdlib.h>
 #include <fstream>
 #include <memory>
-#if defined(WIN32) || defined(WINx64)
-#include <winsock2.h>
-#endif
 #include <MacAddress.h>
 #include <IpAddress.h>
 #include <PcapPlusPlusVersion.h>
@@ -15,8 +12,12 @@
 #include <EthLayer.h>
 #include <ArpLayer.h>
 #include <Logger.h>
-#if !defined(WIN32) && !defined(WINx64) //for using ntohl, ntohs, etc.
+#ifdef WIN32 // for using ntohl, ntohs, etc.
+#include <winsock2.h>
+#elif LINUX
 #include <in.h>
+#elif MAC_OS_X
+#include <arpa/inet.h>
 #endif
 #include <getopt.h>
 

--- a/Examples/DnsSpoofing/Makefile
+++ b/Examples/DnsSpoofing/Makefile
@@ -11,9 +11,19 @@ include ../../mk/PcapPlusPlus.mk
 SOURCES := $(wildcard *.cpp)
 OBJS_FILENAMES := $(patsubst %.cpp,Obj/%.o,$(SOURCES))
 
+ifdef WIN32
+DEPS := -DWPCAP -DHAVE_REMOTE
+endif
+ifdef LINUX
+DEPS := -DLINUX
+endif
+ifdef MAC_OS_X
+DEPS := -DMAC_OS_X
+endif
+
 Obj/%.o: %.cpp
 	@echo 'Building file: $<'
-	@$(CXX) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
+	@$(CXX) $(DEPS) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
 
 
 UNAME := $(shell uname)

--- a/Examples/DnsSpoofing/main.cpp
+++ b/Examples/DnsSpoofing/main.cpp
@@ -11,9 +11,11 @@
 #include <sstream>
 #include <utility>
 #include <map>
-#if !defined(WIN32) && !defined(WINx64) && !defined(PCAPPP_MINGW_ENV) //for using ntohl, ntohs, etc.
-#include <in.h>
 #include <errno.h>
+#ifdef LINUX // for using ntohl, ntohs, etc.
+#include <in.h>
+#elif MAC_OS_X
+#include <arpa/inet.h>
 #endif
 #include "IpAddress.h"
 #include "RawPacket.h"

--- a/Examples/HttpAnalyzer/Makefile
+++ b/Examples/HttpAnalyzer/Makefile
@@ -11,10 +11,19 @@ include ../../mk/PcapPlusPlus.mk
 SOURCES := $(wildcard *.cpp)
 OBJS_FILENAMES := $(patsubst %.cpp,Obj/%.o,$(SOURCES))
 
+ifdef WIN32
+DEPS := -DWPCAP -DHAVE_REMOTE
+endif
+ifdef LINUX
+DEPS := -DLINUX
+endif
+ifdef MAC_OS_X
+DEPS := -DMAC_OS_X
+endif
+
 Obj/%.o: %.cpp
 	@echo 'Building file: $<'
-	@$(CXX) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
-
+	@$(CXX) $(DEPS) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
 
 UNAME := $(shell uname)
 CUR_TARGET := $(notdir $(shell pwd))

--- a/Examples/HttpAnalyzer/main.cpp
+++ b/Examples/HttpAnalyzer/main.cpp
@@ -18,9 +18,12 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <algorithm>
-#if !defined(WIN32) && !defined(WINx64) && !defined(PCAPPP_MINGW_ENV) //for using ntohl, ntohs, etc.
+#ifdef WIN32
+#include <winsock2.h>
+#elif LINUX
 #include <in.h>
+#elif MAC_OS_X
+#include <arpa/inet.h>
 #endif
 #include "PcapLiveDeviceList.h"
 #include "PcapFilter.h"

--- a/Examples/HttpAnalyzer/main.cpp
+++ b/Examples/HttpAnalyzer/main.cpp
@@ -18,7 +18,8 @@
 
 #include <stdlib.h>
 #include <string.h>
-#ifdef WIN32
+#include <algorithm>
+#if defined(WIN32) || defined(WINx64)
 #include <winsock2.h>
 #elif LINUX
 #include <in.h>

--- a/Examples/IPDefragUtil/Makefile
+++ b/Examples/IPDefragUtil/Makefile
@@ -11,10 +11,19 @@ include ../../mk/PcapPlusPlus.mk
 SOURCES := $(wildcard *.cpp)
 OBJS_FILENAMES := $(patsubst %.cpp,Obj/%.o,$(SOURCES))
 
+ifdef WIN32
+DEPS := -DWPCAP -DHAVE_REMOTE
+endif
+ifdef LINUX
+DEPS := -DLINUX
+endif
+ifdef MAC_OS_X
+DEPS := -DMAC_OS_X
+endif
+
 Obj/%.o: %.cpp
 	@echo 'Building file: $<'
-	@$(CXX) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
-
+	@$(CXX) $(DEPS) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
 
 UNAME := $(shell uname)
 CUR_TARGET := $(notdir $(shell pwd))

--- a/Examples/IPDefragUtil/main.cpp
+++ b/Examples/IPDefragUtil/main.cpp
@@ -3,8 +3,10 @@
 #include <sstream>
 #include <stdlib.h>
 #include <string.h>
-#if !defined(WIN32) && !defined(WINx64) && !defined(PCAPPP_MINGW_ENV)  //for using ntohl, ntohs, etc.
+#ifdef LINUX // for using ntohl, ntohs, etc.
 #include <in.h>
+#elif MAC_OS_X
+#include <arpa/inet.h>
 #endif
 #include "PcapPlusPlusVersion.h"
 #include "IPv4Layer.h"

--- a/Examples/IPFragUtil/Makefile
+++ b/Examples/IPFragUtil/Makefile
@@ -11,10 +11,19 @@ include ../../mk/PcapPlusPlus.mk
 SOURCES := $(wildcard *.cpp)
 OBJS_FILENAMES := $(patsubst %.cpp,Obj/%.o,$(SOURCES))
 
+ifdef WIN32
+DEPS := -DWPCAP -DHAVE_REMOTE
+endif
+ifdef LINUX
+DEPS := -DLINUX
+endif
+ifdef MAC_OS_X
+DEPS := -DMAC_OS_X
+endif
+
 Obj/%.o: %.cpp
 	@echo 'Building file: $<'
-	@$(CXX) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
-
+	@$(CXX) $(DEPS) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
 
 UNAME := $(shell uname)
 CUR_TARGET := $(notdir $(shell pwd))

--- a/Examples/IPFragUtil/main.cpp
+++ b/Examples/IPFragUtil/main.cpp
@@ -4,8 +4,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
-#if !defined(WIN32) && !defined(WINx64) && !defined(PCAPPP_MINGW_ENV) //for using ntohl, ntohs, etc.
+#ifdef LINUX // for using ntohl, ntohs, etc.
 #include <in.h>
+#elif MAC_OS_X
+#include <arpa/inet.h>
 #endif
 #include "PcapPlusPlusVersion.h"
 #include "Packet.h"

--- a/Examples/IcmpFileTransfer/Common.cpp
+++ b/Examples/IcmpFileTransfer/Common.cpp
@@ -2,8 +2,10 @@
 #include <stdlib.h>
 #include <vector>
 #include <getopt.h>
-#if !defined(WIN32) && !defined(WINx64)
+#ifdef LINUX // for using ntohl, ntohs, etc.
 #include <in.h>
+#elif MAC_OS_X
+#include <arpa/inet.h>
 #endif
 #include "EthLayer.h"
 #include "IPv4Layer.h"

--- a/Examples/IcmpFileTransfer/IcmpFileTransfer-catcher.cpp
+++ b/Examples/IcmpFileTransfer/IcmpFileTransfer-catcher.cpp
@@ -9,8 +9,10 @@
 #include <stdlib.h>
 #include <iostream>
 #include <fstream>
-#if !defined(WIN32) && !defined(WINx64) && !defined(PCAPPP_MINGW_ENV) 
+#ifdef LINUX // for using ntohl, ntohs, etc.
 #include <in.h>
+#elif MAC_OS_X
+#include <arpa/inet.h>
 #endif
 #include "EthLayer.h"
 #include "IPv4Layer.h"

--- a/Examples/IcmpFileTransfer/IcmpFileTransfer-pitcher.cpp
+++ b/Examples/IcmpFileTransfer/IcmpFileTransfer-pitcher.cpp
@@ -12,8 +12,10 @@
 #ifndef _MSC_VER
 #include "unistd.h"
 #endif
-#if !defined(WIN32) && !defined(WINx64) && !defined(PCAPPP_MINGW_ENV) 
+#ifdef LINUX // for using ntohl, ntohs, etc.
 #include <in.h>
+#elif MAC_OS_X
+#include <arpa/inet.h>
 #endif
 #include "EthLayer.h"
 #include "IPv4Layer.h"

--- a/Examples/IcmpFileTransfer/Makefile
+++ b/Examples/IcmpFileTransfer/Makefile
@@ -11,10 +11,19 @@ include ../../mk/PcapPlusPlus.mk
 SOURCES := $(wildcard *.cpp)
 OBJS_FILENAMES := $(patsubst %.cpp,Obj/%.o,$(SOURCES))
 
+ifdef WIN32
+DEPS := -DWPCAP -DHAVE_REMOTE
+endif
+ifdef LINUX
+DEPS := -DLINUX
+endif
+ifdef MAC_OS_X
+DEPS := -DMAC_OS_X
+endif
+
 Obj/%.o: %.cpp
 	@echo 'Building file: $<'
-	@$(CXX) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
-
+	@$(CXX) $(DEPS) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
 
 UNAME := $(shell uname)
 CUR_TARGET := $(notdir $(shell pwd))

--- a/Examples/PcapSplitter/IPPortSplitters.h
+++ b/Examples/PcapSplitter/IPPortSplitters.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "Splitters.h"
-#if !defined(WIN32) && !defined(WINx64) //for using ntohl, ntohs, etc.
+#ifdef LINUX // for using ntohl, ntohs, etc.
 #include <in.h>
+#elif MAC_OS_X
+#include <arpa/inet.h>
 #endif
-
 
 /**
  * A virtual abstract class for all splitters that split files by IP address or TCP/UDP port. Inherits from ValueBasedSplitter,

--- a/Examples/PcapSplitter/Makefile
+++ b/Examples/PcapSplitter/Makefile
@@ -11,9 +11,19 @@ include ../../mk/PcapPlusPlus.mk
 SOURCES := $(wildcard *.cpp)
 OBJS_FILENAMES := $(patsubst %.cpp,Obj/%.o,$(SOURCES))
 
+ifdef WIN32
+DEPS := -DWPCAP -DHAVE_REMOTE
+endif
+ifdef LINUX
+DEPS := -DLINUX
+endif
+ifdef MAC_OS_X
+DEPS := -DMAC_OS_X
+endif
+
 Obj/%.o: %.cpp
 	@echo 'Building file: $<'
-	@$(CXX) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
+	@$(CXX) $(DEPS) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
 
 
 UNAME := $(shell uname)

--- a/Examples/SSLAnalyzer/Makefile
+++ b/Examples/SSLAnalyzer/Makefile
@@ -11,10 +11,19 @@ include ../../mk/PcapPlusPlus.mk
 SOURCES := $(wildcard *.cpp)
 OBJS_FILENAMES := $(patsubst %.cpp,Obj/%.o,$(SOURCES))
 
+ifdef WIN32
+DEPS := -DWPCAP -DHAVE_REMOTE
+endif
+ifdef LINUX
+DEPS := -DLINUX
+endif
+ifdef MAC_OS_X
+DEPS := -DMAC_OS_X
+endif
+
 Obj/%.o: %.cpp
 	@echo 'Building file: $<'
-	@$(CXX) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
-
+	@$(CXX) $(DEPS) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
 
 UNAME := $(shell uname)
 CUR_TARGET := $(notdir $(shell pwd))

--- a/Examples/SSLAnalyzer/main.cpp
+++ b/Examples/SSLAnalyzer/main.cpp
@@ -20,8 +20,10 @@
 #include <stdlib.h>
 #include <string.h>
 #include <algorithm>
-#if !defined(WIN32) && !defined(WINx64) && !defined(PCAPPP_MINGW_ENV)  //for using ntohl, ntohs, etc.
+#ifdef LINUX // for using ntohl, ntohs, etc.
 #include <in.h>
+#elif MAC_OS_X
+#include <arpa/inet.h>
 #endif
 #include "PcapLiveDeviceList.h"
 #include "PcapFilter.h"

--- a/Packet++/src/IgmpLayer.cpp
+++ b/Packet++/src/IgmpLayer.cpp
@@ -4,11 +4,11 @@
 #include "IpUtils.h"
 #include "Logger.h"
 #include <string.h>
-#ifdef WIN32 //for using ntohl, ntohs, etc.
+#if defined(WIN32) || defined(WINx64) //for using ntohl, ntohs, etc.
 #include <winsock2.h>
-#elif LINUX
+#elif defined(LINUX)
 #include <in.h> //for using ntohl, ntohs, etc.
-#elif MAC_OS_X
+#elif defined(MAC_OS_X)
 #include <arpa/inet.h> //for using ntohl, ntohs, etc.
 #endif
 

--- a/Tests/Packet++Test/Makefile
+++ b/Tests/Packet++Test/Makefile
@@ -22,9 +22,19 @@ ENDIAN_PORTABLE_INCLUDE := $(PCAPPLUSPLUS_HOME)/3rdParty/EndianPortable/include
 
 PCAPPP_INCLUDES += -I$(DEBUG_NEW_HOME) -I$(ENDIAN_PORTABLE_INCLUDE)
 
+ifdef WIN32
+DEPS := -DWPCAP -DHAVE_REMOTE
+endif
+ifdef LINUX
+DEPS := -DLINUX
+endif
+ifdef MAC_OS_X
+DEPS := -DMAC_OS_X
+endif
+
 Obj/%.o: %.cpp
 	@echo 'Building file: $<'
-	@$(CXX) $(PCAPPP_INCLUDES) $(PCAPPP_BUILD_FLAGS) -O2 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
+	@$(CXX) $(DEPS) $(PCAPPP_INCLUDES) $(PCAPPP_BUILD_FLAGS) -O2 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
 
 
 UNAME := $(shell uname)

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -1,4 +1,11 @@
 #include <Logger.h>
+#if defined(WIN32) || defined(WINx64) // for using ntohl, ntohs, etc.
+#include <winsock2.h>
+#elif defined(MAC_OS_X)
+#include <arpa/inet.h>
+#elif defined(LINUX)
+#include <in.h>
+#endif
 #include <PcapPlusPlusVersion.h>
 #include <Packet.h>
 #include <EthLayer.h>
@@ -32,13 +39,6 @@
 #include <iostream>
 #include <sstream>
 #include <string.h>
-#ifdef WIN32 // for using ntohl, ntohs, etc.
-#include <winsock2.h>
-#elif LINUX
-#include <in.h>
-#elif MAC_OS_X
-#include <arpa/inet.h>
-#endif
 #ifdef _MSC_VER
 #include <SystemUtils.h>
 #endif

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -32,10 +32,12 @@
 #include <iostream>
 #include <sstream>
 #include <string.h>
-#ifdef WIN32
+#ifdef WIN32 // for using ntohl, ntohs, etc.
 #include <winsock2.h>
-#else
+#elif LINUX
 #include <in.h>
+#elif MAC_OS_X
+#include <arpa/inet.h>
 #endif
 #ifdef _MSC_VER
 #include <SystemUtils.h>

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -41,8 +41,10 @@
 #include <DpdkDevice.h>
 #include <NetworkUtils.h>
 #include <RawSocketDevice.h>
-#if !defined(WIN32) && !defined(WINx64) && !defined(PCAPPP_MINGW_ENV)  //for using ntohl, ntohs, etc.
+#ifdef LINUX // for using ntohl, ntohs, etc.
 #include <in.h>
+#elif MAC_OS_X
+#include <arpa/inet.h>
 #endif
 
 using namespace std;


### PR DESCRIPTION
This is an extended fix from the '[in.h' file not found #include <in.h>](https://github.com/seladb/PcapPlusPlus/issues/29)'

No implementation is touched; this PR only contains modification against the order of `#include` and adding `DEPS` in a few `Makefile`s.

Tested in the following env:
- Windows 7 and Visual Studio 2017
- MacOS(10.14) with _apple-clang++_
- RHEL 7.5 with _g++ 4.8.5_
 