### PR TITLE
Code cleanup, small fixes (part 2)

### DIFF
--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -59,7 +59,7 @@ namespace pcpp
 			IPv6AddressType
 		};
 
-		virtual ~IPAddress();
+		virtual ~IPAddress() {}
 
 		/**
 		 * Gets the address type: IPv4 or IPv6
@@ -92,7 +92,7 @@ namespace pcpp
 		 * It fits cases when you're not sure which type you currently have
 		 * @return True if addresses match or false otherwise
 		 */
-		bool equals(const IPAddress* other);
+		bool equals(const IPAddress* other) const;
 
 		/**
 		 * Constructs an IP address of type IPv4 or IPv6 from a string (char*) representation
@@ -173,7 +173,7 @@ namespace pcpp
 		 * Returns a in_addr struct pointer representing the IPv4 address
 		 * @return a in_addr struct pointer representing the IPv4 address
 		 */
-		in_addr* toInAddr() { return m_pInAddr; }
+		in_addr* toInAddr() const { return m_pInAddr; }
 
 		/**
 		 * Overload of the comparison operator
@@ -271,14 +271,14 @@ namespace pcpp
 		 * Returns a in6_addr struct pointer representing the IPv6 address
 		 * @return a in6_addr struct pointer representing the IPv6 address
 		 */
-		in6_addr* toIn6Addr() { return m_pInAddr; }
+		in6_addr* toIn6Addr() const { return m_pInAddr; }
 
 		/**
 		 * Allocates a byte array and copies address value into it. Array deallocation is user responsibility
 		 * @param[in] arr A pointer to where array will be allocated
 		 * @param[out] length Returns the length in bytes of the array that was allocated
 		 */
-		void copyTo(uint8_t** arr, size_t& length);
+		void copyTo(uint8_t** arr, size_t& length) const;
 
 		/**
 		 * Gets a pointer to an already allocated byte array and copies the address value to it.
@@ -297,7 +297,7 @@ namespace pcpp
 		 * Overload of the non-equal operator
 		 * @return true if 2 addresses are not equal. False otherwise
 		 */
-		bool operator!=(const IPv6Address& other);
+		bool operator!=(const IPv6Address& other) const;
 
 		/**
 		 * Overload of the assignment operator

--- a/Common++/header/LRUList.h
+++ b/Common++/header/LRUList.h
@@ -76,7 +76,7 @@ namespace pcpp
 		 * Get the most recently used element (the one at the beginning of the list)
 		 * @return The most recently used element
 		 */
-		const T& getMRUElement()
+		const T& getMRUElement() const
 		{
 			return m_CacheItemsList.front();
 		}
@@ -85,7 +85,7 @@ namespace pcpp
 		 * Get the least recently used element (the one at the end of the list)
 		 * @return The least recently used element
 		 */
-		const T& getLRUElement()
+		const T& getLRUElement() const
 		{
 			return m_CacheItemsList.back();
 		}
@@ -107,12 +107,12 @@ namespace pcpp
 		/**
 		 * @return The max size of this list as determined in the c'tor
 		 */
-		inline size_t getMaxSize() { return m_MaxSize; }
+		size_t getMaxSize() const { return m_MaxSize; }
 
 		/**
 		 * @return The number of elements currently in this list
 		 */
-		inline size_t getSize() { return m_CacheItemsMap.size(); }
+		size_t getSize() const { return m_CacheItemsMap.size(); }
 
 	private:
 		std::list<T> m_CacheItemsList;

--- a/Common++/src/IpAddress.cpp
+++ b/Common++/src/IpAddress.cpp
@@ -13,12 +13,7 @@
 namespace pcpp
 {
 
-IPAddress::~IPAddress()
-{
-
-}
-
-bool IPAddress::equals(const IPAddress* other)
+bool IPAddress::equals(const IPAddress* other) const
 {
 	if (other == NULL)
 		return false;
@@ -64,7 +59,7 @@ IPv4Address::IPv4Address(const IPv4Address& other)
 	m_pInAddr = new in_addr();
 	memcpy(m_pInAddr, other.m_pInAddr, sizeof(in_addr));
 
-	strncpy(m_AddressAsString, other.m_AddressAsString, 40);
+	strncpy(m_AddressAsString, other.m_AddressAsString, MAX_ADDR_STRING_LEN);
 	m_IsValid = other.m_IsValid;
 }
 
@@ -135,7 +130,7 @@ IPv4Address& IPv4Address::operator=(const IPv4Address& other)
 		m_pInAddr = new in_addr();
 	memcpy(m_pInAddr, other.m_pInAddr, sizeof(in_addr));
 
-	strncpy(m_AddressAsString, other.m_AddressAsString, 40);
+	strncpy(m_AddressAsString, other.m_AddressAsString, MAX_ADDR_STRING_LEN);
 	m_IsValid = other.m_IsValid;
 
 	return *this;
@@ -171,8 +166,7 @@ IPv6Address::IPv6Address(const IPv6Address& other)
 	m_pInAddr = (in6_addr*)new uint8_t[sizeof(in6_addr)];
 	memcpy(m_pInAddr, other.m_pInAddr, sizeof(in6_addr));
 
-	strncpy(m_AddressAsString, other.m_AddressAsString, MAX_ADDR_STRING_LEN-1);
-	m_AddressAsString[MAX_ADDR_STRING_LEN - 1] = '\0';
+	strncpy(m_AddressAsString, other.m_AddressAsString, MAX_ADDR_STRING_LEN);
 	m_IsValid = other.m_IsValid;
 }
 
@@ -203,7 +197,7 @@ void IPv6Address::init(char* addressAsString)
 IPv6Address::IPv6Address(uint8_t* addressAsUintArr)
 {
 	m_pInAddr = (in6_addr*)new uint8_t[sizeof(in6_addr)];
-	memcpy(m_pInAddr, addressAsUintArr, 16);
+	memcpy(m_pInAddr, addressAsUintArr, sizeof(in6_addr));
 	if (inet_ntop(AF_INET6, m_pInAddr, m_AddressAsString, MAX_ADDR_STRING_LEN) == 0)
 		m_IsValid = false;
 	else
@@ -220,24 +214,25 @@ IPv6Address::IPv6Address(std::string addressAsString)
 	init((char*)addressAsString.c_str());
 }
 
-void IPv6Address::copyTo(uint8_t** arr, size_t& length)
+void IPv6Address::copyTo(uint8_t** arr, size_t& length) const
 {
-	length = 16;
-	(*arr) = new uint8_t[length];
-	memcpy((*arr), m_pInAddr, length);
+	const size_t addrLen = sizeof(in6_addr);
+	length = addrLen;
+	(*arr) = new uint8_t[addrLen];
+	memcpy((*arr), m_pInAddr, addrLen);
 }
 
 void IPv6Address::copyTo(uint8_t* arr) const
 {
-	memcpy(arr, m_pInAddr, 16);
+	memcpy(arr, m_pInAddr, sizeof(in6_addr));
 }
 
 bool IPv6Address::operator==(const IPv6Address& other) const
 {
-	return (memcmp(m_pInAddr, other.m_pInAddr, 16) == 0);
+	return (memcmp(m_pInAddr, other.m_pInAddr, sizeof(in6_addr)) == 0);
 }
 
-bool IPv6Address::operator!=(const IPv6Address& other)
+bool IPv6Address::operator!=(const IPv6Address& other) const
 {
 	return !(*this == other);
 }
@@ -248,7 +243,7 @@ IPv6Address& IPv6Address::operator=(const IPv6Address& other)
 		m_pInAddr = (in6_addr*)new uint8_t[sizeof(in6_addr)];
 	memcpy(m_pInAddr, other.m_pInAddr, sizeof(in6_addr));
 
-	strncpy(m_AddressAsString, other.m_AddressAsString, 40);
+	strncpy(m_AddressAsString, other.m_AddressAsString, MAX_ADDR_STRING_LEN);
 	m_IsValid = other.m_IsValid;
 
 	return *this;

--- a/Pcap++/header/DpdkDevice.h
+++ b/Pcap++/header/DpdkDevice.h
@@ -360,38 +360,38 @@ namespace pcpp
 		/**
 		 * @return The device ID (DPDK port ID)
 		 */
-		inline int getDeviceId() { return m_Id; }
+		int getDeviceId() const { return m_Id; }
 		/**
 		 * @return The device name which is in the format of 'DPDK_[PORT-ID]'
 		 */
-		inline std::string getDeviceName() { return std::string(m_DeviceName); }
+		std::string getDeviceName() const { return std::string(m_DeviceName); }
 
 		/**
 		 * @return The MAC address of the device (DPDK port)
 		 */
-		inline MacAddress getMacAddress() { return m_MacAddress; }
+		MacAddress getMacAddress() const { return m_MacAddress; }
 
 		/**
 		 * @return The name of the PMD (poll mode driver) DPDK is using for this device. You can read about PMDs in the DPDK documentation:
 		 * http://dpdk.org/doc/guides/prog_guide/poll_mode_drv.html
 		 */
-		inline std::string getPMDName() { return m_PMDName; }
+		std::string getPMDName() const { return m_PMDName; }
 
 		/**
 		 * @return The enum type of the PMD (poll mode driver) DPDK is using for this device. You can read about PMDs in the DPDK documentation:
 		 * http://dpdk.org/doc/guides/prog_guide/poll_mode_drv.html
 		 */
-		inline DpdkPMDType getPMDType() { return m_PMDType; }
+		DpdkPMDType getPMDType() const { return m_PMDType; }
 
 		/**
 		 * @return The PCI address of the device
 		 */
-		inline std::string getPciAddress() { return m_PciAddress; }
+		std::string getPciAddress() const { return m_PciAddress; }
 
 		/**
 		 * @return The device's maximum transmission unit (MTU) in bytes
 		 */
-		inline uint16_t getMtu() { return m_DeviceMtu; }
+		uint16_t getMtu() const { return m_DeviceMtu; }
 
 		/**
 		 * Set a new maximum transmission unit (MTU) for this device
@@ -403,38 +403,38 @@ namespace pcpp
 		/**
 		 * @return True if this device is a virtual interface (such as VMXNET3, 1G/10G virtual function, etc.), false otherwise
 		 */
-		bool isVirtual();
+		bool isVirtual() const;
 
 		/**
 		 * Get the link status (link up/down, link speed and link duplex)
 		 * @param[out] linkStatus A reference to object the result shall be written to
 		 */
-		void getLinkStatus(LinkStatus& linkStatus);
+		void getLinkStatus(LinkStatus& linkStatus) const;
 
 		/**
 		 * @return The core ID used in this context
 		 */
-		uint32_t getCurrentCoreId();
+		uint32_t getCurrentCoreId() const;
 
 		/**
 		 * @return The number of RX queues currently opened for this device (as configured in openMultiQueues() )
 		 */
-		uint16_t getNumOfOpenedRxQueues() { return m_NumOfRxQueuesOpened; }
+		uint16_t getNumOfOpenedRxQueues() const { return m_NumOfRxQueuesOpened; }
 
 		/**
 		 * @return The number of TX queues currently opened for this device (as configured in openMultiQueues() )
 		 */
-		uint16_t getNumOfOpenedTxQueues() { return m_NumOfTxQueuesOpened; }
+		uint16_t getNumOfOpenedTxQueues() const { return m_NumOfTxQueuesOpened; }
 
 		/**
 		 * @return The total number of RX queues available on this device
 		 */
-		uint16_t getTotalNumOfRxQueues() { return m_TotalAvailableRxQueues; }
+		uint16_t getTotalNumOfRxQueues() const { return m_TotalAvailableRxQueues; }
 
 		/**
 		 * @return The total number of TX queues available on this device
 		 */
-		uint16_t getTotalNumOfTxQueues() { return m_TotalAvailableTxQueues; }
+		uint16_t getTotalNumOfTxQueues() const { return m_TotalAvailableTxQueues; }
 
 
 		/**
@@ -443,7 +443,7 @@ namespace pcpp
 		 * @param[in] rxQueueId The RX queue to receive packets from
 		 * @return The number of packets received. If an error occurred 0 will be returned and the error will be printed to log
 		 */
-		uint16_t receivePackets(MBufRawPacketVector& rawPacketsArr, uint16_t rxQueueId);
+		uint16_t receivePackets(MBufRawPacketVector& rawPacketsArr, uint16_t rxQueueId) const;
 
 		/**
 		 * Receive raw packets from the network. Please notice that in terms of performance, this is the best method to use
@@ -457,7 +457,7 @@ namespace pcpp
 		 * @param[in] rxQueueId The RX queue to receive packets from
 		 * @return The number of packets received. If an error occurred 0 will be returned and the error will be printed to log
 		 */
-		uint16_t receivePackets(MBufRawPacket** rawPacketsArr, uint16_t rawPacketArrLength, uint16_t rxQueueId);
+		uint16_t receivePackets(MBufRawPacket** rawPacketsArr, uint16_t rawPacketArrLength, uint16_t rxQueueId) const;
 
 		/**
 		 * Receive parsed packets from the network
@@ -468,7 +468,7 @@ namespace pcpp
 		 * @param[in] rxQueueId The RX queue to receive packets from
 		 * @return The number of packets received. If an error occurred 0 will be returned and the error will be printed to log
 		 */
-		uint16_t receivePackets(Packet** packetsArr, uint16_t packetsArrLength, uint16_t rxQueueId);
+		uint16_t receivePackets(Packet** packetsArr, uint16_t packetsArrLength, uint16_t rxQueueId) const;
 
 		/**
 		 * Send an array of MBufRawPacket to the network. Please notice the following:<BR>
@@ -668,18 +668,18 @@ namespace pcpp
 		/**
 		 * @return The number of free mbufs in device's mbufs pool
 		 */
-		int getAmountOfFreeMbufs();
+		int getAmountOfFreeMbufs() const;
 
 		/**
 		 * @return The number of mbufs currently in use in device's mbufs pool
 		 */
-		int getAmountOfMbufsInUse();
+		int getAmountOfMbufsInUse() const;
 
 		/**
 		 * Retrieve RX/TX statistics from device
 		 * @param[out] stats A reference to a DpdkDeviceStats object where stats will be written into
 		 */
-		void getStatistics(DpdkDeviceStats& stats);
+		void getStatistics(DpdkDeviceStats& stats) const;
 
 		/**
 		 * Clear device statistics
@@ -706,20 +706,20 @@ namespace pcpp
 		 * @param[in] rssHF RSS hash function to check
 		 * @return True if this hash function is supported, false otherwise
 		 */
-		bool isDeviceSupportRssHashFunction(DpdkRssHashFunction rssHF);
+		bool isDeviceSupportRssHashFunction(DpdkRssHashFunction rssHF) const;
 
 		/**
 		 * Check whether a mask of RSS hash functions is supported by this device (PMD)
 		 * @param[in] rssHFMask RSS hash functions mask to check. This mask should be built from values in DpdkRssHashFunction enum
 		 * @return True if all hash functions in this mask are supported, false otherwise
 		 */
-		bool isDeviceSupportRssHashFunction(uint64_t rssHFMask);
+		bool isDeviceSupportRssHashFunction(uint64_t rssHFMask) const;
 
 		/**
 		 * @return A mask of all RSS hash functions supported by this device (PMD). This mask is built from values in DpdkRssHashFunction enum.
 		 * Value of zero means RSS is not supported by this device
 		 */
-		uint64_t getSupportedRssHashFunctions();
+		uint64_t getSupportedRssHashFunctions() const;
 
 
 		//overridden methods
@@ -767,8 +767,8 @@ namespace pcpp
 		typedef rte_mbuf* (*PacketIterator)(void* packetStorage, int index);
 		uint16_t sendPacketsInner(uint16_t txQueueId, void* packetStorage, PacketIterator iter, int arrLength, bool useTxBuffer);
 
-		uint64_t convertRssHfToDpdkRssHf(uint64_t rssHF);
-		uint64_t convertDpdkRssHfToRssHf(uint64_t dpdkRssHF);
+		uint64_t convertRssHfToDpdkRssHf(uint64_t rssHF) const;
+		uint64_t convertDpdkRssHfToRssHf(uint64_t dpdkRssHF) const;
 
 		char m_DeviceName[30];
 		DpdkPMDType m_PMDType;
@@ -798,7 +798,7 @@ namespace pcpp
 		 // RSS key used by the NIC for load balancing the packets between cores
 		static uint8_t m_RSSKey[40];
 
-		DpdkDeviceStats m_PrevStats;
+		mutable DpdkDeviceStats m_PrevStats;
 	};
 
 } // namespace pcpp

--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -81,7 +81,7 @@ namespace pcpp
 
 		DpdkDeviceList();
 
-		inline bool isInitialized() { return (m_IsInitialized && m_IsDpdkInitialized); }
+		bool isInitialized() const { return (m_IsInitialized && m_IsDpdkInitialized); }
 		bool initDpdkDevices(uint32_t mBufPoolSizePerDevice);
 		static bool verifyHugePagesAndDpdkDriver();
 
@@ -95,7 +95,7 @@ namespace pcpp
 		 * initDpdk() was not called or returned false this instance won't be initialized and DpdkDevices won't be initialized either
 		 * @return The singleton instance of DpdkDeviceList
 		 */
-		static inline DpdkDeviceList& getInstance()
+		static DpdkDeviceList& getInstance()
 		{
 			static DpdkDeviceList instance;
 			if (!instance.isInitialized())
@@ -131,24 +131,24 @@ namespace pcpp
 		 * @param[in] portId The port ID
 		 * @return A pointer to the DpdkDevice or NULL if no such device is found
 		 */
-		DpdkDevice* getDeviceByPort(int portId);
+		DpdkDevice* getDeviceByPort(int portId) const;
 
 		/**
 		 * Get a DpdkDevice by port PCI address
 		 * @param[in] pciAddr The port PCI address
 		 * @return A pointer to the DpdkDevice or NULL if no such device is found
 		 */
-		DpdkDevice* getDeviceByPciAddress(const std::string& pciAddr);
+		DpdkDevice* getDeviceByPciAddress(const std::string& pciAddr) const;
 
 		/**
 		 * @return A vector of all DpdkDevice instances
 		 */
-		inline const std::vector<DpdkDevice*>& getDpdkDeviceList() { return m_DpdkDeviceList; }
+		const std::vector<DpdkDevice*>& getDpdkDeviceList() const { return m_DpdkDeviceList; }
 
 		/**
 		 * @return DPDK master core which is the core that initializes the application
 		 */
-		SystemCore getDpdkMasterCore();
+		SystemCore getDpdkMasterCore() const;
 
 		/**
 		 * Change the log level of all modules of DPDK
@@ -160,7 +160,7 @@ namespace pcpp
 		 * @return The current DPDK log level. RTE_LOG_NOTICE and lower are considered as LoggerPP#Normal. RTE_LOG_INFO or RTE_LOG_DEBUG
 		 * are considered as LoggerPP#Debug
 		 */
-		LoggerPP::LogLevel getDpdkLogLevel();
+		LoggerPP::LogLevel getDpdkLogLevel() const;
 
 		/**
 		 * Order DPDK to write all its logs to a file

--- a/Pcap++/header/PcapDevice.h
+++ b/Pcap++/header/PcapDevice.h
@@ -50,7 +50,7 @@ namespace pcpp
 		 * - pcap_stat#ps_ifdorp: number of packets dropped by interface
 		 * @param[out] stats The stats struct where stats are returned
 		 */
-		virtual void getStatistics(pcap_stat& stats) = 0;
+		virtual void getStatistics(pcap_stat& stats) const = 0;
 
 		/**
 		 * A static method for retreiving pcap lib (libpcap/WinPcap/etc.) version information. This method is actually

--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -30,7 +30,7 @@ namespace pcpp
 		/**
 		* @return The name of the file
 		*/
-		std::string getFileName();
+		std::string getFileName() const;
 
 
 		//override methods
@@ -69,7 +69,7 @@ namespace pcpp
 		/**
 		* @return The file size in bytes
 		*/
-		uint64_t getFileSize();
+		uint64_t getFileSize() const;
 
 		virtual bool getNextPacket(RawPacket& rawPacket) = 0;
 
@@ -145,7 +145,7 @@ namespace pcpp
 		 * Get statistics of packets read so far. In the pcap_stat struct, only ps_recv member is relevant. The rest of the members will contain 0
 		 * @param[out] stats The stats struct where stats are returned
 		 */
-		void getStatistics(pcap_stat& stats);
+		void getStatistics(pcap_stat& stats) const;
 	};
 
 
@@ -187,7 +187,7 @@ namespace pcpp
 		 * returns it
 		 * @return The operating system string if exists, or an empty string otherwise
 		 */
-		std::string getOS();
+		std::string getOS() const;
 
 		/**
 		 * The pcap-ng format allows storing metadata at the header of the file. Part of this metadata is a string specifying the
@@ -195,7 +195,7 @@ namespace pcpp
 		 * returns it
 		 * @return The hardware string if exists, or an empty string otherwise
 		 */
-		std::string getHardware();
+		std::string getHardware() const;
 
 		/**
 		 * The pcap-ng format allows storing metadata at the header of the file. Part of this metadata is a string specifying the
@@ -203,7 +203,7 @@ namespace pcpp
 		 * returns it
 		 * @return The capture application string if exists, or an empty string otherwise
 		 */
-		std::string getCaptureApplication();
+		std::string getCaptureApplication() const;
 
 		/**
 		 * The pcap-ng format allows storing metadata at the header of the file. Part of this metadata is a string containing a user-defined
@@ -211,7 +211,7 @@ namespace pcpp
 		 * returns it
 		 * @return The comment written inside the file if exists, or an empty string otherwise
 		 */
-		std::string getCaptureFileComment();
+		std::string getCaptureFileComment() const;
 
 		/**
 		 * The pcap-ng format allows storing a user-defined comment for every packet (besides the comment per-file). This method reads
@@ -244,7 +244,7 @@ namespace pcpp
 		 * Get statistics of packets read so far. In the pcap_stat struct, only ps_recv member is relevant. The rest of the members will contain 0
 		 * @param[out] stats The stats struct where stats are returned
 		 */
-		void getStatistics(pcap_stat& stats);
+		void getStatistics(pcap_stat& stats) const;
 
 		/**
 		 * Set a filter for PcapNG reader device. Only packets that match the filter will be received
@@ -372,7 +372,7 @@ namespace pcpp
 		 * Get statistics of packets written so far. In the pcap_stat struct, only ps_recv member is relevant. The rest of the members will contain 0
 		 * @param[out] stats The stats struct where stats are returned
 		 */
-		virtual void getStatistics(pcap_stat& stats);
+		virtual void getStatistics(pcap_stat& stats) const;
 	};
 
 
@@ -488,7 +488,7 @@ namespace pcpp
 		 * Get statistics of packets written so far. In the pcap_stat struct, only ps_recv member is relevant. The rest of the members will contain 0
 		 * @param[out] stats The stats struct where stats are returned
 		 */
-		void getStatistics(pcap_stat& stats);
+		void getStatistics(pcap_stat& stats) const;
 
 		/**
 		 * Set a filter for PcapNG writer device. Only packets that match the filter will be persisted

--- a/Pcap++/header/PcapFilter.h
+++ b/Pcap++/header/PcapFilter.h
@@ -100,12 +100,12 @@ namespace pcpp
 		*/
 		bool matchPacketWithFilter(RawPacket* rawPacket);
 
-		GeneralFilter();
+		GeneralFilter() : m_program(NULL) {}
 
 		/**
 		 * Virtual destructor, frees the bpf program
 		 */
-		virtual ~GeneralFilter();
+		virtual ~GeneralFilter() { freeProgram(); }
 	};
 
 	/**
@@ -118,9 +118,9 @@ namespace pcpp
 		const std::string m_filterStr;
 
 	public:
-		BPFStringFilter(const std::string& filterStr);
+		BPFStringFilter(const std::string &filterStr) : m_filterStr(filterStr) {}
 
-		virtual ~BPFStringFilter();
+		virtual ~BPFStringFilter() {}
 
 		/**
 		 * A method that parses the class instance into BPF string format
@@ -148,7 +148,7 @@ namespace pcpp
 		Direction m_Dir;
 	protected:
 		void parseDirection(std::string& directionAsString);
-		inline Direction getDir() { return m_Dir; }
+		Direction getDir() const { return m_Dir; }
 		IFilterWithDirection(Direction dir) { m_Dir = dir; }
 	public:
 		/**
@@ -171,7 +171,7 @@ namespace pcpp
 		FilterOperator m_Operator;
 	protected:
 		std::string parseOperator();
-		inline FilterOperator getOperator() { return m_Operator; }
+		FilterOperator getOperator() const { return m_Operator; }
 		IFilterWithOperator(FilterOperator op) { m_Operator = op; }
 	public:
 		/**
@@ -195,8 +195,8 @@ namespace pcpp
 		std::string m_Address;
 		std::string m_IPv4Mask;
 		int m_Len;
-		void convertToIPAddressWithMask(std::string& ipAddrmodified, std::string& mask);
-		void convertToIPAddressWithLen(std::string& ipAddrmodified, int& len);
+		void convertToIPAddressWithMask(std::string& ipAddrmodified, std::string& mask) const;
+		void convertToIPAddressWithLen(std::string& ipAddrmodified, int& len) const;
 	public:
 		/**
 		 * The basic constructor that creates the filter from an IPv4 address and direction (source or destination)

--- a/Pcap++/header/PcapFilter.h
+++ b/Pcap++/header/PcapFilter.h
@@ -118,7 +118,7 @@ namespace pcpp
 		const std::string m_filterStr;
 
 	public:
-		BPFStringFilter(const std::string &filterStr) : m_filterStr(filterStr) {}
+		BPFStringFilter(const std::string& filterStr) : m_filterStr(filterStr) {}
 
 		virtual ~BPFStringFilter() {}
 

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -251,7 +251,7 @@ namespace pcpp
 		/**
 		 * @return A vector containing all addresses defined for this interface, each in pcap_addr_t struct
 		 */
-		std::vector<pcap_addr_t>& getAddresses() { return m_Addresses; } // TODO: Should getAddress really return non-const reference?
+		const std::vector<pcap_addr_t>& getAddresses() const { return m_Addresses; }
 
 		/**
 		 * @return The MAC address for this interface
@@ -275,7 +275,7 @@ namespace pcpp
 		 * couldn't be extracted from some reason. This list is created in PcapLiveDeviceList class and can be also retrieved from there.
 		 * This method exists for convenience - so it'll be possible to get this list from PcapLiveDevice as well
 		 */
-		std::vector<IPv4Address>& getDnsServers() const;
+		const std::vector<IPv4Address>& getDnsServers() const;
 
 		/**
 		 * Start capturing packets on this network interface (device). Each time a packet is captured the onPacketArrives callback is called.

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -113,11 +113,11 @@ namespace pcpp
 		void setDeviceMtu();
 		void setDeviceMacAddress();
 		void setDefaultGateway();
-		static void* captureThreadMain(void *ptr);
-		static void* statsThreadMain(void *ptr);
-		static void onPacketArrives(uint8_t *user, const struct pcap_pkthdr *pkthdr, const uint8_t *packet);
-		static void onPacketArrivesNoCallback(uint8_t *user, const struct pcap_pkthdr *pkthdr, const uint8_t *packet);
-		static void onPacketArrivesBlockingMode(uint8_t *user, const struct pcap_pkthdr *pkthdr, const uint8_t *packet);
+		static void* captureThreadMain(void* ptr);
+		static void* statsThreadMain(void* ptr);
+		static void onPacketArrives(uint8_t* user, const struct pcap_pkthdr* pkthdr, const uint8_t* packet);
+		static void onPacketArrivesNoCallback(uint8_t* user, const struct pcap_pkthdr* pkthdr, const uint8_t* packet);
+		static void onPacketArrivesBlockingMode(uint8_t* user, const struct pcap_pkthdr* pkthdr, const uint8_t* packet);
 		std::string printThreadId(PcapThread* id);
 		virtual ThreadStart getCaptureThreadStart();
 	public:

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -153,10 +153,10 @@ namespace pcpp
 		 */
 		enum PcapDirection
 		{
-		    	/** Capture traffics both incoming and outgoing */
-		    	PCPP_INOUT = 0,
-	    		/** Only capture incoming traffics */
-		    	PCPP_IN,
+			/** Capture traffics both incoming and outgoing */
+			PCPP_INOUT = 0,
+			/** Only capture incoming traffics */
+			PCPP_IN,
 			/** Only capture outgoing traffics */
 			PCPP_OUT
 		};
@@ -188,10 +188,10 @@ namespace pcpp
 			 */
 			int packetBufferSize;
 
-	    		/**
-		    	* Set the direction for capturing packets. You can read more here:
-		    	* <https://www.tcpdump.org/manpages/pcap.3pcap.html#lbAI>.
-		    	*/
+			/**
+			 * Set the direction for capturing packets. You can read more here:
+			 * <https://www.tcpdump.org/manpages/pcap.3pcap.html#lbAI>.
+			*/
 			PcapDirection direction;
 
 			/**
@@ -222,60 +222,60 @@ namespace pcpp
 		/**
 		 * @return The type of the device (libPcap, WinPcap or a remote device)
 		 */
-		virtual LiveDeviceType getDeviceType() { return LibPcapDevice; }
+		virtual LiveDeviceType getDeviceType() const { return LibPcapDevice; }
 
 		/**
 		 * @return The name of the device (e.g eth0), taken from pcap_if_t->name
 		 */
-		inline const char* getName() { return m_Name; }
+		const char* getName() const { return m_Name; }
 
 		/**
 		 * @return A human-readable description of the device, taken from pcap_if_t->description. May be NULL in some interfaces
 		 */
-		inline const char* getDesc() { return m_Description; }
+		const char* getDesc() const { return m_Description; }
 
 		/**
 		 * @return True if this interface is a loopback interface, false otherwise
 		 */
-		inline bool getLoopback() { return m_IsLoopback; }
+		bool getLoopback() const { return m_IsLoopback; }
 
 		/**
 		 * @return The device's maximum transmission unit (MTU) in bytes
 		 */
-		virtual inline uint16_t getMtu() { return m_DeviceMtu; }
+		virtual uint16_t getMtu() const { return m_DeviceMtu; }
 
 		/**
 		 * @return The device's link layer type
 		 */
-		virtual inline LinkLayerType getLinkType() { return m_LinkType; }
+		virtual LinkLayerType getLinkType() const { return m_LinkType; }
 		/**
 		 * @return A vector containing all addresses defined for this interface, each in pcap_addr_t struct
 		 */
-		inline std::vector<pcap_addr_t>& getAddresses() { return m_Addresses; }
+		std::vector<pcap_addr_t>& getAddresses() { return m_Addresses; } // TODO: Should getAddress really return non-const reference?
 
 		/**
 		 * @return The MAC address for this interface
 		 */
-		virtual inline MacAddress getMacAddress() { return m_MacAddress; }
+		virtual MacAddress getMacAddress() const { return m_MacAddress; }
 
 		/**
 		 * @return The IPv4 address for this interface. If multiple IPv4 addresses are defined for this interface, the first will be picked.
 		 * If no IPv4 addresses are defined, a zeroed IPv4 address (IPv4Address#Zero) will be returned
 		 */
-		IPv4Address getIPv4Address();
+		IPv4Address getIPv4Address() const;
 
 		/**
 		 * @return The default gateway defined for this interface. If no default gateway is defined, if it's not IPv4 or if couldn't extract
 		 * default gateway IPv4Address#Zero will be returned. If multiple gateways were defined the first one will be returned
 		 */
-		IPv4Address getDefaultGateway();
+		IPv4Address getDefaultGateway() const;
 
 		/**
 		 * @return A list of all DNS servers defined for this machine. If this list is empty it means no DNS servers were defined or they
 		 * couldn't be extracted from some reason. This list is created in PcapLiveDeviceList class and can be also retrieved from there.
 		 * This method exists for convenience - so it'll be possible to get this list from PcapLiveDevice as well
 		 */
-		std::vector<IPv4Address>& getDnsServers();
+		std::vector<IPv4Address>& getDnsServers() const;
 
 		/**
 		 * Start capturing packets on this network interface (device). Each time a packet is captured the onPacketArrives callback is called.
@@ -479,7 +479,7 @@ namespace pcpp
 
 		void close();
 
-		virtual void getStatistics(pcap_stat& stats);
+		virtual void getStatistics(pcap_stat& stats) const;
 
 	protected:
 		pcap_t* doOpen(const DeviceConfiguration& config);

--- a/Pcap++/header/PcapLiveDeviceList.h
+++ b/Pcap++/header/PcapLiveDeviceList.h
@@ -95,7 +95,7 @@ namespace pcpp
 		 * @return A list of all DNS servers defined for this machine. If this list is empty it means no DNS servers were defined or they
 		 * couldn't be extracted from some reason
 		 */
-		std::vector<IPv4Address>& getDnsServers() { return m_DnsServers; } // TODO: Should this method really return a non-const reference?
+		const std::vector<IPv4Address>& getDnsServers() const { return m_DnsServers; }
 
 		/**
 		 * Reset the live device list and DNS server list, meaning clear and refetch them

--- a/Pcap++/header/PcapLiveDeviceList.h
+++ b/Pcap++/header/PcapLiveDeviceList.h
@@ -95,7 +95,7 @@ namespace pcpp
 		 * @return A list of all DNS servers defined for this machine. If this list is empty it means no DNS servers were defined or they
 		 * couldn't be extracted from some reason
 		 */
-		std::vector<IPv4Address> &getDnsServers() { return m_DnsServers; } // TODO: Should this method really return a non-const reference?
+		std::vector<IPv4Address>& getDnsServers() { return m_DnsServers; } // TODO: Should this method really return a non-const reference?
 
 		/**
 		 * Reset the live device list and DNS server list, meaning clear and refetch them

--- a/Pcap++/header/PcapLiveDeviceList.h
+++ b/Pcap++/header/PcapLiveDeviceList.h
@@ -45,7 +45,7 @@ namespace pcpp
 		 * The access method to the singleton
 		 * @return The singleton instance of this class
 		 */
-		static inline PcapLiveDeviceList& getInstance()
+		static PcapLiveDeviceList& getInstance()
 		{
 			static PcapLiveDeviceList instance;
 			return instance;
@@ -54,48 +54,48 @@ namespace pcpp
 		/**
 		 * @return A vector containing pointers to all live devices currently installed on the machine
 		 */
-		inline const std::vector<PcapLiveDevice*>& getPcapLiveDevicesList() { return m_LiveDeviceList; }
+		const std::vector<PcapLiveDevice*>& getPcapLiveDevicesList() const { return m_LiveDeviceList; }
 
 		/**
 		 * Get a pointer to the live device by its IP address. IP address can be both IPv4 or IPv6
 		 * @param[in] ipAddr The IP address defined for the device
 		 * @return A pointer to the live device if this IP address exists. NULL otherwise
 		 */
-		PcapLiveDevice* getPcapLiveDeviceByIp(IPAddress* ipAddr);
+		PcapLiveDevice* getPcapLiveDeviceByIp(IPAddress* ipAddr) const;
 
 		/**
 		 * Get a pointer to the live device by its IPv4 address
 		 * @param[in] ipAddr The IPv4 address defined for the device
 		 * @return A pointer to the live device if this IPv4 address exists. NULL otherwise
 		 */
-		PcapLiveDevice* getPcapLiveDeviceByIp(IPv4Address ipAddr);
+		PcapLiveDevice* getPcapLiveDeviceByIp(IPv4Address ipAddr) const;
 
 		/**
 		 * Get a pointer to the live device by its IPv6 address
 		 * @param[in] ip6Addr The IPv6 address defined for the device
 		 * @return A pointer to the live device if this IPv6 address exists. NULL otherwise
 		 */
-		PcapLiveDevice* getPcapLiveDeviceByIp(IPv6Address ip6Addr);
+		PcapLiveDevice* getPcapLiveDeviceByIp(IPv6Address ip6Addr) const;
 
 		/**
 		 * Get a pointer to the live device by its IP address represented as string. IP address can be both IPv4 or IPv6
 		 * @param[in] ipAddrAsString The IP address defined for the device as string
 		 * @return A pointer to the live device if this IP address is valid and exists. NULL otherwise
 		 */
-		PcapLiveDevice* getPcapLiveDeviceByIp(const char* ipAddrAsString);
+		PcapLiveDevice* getPcapLiveDeviceByIp(const char* ipAddrAsString) const;
 
 		/**
 		 * Get a pointer to the live device by its name
 		 * @param[in] name The name of the interface (e.g eth0)
 		 * @return A pointer to the live device if this name exists. NULL otherwise
 		 */
-		PcapLiveDevice* getPcapLiveDeviceByName(const std::string& name);
+		PcapLiveDevice* getPcapLiveDeviceByName(const std::string& name) const;
 
 		/**
 		 * @return A list of all DNS servers defined for this machine. If this list is empty it means no DNS servers were defined or they
 		 * couldn't be extracted from some reason
 		 */
-		std::vector<IPv4Address>& getDnsServers();
+		std::vector<IPv4Address> &getDnsServers() { return m_DnsServers; } // TODO: Should this method really return a non-const reference?
 
 		/**
 		 * Reset the live device list and DNS server list, meaning clear and refetch them

--- a/Pcap++/header/PcapRemoteDevice.h
+++ b/Pcap++/header/PcapRemoteDevice.h
@@ -56,7 +56,7 @@ namespace pcpp
 		 * freeing this memory
 		 * @return A pcap_rmtauth that is converted from this class
 		 */
-		pcap_rmtauth getPcapRmAuth();
+		pcap_rmtauth getPcapRmAuth() const;
 	};
 
 	/**
@@ -103,28 +103,28 @@ namespace pcpp
 		/**
 		 * @return The IP address of the remote machine where packets are transmitted from the remote machine to the client machine
 		 */
-		IPAddress* getRemoteMachineIpAddress() { return m_RemoteMachineIpAddress; }
+		IPAddress* getRemoteMachineIpAddress() const { return m_RemoteMachineIpAddress; }
 
 		/**
 		 * @return The port of the remote machine where packets are transmitted from the remote machine to the client machine
 		 */
-		uint16_t getRemoteMachinePort() { return m_RemoteMachinePort; }
+		uint16_t getRemoteMachinePort() const { return m_RemoteMachinePort; }
 
 		//overridden methods
 
-		virtual LiveDeviceType getDeviceType() { return RemoteDevice; }
+		virtual LiveDeviceType getDeviceType() const { return RemoteDevice; }
 
 		/**
 		 * MTU isn't supported for remote devices
 		 * @return 0
 		 */
-		virtual uint16_t getMtu();
+		virtual uint16_t getMtu() const;
 
 		/**
 		 * MAC address isn't supported for remote devices
 		 * @return MacAddress#Zero
 		 */
-		virtual MacAddress getMacAddress();
+		virtual MacAddress getMacAddress() const;
 
 		/**
 		 * Open the device using pcap_open. Opening the device makes the connection to the remote daemon (including authentication if needed
@@ -137,7 +137,7 @@ namespace pcpp
 		 */
 		virtual bool open();
 
-		void getStatistics(pcap_stat& stats);
+		virtual void getStatistics(pcap_stat& stats) const;
 	};
 
 } // namespace pcpp

--- a/Pcap++/header/PcapRemoteDeviceList.h
+++ b/Pcap++/header/PcapRemoteDeviceList.h
@@ -88,60 +88,60 @@ namespace pcpp
 		/**
 		 * @return The IP address of the remote machine
 		 */
-		IPAddress* getRemoteMachineIpAddress() { return m_RemoteMachineIpAddress; }
+		IPAddress* getRemoteMachineIpAddress() const { return m_RemoteMachineIpAddress; }
 
 		/**
 		 * @return The port of the remote machine where packets are transmitted from the remote machine to the client machine
 		 */
-		uint16_t getRemoteMachinePort() { return m_RemoteMachinePort; }
+		uint16_t getRemoteMachinePort() const { return m_RemoteMachinePort; }
 
 		/**
 		 * Search a PcapRemoteDevice in the list by its IPv4 address
 		 * @param[in] ip4Addr The IPv4 address
 		 * @return The PcapRemoteDevice if found, NULL otherwise
 		 */
-		PcapRemoteDevice* getRemoteDeviceByIP(IPv4Address ip4Addr);
+		PcapRemoteDevice* getRemoteDeviceByIP(IPv4Address ip4Addr) const;
 
 		/**
 		 * Search a PcapRemoteDevice in the list by its IPv6 address
 		 * @param[in] ip6Addr The IPv6 address
 		 * @return The PcapRemoteDevice if found, NULL otherwise
 		 */
-		PcapRemoteDevice* getRemoteDeviceByIP(IPv6Address ip6Addr);
+		PcapRemoteDevice* getRemoteDeviceByIP(IPv6Address ip6Addr) const;
 
 		/**
 		 * Search a PcapRemoteDevice in the list by its IP address (IPv4 or IPv6)
 		 * @param[in] ipAddr The IP address
 		 * @return The PcapRemoteDevice if found, NULL otherwise
 		 */
-		PcapRemoteDevice* getRemoteDeviceByIP(IPAddress* ipAddr);
+		PcapRemoteDevice* getRemoteDeviceByIP(IPAddress* ipAddr) const;
 
 		/**
 		 * Search a PcapRemoteDevice in the list by its IP address
 		 * @param[in] ipAddrAsString The IP address in string format
 		 * @return The PcapRemoteDevice if found, NULL otherwise
 		 */
-		PcapRemoteDevice* getRemoteDeviceByIP(const char* ipAddrAsString);
+		PcapRemoteDevice* getRemoteDeviceByIP(const char* ipAddrAsString) const;
 
 		/**
 		 * @return An iterator object pointing to the first PcapRemoteDevice in list
 		 */
-		inline RemoteDeviceListIterator begin() { return m_RemoteDeviceList.begin(); }
+		RemoteDeviceListIterator begin() { return m_RemoteDeviceList.begin(); }
 
 		/**
 		 * @return A const iterator object pointing to the first PcapRemoteDevice in list
 		 */
-		inline ConstRemoteDeviceListIterator begin() const { return m_RemoteDeviceList.begin(); }
+		ConstRemoteDeviceListIterator begin() const { return m_RemoteDeviceList.begin(); }
 
 		/**
 		 * @return An iterator object pointing to the last PcapRemoteDevice in list
 		 */
-		inline RemoteDeviceListIterator end() { return m_RemoteDeviceList.end(); }
+		RemoteDeviceListIterator end() { return m_RemoteDeviceList.end(); }
 
 		/**
 		 * @return A const iterator object pointing to the last PcapRemoteDevice in list
 		 */
-		inline ConstRemoteDeviceListIterator end() const { return m_RemoteDeviceList.end(); }
+		ConstRemoteDeviceListIterator end() const { return m_RemoteDeviceList.end(); }
 
 	};
 

--- a/Pcap++/header/PfRingDevice.h
+++ b/Pcap++/header/PfRingDevice.h
@@ -66,7 +66,7 @@ namespace pcpp
 
 		int openSingleRxChannel(const char* deviceName, pfring** ring);
 
-		inline bool getIsHwClockEnable() { setPfRingDeviceAttributes(); return m_HwClockEnabled; }
+		bool getIsHwClockEnable() { setPfRingDeviceAttributes(); return m_HwClockEnabled; }
 		bool setPfRingDeviceClock(pfring* ring);
 
 		void clearCoreConfiguration();
@@ -138,7 +138,7 @@ namespace pcpp
 		 * Gets the interface name (e.g eth0, eth1, etc.)
 		 * @return The interface name
 		 */
-		inline std::string getDeviceName() { return std::string(m_DeviceName); }
+		std::string getDeviceName() const { return std::string(m_DeviceName); }
 
 
 		/**
@@ -205,45 +205,45 @@ namespace pcpp
 		 * opened for each RX queue
 		 * @return Number of opened RX channels
 		 */
-		inline uint8_t getNumOfOpenedRxChannels() { return m_NumOfOpenedRxChannels; }
+		uint8_t getNumOfOpenedRxChannels() const { return m_NumOfOpenedRxChannels; }
 
 		/**
 		 * Gets the total number of RX channels (RX queues) this interface has
 		 * @return The number of RX channels (queues) for this interface
 		 */
-		uint8_t getTotalNumOfRxChannels();
+		uint8_t getTotalNumOfRxChannels() const;
 
 		/**
 		 * Gets the core used in the current thread context
 		 * @return The system core used in the current thread context
 		 */
-		SystemCore getCurrentCoreId();
+		SystemCore getCurrentCoreId() const;
 
 		/**
 		 * Get the statistics of a specific thread/core (=RX channel)
 		 * @param[in] core The requested core
 		 * @param[out] stats A reference for the stats object where the stats are written. Current values will be overriden
 		 */
-		void getThreadStatistics(SystemCore core, PfRingStats& stats);
+		void getThreadStatistics(SystemCore core, PfRingStats& stats) const;
 
 		/**
 		 * Get the statistics of the current thread/core (=RX channel)
 		 * @param[out] stats A reference for the stats object where the stats are written. Current values will be overriden
 		 */
-		void getCurrentThreadStatistics(PfRingStats& stats);
+		void getCurrentThreadStatistics(PfRingStats& stats) const;
 
 		/**
 		 * Get the statistics for the entire device. If more than 1 RX channel is opened, this method aggregates the stats
 		 * of all channels
 		 * @param[out] stats A reference for the stats object where the stats are written. Current values will be overriden
 		 */
-		void getStatistics(PfRingStats& stats);
+		void getStatistics(PfRingStats& stats) const;
 
 		/**
 		 * Return true if filter is currently set
 		 * @return True if filter is currently set, false otherwise
 		 */
-		bool isFilterCurrentlySet();
+		bool isFilterCurrentlySet() const;
 
 		/**
 		 * Send a raw packet. This packet must be fully specified (the MAC address up)

--- a/Pcap++/header/PfRingDeviceList.h
+++ b/Pcap++/header/PfRingDeviceList.h
@@ -46,7 +46,7 @@ namespace pcpp
 		 * Return a list of all available PF_RING devices
 		 * @return a list of all available PF_RING devices
 		 */
-		const std::vector<PfRingDevice*>& getPfRingDevicesList() { return m_PfRingDeviceList; } // TODO: Should this method really return a non-const reference?
+		const std::vector<PfRingDevice*>& getPfRingDevicesList() const { return m_PfRingDeviceList; }
 
 		/**
 		 * Get a PF_RING device by name. The name is the Linux interface name which appears in ifconfig

--- a/Pcap++/header/PfRingDeviceList.h
+++ b/Pcap++/header/PfRingDeviceList.h
@@ -36,7 +36,7 @@ namespace pcpp
 		 * A static method that returns the singleton object for PfRingDeviceList
 		 * @return PfRingDeviceList singleton
 		 */
-		static inline PfRingDeviceList& getInstance()
+		static PfRingDeviceList& getInstance()
 		{
 			static PfRingDeviceList instance;
 			return instance;
@@ -46,7 +46,7 @@ namespace pcpp
 		 * Return a list of all available PF_RING devices
 		 * @return a list of all available PF_RING devices
 		 */
-		inline const std::vector<PfRingDevice*>& getPfRingDevicesList() { return m_PfRingDeviceList; }
+		const std::vector<PfRingDevice*>& getPfRingDevicesList() { return m_PfRingDeviceList; } // TODO: Should this method really return a non-const reference?
 
 		/**
 		 * Get a PF_RING device by name. The name is the Linux interface name which appears in ifconfig
@@ -60,7 +60,7 @@ namespace pcpp
 		 * Get installed PF_RING version
 		 * @return A string representing PF_RING version
 		 */
-		inline std::string getPfRingVersion() { return m_PfRingVersion; }
+		std::string getPfRingVersion() const { return m_PfRingVersion; }
 	};
 
 } // namespace pcpp

--- a/Pcap++/header/RawSocketDevice.h
+++ b/Pcap++/header/RawSocketDevice.h
@@ -156,7 +156,7 @@ namespace pcpp
 		void* m_Socket;
 		IPAddress* m_InterfaceIP;
 
-		RecvPacketResult getError(int& errorCode);
+		RecvPacketResult getError(int& errorCode) const;
 
 	};
 }

--- a/Pcap++/header/WinPcapLiveDevice.h
+++ b/Pcap++/header/WinPcapLiveDevice.h
@@ -54,7 +54,7 @@ namespace pcpp
 		 * @return The current amount of data in the kernel buffer that causes a read from the application to return (see also
 		 * setMinAmountOfDataToCopyFromKernelToApplication())
 		 */
-		int getMinAmountOfDataToCopyFromKernelToApplication() { return m_MinAmountOfDataToCopyFromKernelToApplication; }
+		int getMinAmountOfDataToCopyFromKernelToApplication() const { return m_MinAmountOfDataToCopyFromKernelToApplication; }
 	};
 
 } // namespace pcpp

--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -101,7 +101,7 @@ DpdkDevice::~DpdkDevice()
 		delete [] m_TxBufferLastDrainTsc;
 }
 
-uint32_t DpdkDevice::getCurrentCoreId()
+uint32_t DpdkDevice::getCurrentCoreId() const
 {
 	return rte_lcore_id();
 }
@@ -455,7 +455,7 @@ void DpdkDevice::setDeviceInfo()
 }
 
 
-bool DpdkDevice::isVirtual()
+bool DpdkDevice::isVirtual() const
 {
 	switch (m_PMDType)
 	{
@@ -474,7 +474,7 @@ bool DpdkDevice::isVirtual()
 }
 
 
-void DpdkDevice::getLinkStatus(LinkStatus& linkStatus)
+void DpdkDevice::getLinkStatus(LinkStatus& linkStatus) const
 {
 	struct rte_eth_link link;
 	rte_eth_link_get((uint8_t) m_Id, &link);
@@ -674,7 +674,7 @@ int DpdkDevice::dpdkCaptureThreadMain(void *ptr)
 
 #define nanosec_gap(begin, end) ((end.tv_sec - begin.tv_sec) * 1000000000.0 + (end.tv_nsec - begin.tv_nsec))
 
-void DpdkDevice::getStatistics(DpdkDeviceStats& stats)
+void DpdkDevice::getStatistics(DpdkDeviceStats& stats) const
 {
 	timespec timestamp;
 	clock_gettime(CLOCK_MONOTONIC, &timestamp);
@@ -741,7 +741,7 @@ bool DpdkDevice::setFilter(std::string filterAsString)
 	return false;
 }
 
-uint16_t DpdkDevice::receivePackets(MBufRawPacketVector& rawPacketsArr, uint16_t rxQueueId)
+uint16_t DpdkDevice::receivePackets(MBufRawPacketVector& rawPacketsArr, uint16_t rxQueueId) const
 {
 	if (!m_DeviceOpened)
 	{
@@ -786,7 +786,7 @@ uint16_t DpdkDevice::receivePackets(MBufRawPacketVector& rawPacketsArr, uint16_t
 	return numOfPktsReceived;
 }
 
-uint16_t DpdkDevice::receivePackets(MBufRawPacket** rawPacketsArr, uint16_t rawPacketArrLength, uint16_t rxQueueId)
+uint16_t DpdkDevice::receivePackets(MBufRawPacket** rawPacketsArr, uint16_t rawPacketArrLength, uint16_t rxQueueId) const
 {
 	if (unlikely(!m_DeviceOpened))
 	{
@@ -836,7 +836,7 @@ uint16_t DpdkDevice::receivePackets(MBufRawPacket** rawPacketsArr, uint16_t rawP
 	return packetsReceived;
 }
 
-uint16_t DpdkDevice::receivePackets(Packet** packetsArr, uint16_t packetsArrLength, uint16_t rxQueueId)
+uint16_t DpdkDevice::receivePackets(Packet** packetsArr, uint16_t packetsArrLength, uint16_t rxQueueId) const
 {
 	if (unlikely(!m_DeviceOpened))
 	{
@@ -1141,17 +1141,17 @@ bool DpdkDevice::sendPacket(Packet& packet, uint16_t txQueueId, bool useTxBuffer
 	return sendPacket(*(packet.getRawPacket()), txQueueId);
 }
 
-int DpdkDevice::getAmountOfFreeMbufs()
+int DpdkDevice::getAmountOfFreeMbufs() const
 {
 	return (int)rte_mempool_avail_count(m_MBufMempool);
 }
 
-int DpdkDevice::getAmountOfMbufsInUse()
+int DpdkDevice::getAmountOfMbufsInUse() const
 {
 	return (int)rte_mempool_in_use_count(m_MBufMempool);
 }
 
-uint64_t DpdkDevice::convertRssHfToDpdkRssHf(uint64_t rssHF)
+uint64_t DpdkDevice::convertRssHfToDpdkRssHf(uint64_t rssHF) const
 {
 	if (rssHF == (uint64_t)-1)
 	{
@@ -1225,7 +1225,7 @@ uint64_t DpdkDevice::convertRssHfToDpdkRssHf(uint64_t rssHF)
 	return dpdkRssHF;
 }
 
-uint64_t DpdkDevice::convertDpdkRssHfToRssHf(uint64_t dpdkRssHF)
+uint64_t DpdkDevice::convertDpdkRssHfToRssHf(uint64_t dpdkRssHF) const
 {
 	uint64_t rssHF = 0;
 
@@ -1292,12 +1292,12 @@ uint64_t DpdkDevice::convertDpdkRssHfToRssHf(uint64_t dpdkRssHF)
 	return rssHF;
 }
 
-bool DpdkDevice::isDeviceSupportRssHashFunction(DpdkRssHashFunction rssHF)
+bool DpdkDevice::isDeviceSupportRssHashFunction(DpdkRssHashFunction rssHF) const
 {
 	return isDeviceSupportRssHashFunction((uint64_t)rssHF);
 }
 
-bool DpdkDevice::isDeviceSupportRssHashFunction(uint64_t rssHFMask)
+bool DpdkDevice::isDeviceSupportRssHashFunction(uint64_t rssHFMask) const
 {
 	uint64_t dpdkRssHF = convertRssHfToDpdkRssHf(rssHFMask);
 
@@ -1307,7 +1307,7 @@ bool DpdkDevice::isDeviceSupportRssHashFunction(uint64_t rssHFMask)
 	return ((devInfo.flow_type_rss_offloads & dpdkRssHF) == dpdkRssHF);
 }
 
-uint64_t DpdkDevice::getSupportedRssHashFunctions()
+uint64_t DpdkDevice::getSupportedRssHashFunctions() const
 {
 	rte_eth_dev_info devInfo;
 	rte_eth_dev_info_get(m_Id, &devInfo);

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -185,7 +185,7 @@ bool DpdkDeviceList::initDpdkDevices(uint32_t mBufPoolSizePerDevice)
 	return true;
 }
 
-DpdkDevice* DpdkDeviceList::getDeviceByPort(int portId)
+DpdkDevice* DpdkDeviceList::getDeviceByPort(int portId) const
 {
 	if (!isInitialized())
 	{
@@ -201,7 +201,7 @@ DpdkDevice* DpdkDeviceList::getDeviceByPort(int portId)
 	return m_DpdkDeviceList.at(portId);
 }
 
-DpdkDevice* DpdkDeviceList::getDeviceByPciAddress(const std::string& pciAddr)
+DpdkDevice* DpdkDeviceList::getDeviceByPciAddress(const std::string& pciAddr) const
 {
 	if (!isInitialized())
 	{
@@ -209,7 +209,7 @@ DpdkDevice* DpdkDeviceList::getDeviceByPciAddress(const std::string& pciAddr)
 		return NULL;
 	}
 
-	for (std::vector<DpdkDevice*>::iterator iter = m_DpdkDeviceList.begin(); iter != m_DpdkDeviceList.end(); iter++)
+	for (std::vector<DpdkDevice*>::const_iterator iter = m_DpdkDeviceList.begin(); iter != m_DpdkDeviceList.end(); iter++)
 	{
 		if ((*iter)->getPciAddress() == pciAddr)
 			return (*iter);
@@ -249,7 +249,7 @@ bool DpdkDeviceList::verifyHugePagesAndDpdkDriver()
 	return true;
 }
 
-SystemCore DpdkDeviceList::getDpdkMasterCore()
+SystemCore DpdkDeviceList::getDpdkMasterCore() const
 {
 	return SystemCores::IdToSystemCore[rte_get_master_lcore()];
 }
@@ -269,7 +269,7 @@ void DpdkDeviceList::setDpdkLogLevel(LoggerPP::LogLevel logLevel)
 #endif
 }
 
-LoggerPP::LogLevel DpdkDeviceList::getDpdkLogLevel()
+LoggerPP::LogLevel DpdkDeviceList::getDpdkLogLevel() const
 {
 #if (RTE_VER_YEAR > 17) || (RTE_VER_YEAR == 17 && RTE_VER_MONTH >= 11)
 	if (rte_log_get_global_level() <= RTE_LOG_NOTICE)

--- a/Pcap++/src/NetworkUtils.cpp
+++ b/Pcap++/src/NetworkUtils.cpp
@@ -86,7 +86,7 @@ static void arpPacketRecieved(RawPacket* rawPacket, PcapLiveDevice* device, void
 	// signal the main thread the ARP reply was received
 	pthread_mutex_lock(data->mutex);
 	pthread_cond_signal(data->cond);
-  pthread_mutex_unlock(data->mutex);
+	pthread_mutex_unlock(data->mutex);
 }
 
 
@@ -313,7 +313,7 @@ static void dnsResponseRecieved(RawPacket* rawPacket, PcapLiveDevice* device, vo
 	// signal the main thread the ARP reply was received
 	pthread_mutex_lock(data->mutex);
 	pthread_cond_signal(data->cond);
-  pthread_mutex_unlock(data->mutex);
+	pthread_mutex_unlock(data->mutex);
 }
 
 

--- a/Pcap++/src/NetworkUtils.cpp
+++ b/Pcap++/src/NetworkUtils.cpp
@@ -86,7 +86,7 @@ static void arpPacketRecieved(RawPacket* rawPacket, PcapLiveDevice* device, void
 	// signal the main thread the ARP reply was received
 	pthread_mutex_lock(data->mutex);
 	pthread_cond_signal(data->cond);
-    pthread_mutex_unlock(data->mutex);
+  pthread_mutex_unlock(data->mutex);
 }
 
 
@@ -313,7 +313,7 @@ static void dnsResponseRecieved(RawPacket* rawPacket, PcapLiveDevice* device, vo
 	// signal the main thread the ARP reply was received
 	pthread_mutex_lock(data->mutex);
 	pthread_cond_signal(data->cond);
-    pthread_mutex_unlock(data->mutex);
+  pthread_mutex_unlock(data->mutex);
 }
 
 

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -46,7 +46,7 @@ IFileDevice::~IFileDevice()
 	delete[] m_FileName;
 }
 
-std::string IFileDevice::getFileName()
+std::string IFileDevice::getFileName() const
 {
 	return std::string(m_FileName);
 }
@@ -85,7 +85,7 @@ IFileReaderDevice* IFileReaderDevice::getReader(const char* fileName)
 		return new PcapFileReaderDevice(fileName);
 }
 
-uint64_t IFileReaderDevice::getFileSize()
+uint64_t IFileReaderDevice::getFileSize() const
 {
 	std::ifstream fileStream(m_FileName, std::ifstream::ate | std::ifstream::binary);
 	return fileStream.tellg();
@@ -155,7 +155,7 @@ bool PcapFileReaderDevice::open()
 	return true;
 }
 
-void PcapFileReaderDevice::getStatistics(pcap_stat& stats)
+void PcapFileReaderDevice::getStatistics(pcap_stat& stats) const
 {
 	stats.ps_recv = m_NumOfPacketsRead;
 	stats.ps_drop = m_NumOfPacketsNotParsed;
@@ -306,7 +306,7 @@ bool PcapNgFileReaderDevice::getNextPacket(RawPacket& rawPacket)
 	return getNextPacket(rawPacket, temp);
 }
 
-void PcapNgFileReaderDevice::getStatistics(pcap_stat& stats)
+void PcapNgFileReaderDevice::getStatistics(pcap_stat& stats) const
 {
 	stats.ps_recv = m_NumOfPacketsRead;
 	stats.ps_drop = m_NumOfPacketsNotParsed;
@@ -342,7 +342,7 @@ void PcapNgFileReaderDevice::close()
 }
 
 
-std::string PcapNgFileReaderDevice::getOS()
+std::string PcapNgFileReaderDevice::getOS() const
 {
 	if (m_LightPcapNg == NULL)
 	{
@@ -359,7 +359,7 @@ std::string PcapNgFileReaderDevice::getOS()
 	return std::string(res, len);
 }
 
-std::string PcapNgFileReaderDevice::getHardware()
+std::string PcapNgFileReaderDevice::getHardware() const
 {
 	if (m_LightPcapNg == NULL)
 	{
@@ -376,7 +376,7 @@ std::string PcapNgFileReaderDevice::getHardware()
 	return std::string(res, len);
 }
 
-std::string PcapNgFileReaderDevice::getCaptureApplication()
+std::string PcapNgFileReaderDevice::getCaptureApplication() const
 {
 	if (m_LightPcapNg == NULL)
 	{
@@ -393,7 +393,7 @@ std::string PcapNgFileReaderDevice::getCaptureApplication()
 	return std::string(res, len);
 }
 
-std::string PcapNgFileReaderDevice::getCaptureFileComment()
+std::string PcapNgFileReaderDevice::getCaptureFileComment() const
 {
 	if (m_LightPcapNg == NULL)
 	{
@@ -575,7 +575,7 @@ void PcapFileWriterDevice::close()
 	LOG_DEBUG("File writer closed for file '%s'", m_FileName);
 }
 
-void PcapFileWriterDevice::getStatistics(pcap_stat& stats)
+void PcapFileWriterDevice::getStatistics(pcap_stat& stats) const
 {
 	stats.ps_recv = m_NumOfPacketsWritten;
 	stats.ps_drop = m_NumOfPacketsNotWritten;
@@ -824,7 +824,7 @@ void PcapNgFileWriterDevice::close()
 	LOG_DEBUG("File writer closed for file '%s'", m_FileName);
 }
 
-void PcapNgFileWriterDevice::getStatistics(pcap_stat& stats)
+void PcapNgFileWriterDevice::getStatistics(pcap_stat& stats) const
 {
 	stats.ps_recv = m_NumOfPacketsWritten;
 	stats.ps_drop = m_NumOfPacketsNotWritten;

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -13,13 +13,13 @@ namespace pcpp
 
 struct pcap_file_header
 {
-    uint32_t magic;
-    uint16_t version_major;
-    uint16_t version_minor;
-    int32_t thiszone;
-    uint32_t sigfigs;
-    uint32_t snaplen;
-    uint32_t linktype;
+	uint32_t magic;
+	uint16_t version_major;
+	uint16_t version_minor;
+	int32_t thiszone;
+	uint32_t sigfigs;
+	uint32_t snaplen;
+	uint32_t linktype;
 };
 
 struct packet_header

--- a/Pcap++/src/PcapFilter.cpp
+++ b/Pcap++/src/PcapFilter.cpp
@@ -15,9 +15,6 @@
 namespace pcpp
 {
 
-GeneralFilter::GeneralFilter() : m_program(NULL)
-{}
-
 bool GeneralFilter::matchPacketWithFilter(RawPacket* rawPacket)
 {
 	std::string filterStr;
@@ -58,16 +55,6 @@ void GeneralFilter::freeProgram()
 	}
 }
 
-GeneralFilter::~GeneralFilter()
-{
-	freeProgram();
-}
-
-BPFStringFilter::BPFStringFilter(const std::string &filterStr) : m_filterStr(filterStr)
-{}
-
-BPFStringFilter::~BPFStringFilter()
-{}
 
 void BPFStringFilter::parseToString(std::string& result)
 {
@@ -133,10 +120,9 @@ std::string IFilterWithOperator::parseOperator()
 	}
 }
 
-void IPFilter::convertToIPAddressWithMask(std::string& ipAddrmodified, std::string& mask)
+void IPFilter::convertToIPAddressWithMask(std::string& ipAddrmodified, std::string& mask) const
 {
 	if (m_IPv4Mask == "")
-
 		return;
 
 	// Handle the mask
@@ -167,7 +153,7 @@ void IPFilter::convertToIPAddressWithMask(std::string& ipAddrmodified, std::stri
 	ipAddrmodified = IPv4Address(addrAsIntAfterMask).toString();
 }
 
-void IPFilter::convertToIPAddressWithLen(std::string& ipAddrmodified, int& len)
+void IPFilter::convertToIPAddressWithLen(std::string& ipAddrmodified, int& len) const
 {
 	if (m_Len == 0)
 		return;

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -50,12 +50,12 @@ struct PcapThread
 #ifdef HAS_SET_DIRECTION_ENABLED
 static pcap_direction_t directionTypeMap(PcapLiveDevice::PcapDirection direction)
 {
-    	switch (direction)
-    	{
-        	case PcapLiveDevice::PCPP_IN: return PCAP_D_IN;
-        	case PcapLiveDevice::PCPP_OUT: return PCAP_D_OUT;
-        	case PcapLiveDevice::PCPP_INOUT: return PCAP_D_INOUT;
-   	}
+	switch (direction)
+	{
+		case PcapLiveDevice::PCPP_IN:    return PCAP_D_IN;
+		case PcapLiveDevice::PCPP_OUT:   return PCAP_D_OUT;
+		case PcapLiveDevice::PCPP_INOUT: return PCAP_D_INOUT;
+	}
 }
 #endif
 
@@ -64,7 +64,6 @@ static pcap_direction_t directionTypeMap(PcapLiveDevice::PcapDirection direction
 PcapLiveDevice::PcapLiveDevice(pcap_if_t* pInterface, bool calculateMTU, bool calculateMacAddress, bool calculateDefaultGateway) : IPcapDevice(),
 		m_MacAddress(""), m_DefaultGateway(IPv4Address::Zero)
 {
-
 	m_Name = NULL;
 	m_Description = NULL;
 	m_DeviceMtu = 0;
@@ -201,7 +200,6 @@ void* PcapLiveDevice::captureThreadMain(void *ptr)
 	{
 		while (!pThis->m_StopThread)
 			pcap_dispatch(pThis->m_PcapDescriptor, 100, onPacketArrivesNoCallback, (uint8_t*)pThis);
-
 	}
 	LOG_DEBUG("Ended capture thread for device '%s'", pThis->m_Name);
 	return 0;
@@ -269,28 +267,34 @@ pcap_t* PcapLiveDevice::doOpen(const DeviceConfiguration& config)
 	if (ret == 0)
 	{
 		LOG_DEBUG("Immediate mode is activated");
-	} else {
-		LOG_ERROR("Failed to activate immediate mode, error code: '%d', error message: '%s'",
-			       ret, pcap_geterr(pcap));
+	}
+	else
+	{
+		LOG_ERROR("Failed to activate immediate mode, error code: '%d', error message: '%s'", ret, pcap_geterr(pcap));
 	}
 #endif
 
 #ifdef HAS_SET_DIRECTION_ENABLED
-    	pcap_direction_t directionToSet = directionTypeMap(config.direction);
+	pcap_direction_t directionToSet = directionTypeMap(config.direction);
 	ret = pcap_setdirection(pcap, directionToSet);
 	if (ret != 0)
-    	{
+	{
 		if (config.direction == PCPP_IN)
 		{
-		    	LOG_DEBUG("Only incoming traffics will be captured");
-		}else if (config.direction == PCPP_OUT) {
-		    	LOG_DEBUG("Only outgoing traffics will be captured");
-		}else {
-	  		LOG_DEBUG("Both incoming and outgoing traffics will be captured");
+		  LOG_DEBUG("Only incoming traffics will be captured");
 		}
-    	}else {
-			LOG_ERROR("Failed to set direction for capturing packets, error code: '%d', error message: '%s'",
-				       ret, pcap_geterr(pcap));
+		else if (config.direction == PCPP_OUT) 
+		{
+		  LOG_DEBUG("Only outgoing traffics will be captured");
+		}
+		else
+		{
+			LOG_DEBUG("Both incoming and outgoing traffics will be captured");
+		}
+	}
+	else
+	{
+		LOG_ERROR("Failed to set direction for capturing packets, error code: '%d', error message: '%s'", ret, pcap_geterr(pcap));
 	}
 #endif
 	ret = pcap_activate(pcap);
@@ -469,7 +473,6 @@ int PcapLiveDevice::startCaptureBlockingMode(OnPacketArrivesStopBlocking onPacke
 	}
 	else
 	{
-
 		while (!m_StopThread && curTimeSec <= (startTimeSec + timeout))
 		{
 			pcap_dispatch(m_PcapDescriptor, -1, onPacketArrivesBlockingMode, (uint8_t*)this);
@@ -520,7 +523,7 @@ bool PcapLiveDevice::captureActive()
 	return m_CaptureThreadStarted;
 }
 
-void PcapLiveDevice::getStatistics(pcap_stat& stats)
+void PcapLiveDevice::getStatistics(pcap_stat& stats) const
 {
 	if(pcap_stats(m_PcapDescriptor, &stats) < 0)
 	{
@@ -610,17 +613,17 @@ int PcapLiveDevice::sendPackets(const RawPacketVector& rawPackets)
 
 std::string PcapLiveDevice::printThreadId(PcapThread* id)
 {
-    size_t i;
-    std::string result("");
-    pthread_t pthread = id->pthread;
-    for (i = sizeof(pthread); i; --i)
-    {
-    	char currByte[3];
-    	snprintf(currByte, 3, "%02x", *(((unsigned char*) &pthread) + i - 1));
-    	result += currByte;
-    }
+	size_t i;
+	std::string result("");
+	pthread_t pthread = id->pthread;
+	for (i = sizeof(pthread); i; --i)
+	{
+		char currByte[3];
+		snprintf(currByte, 3, "%02x", *(((unsigned char*) &pthread) + i - 1));
+		result += currByte;
+	}
 
-    return result;
+	return result;
 }
 
 void PcapLiveDevice::setDeviceMtu()
@@ -644,28 +647,28 @@ void PcapLiveDevice::setDeviceMtu()
 
 	uint8_t buffer[512];
 	PACKET_OID_DATA* oidData = (PACKET_OID_DATA*)buffer;
-    oidData->Oid = OID_GEN_MAXIMUM_TOTAL_SIZE;
-    oidData->Length = sizeof(uint32_t);
-    memcpy(oidData->Data, &mtuValue, sizeof(uint32_t));
-    bool status = PacketRequest(adapter, false, oidData);
-    if(status)
-    {
-        if(oidData->Length <= sizeof(uint32_t))
-        {
-            /* copy value from driver */
-            memcpy(&mtuValue, oidData->Data, oidData->Length);
-            m_DeviceMtu = mtuValue;
-        } else
-        {
-            /* the driver returned a value that is longer than expected (and longer than the given buffer) */
-            LOG_ERROR("Error in retrieving MTU: Size of Oid larger than uint32_t, OidLen:%lu", oidData->Length);
-            return;
-        }
-    }
-    else
-    {
-    	LOG_ERROR("Error in retrieving MTU: PacketRequest failed");
-    }
+	oidData->Oid = OID_GEN_MAXIMUM_TOTAL_SIZE;
+	oidData->Length = sizeof(uint32_t);
+	memcpy(oidData->Data, &mtuValue, sizeof(uint32_t));
+	if(PacketRequest(adapter, false, oidData))
+	{
+		if(oidData->Length <= sizeof(uint32_t))
+		{
+			/* copy value from driver */
+			memcpy(&mtuValue, oidData->Data, oidData->Length);
+			m_DeviceMtu = mtuValue;
+		}
+		else
+		{
+			/* the driver returned a value that is longer than expected (and longer than the given buffer) */
+			LOG_ERROR("Error in retrieving MTU: Size of Oid larger than uint32_t, OidLen:%lu", oidData->Length);
+			return;
+		}
+	}
+	else
+	{
+		LOG_ERROR("Error in retrieving MTU: PacketRequest failed");
+	}
 
 #else
 	struct ifreq ifr;
@@ -698,31 +701,31 @@ void PcapLiveDevice::setDeviceMacAddress()
 
 	uint8_t buffer[512];
 	PACKET_OID_DATA* oidData = (PACKET_OID_DATA*)buffer;
-    oidData->Oid = OID_802_3_CURRENT_ADDRESS;
-    oidData->Length = 6;
-    oidData->Data[0] = 0;
-    bool status = PacketRequest(adapter, false, oidData);
-    if(status)
-    {
-        if(oidData->Length == 6)
-        {
+	oidData->Oid = OID_802_3_CURRENT_ADDRESS;
+	oidData->Length = 6;
+	oidData->Data[0] = 0;
+	if(PacketRequest(adapter, false, oidData))
+	{
+		if(oidData->Length == 6)
+		{
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
-            /* copy value from driver */
-        	m_MacAddress = MacAddress(oidData->Data[0], oidData->Data[1], oidData->Data[2], oidData->Data[3], oidData->Data[4], oidData->Data[5]);
+			/* copy value from driver */
+			m_MacAddress = MacAddress(oidData->Data[0], oidData->Data[1], oidData->Data[2], oidData->Data[3], oidData->Data[4], oidData->Data[5]);
 #pragma GCC diagnostic pop
-        	LOG_DEBUG("   MAC address: %s", m_MacAddress.toString().c_str());
-        } else
-        {
-            /* the driver returned a value that is longer than expected (and longer than the given buffer) */
-        	LOG_DEBUG("Error in retrieving MAC address: Size of Oid larger than 6, OidLen:%lu", oidData->Length);
-            return;
-        }
-    }
-    else
-    {
-    	LOG_DEBUG("Error in retrieving MAC address: PacketRequest failed");
-    }
+			LOG_DEBUG("   MAC address: %s", m_MacAddress.toString().c_str());
+		}
+		else
+		{
+			/* the driver returned a value that is longer than expected (and longer than the given buffer) */
+			LOG_DEBUG("Error in retrieving MAC address: Size of Oid larger than 6, OidLen:%lu", oidData->Length);
+			return;
+		}
+	}
+	else
+	{
+		LOG_DEBUG("Error in retrieving MAC address: PacketRequest failed");
+	}
 #elif LINUX
 	struct ifreq ifr;
 
@@ -736,10 +739,10 @@ void PcapLiveDevice::setDeviceMacAddress()
 		return;
 	}
 
-    m_MacAddress = MacAddress(ifr.ifr_hwaddr.sa_data[0], ifr.ifr_hwaddr.sa_data[1], ifr.ifr_hwaddr.sa_data[2], ifr.ifr_hwaddr.sa_data[3], ifr.ifr_hwaddr.sa_data[4], ifr.ifr_hwaddr.sa_data[5]);
+	m_MacAddress = MacAddress(ifr.ifr_hwaddr.sa_data[0], ifr.ifr_hwaddr.sa_data[1], ifr.ifr_hwaddr.sa_data[2], ifr.ifr_hwaddr.sa_data[3], ifr.ifr_hwaddr.sa_data[4], ifr.ifr_hwaddr.sa_data[5]);
 #elif MAC_OS_X || FREEBSD
-    int	mib[6];
-    size_t len;
+	int	mib[6];
+	size_t len;
 
 	mib[0] = CTL_NET;
 	mib[1] = AF_ROUTE;
@@ -782,10 +785,10 @@ void PcapLiveDevice::setDefaultGateway()
 
 	retVal = GetAdaptersInfo(adapterInfo, &outBufLen);
 	uint8_t* buffer2 = new uint8_t[outBufLen];
-    if (retVal == ERROR_BUFFER_OVERFLOW)
-        adapterInfo = (IP_ADAPTER_INFO *)buffer2;
+	if (retVal == ERROR_BUFFER_OVERFLOW)
+		adapterInfo = (IP_ADAPTER_INFO *)buffer2;
 
-    retVal = GetAdaptersInfo(adapterInfo, &outBufLen);
+	retVal = GetAdaptersInfo(adapterInfo, &outBufLen);
 
 	if (retVal == NO_ERROR)
 	{
@@ -796,7 +799,7 @@ void PcapLiveDevice::setDefaultGateway()
 			if (name.find(curAdapterInfo->AdapterName) != std::string::npos)
 				m_DefaultGateway = IPv4Address(curAdapterInfo->GatewayList.IpAddress.String);
 
-            curAdapterInfo = curAdapterInfo->Next;
+			curAdapterInfo = curAdapterInfo->Next;
 		}
 	}
 	else
@@ -811,25 +814,25 @@ void PcapLiveDevice::setDefaultGateway()
 	std::string line;
 	while (std::getline(routeFile, line))
 	{
-	    std::stringstream lineStream(line);
-	    std::string interfaceName;
-	    std::getline(lineStream, interfaceName, '\t');
-	    if (interfaceName != std::string(m_Name))
-	    	continue;
+	  std::stringstream lineStream(line);
+	  std::string interfaceName;
+	  std::getline(lineStream, interfaceName, '\t');
+	  if (interfaceName != std::string(m_Name))
+	    continue;
 
-	    std::string interfaceDest;
-	    std::getline(lineStream, interfaceDest, '\t');
-	    if (interfaceDest != "00000000")
-	    	continue;
+	  std::string interfaceDest;
+	  std::getline(lineStream, interfaceDest, '\t');
+	  if (interfaceDest != "00000000")
+	    continue;
 
-	    std::string interfaceGateway;
-	    std::getline(lineStream, interfaceGateway, '\t');
+	  std::string interfaceGateway;
+	  std::getline(lineStream, interfaceGateway, '\t');
 
-	    uint32_t interfaceGatewayIPInt;
-	    std::stringstream interfaceGatewayStream;
-	    interfaceGatewayStream << std::hex << interfaceGateway;
-	    interfaceGatewayStream >> interfaceGatewayIPInt;
-	    m_DefaultGateway = IPv4Address(interfaceGatewayIPInt);
+	  uint32_t interfaceGatewayIPInt;
+	  std::stringstream interfaceGatewayStream;
+	  interfaceGatewayStream << std::hex << interfaceGateway;
+	  interfaceGatewayStream >> interfaceGatewayIPInt;
+	  m_DefaultGateway = IPv4Address(interfaceGatewayIPInt);
 	}
 #elif MAC_OS_X || FREEBSD
 	std::string ifaceStr = std::string(m_Name);
@@ -855,9 +858,9 @@ void PcapLiveDevice::setDefaultGateway()
 #endif
 }
 
-IPv4Address PcapLiveDevice::getIPv4Address()
+IPv4Address PcapLiveDevice::getIPv4Address() const
 {
-	for(std::vector<pcap_addr_t>::iterator addrIter = m_Addresses.begin(); addrIter != m_Addresses.end(); addrIter++)
+	for(std::vector<pcap_addr_t>::const_iterator addrIter = m_Addresses.begin(); addrIter != m_Addresses.end(); addrIter++)
 	{
 		if (LoggerPP::getInstance().isDebugEnabled(PcapLogModuleLiveDevice) && addrIter->addr != NULL)
 		{
@@ -880,12 +883,12 @@ IPv4Address PcapLiveDevice::getIPv4Address()
 }
 
 
-IPv4Address PcapLiveDevice::getDefaultGateway()
+IPv4Address PcapLiveDevice::getDefaultGateway() const
 {
 	return m_DefaultGateway;
 }
 
-std::vector<IPv4Address>& PcapLiveDevice::getDnsServers()
+std::vector<IPv4Address>& PcapLiveDevice::getDnsServers() const
 {
 	return PcapLiveDeviceList::getInstance().getDnsServers();
 }

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -888,7 +888,7 @@ IPv4Address PcapLiveDevice::getDefaultGateway() const
 	return m_DefaultGateway;
 }
 
-std::vector<IPv4Address>& PcapLiveDevice::getDnsServers() const
+const std::vector<IPv4Address>& PcapLiveDevice::getDnsServers() const
 {
 	return PcapLiveDeviceList::getInstance().getDnsServers();
 }

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -135,7 +135,7 @@ PcapLiveDevice::PcapLiveDevice(pcap_if_t* pInterface, bool calculateMTU, bool ca
 	}
 }
 
-void PcapLiveDevice::onPacketArrives(uint8_t *user, const struct pcap_pkthdr *pkthdr, const uint8_t *packet)
+void PcapLiveDevice::onPacketArrives(uint8_t* user, const struct pcap_pkthdr* pkthdr, const uint8_t* packet)
 {
 	PcapLiveDevice* pThis = (PcapLiveDevice*)user;
 	if (pThis == NULL)
@@ -150,7 +150,7 @@ void PcapLiveDevice::onPacketArrives(uint8_t *user, const struct pcap_pkthdr *pk
 		pThis->m_cbOnPacketArrives(&rawPacket, pThis, pThis->m_cbOnPacketArrivesUserCookie);
 }
 
-void PcapLiveDevice::onPacketArrivesNoCallback(uint8_t *user, const struct pcap_pkthdr *pkthdr, const uint8_t *packet)
+void PcapLiveDevice::onPacketArrivesNoCallback(uint8_t* user, const struct pcap_pkthdr* pkthdr, const uint8_t* packet)
 {
 	PcapLiveDevice* pThis = (PcapLiveDevice*)user;
 	if (pThis == NULL)
@@ -165,7 +165,7 @@ void PcapLiveDevice::onPacketArrivesNoCallback(uint8_t *user, const struct pcap_
 	pThis->m_CapturedPackets->pushBack(rawPacketPtr);
 }
 
-void PcapLiveDevice::onPacketArrivesBlockingMode(uint8_t *user, const struct pcap_pkthdr *pkthdr, const uint8_t *packet)
+void PcapLiveDevice::onPacketArrivesBlockingMode(uint8_t* user, const struct pcap_pkthdr* pkthdr, const uint8_t* packet)
 {
 	PcapLiveDevice* pThis = (PcapLiveDevice*)user;
 	if (pThis == NULL)
@@ -181,7 +181,7 @@ void PcapLiveDevice::onPacketArrivesBlockingMode(uint8_t *user, const struct pca
 			pThis->m_StopThread = true;
 }
 
-void* PcapLiveDevice::captureThreadMain(void *ptr)
+void* PcapLiveDevice::captureThreadMain(void* ptr)
 {
 	PcapLiveDevice* pThis = (PcapLiveDevice*)ptr;
 	if (pThis == NULL)
@@ -205,7 +205,7 @@ void* PcapLiveDevice::captureThreadMain(void *ptr)
 	return 0;
 }
 
-void* PcapLiveDevice::statsThreadMain(void *ptr)
+void* PcapLiveDevice::statsThreadMain(void* ptr)
 {
 	PcapLiveDevice* pThis = (PcapLiveDevice*)ptr;
 	if (pThis == NULL)
@@ -308,7 +308,7 @@ pcap_t* PcapLiveDevice::doOpen(const DeviceConfiguration& config)
 	if (pcap)
 	{
 		int dlt = pcap_datalink(pcap);
-		const char *dlt_name = pcap_datalink_val_to_name(dlt);
+		const char* dlt_name = pcap_datalink_val_to_name(dlt);
 		if (dlt_name)
 		{
 			LOG_DEBUG("link-type %u: %s (%s)\n", dlt, dlt_name, pcap_datalink_val_to_description(dlt));
@@ -525,7 +525,7 @@ bool PcapLiveDevice::captureActive()
 
 void PcapLiveDevice::getStatistics(pcap_stat& stats) const
 {
-	if(pcap_stats(m_PcapDescriptor, &stats) < 0)
+	if (pcap_stats(m_PcapDescriptor, &stats) < 0)
 	{
 		LOG_ERROR("Error getting statistics from live device '%s'", m_Name);
 	}
@@ -650,9 +650,9 @@ void PcapLiveDevice::setDeviceMtu()
 	oidData->Oid = OID_GEN_MAXIMUM_TOTAL_SIZE;
 	oidData->Length = sizeof(uint32_t);
 	memcpy(oidData->Data, &mtuValue, sizeof(uint32_t));
-	if(PacketRequest(adapter, false, oidData))
+	if (PacketRequest(adapter, false, oidData))
 	{
-		if(oidData->Length <= sizeof(uint32_t))
+		if (oidData->Length <= sizeof(uint32_t))
 		{
 			/* copy value from driver */
 			memcpy(&mtuValue, oidData->Data, oidData->Length);
@@ -704,9 +704,9 @@ void PcapLiveDevice::setDeviceMacAddress()
 	oidData->Oid = OID_802_3_CURRENT_ADDRESS;
 	oidData->Length = 6;
 	oidData->Data[0] = 0;
-	if(PacketRequest(adapter, false, oidData))
+	if (PacketRequest(adapter, false, oidData))
 	{
-		if(oidData->Length == 6)
+		if (oidData->Length == 6)
 		{
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"

--- a/Pcap++/src/PcapLiveDeviceList.cpp
+++ b/Pcap++/src/PcapLiveDeviceList.cpp
@@ -29,7 +29,6 @@ PcapLiveDeviceList::~PcapLiveDeviceList()
 	{
 		delete (*devIter);
 	}
-
 }
 
 void PcapLiveDeviceList::init()
@@ -196,7 +195,7 @@ void PcapLiveDeviceList::setDnsServers()
 #endif
 }
 
-PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(IPAddress* ipAddr)
+PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(IPAddress* ipAddr) const
 {
 	if (ipAddr->getType() == IPAddress::IPv4AddressType)
 	{
@@ -210,10 +209,10 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(IPAddress* ipAddr)
 	}
 }
 
-PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(IPv4Address ipAddr)
+PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(IPv4Address ipAddr) const
 {
 	LOG_DEBUG("Searching all live devices...");
-	for(std::vector<PcapLiveDevice*>::iterator devIter = m_LiveDeviceList.begin(); devIter != m_LiveDeviceList.end(); devIter++)
+	for(std::vector<PcapLiveDevice*>::const_iterator devIter = m_LiveDeviceList.begin(); devIter != m_LiveDeviceList.end(); devIter++)
 	{
 		LOG_DEBUG("Searching device '%s'. Searching all addresses...", (*devIter)->m_Name);
 		for(std::vector<pcap_addr_t>::iterator addrIter = (*devIter)->m_Addresses.begin(); addrIter != (*devIter)->m_Addresses.end(); addrIter++)
@@ -243,10 +242,10 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(IPv4Address ipAddr)
 	return NULL;
 }
 
-PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(IPv6Address ip6Addr)
+PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(IPv6Address ip6Addr) const
 {
 	LOG_DEBUG("Searching all live devices...");
-	for(std::vector<PcapLiveDevice*>::iterator devIter = m_LiveDeviceList.begin(); devIter != m_LiveDeviceList.end(); devIter++)
+	for(std::vector<PcapLiveDevice*>::const_iterator devIter = m_LiveDeviceList.begin(); devIter != m_LiveDeviceList.end(); devIter++)
 	{
 		LOG_DEBUG("Searching device '%s'. Searching all addresses...", (*devIter)->m_Name);
 		for(std::vector<pcap_addr_t>::iterator addrIter = (*devIter)->m_Addresses.begin(); addrIter != (*devIter)->m_Addresses.end(); addrIter++)
@@ -281,12 +280,7 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(IPv6Address ip6Addr)
 	return NULL;
 }
 
-std::vector<IPv4Address>& PcapLiveDeviceList::getDnsServers()
-{
-	return m_DnsServers;
-}
-
-PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const char* ipAddrAsString)
+PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const char* ipAddrAsString) const
 {
 	IPAddress::Ptr_t apAddr = IPAddress::fromString(ipAddrAsString);
 	if (apAddr.get() == NULL || !apAddr->isValid())
@@ -300,10 +294,10 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const char* ipAddrAsSt
 }
 
 
-PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByName(const std::string& name)
+PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByName(const std::string& name) const
 {
 	LOG_DEBUG("Searching all live devices...");
-	for(std::vector<PcapLiveDevice*>::iterator devIter = m_LiveDeviceList.begin(); devIter != m_LiveDeviceList.end(); devIter++)
+	for(std::vector<PcapLiveDevice*>::const_iterator devIter = m_LiveDeviceList.begin(); devIter != m_LiveDeviceList.end(); devIter++)
 	{
 		std::string devName((*devIter)->getName());
 		if (name == devName)

--- a/Pcap++/src/PcapRemoteDevice.cpp
+++ b/Pcap++/src/PcapRemoteDevice.cpp
@@ -10,7 +10,7 @@
 namespace pcpp
 {
 
-pcap_rmtauth PcapRemoteAuthentication::getPcapRmAuth()
+pcap_rmtauth PcapRemoteAuthentication::getPcapRmAuth() const
 {
 	pcap_rmtauth result;
 	result.type = RPCAP_RMTAUTH_PWD;
@@ -109,7 +109,7 @@ ThreadStart PcapRemoteDevice::getCaptureThreadStart()
 	return &remoteDeviceCaptureThreadMain;
 }
 
-void PcapRemoteDevice::getStatistics(pcap_stat& stats)
+void PcapRemoteDevice::getStatistics(pcap_stat& stats) const
 {
 	int allocatedMemory;
 	pcap_stat* tempStats = pcap_stats_ex(m_PcapDescriptor, &allocatedMemory);
@@ -123,13 +123,13 @@ void PcapRemoteDevice::getStatistics(pcap_stat& stats)
 	stats.ps_ifdrop = tempStats->ps_ifdrop;
 }
 
-uint16_t PcapRemoteDevice::getMtu()
+uint16_t PcapRemoteDevice::getMtu() const
 {
 	LOG_DEBUG("MTU isn't supported for remote devices");
 	return 0;
 }
 
-MacAddress PcapRemoteDevice::getMacAddress()
+MacAddress PcapRemoteDevice::getMacAddress() const
 {
 	LOG_ERROR("MAC address isn't supported for remote devices");
 	return MacAddress::Zero;

--- a/Pcap++/src/PcapRemoteDeviceList.cpp
+++ b/Pcap++/src/PcapRemoteDeviceList.cpp
@@ -71,7 +71,7 @@ PcapRemoteDeviceList* PcapRemoteDeviceList::getRemoteDeviceList(IPAddress* ipAdd
 	return resultList;
 }
 
-PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(const char* ipAddrAsString)
+PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(const char* ipAddrAsString) const
 {
 	IPAddress::Ptr_t apAddr = IPAddress::fromString(ipAddrAsString);
 	if (!apAddr->isValid())
@@ -84,7 +84,7 @@ PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(const char* ipAddrAs
 	return result;
 }
 
-PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(IPAddress* ipAddr)
+PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(IPAddress* ipAddr) const
 {
 	if (ipAddr->getType() == IPAddress::IPv4AddressType)
 	{
@@ -99,10 +99,10 @@ PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(IPAddress* ipAddr)
 }
 
 
-PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(IPv4Address ip4Addr)
+PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(IPv4Address ip4Addr) const
 {
 	LOG_DEBUG("Searching all remote devices in list...");
-	for(RemoteDeviceListIterator devIter = m_RemoteDeviceList.begin(); devIter != m_RemoteDeviceList.end(); devIter++)
+	for(ConstRemoteDeviceListIterator devIter = m_RemoteDeviceList.begin(); devIter != m_RemoteDeviceList.end(); devIter++)
 	{
 		LOG_DEBUG("Searching device '%s'. Searching all addresses...", (*devIter)->m_Name);
 		for(std::vector<pcap_addr_t>::iterator addrIter = (*devIter)->m_Addresses.begin(); addrIter != (*devIter)->m_Addresses.end(); addrIter++)
@@ -133,10 +133,10 @@ PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(IPv4Address ip4Addr)
 
 }
 
-PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(IPv6Address ip6Addr)
+PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(IPv6Address ip6Addr) const
 {
 	LOG_DEBUG("Searching all remote devices in list...");
-	for(RemoteDeviceListIterator devIter = m_RemoteDeviceList.begin(); devIter != m_RemoteDeviceList.end(); devIter++)
+	for(ConstRemoteDeviceListIterator devIter = m_RemoteDeviceList.begin(); devIter != m_RemoteDeviceList.end(); devIter++)
 	{
 		LOG_DEBUG("Searching device '%s'. Searching all addresses...", (*devIter)->m_Name);
 		for(std::vector<pcap_addr_t>::iterator addrIter = (*devIter)->m_Addresses.begin(); addrIter != (*devIter)->m_Addresses.end(); addrIter++)

--- a/Pcap++/src/PfRingDevice.cpp
+++ b/Pcap++/src/PfRingDevice.cpp
@@ -100,8 +100,8 @@ int PfRingDevice::openSingleRxChannel(const char* deviceName, pfring** ring)
 
 	if (pfring_enable_rss_rehash(*ring) < 0 || pfring_enable_ring(*ring) < 0)
 	{
-	    pfring_close(*ring);
-	    return 2;
+		pfring_close(*ring);
+		return 2;
 	}
 
 	LOG_DEBUG("pfring enabled for device [%s]", deviceName);
@@ -111,20 +111,20 @@ int PfRingDevice::openSingleRxChannel(const char* deviceName, pfring** ring)
 
 bool PfRingDevice::setPfRingDeviceClock(pfring* ring)
 {
-    struct timespec ltime;
-    if (clock_gettime(CLOCK_REALTIME, &ltime) != 0)
-    {
-    	LOG_ERROR("Could not set pfring devices clock, clock_gettime failed");
-    	return false;
-    }
+	struct timespec ltime;
+	if (clock_gettime(CLOCK_REALTIME, &ltime) != 0)
+	{
+		LOG_ERROR("Could not set pfring devices clock, clock_gettime failed");
+		return false;
+	}
 
-   	if (pfring_set_device_clock(ring, &ltime) < 0)
-   	{
-   		LOG_DEBUG("Could not set pfring devices clock, pfring_set_device_clock failed");
-   		return false;
-   	}
+	if (pfring_set_device_clock(ring, &ltime) < 0)
+	{
+		LOG_DEBUG("Could not set pfring devices clock, pfring_set_device_clock failed");
+		return false;
+	}
 
-    return true;
+	return true;
 }
 
 bool PfRingDevice::openMultiRxChannels(const uint8_t* channelIds, int numOfChannelIds)
@@ -261,7 +261,6 @@ bool PfRingDevice::openMultiRxChannels(uint8_t numOfRxChannelsToOpen, ChannelDis
 			{
 				LOG_ERROR("Couldn't set ring [%d] in channel [%d] to the cluster [%d]", numOfRingsPerRxChannel+1, channelId, channelId);
 				break;
-
 			}
 
 			ringsOpen++;
@@ -274,9 +273,9 @@ bool PfRingDevice::openMultiRxChannels(uint8_t numOfRxChannelsToOpen, ChannelDis
 
 	if (ringsOpen < numOfRxChannelsToOpen)
 	{
-	    for (uint8_t i = 0; i < ringsOpen; i++)
-	    	pfring_close(m_PfRingDescriptors[i]);
-	    return false;
+	  for (uint8_t i = 0; i < ringsOpen; i++)
+	    pfring_close(m_PfRingDescriptors[i]);
+	  return false;
 	}
 
 	if (getIsHwClockEnable())
@@ -293,11 +292,11 @@ bool PfRingDevice::openMultiRxChannels(uint8_t numOfRxChannelsToOpen, ChannelDis
 	{
 		if (pfring_enable_rss_rehash(m_PfRingDescriptors[i]) < 0 || pfring_enable_ring(m_PfRingDescriptors[i]) < 0)
 		{
-		    LOG_ERROR("Unable to enable ring [%d] for device [%s]", i, m_DeviceName);
-		    // close all pfring's that were enabled until now
-		    for (int j = 0; j <ringsOpen; j++)
-		    	pfring_close(m_PfRingDescriptors[j]);
-		    return false;
+		  LOG_ERROR("Unable to enable ring [%d] for device [%s]", i, m_DeviceName);
+		  // close all pfring's that were enabled until now
+		  for (int j = 0; j <ringsOpen; j++)
+		    pfring_close(m_PfRingDescriptors[j]);
+		  return false;
 		}
 	}
 
@@ -307,7 +306,7 @@ bool PfRingDevice::openMultiRxChannels(uint8_t numOfRxChannelsToOpen, ChannelDis
 	return true;
 }
 
-uint8_t PfRingDevice::getTotalNumOfRxChannels()
+uint8_t PfRingDevice::getTotalNumOfRxChannels() const
 {
 	if (m_NumOfOpenedRxChannels > 0)
 	{
@@ -325,7 +324,7 @@ uint8_t PfRingDevice::getTotalNumOfRxChannels()
 }
 
 
-SystemCore PfRingDevice::getCurrentCoreId()
+SystemCore PfRingDevice::getCurrentCoreId() const
 {
 	return SystemCores::IdToSystemCore[sched_getcpu()];
 }
@@ -354,8 +353,8 @@ bool PfRingDevice::setFilter(std::string filterAsString)
 
 	m_IsFilterCurrentlySet = true;
 
-    LOG_DEBUG("Successfully set filter '%s'", filterAsString.c_str());
-    return true;
+	LOG_DEBUG("Successfully set filter '%s'", filterAsString.c_str());
+	return true;
 }
 
 
@@ -376,12 +375,12 @@ bool PfRingDevice::clearFilter()
 
 	m_IsFilterCurrentlySet = false;
 
-    LOG_DEBUG("Successfully removed filter from all open RX channels");
-    return true;
+	LOG_DEBUG("Successfully removed filter from all open RX channels");
+	return true;
 }
 
 
-bool PfRingDevice::isFilterCurrentlySet()
+bool PfRingDevice::isFilterCurrentlySet() const
 {
 	return m_IsFilterCurrentlySet;
 }
@@ -514,18 +513,18 @@ bool PfRingDevice::startCaptureSingleThread(OnPfRingPacketsArriveCallback onPack
 	}
 
 	cpu_set_t cpuset;
-    CPU_ZERO(&cpuset);
+	CPU_ZERO(&cpuset);
 	pthread_getaffinity_np(newThread, sizeof(cpu_set_t), &cpuset);
-    for (int i = 0; i < CPU_SETSIZE; i++)
-    {
-        if (CPU_ISSET(i, &cpuset))
-        {
-        	m_CoreConfiguration[i].IsInUse = true;
-        	m_CoreConfiguration[i].Channel = m_PfRingDescriptors[0];
-        	m_CoreConfiguration[i].RxThread = newThread;
-        	m_CoreConfiguration[i].IsAffinitySet = false;
-        }
-    }
+	for (int i = 0; i < CPU_SETSIZE; i++)
+	{
+		if (CPU_ISSET(i, &cpuset))
+		{
+			m_CoreConfiguration[i].IsInUse = true;
+			m_CoreConfiguration[i].Channel = m_PfRingDescriptors[0];
+			m_CoreConfiguration[i].RxThread = newThread;
+			m_CoreConfiguration[i].IsAffinitySet = false;
+		}
+	}
 
 	LOG_DEBUG("Capturing started for device [%s]", m_DeviceName);
 	return true;
@@ -602,7 +601,7 @@ void* PfRingDevice::captureThreadMain(void *ptr)
 	return (void*)NULL;
 }
 
-void PfRingDevice::getThreadStatistics(SystemCore core, PfRingStats& stats)
+void PfRingDevice::getThreadStatistics(SystemCore core, PfRingStats& stats) const
 {
 	pfring* ring = NULL;
 	uint8_t coreId = core.Id;
@@ -626,12 +625,12 @@ void PfRingDevice::getThreadStatistics(SystemCore core, PfRingStats& stats)
 	}
 }
 
-void PfRingDevice::getCurrentThreadStatistics(PfRingStats& stats)
+void PfRingDevice::getCurrentThreadStatistics(PfRingStats& stats) const
 {
 	getThreadStatistics(getCurrentCoreId(), stats);
 }
 
-void PfRingDevice::getStatistics(PfRingStats& stats)
+void PfRingDevice::getStatistics(PfRingStats& stats) const
 {
 	stats.drop = 0;
 	stats.recv = 0;

--- a/Pcap++/src/PfRingDevice.cpp
+++ b/Pcap++/src/PfRingDevice.cpp
@@ -292,11 +292,11 @@ bool PfRingDevice::openMultiRxChannels(uint8_t numOfRxChannelsToOpen, ChannelDis
 	{
 		if (pfring_enable_rss_rehash(m_PfRingDescriptors[i]) < 0 || pfring_enable_ring(m_PfRingDescriptors[i]) < 0)
 		{
-		  LOG_ERROR("Unable to enable ring [%d] for device [%s]", i, m_DeviceName);
-		  // close all pfring's that were enabled until now
-		  for (int j = 0; j <ringsOpen; j++)
-		    pfring_close(m_PfRingDescriptors[j]);
-		  return false;
+			LOG_ERROR("Unable to enable ring [%d] for device [%s]", i, m_DeviceName);
+			// close all pfring's that were enabled until now
+			for (int j = 0; j <ringsOpen; j++)
+				pfring_close(m_PfRingDescriptors[j]);
+			return false;
 		}
 	}
 
@@ -545,7 +545,7 @@ void PfRingDevice::stopCapture()
 	LOG_DEBUG("All capturing threads stopped");
 }
 
-void* PfRingDevice::captureThreadMain(void *ptr)
+void* PfRingDevice::captureThreadMain(void* ptr)
 {
 	PfRingDevice* device = (PfRingDevice*)ptr;
 	int coreId = device->getCurrentCoreId().Id;

--- a/Pcap++/src/PfRingDevice.cpp
+++ b/Pcap++/src/PfRingDevice.cpp
@@ -273,9 +273,9 @@ bool PfRingDevice::openMultiRxChannels(uint8_t numOfRxChannelsToOpen, ChannelDis
 
 	if (ringsOpen < numOfRxChannelsToOpen)
 	{
-	  for (uint8_t i = 0; i < ringsOpen; i++)
-	    pfring_close(m_PfRingDescriptors[i]);
-	  return false;
+		for (uint8_t i = 0; i < ringsOpen; i++)
+			pfring_close(m_PfRingDescriptors[i]);
+		return false;
 	}
 
 	if (getIsHwClockEnable())

--- a/Pcap++/src/PfRingDeviceList.cpp
+++ b/Pcap++/src/PfRingDeviceList.cpp
@@ -83,20 +83,20 @@ void PfRingDeviceList::calcPfRingVersion(void* ring)
 {
 	pfring* ringPtr = (pfring*)ring;
 	uint32_t version;
-    if (pfring_version(ringPtr, &version) < 0)
-    {
-    	LOG_ERROR("Couldn't retrieve PF_RING version, pfring_version returned an error");
-    	return;
-    }
+	if (pfring_version(ringPtr, &version) < 0)
+	{
+		LOG_ERROR("Couldn't retrieve PF_RING version, pfring_version returned an error");
+		return;
+	}
 
-    char versionAsString[25];
-    sprintf(versionAsString, "PF_RING v.%d.%d.%d\n",
-	   (version & 0xFFFF0000) >> 16,
-	   (version & 0x0000FF00) >> 8,
-	   version & 0x000000FF);
+	char versionAsString[25];
+	sprintf(versionAsString, "PF_RING v.%d.%d.%d\n",
+	  (version & 0xFFFF0000) >> 16,
+	  (version & 0x0000FF00) >> 8,
+	  version & 0x000000FF);
 
-    LOG_DEBUG("PF_RING version is: %s", versionAsString);
-    m_PfRingVersion = std::string(versionAsString);
+	LOG_DEBUG("PF_RING version is: %s", versionAsString);
+	m_PfRingVersion = std::string(versionAsString);
 }
 
 } // namespace pcpp

--- a/Pcap++/src/RawSocketDevice.cpp
+++ b/Pcap++/src/RawSocketDevice.cpp
@@ -44,16 +44,16 @@ public:
 		if (m_IsInitialized)
 			return;
 
-	    // Load Winsock
+		// Load Winsock
 		WSADATA wsaData;
-		int res;
-	    if ((res = WSAStartup(MAKEWORD(2,2), &wsaData)) != 0)
-	    {
-	    	LOG_ERROR("WSAStartup failed with error code: %d", res);
-	    	m_IsInitialized = false;
-	    }
+		int res = WSAStartup(MAKEWORD(2,2), &wsaData);
+		if (res != 0)
+		{
+			LOG_ERROR("WSAStartup failed with error code: %d", res);
+			m_IsInitialized = false;
+		}
 
-	    m_IsInitialized = true;
+		m_IsInitialized = true;
 	}
 };
 
@@ -549,7 +549,7 @@ void RawSocketDevice::close()
 	}
 }
 
-RawSocketDevice::RecvPacketResult RawSocketDevice::getError(int& errorCode)
+RawSocketDevice::RecvPacketResult RawSocketDevice::getError(int& errorCode) const
 {
 #if defined(WIN32) || defined(WINx64) || defined(PCAPPP_MINGW_ENV)
 	errorCode = WSAGetLastError();

--- a/Pcap++/src/WinPcapLiveDevice.cpp
+++ b/Pcap++/src/WinPcapLiveDevice.cpp
@@ -15,26 +15,26 @@ WinPcapLiveDevice::WinPcapLiveDevice(pcap_if_t* iface, bool calculateMTU, bool c
 
 bool WinPcapLiveDevice::startCapture(OnPacketArrivesCallback onPacketArrives, void* onPacketArrivesUserCookie, int intervalInSecondsToUpdateStats, OnStatsUpdateCallback onStatsUpdate, void* onStatsUpdateUsrrCookie)
 {
-    //Put the interface in capture mode
-    if (pcap_setmode(m_PcapDescriptor, MODE_CAPT) < 0)
-    {
-        LOG_ERROR("Error setting the capture mode for device '%s'", m_Name);
-        return false;
-    }
+	//Put the interface in capture mode
+	if (pcap_setmode(m_PcapDescriptor, MODE_CAPT) < 0)
+	{
+		LOG_ERROR("Error setting the capture mode for device '%s'", m_Name);
+		return false;
+	}
 
-    return PcapLiveDevice::startCapture(onPacketArrives, onPacketArrivesUserCookie, intervalInSecondsToUpdateStats, onStatsUpdate, onStatsUpdateUsrrCookie);
+	return PcapLiveDevice::startCapture(onPacketArrives, onPacketArrivesUserCookie, intervalInSecondsToUpdateStats, onStatsUpdate, onStatsUpdateUsrrCookie);
 }
 
 bool WinPcapLiveDevice::startCapture(int intervalInSecondsToUpdateStats, OnStatsUpdateCallback onStatsUpdate, void* onStatsUpdateUserCookie)
 {
-    //Put the interface in statistics mode
-    if (pcap_setmode(m_PcapDescriptor, MODE_STAT) < 0)
-    {
-        LOG_ERROR("Error setting the statistics mode for device '%s'", m_Name);
-        return false;
-    }
+	//Put the interface in statistics mode
+	if (pcap_setmode(m_PcapDescriptor, MODE_STAT) < 0)
+	{
+		LOG_ERROR("Error setting the statistics mode for device '%s'", m_Name);
+		return false;
+	}
 
-    return PcapLiveDevice::startCapture(intervalInSecondsToUpdateStats, onStatsUpdate, onStatsUpdateUserCookie);
+	return PcapLiveDevice::startCapture(intervalInSecondsToUpdateStats, onStatsUpdate, onStatsUpdateUserCookie);
 }
 
 int WinPcapLiveDevice::sendPackets(RawPacket* rawPacketsArr, int arrLength)
@@ -64,22 +64,22 @@ int WinPcapLiveDevice::sendPackets(RawPacket* rawPacketsArr, int arrLength)
 
 	int res;
 	if ((res = pcap_sendqueue_transmit(m_PcapDescriptor, sendQueue, 0)) < (int)(sendQueue->len))
-    {
-        LOG_ERROR("An error occurred sending the packets: %s. Only %d bytes were sent\n", pcap_geterr(m_PcapDescriptor), res);
-        packetsSent = 0;
-        dataSize = 0;
-    	for (int i = 0; i < arrLength; i++)
-    	{
-    		dataSize += rawPacketsArr[i].getRawDataLen();
-    		//printf("dataSize = %d\n", dataSize);
-    		if (dataSize > res)
-    		{
-    			return packetsSent;
-    		}
-    		packetsSent++;
-    	}
-    	return packetsSent;
-    }
+	{
+		LOG_ERROR("An error occurred sending the packets: %s. Only %d bytes were sent\n", pcap_geterr(m_PcapDescriptor), res);
+		packetsSent = 0;
+		dataSize = 0;
+		for (int i = 0; i < arrLength; i++)
+		{
+			dataSize += rawPacketsArr[i].getRawDataLen();
+			//printf("dataSize = %d\n", dataSize);
+			if (dataSize > res)
+			{
+				return packetsSent;
+			}
+			packetsSent++;
+		}
+		return packetsSent;
+	}
 	LOG_DEBUG("Packets were sent successfully");
 
 	pcap_sendqueue_destroy(sendQueue);


### PR DESCRIPTION
Note the IPcapDevice::getStatistics pure virtual method has been changed. A qualifier const was added.
It may lead to compilation errors if the user class is derived from this base class. But I think it should be done.