### PR TITLE
Many improvements in class MacAddress

### DIFF
--- a/Common++/header/MacAddress.h
+++ b/Common++/header/MacAddress.h
@@ -67,7 +67,7 @@ namespace pcpp
 		MacAddress(std::initializer_list<uint8_t> octets) : m_IsValid { octets.size() == sizeof m_Address }
 		{
 			if(m_IsValid)
-				std::copy_n(std::cbegin(octets), sizeof m_Address, std::begin(m_Address));
+				std::copy(octets.begin(), octets.end(), std::begin(m_Address));
 		}
 #endif
 

--- a/Common++/header/MacAddress.h
+++ b/Common++/header/MacAddress.h
@@ -113,7 +113,11 @@ namespace pcpp
 		 * Allocates a byte array of length 6 and copies address value into it. Array deallocation is user responsibility
 		 * @param[in] arr A pointer to where array will be allocated
 		 */
-		void copyTo(uint8_t** arr) const;
+		void copyTo(uint8_t** arr) const
+		{
+				(*arr) = new uint8_t[sizeof m_Address];
+				memcpy((*arr), m_Address, sizeof m_Address);
+		}
 
 		/**
 		 * Gets a pointer to an already allocated byte array and copies the address value to it.

--- a/Common++/src/MacAddress.cpp
+++ b/Common++/src/MacAddress.cpp
@@ -15,12 +15,6 @@ std::string MacAddress::toString() const
 	return std::string(str);
 }
 
-void MacAddress::copyTo(uint8_t** arr) const
-{
-	(*arr) = new uint8_t[sizeof m_Address];
-	memcpy((*arr), m_Address, sizeof m_Address);
-}
-
 void MacAddress::init(const char* addr)
 {
 	const unsigned int addrLen = sizeof m_Address;

--- a/Common++/src/MacAddress.cpp
+++ b/Common++/src/MacAddress.cpp
@@ -1,93 +1,52 @@
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "MacAddress.h"
-#include "string.h"
-#include "stdio.h"
-#include "stdlib.h"
 
 namespace pcpp
 {
 
 MacAddress MacAddress::Zero(0,0,0,0,0,0);
 
-MacAddress::MacAddress(uint8_t* addr)
-{
-	memcpy(m_Address, addr, 6);
-	m_IsValid = true;
-}
-
-MacAddress::MacAddress(const char* addr)
-{
-	init(addr);
-}
-
-MacAddress::MacAddress(const std::string& addr)
-{
-	init(addr.c_str());
-}
-
-MacAddress::MacAddress(uint8_t firstOctest, uint8_t secondOctet, uint8_t thirdOctet, uint8_t fourthOctet, uint8_t fifthOctet, uint8_t sixthOctet)
-{
-	m_Address[0] = firstOctest;
-	m_Address[1] = secondOctet;
-	m_Address[2] = thirdOctet;
-	m_Address[3] = fourthOctet;
-	m_Address[4] = fifthOctet;
-	m_Address[5] = sixthOctet;
-	m_IsValid = true;
-}
-
-MacAddress::MacAddress(const MacAddress& other)
-{
-	memcpy(m_Address, other.m_Address, 6);
-	m_IsValid = true;
-}
-
-MacAddress& MacAddress::operator=(const MacAddress& other)
-{
-	memcpy(m_Address, other.m_Address, 6);
-	m_IsValid = other.m_IsValid;
-
-	return *this;
-}
-
-std::string MacAddress::toString()
+std::string MacAddress::toString() const
 {
 	char str[19];
-	sprintf(str, "%02x:%02x:%02x:%02x:%02x:%02x",m_Address[0], m_Address[1], m_Address[2], m_Address[3], m_Address[4],m_Address[5]);
+	snprintf(str, sizeof str, "%02x:%02x:%02x:%02x:%02x:%02x", m_Address[0], m_Address[1], m_Address[2], m_Address[3], m_Address[4], m_Address[5]);
 	return std::string(str);
 }
 
-void MacAddress::copyTo(uint8_t** arr)
+void MacAddress::copyTo(uint8_t** arr) const
 {
-	(*arr) = new uint8_t[6];
-	memcpy((*arr), m_Address, 6);
+	(*arr) = new uint8_t[sizeof m_Address];
+	memcpy((*arr), m_Address, sizeof m_Address);
 }
-
-void MacAddress::copyTo(uint8_t* arr) const
-{
-	memcpy(arr, m_Address, 6);
-}
-
 
 void MacAddress::init(const char* addr)
 {
-	int i = 0;
-	while((*addr) != 0)
+	const unsigned int addrLen = sizeof m_Address;
+	unsigned int i = 0;
+
+	for(; *addr != 0 && i < addrLen; ++i)
 	{
 		char byte[3];
-		memset(byte, 0, 3);
-		byte[0] = (*addr); addr++;
-		if ((*addr) == 0) break;
-		byte[1] = (*addr); addr++;
-		if ((*addr) != 0) // holds the ":" char or end of string
-			addr++; // ignore the ":" char
-		m_Address[i] = (uint8_t)strtol(byte, NULL, 16);
-		i++;
+		memset(byte, 0, sizeof byte);
+		byte[0] = *addr++;
+		if(*addr == '\0') break;
+		byte[1] = *addr++;
+		if(*addr != '\0') // holds the ":" char or end of string
+			++addr; // ignore the ":" char
+		m_Address[i] = static_cast<uint8_t>(strtol(byte, NULL, 16));
+
+		// The strtol function returns zero value in two cases: when an error occures or the string '00' is converted.
+		// This code verifies that it's the second case.
+		if(m_Address[i] == 0 && (byte[0] != '0' || byte[1] != '0'))
+		{
+			m_IsValid = false;
+			return;
+		}
 	}
 
-	if (i != 6)
-		m_IsValid = false;
-	else
-		m_IsValid = true;
+	m_IsValid = (i == addrLen && *addr == '\0');
 }
 
 } // namespace pcpp

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -7113,50 +7113,6 @@ PACKETPP_TEST(RadiusLayerEditTest)
 	PACKETPP_TEST_PASSED;
 }
 
-PACKETPP_TEST(MacAddressTests)
-{
-	uint8_t macAsBytes[6] = { 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB };
-	MacAddress mac1(macAsBytes);
-	MacAddress mac2("aa:aa:00:aa:00:aa");
-	MacAddress mac3(0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB);
-	MacAddress macWrong1("aa:aa:aa:aa:aa:aa:bb:bb:bb:bb");
-	MacAddress macWrong2("aa:aa:aa");
-	MacAddress macWrong3("aa:aa:aa:ZZ:aa:aa");
-	#if __cplusplus > 199711L
-	MacAddress mac4 { 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB };
-	MacAddress mac5 { 0xBB, 0xBB, 0xBB, 0xBB, 0xBB };
-	PACKETPP_ASSERT(mac4.isValid(), "mac4 is not valid");
-	PACKETPP_ASSERT(!mac5.isValid(), "mac5 is valid");
-	#endif
-	PACKETPP_ASSERT(mac1.isValid(), "mac1 is not valid");
-	PACKETPP_ASSERT(mac2.isValid(), "mac2 is not valid");
-	PACKETPP_ASSERT(mac3.isValid(), "mac3 is not valid");
-	PACKETPP_ASSERT(!macWrong1.isValid(), "Incorrect macWrong1 is valid");
-	PACKETPP_ASSERT(!macWrong2.isValid(), "Incorrect macWrong2 is valid");
-	PACKETPP_ASSERT(!macWrong3.isValid(), "Incorrect macWrong3 is valid");
-
-	PACKETPP_ASSERT(mac3 == mac1, "mac3 is not equal to mac1");
-	PACKETPP_ASSERT(mac1 != mac2, "mac1 is equal to mac2");
-
-	MacAddress mac6(mac1);
-	PACKETPP_ASSERT(mac6.isValid(), "Incorrect copy constructing: mac6 is not valid");
-	PACKETPP_ASSERT(mac6 == mac1, "Incorrect copy constructing: mac6 is not equal to mac1");
-	mac6 = mac2;
-	PACKETPP_ASSERT(mac6.isValid(), "Incorrect copy assignment: mac6 is not valid");
-	PACKETPP_ASSERT(mac6 == mac2, "Incorrect copy assignment: mac6 is not equal to mac2");
-
-	const uint8_t bytes[6] = { 0xaa, 0xaa, 0x00, 0xaa, 0x00, 0xaa };
-	uint8_t macBytes[6];
-	mac2.copyTo(macBytes);
-	PACKETPP_ASSERT(memcmp(bytes, macBytes, sizeof bytes) == 0, "Incorrect result of calling copyTo(uint8_t* ptr)");
-
-	uint8_t *pMacBytes;
-	mac2.copyTo(&pMacBytes);
-	PACKETPP_ASSERT(memcmp(bytes, pMacBytes, sizeof bytes) == 0, "Incorrect result of calling copyTo(uint8_t** ptr)");
-	delete[] pMacBytes;
-
-	PACKETPP_TEST_PASSED;
-}
 
 int main(int argc, char* argv[]) {
 	start_leak_check();
@@ -7248,6 +7204,5 @@ int main(int argc, char* argv[]) {
 	PACKETPP_RUN_TEST(RadiusLayerParsingTest);
 	PACKETPP_RUN_TEST(RadiusLayerCreationTest);
 	PACKETPP_RUN_TEST(RadiusLayerEditTest);
-	PACKETPP_RUN_TEST(MacAddressTests);
 	PACKETPP_END_RUNNING_TESTS;
 }

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -7113,6 +7113,50 @@ PACKETPP_TEST(RadiusLayerEditTest)
 	PACKETPP_TEST_PASSED;
 }
 
+PACKETPP_TEST(MacAddressTests)
+{
+	uint8_t macAsBytes[6] = { 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB };
+	MacAddress mac1(macAsBytes);
+	MacAddress mac2("aa:aa:00:aa:00:aa");
+	MacAddress mac3(0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB);
+	MacAddress macWrong1("aa:aa:aa:aa:aa:aa:bb:bb:bb:bb");
+	MacAddress macWrong2("aa:aa:aa");
+	MacAddress macWrong3("aa:aa:aa:ZZ:aa:aa");
+	#if __cplusplus > 199711L
+	MacAddress mac4 { 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB };
+	MacAddress mac5 { 0xBB, 0xBB, 0xBB, 0xBB, 0xBB };
+	PACKETPP_ASSERT(mac4.isValid(), "mac4 is not valid");
+	PACKETPP_ASSERT(!mac5.isValid(), "mac5 is valid");
+	#endif
+	PACKETPP_ASSERT(mac1.isValid(), "mac1 is not valid");
+	PACKETPP_ASSERT(mac2.isValid(), "mac2 is not valid");
+	PACKETPP_ASSERT(mac3.isValid(), "mac3 is not valid");
+	PACKETPP_ASSERT(!macWrong1.isValid(), "Incorrect macWrong1 is valid");
+	PACKETPP_ASSERT(!macWrong2.isValid(), "Incorrect macWrong2 is valid");
+	PACKETPP_ASSERT(!macWrong3.isValid(), "Incorrect macWrong3 is valid");
+
+	PACKETPP_ASSERT(mac3 == mac1, "mac3 is not equal to mac1");
+	PACKETPP_ASSERT(mac1 != mac2, "mac1 is equal to mac2");
+
+	MacAddress mac6(mac1);
+	PACKETPP_ASSERT(mac6.isValid(), "Incorrect copy constructing: mac6 is not valid");
+	PACKETPP_ASSERT(mac6 == mac1, "Incorrect copy constructing: mac6 is not equal to mac1");
+	mac6 = mac2;
+	PACKETPP_ASSERT(mac6.isValid(), "Incorrect copy assignment: mac6 is not valid");
+	PACKETPP_ASSERT(mac6 == mac2, "Incorrect copy assignment: mac6 is not equal to mac2");
+
+	const uint8_t bytes[6] = { 0xaa, 0xaa, 0x00, 0xaa, 0x00, 0xaa };
+	uint8_t macBytes[6];
+	mac2.copyTo(macBytes);
+	PACKETPP_ASSERT(memcmp(bytes, macBytes, sizeof bytes) == 0, "Incorrect result of calling copyTo(uint8_t* ptr)");
+
+	uint8_t *pMacBytes;
+	mac2.copyTo(&pMacBytes);
+	PACKETPP_ASSERT(memcmp(bytes, pMacBytes, sizeof bytes) == 0, "Incorrect result of calling copyTo(uint8_t** ptr)");
+	delete[] pMacBytes;
+
+	PACKETPP_TEST_PASSED;
+}
 
 int main(int argc, char* argv[]) {
 	start_leak_check();
@@ -7204,5 +7248,6 @@ int main(int argc, char* argv[]) {
 	PACKETPP_RUN_TEST(RadiusLayerParsingTest);
 	PACKETPP_RUN_TEST(RadiusLayerCreationTest);
 	PACKETPP_RUN_TEST(RadiusLayerEditTest);
+	PACKETPP_RUN_TEST(MacAddressTests);
 	PACKETPP_END_RUNNING_TESTS;
 }

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -683,8 +683,34 @@ PCAPP_TEST(TestMacAddress)
 	uint8_t* arrToCopyTo = NULL;
 	macAddr3.copyTo(&arrToCopyTo);
 	PCAPP_ASSERT(arrToCopyTo[0] == 0x11 && arrToCopyTo[1] == 0x02 && arrToCopyTo[2] == 0x33 && arrToCopyTo[3] == 0x04 && arrToCopyTo[4] == 0x55 && arrToCopyTo[5] == 0x06, "Copy MacAddress to array failed");
-
 	delete [] arrToCopyTo;
+
+	uint8_t macBytes[6];
+	macAddr3.copyTo(macBytes);
+	PCAPP_ASSERT(memcmp(macBytes, addrAsArr, sizeof addrAsArr) == 0, "Incorrect result of calling copyTo(uint8_t* ptr)");
+
+	#if __cplusplus > 199711L
+	MacAddress macCpp11Valid { 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB };
+	MacAddress macCpp11Wrong { 0xBB, 0xBB, 0xBB, 0xBB, 0xBB };
+	PCAPP_ASSERT(macCpp11Valid.isValid(), "macCpp11Valid is not valid");
+	PCAPP_ASSERT(!macCpp11Wrong.isValid(), "macCpp11Wrong is valid");
+	#endif
+
+	MacAddress mac6(macAddr1);
+	PCAPP_ASSERT(mac6.isValid(), "Incorrect copy constructing: mac6 is not valid");
+	PCAPP_ASSERT(mac6 == macAddr1, "Incorrect copy constructing: mac6 is not equal to macAddr1");
+	mac6 = macAddr2;
+	PCAPP_ASSERT(mac6.isValid(), "Incorrect copy assignment: mac6 is not valid");
+	PCAPP_ASSERT(mac6 == macAddr2, "Incorrect copy assignment: mac6 is not equal to macAddr2");
+
+	MacAddress macWithZero("aa:aa:00:aa:00:aa");
+	MacAddress macWrong1("aa:aa:aa:aa:aa:aa:bb:bb:bb:bb");
+	MacAddress macWrong2("aa:aa:aa");
+	MacAddress macWrong3("aa:aa:aa:ZZ:aa:aa");
+	PCAPP_ASSERT(macWithZero.isValid(), "macWithZero is not valid");
+	PCAPP_ASSERT(!macWrong1.isValid(), "macWrong1 is valid");
+	PCAPP_ASSERT(!macWrong2.isValid(), "macWrong2 is valid");
+	PCAPP_ASSERT(!macWrong3.isValid(), "macWrong3 is valid");
 
 	PCAPP_TEST_PASSED;
 }


### PR DESCRIPTION
- The implementation of many constructors and methods have been moved into header file, the implementation of method `operator==` is simplified and optimized.

- Two errors in method `init()` were fixed:
  1. The buffer overflow occures when the length of input argument is more than 6.
  2. For incorrect MAC address string that contains the wrong hexadecimal number the old version of this method is setting `m_IsValid` to true value.

- The qualifier `const` was added to many methods

- The operator of assignment and the copy constructor are unnecessary.

- The new constructor `MacAddress(std::initializer_list<uint8_t>)` was added for the compilers which are supporting C++11 language standard.

- Operator `'sizeof m_Address'` is now used in all cases instead of number 6 to avoid the potential mistakes with buffer overflow.

- Tests were added.