### PR TITLE
New useful methods in MacAddress class

### DIFF
--- a/Common++/header/MacAddress.h
+++ b/Common++/header/MacAddress.h
@@ -111,21 +111,8 @@ namespace pcpp
 				std::copy(octets.begin(), octets.end(), std::begin(m_Address));
 				#endif
 			}
-
 			return *this;
 		}
-
-		/**
-		 * Returns the size of raw data
-		 * @return The size of raw data
-		 */
-		static constexpr size_t rawDataSize() { return 6; }
-#else
-		/**
-		 * Returns the size of raw data
-		 * @return The size of raw data
-		 */
-		static size_t rawDataSize() { return 6; }
 #endif
 
 		/**

--- a/Common++/header/MacAddress.h
+++ b/Common++/header/MacAddress.h
@@ -81,7 +81,6 @@ namespace pcpp
 				std::copy(octets.begin(), octets.end(), std::begin(m_Address));
 				#endif
 			}
-				
 		}
 #endif
 
@@ -115,7 +114,25 @@ namespace pcpp
 
 			return *this;
 		}
+
+		/**
+		 * Returns the size of raw data
+		 * @return The size of raw data
+		 */
+		static constexpr size_t rawDataSize() { return sizeof m_Address; }
+#else
+		/**
+		 * Returns the size of raw data
+		 * @return The size of raw data
+		 */
+		static size_t rawDataSize() { return sizeof m_Address; }
 #endif
+
+		/**
+		 * Returns the pointer to raw data
+		 * @return The pointer to raw data
+		 */
+		const uint8_t *getRawData() const { return m_Address; }
 
 		/**
 		 * Get an indication whether the MAC address is valid. An address can be invalid if it was constructed from illegal input, for example:
@@ -136,8 +153,8 @@ namespace pcpp
 		 */
 		void copyTo(uint8_t** arr) const
 		{
-				(*arr) = new uint8_t[sizeof m_Address];
-				memcpy((*arr), m_Address, sizeof m_Address);
+			*arr = new uint8_t[sizeof m_Address];
+			memcpy(*arr, m_Address, sizeof m_Address);
 		}
 
 		/**
@@ -151,6 +168,7 @@ namespace pcpp
 		 * A static value representing a zero value of MAC address, meaning address of value "00:00:00:00:00:00"
 		 */
 		static MacAddress Zero;
+
 	private:
 		uint8_t m_Address[6];
 		bool m_IsValid;

--- a/Common++/header/MacAddress.h
+++ b/Common++/header/MacAddress.h
@@ -106,7 +106,7 @@ namespace pcpp
 			if(m_IsValid)
 			{
 				#if _MSC_VER >= 1800
-				std::copy(octets.begin(), octets.end(), stdext::checked_array_iterator<uint8_t*>(m_Address, 6));
+				std::copy(octets.begin(), octets.end(), stdext::checked_array_iterator<uint8_t*>(m_Address, sizeof m_Address));
 				#else
 				std::copy(octets.begin(), octets.end(), std::begin(m_Address));
 				#endif
@@ -119,13 +119,13 @@ namespace pcpp
 		 * Returns the size of raw data
 		 * @return The size of raw data
 		 */
-		static constexpr size_t rawDataSize() { return sizeof m_Address; }
+		static constexpr size_t rawDataSize() { return 6; }
 #else
 		/**
 		 * Returns the size of raw data
 		 * @return The size of raw data
 		 */
-		static size_t rawDataSize() { return sizeof m_Address; }
+		static size_t rawDataSize() { return 6; }
 #endif
 
 		/**


### PR DESCRIPTION
Two new methods were added into `MacAddress` class: `rawDataSize` and `getRawData`.

`rawDataSize` allows to know needed size of buffer before calling the method `copyTo(uint8_t* arr)`.

`getRawData` is useful when we need to put MAC into the function that takes the pointer to data. Without this method the copying into temporary buffer is necessary.