### PR TITLE
Fixing an error with buffer overrun

### DIFF
--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -671,7 +671,7 @@ void PcapLiveDevice::setDeviceMtu()
 	struct ifreq ifr;
 
 	memset(&ifr, 0, sizeof(ifr));
-	strncpy(ifr.ifr_name, m_Name, sizeof(ifr.ifr_name));
+	strncpy(ifr.ifr_name, m_Name, sizeof(ifr.ifr_name) - 1);
 
 	int socketfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
 	if (ioctl(socketfd, SIOCGIFMTU, &ifr) == -1)
@@ -727,7 +727,7 @@ void PcapLiveDevice::setDeviceMacAddress()
 	struct ifreq ifr;
 
 	memset(&ifr, 0, sizeof(ifr));
-	strncpy(ifr.ifr_name, m_Name, sizeof(ifr.ifr_name));
+	strncpy(ifr.ifr_name, m_Name, sizeof(ifr.ifr_name) - 1);
 
 	int socketfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
 	if (ioctl(socketfd, SIOCGIFHWADDR, &ifr) == -1)


### PR DESCRIPTION
If `m_Name` will contain a pointer to C-string with length more than 16 bytes then buffer overrun will occur.

From the MAN page for `strncpy`: 

> Warning: If there is no null byte among the first n bytes of src, the string placed in dest will not be null-terminated