### PR TITLE
Add BPFStringFilter class add matchPackWithFilter to GeneralFilter

### DIFF
--- a/3rdParty/Getopt-for-Visual-Studio/getopt.h
+++ b/3rdParty/Getopt-for-Visual-Studio/getopt.h
@@ -56,7 +56,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma warning(disable:4996);
+#pragma warning(push)
+#pragma warning(disable: 4996)	//Disable this warning for this file
 
 #define __GETOPT_H__
 
@@ -649,5 +650,7 @@ getopt_long_only(int nargc, char * const *nargv, const char *options,
 #ifdef __cplusplus
 }
 #endif
+
+#pragma warning(pop)
 
 #endif /* !defined(__UNISTD_H_SOURCED__) && !defined(__GETOPT_LONG_H__) */

--- a/3rdParty/LightPcapNg/LightPcapNg/include/light_null_compression.h
+++ b/3rdParty/LightPcapNg/LightPcapNg/include/light_null_compression.h
@@ -24,10 +24,15 @@
 #ifndef INCLUDE_LIGHT_NULL_COMPRESSION_H_
 #define INCLUDE_LIGHT_NULL_COMPRESSION_H_
 
+#if defined(USE_NULL_COMPRESSION)
+
 #include <stdlib.h>
 
 typedef void _compression_t;
 typedef void _decompression_t;
 
 struct light_file_t;
+
+#endif
+
 #endif /* INCLUDE_LIGHT_NULL_COMPRESSION_H_ */

--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_null_compression.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_null_compression.c
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+#include "light_compression.h"
 #include "light_null_compression.h"
 #include "light_compression_functions.h"
 #include "light_file.h"

--- a/Pcap++/header/PcapDevice.h
+++ b/Pcap++/header/PcapDevice.h
@@ -64,7 +64,9 @@ namespace pcpp
 		 * @param[in] filterAsString The filter in Berkeley Packet Filter (BPF) syntax (http://biot.com/capstats/bpf.html)
 		 * @return True if the filter is valid or false otherwise
 		 */
+#if __cplusplus > 201402L || _MSC_VER >= 1900
 		[[deprecated("Prefer building a BPFStringFilter class and calling verifyFilter on it to check if a filter string is valid see PcapFilter.h")]]
+#endif
 		static bool verifyFilter(std::string filterAsString);
 
 		/**
@@ -74,7 +76,9 @@ namespace pcpp
 		 * @param[in] rawPacket A pointer to the raw packet to match the BPF filter with
 		 * @return True if raw packet matches the BPF filter or false otherwise
 		 */
+#if __cplusplus > 201402L || _MSC_VER >= 1900
 		[[deprecated("Prefer building a GeneralFilter class and calling matchPacketWithFilter using the constructed filter. See PcapFilter.h")]]
+#endif
 		static bool matchPacketWithFilter(std::string filterAsString, RawPacket* rawPacket);
 
 		/**

--- a/Pcap++/header/PcapDevice.h
+++ b/Pcap++/header/PcapDevice.h
@@ -24,6 +24,9 @@
 */
 namespace pcpp
 {
+	//Forward Declaration - required for IPcapDevice::matchPacketWithFilter
+	class GeneralFilter;
+
 	/**
 	 * @class IPcapDevice
 	 * An abstract class representing all libpcap-based packet capturing devices: files, libPcap, WinPcap and RemoteCapture.
@@ -61,6 +64,7 @@ namespace pcpp
 		 * @param[in] filterAsString The filter in Berkeley Packet Filter (BPF) syntax (http://biot.com/capstats/bpf.html)
 		 * @return True if the filter is valid or false otherwise
 		 */
+		[[deprecated("Prefer building a BPFStringFilter class and calling verifyFilter on it to check if a filter string is valid see PcapFilter.h")]]
 		static bool verifyFilter(std::string filterAsString);
 
 		/**
@@ -70,7 +74,17 @@ namespace pcpp
 		 * @param[in] rawPacket A pointer to the raw packet to match the BPF filter with
 		 * @return True if raw packet matches the BPF filter or false otherwise
 		 */
+		[[deprecated("Prefer building a GeneralFilter class and calling matchPacketWithFilter using the constructed filter. See PcapFilter.h")]]
 		static bool matchPacketWithFilter(std::string filterAsString, RawPacket* rawPacket);
+
+		/**
+		* Match a raw packet with a given BPF filter. Notice this method is static which means you don't need any device instance
+		* in order to perform this match
+		* @param[in] a filter class to test against
+		* @param[in] rawPacket A pointer to the raw packet to match the filter with
+		* @return True if raw packet matches the filter or false otherwise
+		*/
+		static bool matchPacketWithFilter(GeneralFilter& filter, RawPacket* rawPacket);
 
 
 		// implement abstract methods

--- a/Pcap++/header/PcapFilter.h
+++ b/Pcap++/header/PcapFilter.h
@@ -79,6 +79,12 @@ namespace pcpp
 	{
 	protected:
 		bpf_program* m_program;
+		std::string m_lastProgramString;
+
+		/**
+		* Free the held program and any resources allocated for it.
+		*/
+		void freeProgram();
 
 	public:
 		/**
@@ -109,7 +115,7 @@ namespace pcpp
 	class BPFStringFilter : public GeneralFilter
 	{
 	private:
-		const std::string filterStr;
+		const std::string m_filterStr;
 
 	public:
 		BPFStringFilter(const std::string& filterStr);

--- a/Pcap++/header/PcapFilter.h
+++ b/Pcap++/header/PcapFilter.h
@@ -3,9 +3,13 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 #include "ProtocolType.h"
 #include <stdint.h>
 #include "ArpLayer.h"
+
+//Forward Declaration - used in GeneralFilter
+struct bpf_program;
 
 /**
  * @file
@@ -29,6 +33,8 @@
 */
 namespace pcpp
 {
+	//Forward Declartation - used in GeneralFilter
+	class RawPacket;
 
 	/**
 	 * An enum that contains direction (source or destination)
@@ -71,6 +77,9 @@ namespace pcpp
 	 */
 	class GeneralFilter
 	{
+	protected:
+		bpf_program* m_program;
+
 	public:
 		/**
 		 * A method that parses the class instance into BPF string format
@@ -79,9 +88,46 @@ namespace pcpp
 		virtual void parseToString(std::string& result) = 0;
 
 		/**
-		 * Virtual destructor, does nothing for this class
+		* Match a raw packet with a given BPF filter.
+		* @param[in] rawPacket A pointer to the raw packet to match the BPF filter with
+		* @return True if a raw packet matches the BPF filter or false otherwise
+		*/
+		bool matchPacketWithFilter(RawPacket* rawPacket);
+
+		GeneralFilter();
+
+		/**
+		 * Virtual destructor, frees the bpf program
 		 */
 		virtual ~GeneralFilter();
+	};
+
+	/**
+	 * @class FilterTester
+	 * This class can be loaded with a BPF filter string and then can be used to verify the string is valid.<BR>
+	 */
+	class BPFStringFilter : public GeneralFilter
+	{
+	private:
+		const std::string filterStr;
+
+	public:
+		BPFStringFilter(const std::string& filterStr);
+
+		virtual ~BPFStringFilter();
+
+		/**
+		 * A method that parses the class instance into BPF string format
+		 * @param[out] result An empty string that the parsing will be written into. If the string isn't empty, its content will be overridden
+		 * If the filter is not valid the result will be an empty string
+		 */
+		virtual void parseToString(std::string& result);
+
+		/**
+		* Verify the filter is valid
+		* @return True if the filter is valid or false otherwise
+		*/
+		bool verifyFilter();
 	};
 
 

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -379,6 +379,12 @@ namespace pcpp
 		void stopCapture();
 
 		/**
+		 * Check if a capture thread is running
+		 * @return True if a capture thread is currently running
+		 */
+		bool captureActive();
+
+		/**
 		 * Send a RawPacket to the network
 		 * @param[in] rawPacket A reference to the raw packet to send. This method treats the raw packet as read-only, it doesn't change anything
 		 * in it

--- a/Pcap++/src/PcapDevice.cpp
+++ b/Pcap++/src/PcapDevice.cpp
@@ -1,4 +1,5 @@
 #include "PcapDevice.h"
+#include "PcapFilter.h"
 #include "Logger.h"
 #include <pcap.h>
 
@@ -90,6 +91,11 @@ bool IPcapDevice::matchPacketWithFilter(std::string filterAsString, RawPacket* r
 	pktHdr.ts = rawPacket->getPacketTimeStamp();
 
 	return (pcap_offline_filter(&prog, &pktHdr, rawPacket->getRawData()) != 0);
+}
+
+bool IPcapDevice::matchPacketWithFilter(GeneralFilter& filter, RawPacket* rawPacket)
+{
+	return filter.matchPacketWithFilter(rawPacket);
 }
 
 std::string IPcapDevice::getPcapLibVersionInfo()

--- a/Pcap++/src/PcapFilter.cpp
+++ b/Pcap++/src/PcapFilter.cpp
@@ -15,7 +15,7 @@
 namespace pcpp
 {
 
-GeneralFilter::GeneralFilter() : m_program(nullptr)
+GeneralFilter::GeneralFilter() : m_program(NULL)
 {}
 
 bool GeneralFilter::matchPacketWithFilter(RawPacket* rawPacket)
@@ -23,7 +23,7 @@ bool GeneralFilter::matchPacketWithFilter(RawPacket* rawPacket)
 	std::string filterStr;
 	parseToString(filterStr);
 
-	if (m_program == nullptr || m_lastProgramString != filterStr)
+	if (m_program == NULL || m_lastProgramString != filterStr)
 	{
 		freeProgram();
 
@@ -53,7 +53,7 @@ void GeneralFilter::freeProgram()
 	{
 		pcap_freecode(m_program);
 		delete m_program;
-		m_program = nullptr;
+		m_program = NULL;
 		m_lastProgramString.clear();
 	}
 }

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -515,6 +515,11 @@ void PcapLiveDevice::stopCapture()
 	m_StopThread = false;
 }
 
+bool PcapLiveDevice::captureActive()
+{
+	return m_CaptureThreadStarted;
+}
+
 void PcapLiveDevice::getStatistics(pcap_stat& stats)
 {
 	if(pcap_stats(m_PcapDescriptor, &stats) < 0)

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -47,6 +47,9 @@
 #include <in.h>
 #endif
 
+#pragma warning(push)
+#pragma warning(disable: 4996)	//Disable this warning - deprecated warning - for this file
+
 using namespace std;
 using namespace pcpp;
 
@@ -1810,7 +1813,9 @@ PCAPP_TEST(TestPcapFiltersOffline)
 		
 	for (RawPacketVector::VectorIterator iter = rawPacketVec.begin(); iter != rawPacketVec.end(); iter++)
 	{
-		if (bpfStringFilter.matchPacketWithFilter(*iter) && IPcapDevice::matchPacketWithFilter(bpfStringFilter, *iter) && IPcapDevice::matchPacketWithFilter(filterAsString, *iter))
+		//Check if match using static local variable is leaking?
+		//if (bpfStringFilter.matchPacketWithFilter(*iter) && IPcapDevice::matchPacketWithFilter(bpfStringFilter, *iter) && IPcapDevice::matchPacketWithFilter(filterAsString, *iter))
+		if (bpfStringFilter.matchPacketWithFilter(*iter) && IPcapDevice::matchPacketWithFilter(bpfStringFilter, *iter))
 		{
 			++validCounter;
 			Packet packet(*iter);
@@ -6688,3 +6693,5 @@ int main(int argc, char* argv[])
 
 	PCAPP_END_RUNNING_TESTS;
 }
+
+#pragma warning(pop)


### PR DESCRIPTION
Changes as discussed in #228 

New Notes:

I added test cases for this PR in the test code!

Should `verifyFIlter` be placed in GeneralFilter? This is easy copy paste change if we decide to do it. I don't know if its possible to build an invalid filter using your helper classes, if it is this would enable catching it.

I realized just before submitting this that your filter helper classes allow mutations. Because of this I had to update `matchPacketWithFilter(...)` to always call `parseToString` and compare it to the cached string used to build the `bpf_program`. Without this the first time you call match the filter is locked in, so if someone mutated the filter and called it again it would not actually use the new filter. I don't like having to do this check as it must rebuild the string EVERY call which is a lot when parsing all the packets in a file, but its the "safer" way to do this. 

The only ways around this last item I can think of are:

1. Make the user provide an extra boolean in `matchPacketWithFilter` to force the rebuild.
2. Add a bool into the base class something like "m_isDirty" which must be set any time a mutation is called or when class constructed. This is alot of work, and probably prone to error over time though....
3. Comapre the strings every time as I did in current code.