### PR TITLE
Add support for FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,12 @@
+task:
+  name: Test FreeBSD
+  freebsd_instance:
+    image_family: freebsd-11-2
+  install_script: pkg install -y git libpcap bash gsed gmake
+  get_code_script: git clone https://github.com/seladb/PcapPlusPlus.git
+  configure_script:
+    - cd PcapPlusPlus
+    - ./configure-freebsd.sh --default
+  build_script:
+    - cd PcapPlusPlus
+    - gmake all

--- a/Common++/Makefile
+++ b/Common++/Makefile
@@ -23,6 +23,9 @@ endif
 ifdef MAC_OS_X
 DEPS := -DMAC_OS_X
 endif
+ifdef FREEBSD
+DEPS := -DFREEBSD
+endif
 
 GIT_CUR_COMMIT := $(shell git rev-parse --verify HEAD)
 GIT_CUR_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)

--- a/Common++/header/IpUtils.h
+++ b/Common++/header/IpUtils.h
@@ -14,6 +14,11 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #endif
+#ifdef FREEBSD
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#endif
 
 /// @file
 

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,10 @@ UNAME := $(shell uname)
 .SILENT:
 
 all: libs
+ifndef FREEBSD
 	@cd $(PACKETPP_TEST)             && $(MAKE) Packet++Test
 	@cd $(PCAPPP_TEST)               && $(MAKE) Pcap++Test
+endif
 	@cd $(EXAMPLE_ARPSPOOF)          && $(MAKE) ArpSpoofing
 	@cd $(EXAMPLE_ARPING)            && $(MAKE) Arping
 	@cd $(EXAMPLE_DNSSPOOF)          && $(MAKE) DnsSpoofing

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,8 @@ UNAME := $(shell uname)
 .SILENT:
 
 all: libs
-ifndef FREEBSD
 	@cd $(PACKETPP_TEST)             && $(MAKE) Packet++Test
 	@cd $(PCAPPP_TEST)               && $(MAKE) Pcap++Test
-endif
 	@cd $(EXAMPLE_ARPSPOOF)          && $(MAKE) ArpSpoofing
 	@cd $(EXAMPLE_ARPING)            && $(MAKE) Arping
 	@cd $(EXAMPLE_DNSSPOOF)          && $(MAKE) DnsSpoofing

--- a/Packet++/Makefile
+++ b/Packet++/Makefile
@@ -24,6 +24,9 @@ endif
 ifdef MAC_OS_X
 DEPS := -DMAC_OS_X
 endif
+ifdef FREEBSD
+DEPS := -DFREEBSD
+endif
 
 INCLUDES := -I"./src" \
 			-I"./header" \

--- a/Packet++/src/ArpLayer.cpp
+++ b/Packet++/src/ArpLayer.cpp
@@ -7,7 +7,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h>
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h>
 #endif
 

--- a/Packet++/src/DnsLayer.cpp
+++ b/Packet++/src/DnsLayer.cpp
@@ -11,6 +11,8 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h>
+#elif FREEBSD
+#include <arpa/inet.h>
 #endif
 
 namespace pcpp

--- a/Packet++/src/DnsResource.cpp
+++ b/Packet++/src/DnsResource.cpp
@@ -8,7 +8,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h> //for using ntohl, ntohs, etc.
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h> //for using ntohl, ntohs, etc.
 #endif
 

--- a/Packet++/src/DnsResourceData.cpp
+++ b/Packet++/src/DnsResourceData.cpp
@@ -9,7 +9,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h> //for using ntohl, ntohs, etc.
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h> //for using ntohl, ntohs, etc.
 #endif
 

--- a/Packet++/src/EthLayer.cpp
+++ b/Packet++/src/EthLayer.cpp
@@ -13,7 +13,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h>
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h>
 #endif
 

--- a/Packet++/src/GreLayer.cpp
+++ b/Packet++/src/GreLayer.cpp
@@ -14,7 +14,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h> //for using ntohl, ntohs, etc.
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h> //for using ntohl, ntohs, etc.
 #endif
 

--- a/Packet++/src/IPv6Extensions.cpp
+++ b/Packet++/src/IPv6Extensions.cpp
@@ -5,7 +5,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h> //for using ntohl, ntohs, etc.
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h> //for using ntohl, ntohs, etc.
 #endif
 #include "Logger.h"

--- a/Packet++/src/IcmpLayer.cpp
+++ b/Packet++/src/IcmpLayer.cpp
@@ -11,7 +11,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h> //for using ntohl, ntohs, etc.
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h> //for using ntohl, ntohs, etc.
 #endif
 

--- a/Packet++/src/IgmpLayer.cpp
+++ b/Packet++/src/IgmpLayer.cpp
@@ -8,7 +8,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h> //for using ntohl, ntohs, etc.
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h> //for using ntohl, ntohs, etc.
 #endif
 

--- a/Packet++/src/MplsLayer.cpp
+++ b/Packet++/src/MplsLayer.cpp
@@ -11,6 +11,8 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h>
+#elif FREEBSD
+#include <arpa/inet.h>
 #endif
 
 namespace pcpp

--- a/Packet++/src/PPPoELayer.cpp
+++ b/Packet++/src/PPPoELayer.cpp
@@ -11,6 +11,8 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h>
+#elif FREEBSD
+#include <arpa/inet.h>
 #endif
 
 namespace pcpp

--- a/Packet++/src/RadiusLayer.cpp
+++ b/Packet++/src/RadiusLayer.cpp
@@ -9,7 +9,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h> //for using ntohl, ntohs, etc.
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h> //for using ntohl, ntohs, etc.
 #endif
 

--- a/Packet++/src/SSLHandshake.cpp
+++ b/Packet++/src/SSLHandshake.cpp
@@ -4,7 +4,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h> //for using ntohl, ntohs, etc.
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h> //for using ntohl, ntohs, etc.
 #endif
 #include <string.h>

--- a/Packet++/src/SSLLayer.cpp
+++ b/Packet++/src/SSLLayer.cpp
@@ -6,7 +6,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h> //for using ntohl, ntohs, etc.
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h> //for using ntohl, ntohs, etc.
 #endif
 #include <sstream>

--- a/Packet++/src/SllLayer.cpp
+++ b/Packet++/src/SllLayer.cpp
@@ -14,7 +14,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h>
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h>
 #endif
 

--- a/Packet++/src/TLVData.cpp
+++ b/Packet++/src/TLVData.cpp
@@ -4,7 +4,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h> //for using ntohl, ntohs, etc.
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h> //for using ntohl, ntohs, etc.
 #endif
 

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -12,7 +12,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h> //for using ntohl, ntohs, etc.
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h> //for using ntohl, ntohs, etc.
 #endif
 

--- a/Packet++/src/VlanLayer.cpp
+++ b/Packet++/src/VlanLayer.cpp
@@ -13,6 +13,8 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h>
+#elif FREEBSD
+#include <arpa/inet.h>
 #endif
 #include "EndianPortable.h"
 

--- a/Packet++/src/VxlanLayer.cpp
+++ b/Packet++/src/VxlanLayer.cpp
@@ -5,7 +5,7 @@
 #include <winsock2.h>
 #elif LINUX
 #include <in.h> //for using ntohl, ntohs, etc.
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 #include <arpa/inet.h> //for using ntohl, ntohs, etc.
 #endif
 

--- a/Pcap++/Makefile
+++ b/Pcap++/Makefile
@@ -36,6 +36,9 @@ endif
 ifdef MAC_OS_X
 DEPS := -DMAC_OS_X
 endif
+ifdef FREEBSD
+DEPS := -DFREEBSD
+endif
 
 INCLUDES := -I"./src" \
 			-I"./header" \

--- a/Pcap++/src/NetworkUtils.cpp
+++ b/Pcap++/src/NetworkUtils.cpp
@@ -16,6 +16,9 @@
 #include <errno.h>
 #elif MAC_OS_X
 #include <sys/errno.h>
+#elif FREEBSD
+#include <arpa/inet.h>
+#include <sys/errno.h>
 #endif
 #ifdef _MSC_VER
 #include "SystemUtils.h"

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -29,9 +29,9 @@
 #include <net/if_dl.h>
 #endif
 
-// On Mac OS X timeout of -1 causes pcap_open_live to fail so value of 1ms is set here.
+// On Mac OS X and FreeBSD timeout of -1 causes pcap_open_live to fail so value of 1ms is set here.
 // On Linux and Windows this is not the case so we keep the -1 value
-#ifdef MAC_OS_X
+#if defined(MAC_OS_X) || defined(FREEBSD)
 #define LIBPCAP_OPEN_LIVE_TIMEOUT 1
 #else
 #define LIBPCAP_OPEN_LIVE_TIMEOUT -1

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -25,7 +25,7 @@
 #include <sys/sysctl.h>
 #include <net/if.h>
 #endif
-#ifdef MAC_OS_X
+#if defined(MAC_OS_X) || defined(FREEBSD)
 #include <net/if_dl.h>
 #endif
 
@@ -737,7 +737,7 @@ void PcapLiveDevice::setDeviceMacAddress()
 	}
 
     m_MacAddress = MacAddress(ifr.ifr_hwaddr.sa_data[0], ifr.ifr_hwaddr.sa_data[1], ifr.ifr_hwaddr.sa_data[2], ifr.ifr_hwaddr.sa_data[3], ifr.ifr_hwaddr.sa_data[4], ifr.ifr_hwaddr.sa_data[5]);
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
     int	mib[6];
     size_t len;
 
@@ -749,19 +749,19 @@ void PcapLiveDevice::setDeviceMacAddress()
 	mib[5] = if_nametoindex(m_Name);
 
 	if (mib[5] == 0){
-		LOG_ERROR("Error in retrieving MAC address: if_nametoindex error");
+		LOG_DEBUG("Error in retrieving MAC address: if_nametoindex error");
 		return;
 	}
 
 	if (sysctl(mib, 6, NULL, &len, NULL, 0) < 0) {
-		LOG_ERROR("Error in retrieving MAC address: sysctl 1 error");
+		LOG_DEBUG("Error in retrieving MAC address: sysctl 1 error");
 		return;
 	}
 
 	uint8_t buf[len];
 
 	if (sysctl(mib, 6, buf, &len, NULL, 0) < 0) {
-		LOG_ERROR("Error in retrieving MAC address: sysctl 2 error");
+		LOG_DEBUG("Error in retrieving MAC address: sysctl 2 error");
 		return;
 	}
 
@@ -831,7 +831,7 @@ void PcapLiveDevice::setDefaultGateway()
 	    interfaceGatewayStream >> interfaceGatewayIPInt;
 	    m_DefaultGateway = IPv4Address(interfaceGatewayIPInt);
 	}
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 	std::string ifaceStr = std::string(m_Name);
 	std::string command = "netstat -nr | grep default | grep " + ifaceStr;
 	std::string ifaceInfo = executeShellCommand(command);

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/seladb/PcapPlusPlus.svg?branch=master)](https://travis-ci.org/seladb/PcapPlusPlus)
 [![Build status](https://ci.appveyor.com/api/projects/status/4u5ui21ibbevkstc?svg=true)](https://ci.appveyor.com/project/seladb/pcapplusplus/branch/master)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/18137/badge.svg)](https://scan.coverity.com/projects/pcapplusplus)
+[![FreeBSD Build Status](https://api.cirrus-ci.com/github/seladb/PcapPlusPlus.svg)](https://cirrus-ci.com/github/seladb/PcapPlusPlus)
 <a href="https://twitter.com/intent/follow?screen_name=seladb">
     <img src="https://img.shields.io/twitter/follow/seladb.svg?label=Follow%20PcapPlusPlus" alt="Follow PcapPlusPlus" />
 </a>

--- a/Tests/Packet++Test/Makefile
+++ b/Tests/Packet++Test/Makefile
@@ -51,11 +51,7 @@ dependents:
 
 Packet++Test: start create-directories $(OBJS_FILENAMES)
 	@cd $(MEMPLUMBER_HOME) && $(MAKE) memplumber_sources
-ifdef FREEBSD
-	@$(CXX) $(COMMON_DEBUG_LIB_DIR) $(PCAPPP_LIBS_DIR) $(PCAPPP_BUILD_FLAGS) -lexecinfo -o "./Bin/Packet++Test$(BIN_EXT)" $(OBJS_FILENAMES) $(MEMPLUMBER_OBJS_FILENAMES) $(PCAPPP_LIBS) 
-else
 	@$(CXX) $(COMMON_DEBUG_LIB_DIR) $(PCAPPP_LIBS_DIR) $(PCAPPP_BUILD_FLAGS) -o "./Bin/Packet++Test$(BIN_EXT)" $(OBJS_FILENAMES) $(MEMPLUMBER_OBJS_FILENAMES) $(PCAPPP_LIBS) 
-endif
 	@$(PCAPPP_POST_BUILD)
 	@echo 'Finished successfully building: $(CUR_TARGET)'
 	@echo ' '

--- a/Tests/Packet++Test/Makefile
+++ b/Tests/Packet++Test/Makefile
@@ -51,7 +51,11 @@ dependents:
 
 Packet++Test: start create-directories $(OBJS_FILENAMES)
 	@cd $(MEMPLUMBER_HOME) && $(MAKE) memplumber_sources
+ifdef FREEBSD
+	@$(CXX) $(COMMON_DEBUG_LIB_DIR) $(PCAPPP_LIBS_DIR) $(PCAPPP_BUILD_FLAGS) -lexecinfo -o "./Bin/Packet++Test$(BIN_EXT)" $(OBJS_FILENAMES) $(MEMPLUMBER_OBJS_FILENAMES) $(PCAPPP_LIBS) 
+else
 	@$(CXX) $(COMMON_DEBUG_LIB_DIR) $(PCAPPP_LIBS_DIR) $(PCAPPP_BUILD_FLAGS) -o "./Bin/Packet++Test$(BIN_EXT)" $(OBJS_FILENAMES) $(MEMPLUMBER_OBJS_FILENAMES) $(PCAPPP_LIBS) 
+endif
 	@$(PCAPPP_POST_BUILD)
 	@echo 'Finished successfully building: $(CUR_TARGET)'
 	@echo ' '

--- a/Tests/Pcap++Test/Makefile
+++ b/Tests/Pcap++Test/Makefile
@@ -31,6 +31,9 @@ endif
 ifdef LINUX
 DEPS := -DLINUX
 endif
+ifdef FREEBSD
+DEPS := -DFREEBSD
+endif
 ifdef PF_RING_HOME
 DEPS += -DUSE_PF_RING
 endif

--- a/Tests/Pcap++Test/Makefile
+++ b/Tests/Pcap++Test/Makefile
@@ -73,11 +73,7 @@ dependents:
 	
 Pcap++Test: start create-directories $(OBJS_FILENAMES)
 	@cd $(MEMPLUMBER_HOME) && $(MAKE) memplumber_sources
-ifdef FREEBSD
-	@$(CXX) $(COMMON_DEBUG_LIB_DIR) $(PCAPPP_LIBS_DIR) $(PCAPPP_BUILD_FLAGS) -lexecinfo -o "./Bin/Pcap++Test$(BIN_EXT)" $(OBJS_FILENAMES) $(MEMPLUMBER_OBJS_FILENAMES) $(PCAPPP_LIBS)
-else
 	@$(CXX) $(COMMON_DEBUG_LIB_DIR) $(PCAPPP_LIBS_DIR) $(PCAPPP_BUILD_FLAGS) -o "./Bin/Pcap++Test$(BIN_EXT)" $(OBJS_FILENAMES) $(MEMPLUMBER_OBJS_FILENAMES) $(PCAPPP_LIBS)
-endif
 	@$(PCAPPP_POST_BUILD)
 	@echo 'Finished successfully building: $(CUR_TARGET)'
 	@echo ' '

--- a/Tests/Pcap++Test/Makefile
+++ b/Tests/Pcap++Test/Makefile
@@ -73,7 +73,11 @@ dependents:
 	
 Pcap++Test: start create-directories $(OBJS_FILENAMES)
 	@cd $(MEMPLUMBER_HOME) && $(MAKE) memplumber_sources
+ifdef FREEBSD
+	@$(CXX) $(COMMON_DEBUG_LIB_DIR) $(PCAPPP_LIBS_DIR) $(PCAPPP_BUILD_FLAGS) -lexecinfo -o "./Bin/Pcap++Test$(BIN_EXT)" $(OBJS_FILENAMES) $(MEMPLUMBER_OBJS_FILENAMES) $(PCAPPP_LIBS)
+else
 	@$(CXX) $(COMMON_DEBUG_LIB_DIR) $(PCAPPP_LIBS_DIR) $(PCAPPP_BUILD_FLAGS) -o "./Bin/Pcap++Test$(BIN_EXT)" $(OBJS_FILENAMES) $(MEMPLUMBER_OBJS_FILENAMES) $(PCAPPP_LIBS)
+endif
 	@$(PCAPPP_POST_BUILD)
 	@echo 'Finished successfully building: $(CUR_TARGET)'
 	@echo ' '

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -536,7 +536,7 @@ bool sendURLRequest(string url)
 	string cmd = "cUrl\\curl_win32.exe -s -o cUrl\\curl_output.txt";
 #elif LINUX
 	string cmd = "cUrl/curl.linux32 -s -o cUrl/curl_output.txt";
-#elif MAC_OS_X
+#elif MAC_OS_X || FREEBSD
 	string cmd = "curl -s -o cUrl/curl_output.txt";
 #endif
 

--- a/configure-freebsd.sh
+++ b/configure-freebsd.sh
@@ -148,7 +148,7 @@ if [ -n "$LIBPCAP_LIB_DIR" ]; then
 fi
 
 # generate installation and uninstallation scripts
-cp mk/install.sh.template mk/install.sh
+cp mk/install.sh.freebsd.template mk/install.sh
 sed -i.bak "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" mk/install.sh && rm mk/install.sh.bak
 chmod +x mk/install.sh
 

--- a/configure-freebsd.sh
+++ b/configure-freebsd.sh
@@ -1,9 +1,9 @@
 #!/usr/local/bin/bash
 
 echo ""
-echo "****************************************"
-echo "PcapPlusPlus Linux configuration script "
-echo "****************************************"
+echo "*******************************************"
+echo "PcapPlusPlus FreeBSD configuration script "
+echo "*******************************************"
 echo ""
 
 # set Script Name variable
@@ -12,25 +12,13 @@ SCRIPT=`basename ${BASH_SOURCE[0]}`
 # help function
 function HELP {
    echo -e \\n"Help documentation for ${SCRIPT}."\\n
-   echo "This script has 2 modes of operation:"
-   echo "  1) Without any switches. In this case the script will guide you through using wizards"
-   echo "  2) With switches, as described below"
-   echo ""
-   echo -e "Basic usage: $SCRIPT [-h] [--pf-ring] [--pf-ring-home] [--dpdk] [--dpdk-home] [--use-immediate-mode] [--set-direction-enabled] [--install-dir] [--libpcap-include-dir] [--libpcap-lib-dir]"\\n
+   echo -e "Basic usage: $SCRIPT [-h] [--use-immediate-mode] [--set-direction-enabled] [--install-dir] [--libpcap-include-dir] [--libpcap-lib-dir]"\\n
    echo "The following switches are recognized:"
-   echo "--default                --Setup PcapPlusPlus for Linux without PF_RING or DPDK. In this case you must not set --pf-ring or --dpdk"
-   echo ""
-   echo "--pf-ring                --Setup PcapPlusPlus with PF_RING. In this case you must also set --pf-ring-home"
-   echo "--pf-ring-home           --Sets PF_RING home directory. Use only when --pf-ring is set"
-   echo ""
-   echo "--dpdk                   --Setup PcapPlusPlus with DPDK. In this case you must also set --dpdk-home"
-   echo "--dpdk-home              --Sets DPDK home directoy. Use only when --dpdk is set"
-   echo ""
    echo "--use-immediate-mode     --Use libpcap immediate mode which enables getting packets as fast as possible (supported on libpcap>=1.5)"
    echo ""
-   echo "--set-direction-enabled  --Set direction for capturing incoming or outgoing packets (supported on libpcap>=0.9.1)"
+   echo "--set-direction-enabled  --Set direction for capturing incoming packets or outgoing packets (supported on libpcap>=0.9.1)"
    echo ""
-   echo "--install-dir            --Installation directory. Default is /usr/local"
+   echo "--install-dir            --Set installation directory. Default is /usr/local"
    echo ""
    echo "--libpcap-include-dir    --libpcap header files directory. This parameter is optional and if omitted PcapPlusPlus will look for"
    echo "                           the header files in the default include paths"
@@ -39,24 +27,15 @@ function HELP {
    echo ""
    echo -e "-h|--help                --Displays this help message and exits. No further actions are performed"\\n
    echo -e "Examples:"
-   echo -e "      $SCRIPT --default"
+   echo -e "      $SCRIPT"
    echo -e "      $SCRIPT --use-immediate-mode"
    echo -e "      $SCRIPT --set-direction-enabled"
    echo -e "      $SCRIPT --libpcap-include-dir /home/myuser/my-libpcap/include --libpcap-lib-dir /home/myuser/my-libpcap/lib"
    echo -e "      $SCRIPT --install-dir /home/myuser/my-install-dir"
-   echo -e "      $SCRIPT --pf-ring --pf-ring-home /home/myuser/PF_RING"
-   echo -e "      $SCRIPT --dpdk --dpdk-home /home/myuser/dpdk-2.1.0"
    echo ""
    exit 1
 }
 
-# initializing PF_RING variables
-COMPILE_WITH_PF_RING=0
-PF_RING_HOME=""
-
-# initializing DPDK variables
-COMPILE_WITH_DPDK=0
-DPDK_HOME=""
 HAS_PCAP_IMMEDIATE_MODE=0
 HAS_SET_DIRECTION_ENABLED=0
 
@@ -71,245 +50,80 @@ INSTALL_DIR=/usr/local
 NUMARGS=$#
 echo -e "Number of arguments: $NUMARGS"\\n
 
-# start wizard mode
-if [ $NUMARGS -eq 0 ]; then
 
-   # ask the user whether to compile with PF_RING. If so, set COMPILE_WITH_PF_RING to 1
-   while true; do
-      read -p "Compile PcapPlusPlus with PF_RING? " yn
-      case $yn in
-          [Yy]* ) COMPILE_WITH_PF_RING=1; break;;
-          [Nn]* ) break;;
-          * ) echo "Please answer yes or no";;
-      esac
-   done
-
-   # if compiling with PF_RING, get PF_RING home dir from the user and set it in PF_RING_HOME
-   if (( $COMPILE_WITH_PF_RING > 0 )) ; then
-      while true; do # don't stop until user provides a valid dir
-         read -e -p "Enter PF_RING source path: " PF_RING_HOME
-         if [ -d "$PF_RING_HOME" ]; then
-            break;
-         else
-            echo "Directory doesn't exist"
-         fi
-      done
-   fi
-
-   # ask the user whether to compile with DPDK. If so, set COMPILE_WITH_DPDK to 1
-   while true; do
-       read -p "Compile PcapPlusPlus with DPDK? " yn
-       case $yn in
-           [Yy]* ) COMPILE_WITH_DPDK=1; break;;
-           [Nn]* ) break;;
-           * ) echo "Please answer yes or no";;
-       esac
-   done
-
-   # if compiling with DPDK, get DPDK home dir and set it in DPDK_HOME
-   if (( $COMPILE_WITH_DPDK > 0 )) ; then
-       while true; do # don't stop until user provides a valid dir
-           read -e -p "Enter DPDK source path: " DPDK_HOME
-           if [ -d "$DPDK_HOME" ]; then
-               break;
-           else
-               echo "Directory doesn't exist"
-           fi
-       done
-   fi
-
-# script was run with parameters, go to param mode
-else
-
-   # these are all the possible switches
-   OPTS=`getopt -o h --long default,pf-ring,pf-ring-home:,dpdk,dpdk-home:,help,use-immediate-mode,set-direction-enabled,install-dir:,libpcap-include-dir:,libpcap-lib-dir: -- "$@"`
-
-   # if user put an illegal switch - print HELP and exit
-   if [ $? -ne 0 ]; then
-      HELP
-   fi
-
-   eval set -- "$OPTS"
-
-   # go over all switches
-   while true ; do
-     case "$1" in
-       # default switch - do nothing basically
-       --default)
-         shift ;;
-
-       # pf-ring switch - set COMPILE_WITH_PF_RING to 1
-       --pf-ring)
-         COMPILE_WITH_PF_RING=1
-         shift ;;
-
-       # pf-ring-home switch - set PF_RING_HOME and make sure it's a valid dir, otherwise exit
-       --pf-ring-home)
-         PF_RING_HOME=$2
-         if [ ! -d "$PF_RING_HOME" ]; then
-            echo "PG_RING home directory '$PF_RING_HOME' not found. Exiting..."
-            exit 1
-         fi
-         shift 2 ;;
-
-       # dpdk switch - set COMPILE_WITH_DPDK to 1
-       --dpdk)
-         COMPILE_WITH_DPDK=1
-         shift 1 ;;
-
-       # dpdk-home switch - set DPDK_HOME and make sure it's a valid dir, otherwise exit
-       --dpdk-home)
-         DPDK_HOME=$2
-         if [ ! -d "$DPDK_HOME" ]; then
-            echo "DPDK home directory '$DPDK_HOME' not found. Exiting..."
-            exit 1
-         fi
-         shift 2 ;;
-
-       # enable libpcap immediate mode
-       --use-immediate-mode)
-         HAS_PCAP_IMMEDIATE_MODE=1
-         shift ;;
-
-       # set direction enabled
-       --set-direction-enabled)
-         HAS_SET_DIRECTION_ENABLED=1
-         shift ;;
-
-       # non-default libpcap include dir
-       --libpcap-include-dir)
-         LIBPCAP_INLCUDE_DIR=$2
-         shift 2 ;;
-
-       # non-default libpcap lib dir
-       --libpcap-lib-dir)
-         LIBPCAP_LIB_DIR=$2
-         shift 2 ;;
-
-       # installation directory prefix
-       --install-dir)
-         INSTALL_DIR=$2
-         if [ ! -d "$INSTALL_DIR" ]; then
-            echo "Installation directory '$INSTALL_DIR' not found. Exiting..."
-            exit 1
-         fi
-         shift 2 ;;
-
-       # help switch - display help and exit
-       -h|--help)
-         HELP
-         ;;
-
-       # empty switch - just go on
-       --)
-         shift ; break ;;
-
-       # illegal switch
-       *)
-         echo -e \\n"Option -$OPTARG not allowed."
-         HELP
-         ;;
-     esac
-   done
-
-   # if --pf-ring was set, make sure --pf-ring-home was also set, otherwise exit with error
-   if [[ $COMPILE_WITH_PF_RING > 0 && $PF_RING_HOME == "" ]]; then
-      echo "Switch --pf-ring-home wasn't set. Exiting..."
-      exit 1
-   fi
-
-   # if --dpdk was set, make sure --dpdk-home is also set, otherwise exit with error
-   if [[ $COMPILE_WITH_DPDK > 0 && $DPDK_HOME == "" ]] ; then
-      echo "Switch --dpdk-home wasn't set. Exiting..."
-      exit 1
-   fi
-
-   ### End getopts code ###
+# if user put an illegal switch - print HELP and exit
+if [ $? -ne 0 ]; then
+  HELP
 fi
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+   # default switch - do nothing basically
+   --default)
+     shift ;;
+
+   # enable libpcap immediate mode
+   --use-immediate-mode)
+     HAS_PCAP_IMMEDIATE_MODE=1
+     shift ;;
+
+   # set direction enabled
+   --set-direction-enabled)
+     HAS_SET_DIRECTION_ENABLED=1
+     shift ;;
+
+   # non-default libpcap include dir
+   --libpcap-include-dir)
+     LIBPCAP_INLCUDE_DIR=$2
+     shift
+     shift ;;
+
+   # non-default libpcap lib dir
+   --libpcap-lib-dir)
+     LIBPCAP_LIB_DIR=$2
+     shift
+     shift ;;
+
+   # installation directory prefix
+   --install-dir)
+     INSTALL_DIR=$2
+     if [ ! -d "$INSTALL_DIR" ]; then
+        echo "Installation directory '$INSTALL_DIR' not found. Exiting..."
+        exit 1
+     fi
+     shift
+     shift ;;
+
+   # help switch - display help and exit
+   -h|--help)
+     HELP ;;
+
+   # empty switch - just go on
+   --)
+     break ;;
+
+   # illegal switch
+   *)
+     echo -e \\n"Option $key not allowed.";
+     HELP;
+     exit 1 ;;
+esac
+done
 
 
 PLATFORM_MK="mk/platform.mk"
 PCAPPLUSPLUS_MK="mk/PcapPlusPlus.mk"
 
-# copy the basic Linux platform.mk
 cp -f mk/platform.mk.freebsd $PLATFORM_MK
-
-# copy the common (all platforms) PcapPlusPlus.mk
 cp -f mk/PcapPlusPlus.mk.common $PCAPPLUSPLUS_MK
 
-# add the Linux definitions to PcapPlusPlus.mk
 cat mk/PcapPlusPlus.mk.freebsd >> $PCAPPLUSPLUS_MK
 
-# set current directory as PCAPPLUSPLUS_HOME in platform.mk
 echo -e "\n\nPCAPPLUSPLUS_HOME := "$PWD >> $PLATFORM_MK
 
-# set current direcrtory as PCAPPLUSPLUS_HOME in PcapPlusPlus.mk (write it in the first line of the file)
-gsed -i "1s|^|PCAPPLUSPLUS_HOME := $PWD\n\n|" $PCAPPLUSPLUS_MK
-
-# if compiling with PF_RING
-if (( $COMPILE_WITH_PF_RING > 0 )) ; then
-
-   # add PF_RING definitions to PcapPlusPlus.mk
-   cat mk/PcapPlusPlus.mk.pf_ring >> $PCAPPLUSPLUS_MK
-
-   # set PF_RING_HOME variable in platform.mk
-   echo -e "\n\nPF_RING_HOME := "$PF_RING_HOME >> $PLATFORM_MK
-
-   # set PF_RING_HOME variable in PcapPlusPlus.mk (write it in the second line of the file)
-   gsed -i "2s|^|PF_RING_HOME := $PF_RING_HOME\n\n|" $PCAPPLUSPLUS_MK
-fi
-
-
-# function to extract DPDK major + minor version from <DPDK_HOM>/pkg/dpdk.spec file
-# return: DPDK version (major + minor only)
-function get_dpdk_version() {
-   echo $(grep "Version" $DPDK_HOME/pkg/dpdk.spec | cut -d' ' -f2 | cut -d'.' -f 1,2)
-}
-
-# function to compare between 2 versions (each constructed of major + minor)
-# param1: first version to compare
-# param2: second version to compate
-# return: 1 if first>=second, 0 otherwise
-function compare_versions() {
-   echo "$1 $2" | awk '{if ($1 >= $2) print 1; else print 0}'
-}
-
-# if compiling with DPDK
-if (( $COMPILE_WITH_DPDK > 0 )) ; then
-
-   # add DPDK definitions to PcapPlusPlus.mk
-   cat mk/PcapPlusPlus.mk.dpdk >> $PCAPPLUSPLUS_MK
-
-   # if DPDK ver >= 17.11 concat additional definitions to PcapPlusPlus.mk
-   CUR_DPDK_VERSION=$(get_dpdk_version)
-   if [ "$(compare_versions $CUR_DPDK_VERSION 17.11)" -eq "1" ] ; then
-      cat mk/PcapPlusPlus.mk.dpdk_new >> $PCAPPLUSPLUS_MK
-   fi
-
-   # set USE_DPDK variable in platform.mk
-   echo -e "\n\nUSE_DPDK := 1" >> $PLATFORM_MK
-
-   # set DPDK home to RTE_SDK variable in platform.mk
-   echo -e "\n\nRTE_SDK := "$DPDK_HOME >> $PLATFORM_MK
-
-   # set USE_DPDK varaible in PcapPlusPlus.mk
-   gsed -i "2s|^|USE_DPDK := 1\n\n|" $PCAPPLUSPLUS_MK
-
-   # set DPDK home to RTE_SDK variable in PcapPlusPlus.mk
-   gsed -i "2s|^|RTE_SDK := $DPDK_HOME\n\n|" $PCAPPLUSPLUS_MK
-
-   # set the setup-dpdk script:
-
-   # copy the initial version to PcapPlusPlus root dir
-   cp mk/setup-dpdk.sh.template setup-dpdk.sh
-
-   # make it an executable
-   chmod +x setup-dpdk.sh
-
-   # replace the RTE_SDK placeholder with DPDK home
-   gsed -i "s|###RTE_SDK###|$DPDK_HOME|g" setup-dpdk.sh
-
-fi
+sed -i -e '1s|^|PCAPPLUSPLUS_HOME := '$PWD'\'$'\n''\'$'\n''|' $PCAPPLUSPLUS_MK
 
 if (( $HAS_PCAP_IMMEDIATE_MODE > 0 )) ; then
    echo -e "HAS_PCAP_IMMEDIATE_MODE := 1\n\n" >> $PCAPPLUSPLUS_MK
@@ -317,7 +131,8 @@ fi
 
 if (( $HAS_SET_DIRECTION_ENABLED > 0 )) ; then 
    echo -e "HAS_SET_DIRECTION_ENABLED := 1\n\n" >> $PCAPPLUSPLUS_MK
-fi
+fi 
+
 # non-default libpcap include dir
 if [ -n "$LIBPCAP_INLCUDE_DIR" ]; then
    echo -e "# non-default libpcap include dir" >> $PCAPPLUSPLUS_MK
@@ -334,13 +149,11 @@ fi
 
 # generate installation and uninstallation scripts
 cp mk/install.sh.template mk/install.sh
-gsed -i.bak "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" mk/install.sh && rm mk/install.sh.bak
+sed -i.bak "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" mk/install.sh && rm mk/install.sh.bak
 chmod +x mk/install.sh
 
 cp mk/uninstall.sh.template mk/uninstall.sh
-gsed -i.bak "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" mk/uninstall.sh && rm mk/uninstall.sh.bak
+sed -i.bak "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" mk/uninstall.sh && rm mk/uninstall.sh.bak
 chmod +x mk/install.sh
 
-
-# finished setup script
-echo "PcapPlusPlus configuration is complete. Files created (or modified): $PLATFORM_MK, $PCAPPLUSPLUS_MK, mk/install.sh, mk/uninstall.sh"
+echo "PcapPlusPlus configuration is complete. Files created (or modified): $PLATFORM_MK, $PCAPPLUSPLUS_MK", mk/install.sh, mk/uninstall.sh

--- a/configure-freebsd.sh
+++ b/configure-freebsd.sh
@@ -1,0 +1,346 @@
+#!/usr/local/bin/bash
+
+echo ""
+echo "****************************************"
+echo "PcapPlusPlus Linux configuration script "
+echo "****************************************"
+echo ""
+
+# set Script Name variable
+SCRIPT=`basename ${BASH_SOURCE[0]}`
+
+# help function
+function HELP {
+   echo -e \\n"Help documentation for ${SCRIPT}."\\n
+   echo "This script has 2 modes of operation:"
+   echo "  1) Without any switches. In this case the script will guide you through using wizards"
+   echo "  2) With switches, as described below"
+   echo ""
+   echo -e "Basic usage: $SCRIPT [-h] [--pf-ring] [--pf-ring-home] [--dpdk] [--dpdk-home] [--use-immediate-mode] [--set-direction-enabled] [--install-dir] [--libpcap-include-dir] [--libpcap-lib-dir]"\\n
+   echo "The following switches are recognized:"
+   echo "--default                --Setup PcapPlusPlus for Linux without PF_RING or DPDK. In this case you must not set --pf-ring or --dpdk"
+   echo ""
+   echo "--pf-ring                --Setup PcapPlusPlus with PF_RING. In this case you must also set --pf-ring-home"
+   echo "--pf-ring-home           --Sets PF_RING home directory. Use only when --pf-ring is set"
+   echo ""
+   echo "--dpdk                   --Setup PcapPlusPlus with DPDK. In this case you must also set --dpdk-home"
+   echo "--dpdk-home              --Sets DPDK home directoy. Use only when --dpdk is set"
+   echo ""
+   echo "--use-immediate-mode     --Use libpcap immediate mode which enables getting packets as fast as possible (supported on libpcap>=1.5)"
+   echo ""
+   echo "--set-direction-enabled  --Set direction for capturing incoming or outgoing packets (supported on libpcap>=0.9.1)"
+   echo ""
+   echo "--install-dir            --Installation directory. Default is /usr/local"
+   echo ""
+   echo "--libpcap-include-dir    --libpcap header files directory. This parameter is optional and if omitted PcapPlusPlus will look for"
+   echo "                           the header files in the default include paths"
+   echo "--libpcap-lib-dir        --libpcap pre compiled lib directory. This parameter is optional and if omitted PcapPlusPlus will look for"
+   echo "                           the lib file in the default lib paths"
+   echo ""
+   echo -e "-h|--help                --Displays this help message and exits. No further actions are performed"\\n
+   echo -e "Examples:"
+   echo -e "      $SCRIPT --default"
+   echo -e "      $SCRIPT --use-immediate-mode"
+   echo -e "      $SCRIPT --set-direction-enabled"
+   echo -e "      $SCRIPT --libpcap-include-dir /home/myuser/my-libpcap/include --libpcap-lib-dir /home/myuser/my-libpcap/lib"
+   echo -e "      $SCRIPT --install-dir /home/myuser/my-install-dir"
+   echo -e "      $SCRIPT --pf-ring --pf-ring-home /home/myuser/PF_RING"
+   echo -e "      $SCRIPT --dpdk --dpdk-home /home/myuser/dpdk-2.1.0"
+   echo ""
+   exit 1
+}
+
+# initializing PF_RING variables
+COMPILE_WITH_PF_RING=0
+PF_RING_HOME=""
+
+# initializing DPDK variables
+COMPILE_WITH_DPDK=0
+DPDK_HOME=""
+HAS_PCAP_IMMEDIATE_MODE=0
+HAS_SET_DIRECTION_ENABLED=0
+
+# initializing libpcap include/lib dirs to an empty string 
+LIBPCAP_INLCUDE_DIR=""
+LIBPCAP_LIB_DIR=""
+
+# default installation directory
+INSTALL_DIR=/usr/local
+
+#Check the number of arguments. If none are passed, continue to wizard mode.
+NUMARGS=$#
+echo -e "Number of arguments: $NUMARGS"\\n
+
+# start wizard mode
+if [ $NUMARGS -eq 0 ]; then
+
+   # ask the user whether to compile with PF_RING. If so, set COMPILE_WITH_PF_RING to 1
+   while true; do
+      read -p "Compile PcapPlusPlus with PF_RING? " yn
+      case $yn in
+          [Yy]* ) COMPILE_WITH_PF_RING=1; break;;
+          [Nn]* ) break;;
+          * ) echo "Please answer yes or no";;
+      esac
+   done
+
+   # if compiling with PF_RING, get PF_RING home dir from the user and set it in PF_RING_HOME
+   if (( $COMPILE_WITH_PF_RING > 0 )) ; then
+      while true; do # don't stop until user provides a valid dir
+         read -e -p "Enter PF_RING source path: " PF_RING_HOME
+         if [ -d "$PF_RING_HOME" ]; then
+            break;
+         else
+            echo "Directory doesn't exist"
+         fi
+      done
+   fi
+
+   # ask the user whether to compile with DPDK. If so, set COMPILE_WITH_DPDK to 1
+   while true; do
+       read -p "Compile PcapPlusPlus with DPDK? " yn
+       case $yn in
+           [Yy]* ) COMPILE_WITH_DPDK=1; break;;
+           [Nn]* ) break;;
+           * ) echo "Please answer yes or no";;
+       esac
+   done
+
+   # if compiling with DPDK, get DPDK home dir and set it in DPDK_HOME
+   if (( $COMPILE_WITH_DPDK > 0 )) ; then
+       while true; do # don't stop until user provides a valid dir
+           read -e -p "Enter DPDK source path: " DPDK_HOME
+           if [ -d "$DPDK_HOME" ]; then
+               break;
+           else
+               echo "Directory doesn't exist"
+           fi
+       done
+   fi
+
+# script was run with parameters, go to param mode
+else
+
+   # these are all the possible switches
+   OPTS=`getopt -o h --long default,pf-ring,pf-ring-home:,dpdk,dpdk-home:,help,use-immediate-mode,set-direction-enabled,install-dir:,libpcap-include-dir:,libpcap-lib-dir: -- "$@"`
+
+   # if user put an illegal switch - print HELP and exit
+   if [ $? -ne 0 ]; then
+      HELP
+   fi
+
+   eval set -- "$OPTS"
+
+   # go over all switches
+   while true ; do
+     case "$1" in
+       # default switch - do nothing basically
+       --default)
+         shift ;;
+
+       # pf-ring switch - set COMPILE_WITH_PF_RING to 1
+       --pf-ring)
+         COMPILE_WITH_PF_RING=1
+         shift ;;
+
+       # pf-ring-home switch - set PF_RING_HOME and make sure it's a valid dir, otherwise exit
+       --pf-ring-home)
+         PF_RING_HOME=$2
+         if [ ! -d "$PF_RING_HOME" ]; then
+            echo "PG_RING home directory '$PF_RING_HOME' not found. Exiting..."
+            exit 1
+         fi
+         shift 2 ;;
+
+       # dpdk switch - set COMPILE_WITH_DPDK to 1
+       --dpdk)
+         COMPILE_WITH_DPDK=1
+         shift 1 ;;
+
+       # dpdk-home switch - set DPDK_HOME and make sure it's a valid dir, otherwise exit
+       --dpdk-home)
+         DPDK_HOME=$2
+         if [ ! -d "$DPDK_HOME" ]; then
+            echo "DPDK home directory '$DPDK_HOME' not found. Exiting..."
+            exit 1
+         fi
+         shift 2 ;;
+
+       # enable libpcap immediate mode
+       --use-immediate-mode)
+         HAS_PCAP_IMMEDIATE_MODE=1
+         shift ;;
+
+       # set direction enabled
+       --set-direction-enabled)
+         HAS_SET_DIRECTION_ENABLED=1
+         shift ;;
+
+       # non-default libpcap include dir
+       --libpcap-include-dir)
+         LIBPCAP_INLCUDE_DIR=$2
+         shift 2 ;;
+
+       # non-default libpcap lib dir
+       --libpcap-lib-dir)
+         LIBPCAP_LIB_DIR=$2
+         shift 2 ;;
+
+       # installation directory prefix
+       --install-dir)
+         INSTALL_DIR=$2
+         if [ ! -d "$INSTALL_DIR" ]; then
+            echo "Installation directory '$INSTALL_DIR' not found. Exiting..."
+            exit 1
+         fi
+         shift 2 ;;
+
+       # help switch - display help and exit
+       -h|--help)
+         HELP
+         ;;
+
+       # empty switch - just go on
+       --)
+         shift ; break ;;
+
+       # illegal switch
+       *)
+         echo -e \\n"Option -$OPTARG not allowed."
+         HELP
+         ;;
+     esac
+   done
+
+   # if --pf-ring was set, make sure --pf-ring-home was also set, otherwise exit with error
+   if [[ $COMPILE_WITH_PF_RING > 0 && $PF_RING_HOME == "" ]]; then
+      echo "Switch --pf-ring-home wasn't set. Exiting..."
+      exit 1
+   fi
+
+   # if --dpdk was set, make sure --dpdk-home is also set, otherwise exit with error
+   if [[ $COMPILE_WITH_DPDK > 0 && $DPDK_HOME == "" ]] ; then
+      echo "Switch --dpdk-home wasn't set. Exiting..."
+      exit 1
+   fi
+
+   ### End getopts code ###
+fi
+
+
+PLATFORM_MK="mk/platform.mk"
+PCAPPLUSPLUS_MK="mk/PcapPlusPlus.mk"
+
+# copy the basic Linux platform.mk
+cp -f mk/platform.mk.freebsd $PLATFORM_MK
+
+# copy the common (all platforms) PcapPlusPlus.mk
+cp -f mk/PcapPlusPlus.mk.common $PCAPPLUSPLUS_MK
+
+# add the Linux definitions to PcapPlusPlus.mk
+cat mk/PcapPlusPlus.mk.freebsd >> $PCAPPLUSPLUS_MK
+
+# set current directory as PCAPPLUSPLUS_HOME in platform.mk
+echo -e "\n\nPCAPPLUSPLUS_HOME := "$PWD >> $PLATFORM_MK
+
+# set current direcrtory as PCAPPLUSPLUS_HOME in PcapPlusPlus.mk (write it in the first line of the file)
+gsed -i "1s|^|PCAPPLUSPLUS_HOME := $PWD\n\n|" $PCAPPLUSPLUS_MK
+
+# if compiling with PF_RING
+if (( $COMPILE_WITH_PF_RING > 0 )) ; then
+
+   # add PF_RING definitions to PcapPlusPlus.mk
+   cat mk/PcapPlusPlus.mk.pf_ring >> $PCAPPLUSPLUS_MK
+
+   # set PF_RING_HOME variable in platform.mk
+   echo -e "\n\nPF_RING_HOME := "$PF_RING_HOME >> $PLATFORM_MK
+
+   # set PF_RING_HOME variable in PcapPlusPlus.mk (write it in the second line of the file)
+   gsed -i "2s|^|PF_RING_HOME := $PF_RING_HOME\n\n|" $PCAPPLUSPLUS_MK
+fi
+
+
+# function to extract DPDK major + minor version from <DPDK_HOM>/pkg/dpdk.spec file
+# return: DPDK version (major + minor only)
+function get_dpdk_version() {
+   echo $(grep "Version" $DPDK_HOME/pkg/dpdk.spec | cut -d' ' -f2 | cut -d'.' -f 1,2)
+}
+
+# function to compare between 2 versions (each constructed of major + minor)
+# param1: first version to compare
+# param2: second version to compate
+# return: 1 if first>=second, 0 otherwise
+function compare_versions() {
+   echo "$1 $2" | awk '{if ($1 >= $2) print 1; else print 0}'
+}
+
+# if compiling with DPDK
+if (( $COMPILE_WITH_DPDK > 0 )) ; then
+
+   # add DPDK definitions to PcapPlusPlus.mk
+   cat mk/PcapPlusPlus.mk.dpdk >> $PCAPPLUSPLUS_MK
+
+   # if DPDK ver >= 17.11 concat additional definitions to PcapPlusPlus.mk
+   CUR_DPDK_VERSION=$(get_dpdk_version)
+   if [ "$(compare_versions $CUR_DPDK_VERSION 17.11)" -eq "1" ] ; then
+      cat mk/PcapPlusPlus.mk.dpdk_new >> $PCAPPLUSPLUS_MK
+   fi
+
+   # set USE_DPDK variable in platform.mk
+   echo -e "\n\nUSE_DPDK := 1" >> $PLATFORM_MK
+
+   # set DPDK home to RTE_SDK variable in platform.mk
+   echo -e "\n\nRTE_SDK := "$DPDK_HOME >> $PLATFORM_MK
+
+   # set USE_DPDK varaible in PcapPlusPlus.mk
+   gsed -i "2s|^|USE_DPDK := 1\n\n|" $PCAPPLUSPLUS_MK
+
+   # set DPDK home to RTE_SDK variable in PcapPlusPlus.mk
+   gsed -i "2s|^|RTE_SDK := $DPDK_HOME\n\n|" $PCAPPLUSPLUS_MK
+
+   # set the setup-dpdk script:
+
+   # copy the initial version to PcapPlusPlus root dir
+   cp mk/setup-dpdk.sh.template setup-dpdk.sh
+
+   # make it an executable
+   chmod +x setup-dpdk.sh
+
+   # replace the RTE_SDK placeholder with DPDK home
+   gsed -i "s|###RTE_SDK###|$DPDK_HOME|g" setup-dpdk.sh
+
+fi
+
+if (( $HAS_PCAP_IMMEDIATE_MODE > 0 )) ; then
+   echo -e "HAS_PCAP_IMMEDIATE_MODE := 1\n\n" >> $PCAPPLUSPLUS_MK
+fi
+
+if (( $HAS_SET_DIRECTION_ENABLED > 0 )) ; then 
+   echo -e "HAS_SET_DIRECTION_ENABLED := 1\n\n" >> $PCAPPLUSPLUS_MK
+fi
+# non-default libpcap include dir
+if [ -n "$LIBPCAP_INLCUDE_DIR" ]; then
+   echo -e "# non-default libpcap include dir" >> $PCAPPLUSPLUS_MK
+   echo -e "LIBPCAP_INLCUDE_DIR := $LIBPCAP_INLCUDE_DIR" >> $PCAPPLUSPLUS_MK
+   echo -e "PCAPPP_INCLUDES += -I\$(LIBPCAP_INLCUDE_DIR)\n" >> $PCAPPLUSPLUS_MK
+fi
+
+# non-default libpcap lib dir
+if [ -n "$LIBPCAP_LIB_DIR" ]; then
+   echo -e "# non-default libpcap lib dir" >> $PCAPPLUSPLUS_MK
+   echo -e "LIBPCAP_LIB_DIR := $LIBPCAP_LIB_DIR" >> $PCAPPLUSPLUS_MK
+   echo -e "PCAPPP_LIBS_DIR += -L\$(LIBPCAP_LIB_DIR)\n" >> $PCAPPLUSPLUS_MK
+fi
+
+# generate installation and uninstallation scripts
+cp mk/install.sh.template mk/install.sh
+gsed -i.bak "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" mk/install.sh && rm mk/install.sh.bak
+chmod +x mk/install.sh
+
+cp mk/uninstall.sh.template mk/uninstall.sh
+gsed -i.bak "s|{{INSTALL_DIR}}|$INSTALL_DIR|g" mk/uninstall.sh && rm mk/uninstall.sh.bak
+chmod +x mk/install.sh
+
+
+# finished setup script
+echo "PcapPlusPlus configuration is complete. Files created (or modified): $PLATFORM_MK, $PCAPPLUSPLUS_MK, mk/install.sh, mk/uninstall.sh"

--- a/mk/PcapPlusPlus.mk.freebsd
+++ b/mk/PcapPlusPlus.mk.freebsd
@@ -1,0 +1,9 @@
+### LINUX ###
+
+# includes
+PCAPPP_INCLUDES += -I/usr/include/netinet
+
+# libs
+PCAPPP_LIBS += -lpcap -lpthread
+
+

--- a/mk/PcapPlusPlus.mk.freebsd
+++ b/mk/PcapPlusPlus.mk.freebsd
@@ -1,4 +1,4 @@
-### LINUX ###
+### FreeBSD ###
 
 # includes
 PCAPPP_INCLUDES += -I/usr/include/netinet

--- a/mk/PcapPlusPlus.mk.freebsd
+++ b/mk/PcapPlusPlus.mk.freebsd
@@ -4,6 +4,6 @@
 PCAPPP_INCLUDES += -I/usr/include/netinet
 
 # libs
-PCAPPP_LIBS += -lpcap -lpthread
+PCAPPP_LIBS += -lpcap -lpthread -lexecinfo
 
 

--- a/mk/install.sh.freebsd.template
+++ b/mk/install.sh.freebsd.template
@@ -1,0 +1,51 @@
+#!/usr/local/bin/bash
+set -e # Exit with nonzero exit code if anything fails
+
+INSTALL_DIR={{INSTALL_DIR}}
+
+# copy libs
+mkdir -p $INSTALL_DIR/lib
+cp libCommon++.a libPacket++.a libPcap++.a $INSTALL_DIR/lib
+
+# copy header files
+mkdir -p $INSTALL_DIR/include
+mkdir -p $INSTALL_DIR/include/pcapplusplus
+cp header/* $INSTALL_DIR/include/pcapplusplus
+
+# copy examples
+mkdir -p $INSTALL_DIR/bin
+cp examples/* $INSTALL_DIR/bin
+
+# create template makefile 
+cp mk/PcapPlusPlus.mk PcapPlusPlus.mk
+gsed -i.bak '/PCAPPLUSPLUS_HOME :=/d' PcapPlusPlus.mk && rm PcapPlusPlus.mk.bak 
+gsed -i.bak '/# libs dir/d' PcapPlusPlus.mk && rm PcapPlusPlus.mk.bak
+gsed -i.bak '/PCAPPP_LIBS_DIR :=/d' PcapPlusPlus.mk && rm PcapPlusPlus.mk.bak
+gsed -i.bak "s|PCAPPP_INCLUDES :=.*|PCAPPP_INCLUDES := -I$INSTALL_DIR/include/pcapplusplus|g" PcapPlusPlus.mk && rm PcapPlusPlus.mk.bak
+
+# create PcapPlusPlus.pc
+echo prefix=$INSTALL_DIR>PcapPlusPlus.pc
+echo 'exec_prefix=${prefix}'>>PcapPlusPlus.pc
+echo 'libdir=${exec_prefix}/lib'>>PcapPlusPlus.pc
+echo 'includedir=${prefix}/include'>>PcapPlusPlus.pc
+echo>>PcapPlusPlus.pc
+echo 'Name: PcapPlusPlus'>>PcapPlusPlus.pc
+echo 'Description: a multiplatform C++ network sniffing and packet parsing and crafting framework. It is meant to be lightweight, efficient and easy to use'>>PcapPlusPlus.pc
+printf 'Version: '>>PcapPlusPlus.pc
+grep '#define PCAPPLUSPLUS_VERSION ' header/PcapPlusPlusVersion.h | cut -d " " -f3 | tr -d "\"" | tr -d '\n'>>PcapPlusPlus.pc
+printf '\n'>>PcapPlusPlus.pc
+echo 'URL: https://seladb.github.io/PcapPlusPlus-Doc'>>PcapPlusPlus.pc
+printf 'Libs: '>>PcapPlusPlus.pc
+grep PCAPPP_LIBS PcapPlusPlus.mk | cut -d " " -f3- | tr -d '\r' | tr '\n' ' '>>PcapPlusPlus.pc
+printf '\nCFlags: '>>PcapPlusPlus.pc
+grep PCAPPP_INCLUDES PcapPlusPlus.mk | cut -d " " -f3- | tr -d '\r' | tr '\n' ' '>>PcapPlusPlus.pc
+printf '\n'>>PcapPlusPlus.pc
+
+# copy template makefile
+mkdir -p $INSTALL_DIR/etc
+mv PcapPlusPlus.mk $INSTALL_DIR/etc
+
+# copy PcapPlusPlus.pc
+PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-$INSTALL_DIR/lib/pkgconfig}"
+mkdir -p $PKG_CONFIG_PATH
+mv PcapPlusPlus.pc $PKG_CONFIG_PATH

--- a/mk/platform.mk.freebsd
+++ b/mk/platform.mk.freebsd
@@ -1,0 +1,25 @@
+FREEBSD := 1
+
+BIN_EXT :=
+
+LIB_PREFIX := lib
+
+LIB_EXT := .a
+
+CXX := clang++
+
+CC := clang
+
+AR := ar
+
+RM := rm
+
+CP := cp
+
+MAKE := gmake
+
+MKDIR := mkdir
+
+INSTALL_SCRIPT := install.sh
+
+UNINSTALL_SCRIPT := uninstall.sh


### PR DESCRIPTION
- Add freebsd build scripts.
- Convert sed to gsed in FreeBSD.
- Use gmake.
- Fix time out in live capture for FreeBSD.
- Disable packet++ and pcap++ test because Memplumber is not compatible
with FreeBSD.

Here is the instruction to build in FreeBSD 11.x

1. Install libpcap, bash, gsed -- `sudo pkg install libpcap bash gsed`
1. Run configure script -- `./configure-freebsd.sh`
1. Run GNU make -- `gmake`

I verified and tested TcpReassembly my pfsense router. It works.

Signed-off-by: Ricky Zhang <rickyzhang@gmail.com>