### PR TITLE
Improvements in IPReassembly and LRUList

### DIFF
--- a/Common++/header/LRUList.h
+++ b/Common++/header/LRUList.h
@@ -40,7 +40,7 @@ namespace pcpp
 		/**
 		 * Puts an element in the list. This element will be inserted (or advanced if it already exists) to the head of the
 		 * list as the most recently used element. If the list already reached its max size and the element is new this method
-		 * will remove the least recently used element and return a pointer to it. Method complexity is O(log(size()))
+		 * will remove the least recently used element and return a pointer to it. Method complexity is O(log(getSize()))
 		 * @param[in] element The element to insert or to advance to the head of the list (if already exists)
 		 * @return A pointer to the element that was removed from the list in case the list already reached its max size.
 		 * If the list didn't reach its max size NULL will be returned. Notice it's the responsibility of the user to free
@@ -75,12 +75,12 @@ namespace pcpp
 		/**
 		 * Puts an element in the list. This element will be inserted (or advanced if it already exists) to the head of the
 		 * list as the most recently used element. If the list already reached its max size and the element is new this method
-		 * will remove the least recently used element and return a value in deletedValue. Method complexity is O(log(size())).
+		 * will remove the least recently used element and return a value in deletedValue. Method complexity is O(log(getSize())).
 		 * This is a optimized version of the method T* put(const T&).
 		 * @param[in] element The element to insert or to advance to the head of the list (if already exists)
 		 * @param[out] deletedValue The value of deleted element (if a pointer is not NULL)
 		 * @return 0 if the list didn't reach its max size, 1 otherwise. In case the list already reached its max size
-		 * and deletedValue is not NULL the value of deleted element is copied into the place the deletedValue is points to.
+		 * and deletedValue is not NULL the value of deleted element is copied into the place the deletedValue points to.
 		 */
 		int put(const T& element, T* deletedValue)
 		{

--- a/Common++/header/LRUList.h
+++ b/Common++/header/LRUList.h
@@ -40,7 +40,7 @@ namespace pcpp
 		/**
 		 * Puts an element in the list. This element will be inserted (or advanced if it already exists) to the head of the
 		 * list as the most recently used element. If the list already reached its max size and the element is new this method
-		 * will remove the least recently used element and return a pointer to it. Method complexity is O(1)
+		 * will remove the least recently used element and return a pointer to it. Method complexity is O(log(size()))
 		 * @param[in] element The element to insert or to advance to the head of the list (if already exists)
 		 * @return A pointer to the element that was removed from the list in case the list already reached its max size.
 		 * If the list didn't reach its max size NULL will be returned. Notice it's the responsibility of the user to free
@@ -58,7 +58,7 @@ namespace pcpp
 				pair.first->second = m_CacheItemsList.begin();
 			}
 
-			if (m_CacheItemsList.size() > m_MaxSize)
+			if (m_CacheItemsMap.size() > m_MaxSize)
 			{
 				ListIterator lruIter = m_CacheItemsList.end();
 				lruIter--;
@@ -73,10 +73,48 @@ namespace pcpp
 		}
 
 		/**
+		 * Puts an element in the list. This element will be inserted (or advanced if it already exists) to the head of the
+		 * list as the most recently used element. If the list already reached its max size and the element is new this method
+		 * will remove the least recently used element and return a value in deletedValue. Method complexity is O(log(size())).
+		 * This is a optimized version of the method T* put(const T&).
+		 * @param[in] element The element to insert or to advance to the head of the list (if already exists)
+		 * @param[out] deletedValue The value of deleted element (if a pointer is not NULL)
+		 * @return 0 if the list didn't reach its max size, 1 otherwise. In case the list already reached its max size
+		 * and deletedValue is not NULL the value of deleted element is copied into the place the deletedValue is points to.
+		 */
+		int put(const T& element, T* deletedValue)
+		{
+			m_CacheItemsList.push_front(element);
+
+			// Inserting a new element. If an element with an equivalent key already exists the method returns an iterator to the element that prevented the insertion
+			std::pair<MapIterator, bool> pair = m_CacheItemsMap.insert(std::make_pair(element, m_CacheItemsList.begin()));
+			if (pair.second == false) // already exists
+			{
+				m_CacheItemsList.erase(pair.first->second);
+				pair.first->second = m_CacheItemsList.begin();
+			}
+
+			if (m_CacheItemsMap.size() > m_MaxSize)
+			{
+				ListIterator lruIter = m_CacheItemsList.end();
+				lruIter--;
+
+				if (deletedValue != NULL)
+					*deletedValue = *lruIter;
+
+				m_CacheItemsMap.erase(*lruIter);
+				m_CacheItemsList.erase(lruIter);
+				return 1;
+			}
+
+			return 0;
+		}
+
+		/**
 		 * Get the most recently used element (the one at the beginning of the list)
 		 * @return The most recently used element
 		 */
-		const T& getMRUElement()
+		const T& getMRUElement() const
 		{
 			return m_CacheItemsList.front();
 		}
@@ -85,7 +123,7 @@ namespace pcpp
 		 * Get the least recently used element (the one at the end of the list)
 		 * @return The least recently used element
 		 */
-		const T& getLRUElement()
+		const T& getLRUElement() const
 		{
 			return m_CacheItemsList.back();
 		}
@@ -107,12 +145,12 @@ namespace pcpp
 		/**
 		 * @return The max size of this list as determined in the c'tor
 		 */
-		inline size_t getMaxSize() { return m_MaxSize; }
+		size_t getMaxSize() const { return m_MaxSize; }
 
 		/**
 		 * @return The number of elements currently in this list
 		 */
-		inline size_t getSize() { return m_CacheItemsMap.size(); }
+		size_t getSize() const { return m_CacheItemsMap.size(); }
 
 	private:
 		std::list<T> m_CacheItemsList;

--- a/Common++/header/LRUList.h
+++ b/Common++/header/LRUList.h
@@ -4,6 +4,10 @@
 #include <map>
 #include <list>
 
+#if __cplusplus > 199711L || _MSC_VER >= 1800
+#include <utility>
+#endif
+
 /// @file
 
 /**
@@ -100,8 +104,11 @@ namespace pcpp
 				lruIter--;
 
 				if (deletedValue != NULL)
+#if __cplusplus > 199711L || _MSC_VER >= 1800
+					*deletedValue = std::move(*lruIter);
+#else
 					*deletedValue = *lruIter;
-
+#endif
 				m_CacheItemsMap.erase(*lruIter);
 				m_CacheItemsList.erase(lruIter);
 				return 1;

--- a/Packet++/header/IPReassembly.h
+++ b/Packet++/header/IPReassembly.h
@@ -298,7 +298,8 @@ namespace pcpp
 		 * onFragmentsCleanCallback. This parameter is optional, default cookie is NULL
 		 * @param[in] maxPacketsToStore Set the capacity limit of the IP reassembly mechanism. Default capacity is #PCPP_IP_REASSEMBLY_DEFAULT_MAX_PACKETS_TO_STORE
 		 */
-		IPReassembly(OnFragmentsClean onFragmentsCleanCallback = NULL, void* callbackUserCookie = NULL, size_t maxPacketsToStore = PCPP_IP_REASSEMBLY_DEFAULT_MAX_PACKETS_TO_STORE);
+		IPReassembly(OnFragmentsClean onFragmentsCleanCallback = NULL, void *callbackUserCookie = NULL, size_t maxPacketsToStore = PCPP_IP_REASSEMBLY_DEFAULT_MAX_PACKETS_TO_STORE)
+			: m_PacketLRU(maxPacketsToStore), m_OnFragmentsCleanCallback(onFragmentsCleanCallback), m_CallbackUserCookie(callbackUserCookie) {}
 
 		/**
 		 * A d'tor for this class
@@ -385,7 +386,7 @@ namespace pcpp
 		/**
 		 * Get the maximum capacity as determined in the c'tor
 		 */
-		size_t getMaxCapacity() const { return (int)m_PacketLRU->getMaxSize(); }
+		size_t getMaxCapacity() const { return m_PacketLRU.getMaxSize(); }
 
 		/**
 		 * Get the current number of packets being processed
@@ -416,7 +417,7 @@ namespace pcpp
 			~IPFragmentData() { delete packetKey; if (deleteData && data != NULL) { delete data; } }
 		};
 
-		LRUList<uint32_t>* m_PacketLRU;
+		LRUList<uint32_t> m_PacketLRU;
 		std::map<uint32_t, IPFragmentData*> m_FragmentMap;
 		OnFragmentsClean m_OnFragmentsCleanCallback;
 		void* m_CallbackUserCookie;

--- a/Packet++/src/IPReassembly.cpp
+++ b/Packet++/src/IPReassembly.cpp
@@ -266,17 +266,8 @@ uint32_t IPReassembly::IPv6PacketKey::getHashValue() const
 
 
 
-IPReassembly::IPReassembly(OnFragmentsClean onFragmentsCleanCallback, void* callbackUserCookie, size_t maxPacketsToStore)
-{
-	m_PacketLRU = new LRUList<uint32_t>(maxPacketsToStore);
-	m_OnFragmentsCleanCallback = onFragmentsCleanCallback;
-	m_CallbackUserCookie = callbackUserCookie;
-}
-
 IPReassembly::~IPReassembly()
 {
-	delete m_PacketLRU;
-
 	// empty the map - go over all keys, delete all IPFragmentData objects and remove them from the map
 	while (!m_FragmentMap.empty())
 	{
@@ -342,9 +333,7 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, 
 		fragData = iter->second;
 
 		// mark this packet as used
-		uint32_t* removedElement = m_PacketLRU->put(hash);
-		if (removedElement != NULL)
-			delete removedElement;
+		m_PacketLRU.put(hash, NULL);
 	}
 
 	bool gotLastFragment = false;
@@ -476,7 +465,7 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, 
 		// delete the IPFragmentData object and remove it from the map
 		delete fragData;
 		m_FragmentMap.erase(iter);
-		m_PacketLRU->eraseElement(hash);
+		m_PacketLRU.eraseElement(hash);
 		status = REASSEMBLED;
 		return reassembledPacket;
 	}
@@ -569,19 +558,19 @@ void IPReassembly::removePacket(const PacketKey& key)
 		m_FragmentMap.erase(iter);
 
 		// remove from LRU list
-		m_PacketLRU->eraseElement(hash);
+		m_PacketLRU.eraseElement(hash);
 	}
 }
 
 void IPReassembly::addNewFragment(uint32_t hash, IPFragmentData* fragData)
 {
 	// put the new frag in the LRU list
-	uint32_t* packetRemoved = m_PacketLRU->put(hash);
+	uint32_t packetRemoved;
 
-	if (packetRemoved != NULL) // this means LRU list was full and the least recently used item was removed
+	if (m_PacketLRU.put(hash, &packetRemoved) == 1) // this means LRU list was full and the least recently used item was removed
 	{
 		// remove this item from the fragment map
-		std::map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(*packetRemoved);
+		std::map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(packetRemoved);
 		IPFragmentData* dataRemoved = iter->second;
 		PacketKey* key = dataRemoved->packetKey->clone();
 		LOG_DEBUG("Reached maximum packet capacity, removing data for FragID=0x%X", dataRemoved->fragmentID);
@@ -595,7 +584,6 @@ void IPReassembly::addNewFragment(uint32_t hash, IPFragmentData* fragData)
 		}
 
 		delete key;
-		delete packetRemoved;
 	}
 
 	// add the new fragment to the map

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -5319,6 +5319,7 @@ PTF_TEST_CASE(TestTcpReassemblyIPv6_OOO)
 }
 
 
+
 PTF_TEST_CASE(TestTcpReassemblyCleanup)
 {
 	TcpReassemblyMultipleConnStats results;
@@ -5365,7 +5366,7 @@ PTF_TEST_CASE(TestTcpReassemblyCleanup)
 	tcpReassembly.purgeClosedConnections(0xFFFFFFFF); // manually initiated cleanup of all items
 	PTF_ASSERT_EQUAL(tcpReassembly.getConnectionInformation().size(), 0, size);
 
-	const TcpReassemblyMultipleConnStats::FlowKeysList &flowKeys = results.flowKeysList;
+	const TcpReassemblyMultipleConnStats::FlowKeysList& flowKeys = results.flowKeysList;
 	iterConn1 = managedConnections.find(flowKeys[0]);
 	iterConn2 = managedConnections.find(flowKeys[1]);
 	iterConn3 = managedConnections.find(flowKeys[2]);
@@ -5375,7 +5376,40 @@ PTF_TEST_CASE(TestTcpReassemblyCleanup)
 	PTF_ASSERT_EQUAL(tcpReassembly.isConnectionOpen(iterConn1->second), -1, int);
 	PTF_ASSERT_EQUAL(tcpReassembly.isConnectionOpen(iterConn2->second), -1, int);
 	PTF_ASSERT_EQUAL(tcpReassembly.isConnectionOpen(iterConn3->second), -1, int);
-}
+} // TestTcpReassemblyCleanup
+
+
+
+PTF_TEST_CASE(TestLRUList)
+{
+	LRUList<uint32_t> lruList(2);
+
+	// testing "int put(const T&, T*)"
+	uint32_t deletedValue = 0;
+	PTF_ASSERT_EQUAL(lruList.put(1, &deletedValue), 0, int);
+	PTF_ASSERT_EQUAL(deletedValue, 0, int);
+
+	PTF_ASSERT_EQUAL(lruList.put(2, NULL), 0, int);
+	PTF_ASSERT_EQUAL(deletedValue, 0, int);
+
+	PTF_ASSERT_EQUAL(lruList.put(3, &deletedValue), 1, int);
+	PTF_ASSERT_EQUAL(deletedValue, 1, u32);
+
+	lruList.eraseElement(1);
+	lruList.eraseElement(2);
+	lruList.eraseElement(3);
+	PTF_ASSERT_EQUAL(lruList.getSize(), 0, size);
+
+	// testing "T* put(const T&)"
+	PTF_ASSERT_NULL(lruList.put(1));
+	PTF_ASSERT_NULL(lruList.put(2));
+
+	uint32_t* pDeletedValue = lruList.put(3);
+	PTF_ASSERT_NOT_NULL(pDeletedValue);
+	PTF_ASSERT_EQUAL(*pDeletedValue, 1, u32);
+	delete pDeletedValue;
+} // TestLRUList
+
 
 
 void savePacketToFile(RawPacket& packet, std::string fileName)
@@ -6767,6 +6801,7 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(TestIPFragMapOverflow, "no_network;ip_frag");
 	PTF_RUN_TEST(TestIPFragRemove, "no_network;ip_frag");
 	PTF_RUN_TEST(TestRawSockets, "raw_sockets");
+	PTF_RUN_TEST(TestLRUList, "no_network");
 
 	PTF_END_RUNNING_TESTS;
 }


### PR DESCRIPTION
1. Fix for #281
2. Code of `IPReassembly` was simplified: the type of private member `m_PacketLRU` was changed from `LRUList<uint32_t>*` to `LRUList<uint32_t>`
3. Performance improvements in both classes

I have prepared the new optimized method `put` in `LRUList` so I suggest to mark the old one as deprecated.