### PR TITLE
Avoiding warning in g++

### DIFF
--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -663,7 +663,7 @@ std::string Packet::printPacketInfo(bool timeAsLocalTime)
 	else
 		nowtm = gmtime(&nowtime);
 
-	char tmbuf[64], buf[64];
+	char tmbuf[64], buf[128];
 	if (nowtm != NULL)
 	{
 		strftime(tmbuf, sizeof(tmbuf), "%Y-%m-%d %H:%M:%S", nowtm);


### PR DESCRIPTION
Next warning arises in g++ 8.3.1:

```
src/Packet.cpp: In member function ‘std::string pcpp::Packet::printPacketInfo(bool)’:
src/Packet.cpp:670:30: warning: ‘%06lu’ directive output may be truncated writing between 6 and 20 bytes into a region of size between 0 and 63 [-Wformat-truncation=]
   snprintf(buf, sizeof(buf), "%s.%06lu", tmbuf, timestamp.tv_usec);
                              ^~~~~~~~~~
src/Packet.cpp:670:30: note: using the range [0, 18446744073709551615] for directive argument
src/Packet.cpp:670:11: note: ‘snprintf’ output between 8 and 85 bytes into a destination of size 64
   snprintf(buf, sizeof(buf), "%s.%06lu", tmbuf, timestamp.tv_usec);
   ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```
