### PR TITLE
TcpReassembly: a new method getConnectionDataRef()

### DIFF
--- a/Packet++/header/TcpReassembly.h
+++ b/Packet++/header/TcpReassembly.h
@@ -191,6 +191,12 @@ public:
 	 */
 	inline ConnectionData getConnectionData() { return m_Connection; }
 
+	/**
+	 * A getter for the connection data
+	 * @return The const reference to connection data
+	 */
+	inline const ConnectionData& getConnectionDataRef() { return m_Connection; }
+
 private:
 	uint8_t* m_Data;
 	size_t m_DataLen;


### PR DESCRIPTION
The existing method getConnectionData return a copy of object but this operation is heavyweight and is unnecessary in many contexts of the using.