### PR TITLE
Feature: let the user add custom LDFLAGS to the main Makefile

### DIFF
--- a/mk/PcapPlusPlus.mk.linux
+++ b/mk/PcapPlusPlus.mk.linux
@@ -6,4 +6,6 @@ PCAPPP_INCLUDES += -I/usr/include/netinet
 # libs
 PCAPPP_LIBS += -lpcap -lpthread
 
+# allow user to add custom LDFLAGS
+PCAPPP_BUILD_FLAGS += $(LDFLAGS)
 


### PR DESCRIPTION
Generally speaking, but especially with [archlinux](https://www.archlinux.org/) [makepkg](https://www.archlinux.org/pacman/makepkg.8.html), it is good practice to compile binaries with full [RELRO](http://tk-blog.blogspot.com/2009/02/relro-not-so-well-known-memory.html) support (`-Wl,-z,relro,-z,now`). Otherwise, [namcap](https://wiki.archlinux.org/index.php/Namcap) complains about it.

> pcapplusplus W: ELF file ('usr/bin/TcpReassembly') lacks FULL RELRO, check LDFLAGS.
> [...]

You can check the files produced by the linux compilation process with [checkrelro.sh](http://www.trapkit.de/tools/checkrelro.sh).

> $ ./checkrelro.sh --file Dist/examples/TcpReassembly
> Dist/examples/TcpReassembly - partial RELRO

This commit enables the linker flags to be added, either via the user environment, or through building tools. Especially with makepkg, who gives the standard `LDFLAGS` variable via `/etc/makepkg.conf`.

> $ grep LDFLAGS /etc/makepkg.conf
> LDFLAGS="-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now"

Feel free to ask if you have any further question.

Thanks
