### PR TITLE
Minor adjustments for pcapng and new minor helper function

### DIFF
--- a/3rdParty/LightPcapNg/LightPcapNg/include/light_null_compression.h
+++ b/3rdParty/LightPcapNg/LightPcapNg/include/light_null_compression.h
@@ -24,10 +24,15 @@
 #ifndef INCLUDE_LIGHT_NULL_COMPRESSION_H_
 #define INCLUDE_LIGHT_NULL_COMPRESSION_H_
 
+#if defined(USE_NULL_COMPRESSION)
+
 #include <stdlib.h>
 
 typedef void _compression_t;
 typedef void _decompression_t;
 
 struct light_file_t;
+
+#endif
+
 #endif /* INCLUDE_LIGHT_NULL_COMPRESSION_H_ */

--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_null_compression.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_null_compression.c
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include "light_compression.h"
 #include "light_null_compression.h"
 #include "light_compression_functions.h"
 #include "light_file.h"

--- a/Pcap++/header/PcapFilter.h
+++ b/Pcap++/header/PcapFilter.h
@@ -3,9 +3,13 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 #include "ProtocolType.h"
 #include <stdint.h>
 #include "ArpLayer.h"
+
+//Required for FilterTester
+struct bpf_program;
 
 /**
  * @file
@@ -82,6 +86,52 @@ namespace pcpp
 		 * Virtual destructor, does nothing for this class
 		 */
 		virtual ~GeneralFilter();
+	};
+
+	//Used in FilterTester
+	class RawPacket;
+
+	/**
+	 * @class FilterTester
+	 * This class can be loaded with a filter string and then can be used to verify the string is valid and check if a packet matches it<BR>
+	 */
+	class FilterTester : public GeneralFilter
+	{
+#if __cplusplus > 199711L || _MSC_VER >= 1800 //Maybe this can be 1600 for VS2010
+		typedef std::unique_ptr<bpf_program> Ptr_t;
+#else
+		typedef std::auto_ptr<bpf_program> Ptr_t;
+#endif
+
+	private:
+		bool verified, verifiedResult;
+		const std::string filterStr;
+		Ptr_t prog;
+
+	public:
+		FilterTester(const std::string& filterStr);
+
+		virtual ~FilterTester();
+
+		/**
+		 * A method that parses the class instance into BPF string format
+		 * @param[out] result An empty string that the parsing will be written into. If the string isn't empty, its content will be overridden
+		 */
+		virtual void parseToString(std::string& result);
+
+		/**
+		* Verify the filter is valid
+		* @return True if the filter is valid or false otherwise
+		*/
+		bool verifyFilter();
+
+		/**
+		 * Match a raw packet with a given BPF filter.
+		 * @param[in] rawPacket A pointer to the raw packet to match the BPF filter with
+		 * @return True if a raw packet matches the BPF filter or false otherwise
+		 */
+		bool matchPacketWithFilter(RawPacket* rawPacket);
+
 	};
 
 

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -379,6 +379,12 @@ namespace pcpp
 		void stopCapture();
 
 		/**
+		 * Check if a capture thread is running
+		 * @return True if a capture thread is currently running
+		 */
+		bool captureActive();
+
+		/**
 		 * Send a RawPacket to the network
 		 * @param[in] rawPacket A reference to the raw packet to send. This method treats the raw packet as read-only, it doesn't change anything
 		 * in it

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -515,6 +515,11 @@ void PcapLiveDevice::stopCapture()
 	m_StopThread = false;
 }
 
+bool PcapLiveDevice::captureActive()
+{
+	return m_CaptureThreadStarted;
+}
+
 void PcapLiveDevice::getStatistics(pcap_stat& stats)
 {
 	if(pcap_stats(m_PcapDescriptor, &stats) < 0)


### PR DESCRIPTION
This PR has a minor adjustment for file streaming PR you took before. I found in some cases the compiler would complain about duplicate definitions (atleast in VS). I also found that depending upon compilation order you could end up NOT Having USE_NULL_COMPRESSION defined in the C file so I added an include to make sure that can't happen.

I added a new function to pcapLiveDevice to tell if the capture thread is currently running for that device. 

I added a new class called FilterTester that duplicates the functionality of IPcapDevice::verifyFilter and IPcapDevice::matchPacketWithFilter but it avoids repeated building and discarding of the filter. I have an application where I expect to playback a file with captures from a variety of sensors and I need to pipe the packets out to the appropriate handlers based upon passing the filter criteria or not. This way I can make a filter for each source and test each packet in the file against that filter and either pass it or reject it. With the current offering there is no way I could find to have a reusable filter object to test packets with.

