### PR TITLE
IP Reassembly improvements

### DIFF
--- a/Packet++/header/IPReassembly.h
+++ b/Packet++/header/IPReassembly.h
@@ -320,13 +320,19 @@ namespace pcpp
 		 * - The input fragment is malformed and will be ignored
 		 * - The input fragment is the last one and the packet is now fully reassembled. In this case the return value will contain
 		 *   a pointer to the reassebmled packet
+		 * @param[in] parseUntil Optional parameter. Parse the reassembled packet until you reach a certain protocol (inclusive). Can be useful for cases when you need to parse only up to a
+		 * certain layer and want to avoid the performance impact and memory consumption of parsing the whole packet. Default value is ::UnknownProtocol which means don't take this
+		 * parameter into account
+		 * @param[in] parseUntilLayer Optional parameter. Parse the reassembled packet until you reach a certain layer in the OSI model (inclusive). Can be useful for cases when you need to
+		 * parse only up to a certain OSI layer (for example transport layer) and want to avoid the performance impact and memory consumption of parsing the whole packet.
+		 * Default value is ::OsiModelLayerUnknown which means don't take this parameter into account
 		 * @return
 		 * - If the input fragment isn't an IPv4/IPv6 packet or if it isn't an IPv4/IPv6 fragment, the return value is a pointer to the input fragment
 		 * - If the input fragment is the last one and the reassembled packet is ready - a pointer to the reassembled packet is
 		 *   returned. Notice it's the user's responsibility to free this pointer when done using it
 		 * - If the reassembled packet isn't ready then NULL is returned
 		 */
-		Packet* processPacket(Packet* fragment, ReassemblyStatus& status);
+		Packet* processPacket(Packet* fragment, ReassemblyStatus& status, ProtocolType parseUntil = UnknownProtocol, OsiModelLayer parseUntilLayer = OsiModelLayerUnknown);
 
 		/**
 		 * The main API that drives IPReassembly. This method should be called whenever a fragment arrives. This method finds the relevant
@@ -343,6 +349,12 @@ namespace pcpp
 		 * - The input fragment is malformed and will be ignored
 		 * - The input fragment is the last one and the packet is now fully reassembled. In this case the return value will contain
 		 *   a pointer to the reassebmled packet
+		 * @param[in] parseUntil Optional parameter. Parse the raw and reassembled packets until you reach a certain protocol (inclusive). Can be useful for cases when you need to parse only up to a
+		 * certain layer and want to avoid the performance impact and memory consumption of parsing the whole packet. Default value is ::UnknownProtocol which means don't take this
+		 * parameter into account
+		 * @param[in] parseUntilLayer Optional parameter. Parse the raw and reassembled packets until you reach a certain layer in the OSI model (inclusive). Can be useful for cases when you need to
+		 * parse only up to a certain OSI layer (for example transport layer) and want to avoid the performance impact and memory consumption of parsing the whole packet.
+		 * Default value is ::OsiModelLayerUnknown which means don't take this parameter into account
 		 * @return
 		 * - If the input fragment isn't an IPv4/IPv6 packet or if it isn't an IPv4/IPv6 fragment, the return value is a pointer to a Packet object
 		 *   wrapping the input fragment RawPacket object. It's the user responsibility to free this instance
@@ -350,7 +362,7 @@ namespace pcpp
 		 *   returned. Notice it's the user's responsibility to free this pointer when done using it
 		 * - If the reassembled packet isn't ready then NULL is returned
 		 */
-		Packet* processPacket(RawPacket* fragment, ReassemblyStatus& status);
+		Packet* processPacket(RawPacket* fragment, ReassemblyStatus& status, ProtocolType parseUntil = UnknownProtocol, OsiModelLayer parseUntilLayer = OsiModelLayerUnknown);
 
 		/**
 		 * Get a partially reassembled packet. This method returns all the reassembled data that was gathered so far which is obviously not

--- a/Packet++/src/IPReassembly.cpp
+++ b/Packet++/src/IPReassembly.cpp
@@ -74,7 +74,7 @@ class IPv4FragmentWrapper : public IPFragmentWrapper
 public:
 	IPv4FragmentWrapper(Packet* fragment)
 	{
-		m_IPLayer =  fragment->getLayerOfType<IPv4Layer>();
+		m_IPLayer = fragment->isPacketOfType(IPv4) ? fragment->getLayerOfType<IPv4Layer>() : NULL;
 	}
 
 	// implement abstract methods
@@ -143,7 +143,7 @@ class IPv6FragmentWrapper : public IPFragmentWrapper
 public:
 	IPv6FragmentWrapper(Packet* fragment)
 	{
-		m_IPLayer =  fragment->getLayerOfType<IPv6Layer>();
+		m_IPLayer = fragment->isPacketOfType(IPv6) ? fragment->getLayerOfType<IPv6Layer>() : NULL;
 		if (m_IPLayer != NULL)
 			m_FragHeader = m_IPLayer->getExtensionOfType<IPv6FragmentationHeader>();
 		else
@@ -285,7 +285,7 @@ IPReassembly::~IPReassembly()
 	}
 }
 
-Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status)
+Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, ProtocolType parseUntil, OsiModelLayer parseUntilLayer)
 {
 	status = NON_IP_PACKET;
 
@@ -448,7 +448,7 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status)
 		}
 
 		// create a new Packet object with the reassembled data as its RawPacket
-		Packet* reassembledPacket = new Packet(fragData->data, true);
+		Packet* reassembledPacket = new Packet(fragData->data, true, parseUntil, parseUntilLayer);
 
 		if (fragData->packetKey->getProtocolType() == IPv4)
 		{
@@ -486,10 +486,10 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status)
 	return NULL;
 }
 
-Packet* IPReassembly::processPacket(RawPacket* fragment, ReassemblyStatus& status)
+Packet* IPReassembly::processPacket(RawPacket* fragment, ReassemblyStatus& status, ProtocolType parseUntil, OsiModelLayer parseUntilLayer)
 {
-	Packet* parsedFragment = new Packet(fragment);
-	Packet* result = processPacket(parsedFragment, status);
+	Packet* parsedFragment = new Packet(fragment, false, parseUntil, parseUntilLayer);
+	Packet* result = processPacket(parsedFragment, status, parseUntil, parseUntilLayer);
 	if (result != parsedFragment)
 		delete parsedFragment;
 


### PR DESCRIPTION
- Performance improvement in constructors of IPv4FragmentWrapper/IPv6FragmentWrapper
- Two new parameters parseUntil and parseUntilLayer were added into methods processPacket. The user can specify how deep the parsing should be done for the reassembled packet.