### PR TITLE
Issue #154 - Fix to help with memory leaks detected with large number of packets.

### DIFF
--- a/Examples/HttpAnalyzer/main.cpp
+++ b/Examples/HttpAnalyzer/main.cpp
@@ -167,13 +167,14 @@ void printMethods(HttpRequestStats& reqStatscollector)
 	columnsWidths.push_back(5);
 	TablePrinter printer(columnNames, columnsWidths);
 
-	std::stringstream values;
 
 	// go over the method count table and print each method and count
 	for(std::map<HttpRequestLayer::HttpMethod, int>::iterator iter = reqStatscollector.methodCount.begin();
 			iter != reqStatscollector.methodCount.end();
 			iter++)
 	{
+        std::stringstream values;
+
 		switch (iter->first)
 		{
 		case HttpRequestLayer::HttpGET:
@@ -182,6 +183,7 @@ void printMethods(HttpRequestStats& reqStatscollector)
 			break;
 		case HttpRequestLayer::HttpPOST:
 			values << "POST" << "|" << reqStatscollector.methodCount[HttpRequestLayer::HttpPOST];
+			printer.printRow(values.str(), '|');
 			break;
 		case HttpRequestLayer::HttpCONNECT:
 			values << "CONNECT" << "|" << reqStatscollector.methodCount[HttpRequestLayer::HttpCONNECT];

--- a/Packet++/header/Packet.h
+++ b/Packet++/header/Packet.h
@@ -143,10 +143,11 @@ namespace pcpp
 		 * and attaches it to the packet. Notice after calling this method the input layer is attached to the packet so
 		 * every change you make in it affect the packet; Also it cannot be attached to other packets
 		 * @param[in] newLayer A pointer to the new layer to be added to the packet
+		 * @param[in] allocateInPacket If true, Packet fully owns newLayer, including memory deletion upon destruct.  Default is false.
 		 * @return True if everything went well or false otherwise (an appropriate error log message will be printed in
 		 * such cases)
 		 */
-		bool addLayer(Layer* newLayer);
+		bool addLayer(Layer* newLayer, bool allocateInPacket=false);
 
 		/**
 		 * Insert a new layer after an existing layer in the packet. This method gets a pointer to the new layer as a
@@ -155,10 +156,11 @@ namespace pcpp
 		 * @param[in] prevLayer A pointer to an existing layer in the packet which the new layer should followed by. If
 		 * this layer isn't attached to a packet and error will be printed to log and false will be returned
 		 * @param[in] newLayer A pointer to the new layer to be added to the packet
+		 * @param[in] allocateInPacket If true, Packet fully owns newLayer, including memory deletion upon destruct.  Default is false.
 		 * @return True if everything went well or false otherwise (an appropriate error log message will be printed in
 		 * such cases)
 		 */
-		bool insertLayer(Layer* prevLayer, Layer* newLayer);
+		bool insertLayer(Layer* prevLayer, Layer* newLayer, bool allocateInPacket=false);
 
 
 		/**

--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -225,12 +225,12 @@ void Packet::reallocateRawData(size_t newSize)
 	}
 }
 
-bool Packet::addLayer(Layer* newLayer)
+bool Packet::addLayer(Layer* newLayer, bool allocateInPacket)
 {
-	return insertLayer(m_LastLayer, newLayer);
+	return insertLayer(m_LastLayer, newLayer, allocateInPacket);
 }
 
-bool Packet::insertLayer(Layer* prevLayer, Layer* newLayer)
+bool Packet::insertLayer(Layer* prevLayer, Layer* newLayer, bool allocateInPacket)
 {
 	if (newLayer == NULL)
 	{
@@ -292,6 +292,10 @@ bool Packet::insertLayer(Layer* prevLayer, Layer* newLayer)
 
 	// assign layer with this packet only
 	newLayer->m_Packet = this;
+
+	// Set flag to indicate if new layer is allocated to packet.
+	if(allocateInPacket)
+	   newLayer->m_IsAllocatedInPacket = true;
 
 	// re-calculate all layers data ptr and data length
 


### PR DESCRIPTION
- Added a parameter allocateInPacket (type bool) to Packet class functions addLayer() and insertLayer().  The default value for allocateInPacket is set to false.
- If allocateInPacket value is set to true then the m_IsAllocatedInPacket of the layer is set to true.  This causes the layer to get deleted when the packet is destroyed.

https://github.com/seladb/PcapPlusPlus/issues/154
