### PR TITLE
Improvements in LRUList and IPReassembly

### DIFF
--- a/Common++/header/LRUList.h
+++ b/Common++/header/LRUList.h
@@ -44,49 +44,14 @@ namespace pcpp
 		/**
 		 * Puts an element in the list. This element will be inserted (or advanced if it already exists) to the head of the
 		 * list as the most recently used element. If the list already reached its max size and the element is new this method
-		 * will remove the least recently used element and return a pointer to it. Method complexity is O(log(getSize()))
-		 * @param[in] element The element to insert or to advance to the head of the list (if already exists)
-		 * @return A pointer to the element that was removed from the list in case the list already reached its max size.
-		 * If the list didn't reach its max size NULL will be returned. Notice it's the responsibility of the user to free
-		 * this pointer's memory when done using it
-		 */
-		T* put(const T& element)
-		{
-			m_CacheItemsList.push_front(element);
-
-			// Inserting a new element. If an element with an equivalent key already exists the method returns an iterator to the element that prevented the insertion
-			std::pair<MapIterator, bool> pair = m_CacheItemsMap.insert(std::make_pair(element, m_CacheItemsList.begin()));
-			if(pair.second == false) // already exists
-			{
-				m_CacheItemsList.erase(pair.first->second);
-				pair.first->second = m_CacheItemsList.begin();
-			}
-
-			if (m_CacheItemsMap.size() > m_MaxSize)
-			{
-				ListIterator lruIter = m_CacheItemsList.end();
-				lruIter--;
-				T* deletedValue = new T(*lruIter);
-				m_CacheItemsMap.erase(*lruIter);
-				m_CacheItemsList.erase(lruIter);
-
-				return deletedValue;
-			}
-
-			return NULL;
-		}
-
-		/**
-		 * Puts an element in the list. This element will be inserted (or advanced if it already exists) to the head of the
-		 * list as the most recently used element. If the list already reached its max size and the element is new this method
 		 * will remove the least recently used element and return a value in deletedValue. Method complexity is O(log(getSize())).
 		 * This is a optimized version of the method T* put(const T&).
 		 * @param[in] element The element to insert or to advance to the head of the list (if already exists)
-		 * @param[out] deletedValue The value of deleted element (if a pointer is not NULL)
+		 * @param[out] deletedValue The value of deleted element if a pointer is not NULL. This parameter is optional.
 		 * @return 0 if the list didn't reach its max size, 1 otherwise. In case the list already reached its max size
 		 * and deletedValue is not NULL the value of deleted element is copied into the place the deletedValue points to.
 		 */
-		int put(const T& element, T* deletedValue)
+		int put(const T& element, T* deletedValue = NULL)
 		{
 			m_CacheItemsList.push_front(element);
 

--- a/Common++/header/LRUList.h
+++ b/Common++/header/LRUList.h
@@ -4,6 +4,10 @@
 #include <map>
 #include <list>
 
+#if __cplusplus > 199711L || _MSC_VER >= 1800
+#include <utility>
+#endif
+
 /// @file
 
 /**
@@ -40,7 +44,7 @@ namespace pcpp
 		/**
 		 * Puts an element in the list. This element will be inserted (or advanced if it already exists) to the head of the
 		 * list as the most recently used element. If the list already reached its max size and the element is new this method
-		 * will remove the least recently used element and return a pointer to it. Method complexity is O(1)
+		 * will remove the least recently used element and return a pointer to it. Method complexity is O(log(getSize()))
 		 * @param[in] element The element to insert or to advance to the head of the list (if already exists)
 		 * @return A pointer to the element that was removed from the list in case the list already reached its max size.
 		 * If the list didn't reach its max size NULL will be returned. Notice it's the responsibility of the user to free
@@ -58,7 +62,7 @@ namespace pcpp
 				pair.first->second = m_CacheItemsList.begin();
 			}
 
-			if (m_CacheItemsList.size() > m_MaxSize)
+			if (m_CacheItemsMap.size() > m_MaxSize)
 			{
 				ListIterator lruIter = m_CacheItemsList.end();
 				lruIter--;
@@ -73,10 +77,51 @@ namespace pcpp
 		}
 
 		/**
+		 * Puts an element in the list. This element will be inserted (or advanced if it already exists) to the head of the
+		 * list as the most recently used element. If the list already reached its max size and the element is new this method
+		 * will remove the least recently used element and return a value in deletedValue. Method complexity is O(log(getSize())).
+		 * This is a optimized version of the method T* put(const T&).
+		 * @param[in] element The element to insert or to advance to the head of the list (if already exists)
+		 * @param[out] deletedValue The value of deleted element (if a pointer is not NULL)
+		 * @return 0 if the list didn't reach its max size, 1 otherwise. In case the list already reached its max size
+		 * and deletedValue is not NULL the value of deleted element is copied into the place the deletedValue points to.
+		 */
+		int put(const T& element, T* deletedValue)
+		{
+			m_CacheItemsList.push_front(element);
+
+			// Inserting a new element. If an element with an equivalent key already exists the method returns an iterator to the element that prevented the insertion
+			std::pair<MapIterator, bool> pair = m_CacheItemsMap.insert(std::make_pair(element, m_CacheItemsList.begin()));
+			if (pair.second == false) // already exists
+			{
+				m_CacheItemsList.erase(pair.first->second);
+				pair.first->second = m_CacheItemsList.begin();
+			}
+
+			if (m_CacheItemsMap.size() > m_MaxSize)
+			{
+				ListIterator lruIter = m_CacheItemsList.end();
+				lruIter--;
+
+				if (deletedValue != NULL)
+#if __cplusplus > 199711L || _MSC_VER >= 1800
+					*deletedValue = std::move(*lruIter);
+#else
+					*deletedValue = *lruIter;
+#endif
+				m_CacheItemsMap.erase(*lruIter);
+				m_CacheItemsList.erase(lruIter);
+				return 1;
+			}
+
+			return 0;
+		}
+
+		/**
 		 * Get the most recently used element (the one at the beginning of the list)
 		 * @return The most recently used element
 		 */
-		const T& getMRUElement()
+		const T& getMRUElement() const
 		{
 			return m_CacheItemsList.front();
 		}
@@ -85,7 +130,7 @@ namespace pcpp
 		 * Get the least recently used element (the one at the end of the list)
 		 * @return The least recently used element
 		 */
-		const T& getLRUElement()
+		const T& getLRUElement() const
 		{
 			return m_CacheItemsList.back();
 		}
@@ -107,12 +152,12 @@ namespace pcpp
 		/**
 		 * @return The max size of this list as determined in the c'tor
 		 */
-		inline size_t getMaxSize() { return m_MaxSize; }
+		size_t getMaxSize() const { return m_MaxSize; }
 
 		/**
 		 * @return The number of elements currently in this list
 		 */
-		inline size_t getSize() { return m_CacheItemsMap.size(); }
+		size_t getSize() const { return m_CacheItemsMap.size(); }
 
 	private:
 		std::list<T> m_CacheItemsList;

--- a/Examples/PcapSplitter/Splitters.h
+++ b/Examples/PcapSplitter/Splitters.h
@@ -83,14 +83,11 @@ protected:
 	 * This method puts the file in the LRU list, and if the list is full it pulls out the least recently used file
 	 * and returns it in filesToClose vector. The application will take care of closing that file
 	 */
-	inline void writingToFile(int fileNum, std::vector<int>& filesToClose)
+	void writingToFile(int fileNum, std::vector<int>& filesToClose)
 	{
-		int* fileToClose = m_LRUFileList.put(fileNum);
-		if (fileToClose != NULL)
-		{
-			filesToClose.push_back(*fileToClose);
-			delete fileToClose;
-		}
+		int fileToClose;
+		if (m_LRUFileList.put(fileNum, &fileToClose) == 1)
+			filesToClose.push_back(fileToClose);
 	}
 
 	/**
@@ -100,7 +97,7 @@ protected:
 	 * In addition the method puts the next file in the LRU list and if the list is full it pulls out the least recently
 	 * used file and returns it in filesToClose vector. The application will take care of closing that file
 	 */
-	inline int getNextFileNumber(std::vector<int>& filesToClose)
+	int getNextFileNumber(std::vector<int>& filesToClose)
 	{
 		int nextFile = 0;
 
@@ -115,12 +112,11 @@ protected:
 
 
 		// put the next file in the LRU list
-		int* fileToClose = m_LRUFileList.put(nextFile);
-		if (fileToClose != NULL)
+		int fileToClose;
+		if (m_LRUFileList.put(nextFile, &fileToClose) == 1)
 		{
 			// if a file is pulled out of the LRU list - return it
-			filesToClose.push_back(*fileToClose);
-			delete fileToClose;
+			filesToClose.push_back(fileToClose);
 		}
 		return nextFile;
 	}

--- a/Examples/PcapSplitter/main.cpp
+++ b/Examples/PcapSplitter/main.cpp
@@ -72,7 +72,7 @@ static struct option PcapSplitterOptions[] =
 	{"filter", required_argument, 0, 'i'},
 	{"help", no_argument, 0, 'h'},
 	{"version", no_argument, 0, 'v'},
-    {0, 0, 0, 0}
+	{0, 0, 0, 0}
 };
 
 
@@ -334,6 +334,7 @@ int main(int argc, char* argv[])
 	std::string errorStr;
 	if (!splitter->isSplitterParamLegal(errorStr))
 	{
+		delete splitter;
 		EXIT_WITH_ERROR("%s", errorStr.c_str());
 	}
 
@@ -456,12 +457,16 @@ int main(int argc, char* argv[])
 
 	// free reader memory
 	delete reader;
+	delete splitter;
 
 	// close the writer files which are still open
 	for(std::map<int, IFileWriterDevice*>::iterator it = outputFiles.begin(); it != outputFiles.end(); ++it)
 	{
 		if (it->second != NULL)
+		{
 			it->second->close();
+			delete it->second;
+		}
 	}
 
 	return 0;

--- a/Packet++/header/IPReassembly.h
+++ b/Packet++/header/IPReassembly.h
@@ -298,7 +298,8 @@ namespace pcpp
 		 * onFragmentsCleanCallback. This parameter is optional, default cookie is NULL
 		 * @param[in] maxPacketsToStore Set the capacity limit of the IP reassembly mechanism. Default capacity is #PCPP_IP_REASSEMBLY_DEFAULT_MAX_PACKETS_TO_STORE
 		 */
-		IPReassembly(OnFragmentsClean onFragmentsCleanCallback = NULL, void* callbackUserCookie = NULL, size_t maxPacketsToStore = PCPP_IP_REASSEMBLY_DEFAULT_MAX_PACKETS_TO_STORE);
+		IPReassembly(OnFragmentsClean onFragmentsCleanCallback = NULL, void *callbackUserCookie = NULL, size_t maxPacketsToStore = PCPP_IP_REASSEMBLY_DEFAULT_MAX_PACKETS_TO_STORE)
+			: m_PacketLRU(maxPacketsToStore), m_OnFragmentsCleanCallback(onFragmentsCleanCallback), m_CallbackUserCookie(callbackUserCookie) {}
 
 		/**
 		 * A d'tor for this class
@@ -385,7 +386,7 @@ namespace pcpp
 		/**
 		 * Get the maximum capacity as determined in the c'tor
 		 */
-		size_t getMaxCapacity() const { return (int)m_PacketLRU->getMaxSize(); }
+		size_t getMaxCapacity() const { return m_PacketLRU.getMaxSize(); }
 
 		/**
 		 * Get the current number of packets being processed
@@ -416,7 +417,7 @@ namespace pcpp
 			~IPFragmentData() { delete packetKey; if (deleteData && data != NULL) { delete data; } }
 		};
 
-		LRUList<uint32_t>* m_PacketLRU;
+		LRUList<uint32_t> m_PacketLRU;
 		std::map<uint32_t, IPFragmentData*> m_FragmentMap;
 		OnFragmentsClean m_OnFragmentsCleanCallback;
 		void* m_CallbackUserCookie;

--- a/Packet++/src/IPReassembly.cpp
+++ b/Packet++/src/IPReassembly.cpp
@@ -572,7 +572,11 @@ void IPReassembly::addNewFragment(uint32_t hash, IPFragmentData* fragData)
 		// remove this item from the fragment map
 		std::map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(packetRemoved);
 		IPFragmentData* dataRemoved = iter->second;
-		PacketKey* key = dataRemoved->packetKey->clone();
+
+		PacketKey* key = NULL;
+		if (m_OnFragmentsCleanCallback != NULL)
+			key = dataRemoved->packetKey->clone();
+
 		LOG_DEBUG("Reached maximum packet capacity, removing data for FragID=0x%X", dataRemoved->fragmentID);
 		delete dataRemoved;
 		m_FragmentMap.erase(iter);
@@ -581,9 +585,8 @@ void IPReassembly::addNewFragment(uint32_t hash, IPFragmentData* fragData)
 		if (m_OnFragmentsCleanCallback != NULL)
 		{
 			m_OnFragmentsCleanCallback(key, m_CallbackUserCookie);
+			delete key;
 		}
-
-		delete key;
 	}
 
 	// add the new fragment to the map

--- a/Packet++/src/IPReassembly.cpp
+++ b/Packet++/src/IPReassembly.cpp
@@ -266,17 +266,8 @@ uint32_t IPReassembly::IPv6PacketKey::getHashValue() const
 
 
 
-IPReassembly::IPReassembly(OnFragmentsClean onFragmentsCleanCallback, void* callbackUserCookie, size_t maxPacketsToStore)
-{
-	m_PacketLRU = new LRUList<uint32_t>(maxPacketsToStore);
-	m_OnFragmentsCleanCallback = onFragmentsCleanCallback;
-	m_CallbackUserCookie = callbackUserCookie;
-}
-
 IPReassembly::~IPReassembly()
 {
-	delete m_PacketLRU;
-
 	// empty the map - go over all keys, delete all IPFragmentData objects and remove them from the map
 	while (!m_FragmentMap.empty())
 	{
@@ -342,9 +333,7 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, 
 		fragData = iter->second;
 
 		// mark this packet as used
-		uint32_t* removedElement = m_PacketLRU->put(hash);
-		if (removedElement != NULL)
-			delete removedElement;
+		m_PacketLRU.put(hash, NULL);
 	}
 
 	bool gotLastFragment = false;
@@ -476,7 +465,7 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, 
 		// delete the IPFragmentData object and remove it from the map
 		delete fragData;
 		m_FragmentMap.erase(iter);
-		m_PacketLRU->eraseElement(hash);
+		m_PacketLRU.eraseElement(hash);
 		status = REASSEMBLED;
 		return reassembledPacket;
 	}
@@ -569,19 +558,19 @@ void IPReassembly::removePacket(const PacketKey& key)
 		m_FragmentMap.erase(iter);
 
 		// remove from LRU list
-		m_PacketLRU->eraseElement(hash);
+		m_PacketLRU.eraseElement(hash);
 	}
 }
 
 void IPReassembly::addNewFragment(uint32_t hash, IPFragmentData* fragData)
 {
 	// put the new frag in the LRU list
-	uint32_t* packetRemoved = m_PacketLRU->put(hash);
+	uint32_t packetRemoved;
 
-	if (packetRemoved != NULL) // this means LRU list was full and the least recently used item was removed
+	if (m_PacketLRU.put(hash, &packetRemoved) == 1) // this means LRU list was full and the least recently used item was removed
 	{
 		// remove this item from the fragment map
-		std::map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(*packetRemoved);
+		std::map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(packetRemoved);
 		IPFragmentData* dataRemoved = iter->second;
 		PacketKey* key = dataRemoved->packetKey->clone();
 		LOG_DEBUG("Reached maximum packet capacity, removing data for FragID=0x%X", dataRemoved->fragmentID);
@@ -595,7 +584,6 @@ void IPReassembly::addNewFragment(uint32_t hash, IPFragmentData* fragData)
 		}
 
 		delete key;
-		delete packetRemoved;
 	}
 
 	// add the new fragment to the map

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -5384,7 +5384,6 @@ PTF_TEST_CASE(TestLRUList)
 {
 	LRUList<uint32_t> lruList(2);
 
-	// testing "int put(const T&, T*)"
 	uint32_t deletedValue = 0;
 	PTF_ASSERT_EQUAL(lruList.put(1, &deletedValue), 0, int);
 	PTF_ASSERT_EQUAL(deletedValue, 0, int);
@@ -5398,15 +5397,6 @@ PTF_TEST_CASE(TestLRUList)
 	lruList.eraseElement(2);
 	lruList.eraseElement(3);
 	PTF_ASSERT_EQUAL(lruList.getSize(), 0, size);
-
-	// testing "T* put(const T&)"
-	PTF_ASSERT_NULL(lruList.put(1));
-	PTF_ASSERT_NULL(lruList.put(2));
-
-	uint32_t* pDeletedValue = lruList.put(3);
-	PTF_ASSERT_NOT_NULL(pDeletedValue);
-	PTF_ASSERT_EQUAL(*pDeletedValue, 1, u32);
-	delete pDeletedValue;
 } // TestLRUList
 
 

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -5390,7 +5390,6 @@ PTF_TEST_CASE(TestLRUList)
 	PTF_ASSERT_EQUAL(deletedValue, 0, int);
 
 	PTF_ASSERT_EQUAL(lruList.put(2, NULL), 0, int);
-	PTF_ASSERT_EQUAL(deletedValue, 0, int);
 
 	PTF_ASSERT_EQUAL(lruList.put(3, &deletedValue), 1, int);
 	PTF_ASSERT_EQUAL(deletedValue, 1, u32);
@@ -5517,6 +5516,7 @@ PTF_TEST_CASE(TestIPFragmentationSanity)
 		}
 	}
 
+	PTF_ASSERT_NOT_NULL(result);
 	// small fix for payload length which is wrong in the original packet
 	result->getLayerOfType<IPv6Layer>()->getIPv6Header()->payloadLength = htons(737);
 
@@ -5613,6 +5613,7 @@ PTF_TEST_CASE(TestIPFragOutOfOrder)
 	PTF_ASSERT(memcmp(result->getRawPacket()->getRawData(), buffer, bufferLength) == 0, "Reassembled packet data is different than expected");
 
 	delete result;
+	result = NULL;
 
 	packetStream.clear();
 
@@ -5653,10 +5654,12 @@ PTF_TEST_CASE(TestIPFragOutOfOrder)
 		}
 	}
 
+	PTF_ASSERT_NOT_NULL(result);
 	PTF_ASSERT(bufferLength == result->getRawPacket()->getRawDataLen(), "Reassembled packet len (%d) is different than read packet len (%d)", result->getRawPacket()->getRawDataLen(), bufferLength);
 	PTF_ASSERT(memcmp(result->getRawPacket()->getRawData(), buffer, bufferLength) == 0, "Reassembled packet data is different than expected");
 
 	delete result;
+	result = NULL;
 
 	packetStream.clear();
 
@@ -5694,6 +5697,7 @@ PTF_TEST_CASE(TestIPFragOutOfOrder)
 		}
 	}
 
+	PTF_ASSERT_NOT_NULL(result);
 	PTF_ASSERT(bufferLength == result->getRawPacket()->getRawDataLen(), "Reassembled packet len (%d) is different than read packet len (%d)", result->getRawPacket()->getRawDataLen(), bufferLength);
 	PTF_ASSERT(memcmp(result->getRawPacket()->getRawData(), buffer, bufferLength) == 0, "Reassembled packet data is different than expected");
 
@@ -5743,6 +5747,7 @@ PTF_TEST_CASE(TestIPFragOutOfOrder)
 	PTF_ASSERT(memcmp(result->getRawPacket()->getRawData(), buffer, bufferLength) == 0, "Reassembled packet data is different than expected");
 
 	delete result;
+	result = NULL;
 
 	packetStream.clear();
 


### PR DESCRIPTION
1. Fix for #281
2. Code of `IPReassembly` was simplified: the type of private member `m_PacketLRU` was changed from `LRUList<uint32_t>*` to `LRUList<uint32_t>`
3. Performance improvements in both classes

The current implementation of `LRUList::put` creates a new dynamically allocated object by copying the existed one. The main goal of the new method is to avoid memory allocation. Another benefit is that the copying can be avoided if the user passes `NULL` as the last argument. The new method is based on the old one.

I suggest to mark the old method `put` as deprecated or to remove at all (this changes the interface of LRUList). If old method will be removed we can change the signature of new method from `int put(const T& element, T* deletedValue` to `int put(const T& element, T* deletedValue = NULL)`