### PR TITLE
HttpRequestFirstLine::setMethod() bugfix

### DIFF
--- a/Packet++/src/HttpLayer.cpp
+++ b/Packet++/src/HttpLayer.cpp
@@ -429,6 +429,7 @@ bool HttpRequestFirstLine::setMethod(HttpRequestLayer::HttpMethod newMethod)
 
 	memcpy(m_HttpRequest->m_Data, MethodEnumToString[newMethod].c_str(), MethodEnumToString[newMethod].length());
 
+	m_Method = newMethod;
 	m_UriOffset += lengthDifference;
 	m_VersionOffset += lengthDifference;
 
@@ -492,6 +493,8 @@ void HttpRequestFirstLine::setVersion(HttpVersion newVersion)
 
 	char* verPos = (char*)(m_HttpRequest->m_Data + m_VersionOffset);
 	memcpy(verPos, VersionEnumToString[newVersion].c_str(), 3);
+
+	m_Version = newVersion;
 }
 
 
@@ -858,6 +861,8 @@ void HttpResponseFirstLine::setVersion(HttpVersion newVersion)
 
 	char* verPos = (char*)(m_HttpResponse->m_Data + 5);
 	memcpy(verPos, VersionEnumToString[newVersion].c_str(), 3);
+
+	m_Version = newVersion;
 }
 
 HttpResponseLayer::HttpResponseStatusCode HttpResponseFirstLine::validateStatusCode(char* data, size_t dataLen, HttpResponseLayer::HttpResponseStatusCode potentialCode)

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -2105,6 +2105,9 @@ PTF_TEST_CASE(HttpRequestLayerCreationTest)
 	PTF_ASSERT(httpPacket.addLayer(&httpLayer), "Adding HTTP request layer failed");
 	hostField->setFieldValue("www.ynet.co.il");
 	httpLayer.getFirstLine()->setMethod(HttpRequestLayer::HttpGET);
+	PTF_ASSERT(httpLayer.getFirstLine()->getMethod() == HttpRequestLayer::HttpGET, "Couldn't set method");
+	httpLayer.getFirstLine()->setVersion(pcpp::OneDotOne);
+	PTF_ASSERT(httpLayer.getFirstLine()->getVersion() == pcpp::OneDotOne, "Couldn't set version");
 	httpLayer.getFirstLine()->setUri("/home/0,7340,L-8,00.html");
 	PTF_ASSERT(httpLayer.removeField("Dummy-Field2") == true, "Couldn't remove Dummy-Field2");
 	userAgentField->setFieldValue("Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.104 Safari/537.36");


### PR DESCRIPTION
Repeated method invocation spoils the query string. eg "POSTTTT", "PATCHCHCHCH", "CONNECTNECTNECTNECT", "OPTIONSIONSIONSIONS".