### PR TITLE
Customizing the port numbers

### DIFF
--- a/Common++/header/PortList.h
+++ b/Common++/header/PortList.h
@@ -26,7 +26,7 @@ namespace pcpp
 		/**
 		 * The default constructor that creates an empty list
 		 */
-		PortList() : m_Ports() {}
+		PortList() : m_Ports(65536, false) {}
 
 		/**
 		 * A constructor that creates an object by the port number
@@ -360,7 +360,7 @@ namespace pcpp
 		}
 
 	protected:
-		bool m_Ports[65536];
+		std::vector<bool> m_Ports;
 	}; // class PortList
 
 
@@ -369,20 +369,20 @@ namespace pcpp
 	// implementation of inline methods
 
 	PortList::PortList(uint16_t p1)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] = true;
 	}
 
 	PortList::PortList(uint16_t p1, uint16_t p2)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] = true;
 	}
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -390,7 +390,7 @@ namespace pcpp
 	}
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -399,7 +399,7 @@ namespace pcpp
 	}
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -409,7 +409,7 @@ namespace pcpp
 	}
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -420,7 +420,7 @@ namespace pcpp
 	}
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -432,7 +432,7 @@ namespace pcpp
 	}
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -445,7 +445,7 @@ namespace pcpp
 	}
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -459,7 +459,7 @@ namespace pcpp
 	}
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -474,7 +474,7 @@ namespace pcpp
 	}
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -491,7 +491,7 @@ namespace pcpp
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
 		uint16_t p12)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -509,7 +509,7 @@ namespace pcpp
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
 		uint16_t p12,	uint16_t p13)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -528,7 +528,7 @@ namespace pcpp
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
 		uint16_t p12,	uint16_t p13, uint16_t p14)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -548,7 +548,7 @@ namespace pcpp
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
 		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -569,7 +569,7 @@ namespace pcpp
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
 		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -591,7 +591,7 @@ namespace pcpp
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
 		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -614,7 +614,7 @@ namespace pcpp
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
 		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -638,7 +638,7 @@ namespace pcpp
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
 		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18, uint16_t p19)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =
@@ -663,7 +663,7 @@ namespace pcpp
 
 	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
 		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18, uint16_t p19, uint16_t p20)
-		: m_Ports()
+		: m_Ports(65536, false)
 	{
 		m_Ports[p1] =
 			m_Ports[p2] =

--- a/Common++/header/PortList.h
+++ b/Common++/header/PortList.h
@@ -2,9 +2,7 @@
 #define PCAPPP_PORT_LIST
 
 #include <stdint.h>
-#include <algorithm>
-
-#define MAX_NUM_OF_PORTS 32
+#include <vector>
 
 /// @file
 
@@ -17,47 +15,677 @@ namespace pcpp
 
 	/**
 	 * @class PortList
-	 * TODO:
+	 * The class that manages the port list. The port list can be changed in runtime.
+	 * Its main purpose is to be used in a class that depends on port numbers and that allows to customize the ports in runtime.
+	 * All the main methods have a constant complexity. The only disadvantage is that it has 64 Kilobytes in size, so it's better to use it as static class member.
+	 * The performance of lookup is almost the same as a function with the hard-coded port numbers (with using of an operator <switch>).
 	 */
 	class PortList
 	{
 	public:
-		PortList() : m_PortsCount(0), m_Ports() {}
+		/**
+		 * The default constructor that creates an empty list
+		 */
+		PortList() : m_Ports() {}
 
-		PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5,
-			uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10)
-			: m_PortsCount(10), m_Ports { p1, p2, p3, p4, p5, p6, p7, p8, p9, p10 }
-		{
-		}
+		/**
+		 * A constructor that creates an object by the port number
+		 * @param[in] p1 A port number
+		 */
+		inline PortList(uint16_t p1);
 
-		bool insert(uint16_t port)
-		{
-			if(port < MAX_NUM_OF_PORTS && m_PortsCount < MAX_NUM_OF_PORTS)
-			{
-				const uint16_t* start = m_Ports, *end = m_Ports + m_PortsCount;
-				if(std::find(start, end, port) == end)
-					m_Ports[m_PortsCount++] = port;
-				return true;
-			}
-			return false;
-		}
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2);
 
-		bool contains(uint16_t port) const
-		{
-			const uint16_t* start = m_Ports, *end = m_Ports + m_PortsCount;
-			return std::find(start, end, port) != end;
-		}
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3);
 
-		bool remove(uint16_t port)
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p8 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12,	uint16_t p13);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 * @param[in] p15 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14, uint16_t p15);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 * @param[in] p15 A port number
+		 * @param[in] p16 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 * @param[in] p15 A port number
+		 * @param[in] p16 A port number
+		 * @param[in] p17 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 * @param[in] p15 A port number
+		 * @param[in] p16 A port number
+		 * @param[in] p17 A port number
+		 * @param[in] p18 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 * @param[in] p15 A port number
+		 * @param[in] p16 A port number
+		 * @param[in] p17 A port number
+		 * @param[in] p19 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18, uint16_t p19);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 * @param[in] p15 A port number
+		 * @param[in] p16 A port number
+		 * @param[in] p17 A port number
+		 * @param[in] p19 A port number
+		 * @param[in] p20 A port number
+		 */
+		inline PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18, uint16_t p19, uint16_t p20);
+
+		/**
+		 * This method inserts a port number to the list with constant complexity
+		 * @param[in] port The port number to be inserted
+		 */
+		void insert(uint16_t port) { m_Ports[port] = true; }
+
+		/**
+		 * This method removes a port number from the list with constant complexity
+		 * @param[in] port The port number to be removed
+		 */
+		void remove(uint16_t port) { m_Ports[port] = false; }
+
+		/**
+		 * Checks wether the certain port stored in the list with constant complexity
+		 * @param[in] port The port number to be checked
+		 * @return True if the port number is contained in the list, False otherwise
+		 */
+		bool contains(uint16_t port) const { return m_Ports[port]; }
+
+		/**
+		 * @return The vector filled by the port numbers which are stored in the list
+		 */
+		std::vector<uint16_t> getPorts() const
 		{
-			// TODO:
-			return true;
+			const uint32_t portsLen = sizeof(m_Ports) / sizeof(m_Ports[0]);
+			std::vector<uint16_t> result;
+			result.reserve(20);
+
+			for (uint32_t i = 0; i < portsLen; ++i)
+				if (m_Ports[i] == true)
+					result.push_back(static_cast<uint16_t>(i));
+
+			return result;
 		}
 
 	protected:
-		uint16_t m_PortsCount;
-		uint16_t m_Ports[MAX_NUM_OF_PORTS];
-	};
+		bool m_Ports[65536];
+	}; // class PortList
+
+
+
+	
+	// implementation of inline methods
+
+	PortList::PortList(uint16_t p1)
+		: m_Ports()
+	{
+		m_Ports[p1] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] =
+			m_Ports[p8] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] =
+			m_Ports[p8] =
+			m_Ports[p9] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] =
+			m_Ports[p8] =
+			m_Ports[p9] =
+			m_Ports[p10] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] =
+			m_Ports[p8] =
+			m_Ports[p9] =
+			m_Ports[p10] =
+			m_Ports[p11] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] =
+			m_Ports[p8] =
+			m_Ports[p9] =
+			m_Ports[p10] =
+			m_Ports[p11] =
+			m_Ports[p12] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] =
+			m_Ports[p8] =
+			m_Ports[p9] =
+			m_Ports[p10] =
+			m_Ports[p11] =
+			m_Ports[p12] =
+			m_Ports[p13] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] =
+			m_Ports[p8] =
+			m_Ports[p9] =
+			m_Ports[p10] =
+			m_Ports[p11] =
+			m_Ports[p12] =
+			m_Ports[p13] =
+			m_Ports[p14] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] =
+			m_Ports[p8] =
+			m_Ports[p9] =
+			m_Ports[p10] =
+			m_Ports[p11] =
+			m_Ports[p12] =
+			m_Ports[p13] =
+			m_Ports[p14] =
+			m_Ports[p15] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] =
+			m_Ports[p8] =
+			m_Ports[p9] =
+			m_Ports[p10] =
+			m_Ports[p11] =
+			m_Ports[p12] =
+			m_Ports[p13] =
+			m_Ports[p14] =
+			m_Ports[p15] =
+			m_Ports[p16] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] =
+			m_Ports[p8] =
+			m_Ports[p9] =
+			m_Ports[p10] =
+			m_Ports[p11] =
+			m_Ports[p12] =
+			m_Ports[p13] = 
+			m_Ports[p14] =
+			m_Ports[p15] =
+			m_Ports[p16] =
+			m_Ports[p17] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] =
+			m_Ports[p8] =
+			m_Ports[p9] =
+			m_Ports[p10] =
+			m_Ports[p11] =
+			m_Ports[p12] =
+			m_Ports[p13] =
+			m_Ports[p14] =
+			m_Ports[p15] =
+			m_Ports[p16] =
+			m_Ports[p17] =
+			m_Ports[p18] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18, uint16_t p19)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] =
+			m_Ports[p8] =
+			m_Ports[p9] =
+			m_Ports[p10] =
+			m_Ports[p11] =
+			m_Ports[p12] =
+			m_Ports[p13] =
+			m_Ports[p14] =
+			m_Ports[p15] =
+			m_Ports[p16] =
+			m_Ports[p17] =
+			m_Ports[p18] =
+			m_Ports[p19] = true;
+	}
+
+	PortList::PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18, uint16_t p19, uint16_t p20)
+		: m_Ports()
+	{
+		m_Ports[p1] =
+			m_Ports[p2] =
+			m_Ports[p3] =
+			m_Ports[p4] =
+			m_Ports[p5] =
+			m_Ports[p6] =
+			m_Ports[p7] =
+			m_Ports[p8] =
+			m_Ports[p9] =
+			m_Ports[p10] =
+			m_Ports[p11] =
+			m_Ports[p12] =
+			m_Ports[p13] =
+			m_Ports[p14] =
+			m_Ports[p15] =
+			m_Ports[p16] =
+			m_Ports[p17] =
+			m_Ports[p18] =
+			m_Ports[p19] =
+			m_Ports[p20] = true;
+	}
 
 
 } // namespace pcpp

--- a/Common++/header/PortList.h
+++ b/Common++/header/PortList.h
@@ -1,0 +1,65 @@
+#ifndef PCAPPP_PORT_LIST
+#define PCAPPP_PORT_LIST
+
+#include <stdint.h>
+#include <algorithm>
+
+#define MAX_NUM_OF_PORTS 32
+
+/// @file
+
+/**
+ * \namespace pcpp
+ * \brief The main namespace for the PcapPlusPlus lib
+ */
+namespace pcpp
+{
+
+	/**
+	 * @class PortList
+	 * TODO:
+	 */
+	class PortList
+	{
+	public:
+		PortList() : m_PortsCount(0), m_Ports() {}
+
+		PortList(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5,
+			uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10)
+			: m_PortsCount(10), m_Ports { p1, p2, p3, p4, p5, p6, p7, p8, p9, p10 }
+		{
+		}
+
+		bool insert(uint16_t port)
+		{
+			if(port < MAX_NUM_OF_PORTS && m_PortsCount < MAX_NUM_OF_PORTS)
+			{
+				const uint16_t* start = m_Ports, *end = m_Ports + m_PortsCount;
+				if(std::find(start, end, port) == end)
+					m_Ports[m_PortsCount++] = port;
+				return true;
+			}
+			return false;
+		}
+
+		bool contains(uint16_t port) const
+		{
+			const uint16_t* start = m_Ports, *end = m_Ports + m_PortsCount;
+			return std::find(start, end, port) != end;
+		}
+
+		bool remove(uint16_t port)
+		{
+			// TODO:
+			return true;
+		}
+
+	protected:
+		uint16_t m_PortsCount;
+		uint16_t m_Ports[MAX_NUM_OF_PORTS];
+	};
+
+
+} // namespace pcpp
+
+#endif /* PCAPPP_PORT_LIST */

--- a/Common++/header/PortList2.h
+++ b/Common++/header/PortList2.h
@@ -1,0 +1,723 @@
+#ifndef PCAPPP_PORT_LIST2
+#define PCAPPP_PORT_LIST2
+
+#include <stdint.h>
+#include <vector>
+#include <algorithm>
+
+/// @file
+
+/**
+ * \namespace pcpp
+ * \brief The main namespace for the PcapPlusPlus lib
+ */
+namespace pcpp
+{
+
+	/**
+	 * @class PortList2
+	 * The class that manages the port list. This list can be changed in runtime.
+	 * Its main purpose is to be used in a class that depends on port numbers and that allows to customize the port numbers in runtime.
+	 */
+	class PortList2
+	{
+	public:
+
+		enum
+		{
+			/**
+			 * The maximum number of ports supported by this class
+			 */
+			PortMaxSize = 20
+		};
+
+		/**
+		 * The default constructor that creates an empty list
+		 */
+		PortList2() : m_PortSize(0), m_Ports() {}
+
+		/**
+		 * A constructor that creates an object by the port number
+		 * @param[in] p1 A port number
+		 */
+		inline PortList2(uint16_t p1);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p8 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12,	uint16_t p13);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 * @param[in] p15 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14, uint16_t p15);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 * @param[in] p15 A port number
+		 * @param[in] p16 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 * @param[in] p15 A port number
+		 * @param[in] p16 A port number
+		 * @param[in] p17 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 * @param[in] p15 A port number
+		 * @param[in] p16 A port number
+		 * @param[in] p17 A port number
+		 * @param[in] p18 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 * @param[in] p15 A port number
+		 * @param[in] p16 A port number
+		 * @param[in] p17 A port number
+		 * @param[in] p19 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18, uint16_t p19);
+
+		/**
+		 * A constructor that creates an object by the port list
+		 * @param[in] p1 A port number
+		 * @param[in] p2 A port number
+		 * @param[in] p3 A port number
+		 * @param[in] p4 A port number
+		 * @param[in] p5 A port number
+		 * @param[in] p6 A port number
+		 * @param[in] p7 A port number
+		 * @param[in] p9 A port number
+		 * @param[in] p10 A port number
+		 * @param[in] p11 A port number
+		 * @param[in] p12 A port number
+		 * @param[in] p13 A port number
+		 * @param[in] p14 A port number
+		 * @param[in] p15 A port number
+		 * @param[in] p16 A port number
+		 * @param[in] p17 A port number
+		 * @param[in] p19 A port number
+		 * @param[in] p20 A port number
+		 */
+		inline PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11, uint16_t p12, uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18, uint16_t p19, uint16_t p20);
+
+
+		/**
+		 * @return The number of ports currently stored in object. It cannot exceed the PortMaxSize.
+		 */
+		size_t size() const { return m_PortSize; }
+
+		/**
+		 * Checks wheter the list is empty
+		 * @return True if the list does not contain any port, False otherwise
+		 */
+		bool empty() const { return m_PortSize == 0; }
+
+		/**
+		 * Checks wheter the list is full
+		 * @return True if the list full, False otherwise
+		 */
+		bool full() const { return size() == PortMaxSize; }
+
+		/**
+		 * This method inserts a port number to the list with complexity O(size())
+		 * @param[in] port The port number to be inserted
+		 * @return True if port is succefully inserted into the list, False otherwise
+		 */
+		bool insert(uint16_t port)
+		{
+			if(!full())
+			{
+				if(!contains(port))
+					m_Ports[m_PortSize++] = port;
+
+				return true;
+			}
+			return false;
+		}
+
+		/**
+		 * This method removes a port number from the list with constant complexity
+		 * @param[in] port The port number to be removed
+		 */
+		void remove(uint16_t port)
+		{
+			// TODO: implement
+		}
+
+		/**
+		 * Checks wether the certain port stored in the list with complexity O(size())
+		 * @param[in] port The port number to be checked
+		 * @return True if the port number is contained in the list, False otherwise
+		 */
+		bool contains(uint16_t port) const { return std::find(m_Ports, m_Ports + m_PortSize, port);	}
+
+		/**
+		 * @return The unsorted vector filled by the port numbers which are stored in the list
+		 */
+		std::vector<uint16_t> getPorts() const { return std::vector<uint16_t>(m_Ports, m_Ports + m_PortSize); }
+
+	protected:
+		uint16_t m_PortSize;
+		uint16_t m_Ports[PortMaxSize];
+	}; // class PortList2
+
+
+
+	
+	// implementation of inline methods
+
+	PortList2::PortList2(uint16_t p1)
+		: m_PortSize(1), m_Ports()
+	{
+		m_Ports[0] = p1;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2)
+		: m_PortSize(2), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3)
+		: m_PortSize(3), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4)
+		: m_PortSize(4), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5)
+		: m_PortSize(5), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6)
+		: m_PortSize(6), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7)
+		: m_PortSize(7), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8)
+		: m_PortSize(8), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+		m_Ports[7] = p8;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9)
+		: m_PortSize(9), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+		m_Ports[7] = p8;
+		m_Ports[8] = p9;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10)
+		: m_PortSize(10), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+		m_Ports[7] = p8;
+		m_Ports[8] = p9;
+		m_Ports[9] = p10;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11)
+		: m_PortSize(11), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+		m_Ports[7] = p8;
+		m_Ports[8] = p9;
+		m_Ports[9] = p10;
+		m_Ports[10] = p11;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12)
+		: m_PortSize(12), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+		m_Ports[7] = p8;
+		m_Ports[8] = p9;
+		m_Ports[9] = p10;
+		m_Ports[10] = p11;
+		m_Ports[11] = p12;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13)
+		: m_PortSize(13), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+		m_Ports[7] = p8;
+		m_Ports[8] = p9;
+		m_Ports[9] = p10;
+		m_Ports[10] = p11;
+		m_Ports[11] = p12;
+		m_Ports[12] = p13;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14)
+		: m_PortSize(14), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+		m_Ports[7] = p8;
+		m_Ports[8] = p9;
+		m_Ports[9] = p10;
+		m_Ports[10] = p11;
+		m_Ports[11] = p12;
+		m_Ports[12] = p13;
+		m_Ports[13] = p14;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15)
+		: m_PortSize(15), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+		m_Ports[7] = p8;
+		m_Ports[8] = p9;
+		m_Ports[9] = p10;
+		m_Ports[10] = p11;
+		m_Ports[11] = p12;
+		m_Ports[12] = p13;
+		m_Ports[13] = p14;
+		m_Ports[14] = p15;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16)
+		: m_PortSize(16), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+		m_Ports[7] = p8;
+		m_Ports[8] = p9;
+		m_Ports[9] = p10;
+		m_Ports[10] = p11;
+		m_Ports[11] = p12;
+		m_Ports[12] = p13;
+		m_Ports[13] = p14;
+		m_Ports[14] = p15;
+		m_Ports[15] = p16;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17)
+		: m_PortSize(17), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+		m_Ports[7] = p8;
+		m_Ports[8] = p9;
+		m_Ports[9] = p10;
+		m_Ports[10] = p11;
+		m_Ports[11] = p12;
+		m_Ports[12] = p13;
+		m_Ports[13] = p14;
+		m_Ports[14] = p15;
+		m_Ports[15] = p16;
+		m_Ports[16] = p17;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18)
+		: m_PortSize(18), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+		m_Ports[7] = p8;
+		m_Ports[8] = p9;
+		m_Ports[9] = p10;
+		m_Ports[10] = p11;
+		m_Ports[11] = p12;
+		m_Ports[12] = p13;
+		m_Ports[13] = p14;
+		m_Ports[14] = p15;
+		m_Ports[15] = p16;
+		m_Ports[16] = p17;
+		m_Ports[17] = p18;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18, uint16_t p19)
+		: m_PortSize(19), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+		m_Ports[7] = p8;
+		m_Ports[8] = p9;
+		m_Ports[9] = p10;
+		m_Ports[10] = p11;
+		m_Ports[11] = p12;
+		m_Ports[12] = p13;
+		m_Ports[13] = p14;
+		m_Ports[14] = p15;
+		m_Ports[15] = p16;
+		m_Ports[16] = p17;
+		m_Ports[17] = p18;
+		m_Ports[18] = p19;
+	}
+
+	PortList2::PortList2(uint16_t p1, uint16_t p2, uint16_t p3, uint16_t p4, uint16_t p5, uint16_t p6, uint16_t p7, uint16_t p8, uint16_t p9, uint16_t p10, uint16_t p11,
+		uint16_t p12,	uint16_t p13, uint16_t p14, uint16_t p15, uint16_t p16, uint16_t p17, uint16_t p18, uint16_t p19, uint16_t p20)
+		: m_PortSize(20), m_Ports()
+	{
+		m_Ports[0] = p1;
+		m_Ports[1] = p2;
+		m_Ports[2] = p3;
+		m_Ports[3] = p4;
+		m_Ports[4] = p5;
+		m_Ports[5] = p6;
+		m_Ports[6] = p7;
+		m_Ports[7] = p8;
+		m_Ports[8] = p9;
+		m_Ports[9] = p10;
+		m_Ports[10] = p11;
+		m_Ports[11] = p12;
+		m_Ports[12] = p13;
+		m_Ports[13] = p14;
+		m_Ports[14] = p15;
+		m_Ports[15] = p16;
+		m_Ports[16] = p17;
+		m_Ports[17] = p18;
+		m_Ports[18] = p19;
+		m_Ports[19] = p20;
+	}
+
+
+} // namespace pcpp
+
+#endif /* PCAPPP_PORT_LIST */

--- a/Packet++/header/SSLLayer.h
+++ b/Packet++/header/SSLLayer.h
@@ -6,6 +6,7 @@
 #include "SSLCommon.h"
 #include "SSLHandshake.h"
 #include "PortList.h"
+#include "PortList2.h"
 
 /**
  * @file
@@ -177,7 +178,7 @@ namespace pcpp
 		 * A static method that checks whether the port is considered as SSL/TLS
 		 * @param[in] port The port number to be checked
 		 */
-		static bool isSSLPort(uint16_t port);
+		static bool isSSLPort(uint16_t port) { return m_PortList.contains(port); }
 
 		/**
 		 * A static methods that gets raw data of a layer and checks whether this data is a SSL/TLS record or not. This check is
@@ -251,10 +252,24 @@ namespace pcpp
 
 		OsiModelLayer getOsiModelLayer() const { return OsiModelPresentationLayer; }
 
+		/**
+		 * A static method that returns a reference to static object that contains the port numbers supported by this layer at certain point of time.
+		 * The port list can be changed by the user in any time.
+		 * @return A reference to static object that contains the port numbers supported by the layer.
+		 */
+		static PortList& getPortList() { return m_PortList; }
+		static PortList2& getPortList2() { return m_PortList2; }
+
 	protected:
 		SSLLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet) : Layer(data, dataLen, prevLayer, packet) { m_Protocol = SSL; }
 
+
+		/**
+		 * A static object that contains the port list supported by this layer at certain point of time.
+		 * This list are filled in by the well known port numbers but can be changed by the users in any time.
+		 */
 		static PortList m_PortList;
+		static PortList2 m_PortList2;
 	};
 
 

--- a/Packet++/header/SSLLayer.h
+++ b/Packet++/header/SSLLayer.h
@@ -5,6 +5,7 @@
 #include "Layer.h"
 #include "SSLCommon.h"
 #include "SSLHandshake.h"
+#include "PortList.h"
 
 /**
  * @file
@@ -253,6 +254,7 @@ namespace pcpp
 	protected:
 		SSLLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet) : Layer(data, dataLen, prevLayer, packet) { m_Protocol = SSL; }
 
+		static PortList m_PortList;
 	};
 
 

--- a/Packet++/header/SSLLayer.h
+++ b/Packet++/header/SSLLayer.h
@@ -178,7 +178,7 @@ namespace pcpp
 		 * A static method that checks whether the port is considered as SSL/TLS
 		 * @param[in] port The port number to be checked
 		 */
-		static bool isSSLPort(uint16_t port) { return m_PortList.contains(port); }
+		static bool isSSLPort(uint16_t port);
 
 		/**
 		 * A static methods that gets raw data of a layer and checks whether this data is a SSL/TLS record or not. This check is

--- a/Packet++/src/SSLLayer.cpp
+++ b/Packet++/src/SSLLayer.cpp
@@ -53,6 +53,32 @@ PortList2 SSLLayer::m_PortList2
 	995  // POP3S
 );
 
+bool SSLLayer::isSSLPort(uint16_t port)
+{
+	if (port == 443) // HTTPS, this is likely case
+		return true;
+
+	switch (port)
+	{
+	case 0:   // default
+	case 261: // NSIIOPS
+	case 448: // DDM-SSL
+	case 465: // SMTPS
+	case 563: // NNTPS
+	case 614: // SSHELL
+	case 636: // LDAPS
+	case 989: // FTPS - data
+	case 990: // FTPS - control
+	case 992: // Telnet over TLS/SSL
+	case 993: // IMAPS
+	case 994: // IRCS
+	case 995: // POP3S
+		return true;
+	default:
+		return false;
+	}
+}
+
 
 // ----------------
 // SSLLayer methods

--- a/Packet++/src/SSLLayer.cpp
+++ b/Packet++/src/SSLLayer.cpp
@@ -15,32 +15,44 @@
 namespace pcpp
 {
 
+// init a static member
+PortList SSLLayer::m_PortList
+(
+	0,   // default
+	261, // NSIIOPS
+	443, // HTTPS
+	448, // DDM-SSL
+	465, // SMTPS
+	563, // NNTPS
+	614, // SSHELL
+	636, // LDAPS
+	989, // FTPS - data
+	990, // FTPS - control
+	992, // Telnet over TLS/SSL
+	993, // IMAPS
+	994, // IRCS
+	995  // POP3S
+);
 
-bool SSLLayer::isSSLPort(uint16_t port)
-{
-	if (port == 443) // HTTPS, this is likely case
-		return true;
+// init a static member (the order of ports does matter)
+PortList2 SSLLayer::m_PortList2
+(
+	443, // HTTPS
+	0,   // default
+	261, // NSIIOPS
+	448, // DDM-SSL
+	465, // SMTPS
+	563, // NNTPS
+	614, // SSHELL
+	636, // LDAPS
+	989, // FTPS - data
+	990, // FTPS - control
+	992, // Telnet over TLS/SSL
+	993, // IMAPS
+	994, // IRCS
+	995  // POP3S
+);
 
-	switch (port)
-	{
-	case 0:   // default
-	case 261: // NSIIOPS
-	case 448: // DDM-SSL
-	case 465: // SMTPS
-	case 563: // NNTPS
-	case 614: // SSHELL
-	case 636: // LDAPS
-	case 989: // FTPS - data
-	case 990: // FTPS - control
-	case 992: // Telnet over TLS/SSL
-	case 993: // IMAPS
-	case 994: // IRCS
-	case 995: // POP3S
-		return true;
-	default:
-		return false;
-	}
-}
 
 // ----------------
 // SSLLayer methods
@@ -66,7 +78,8 @@ bool SSLLayer::IsSSLMessage(uint16_t srcPort, uint16_t dstPort, uint8_t* data, s
 
 	uint16_t recordVersion = ntohs(recordLayer->recordVersion);
 
-	if (recordVersion != SSL3 &&
+	if (recordVersion != SSL2 && 
+			recordVersion != SSL3 &&
 			recordVersion != TLS1_0 &&
 			recordVersion != TLS1_1 &&
 			recordVersion != TLS1_2)


### PR DESCRIPTION
This PR demonstrates the idea how to implement the feature of customizing the port numbers supported by certain layer as had been requested in issue #275. Currently, there are 6 classes that depends from the port numbers: `DNSLayer, HTTPLayer, RadiusLayer, SSLLayer, SIPLayer, GTVv1Layer`. We can implement this feature in all of these.

I have prepared two versions of classes that manage the port numbers and have selected the SSLLayer class for tests.

The first and the fastest implementation is `PortList`. The performance of lookup operation is the same as `isSSLPort` (for Windows) with hard-coded ports and even better (for Linux). The only disadvantage is that the class has the following member: `bool m_Ports[65536]` so the size of object will be 64K. I think it's not a problem for static class members.

The second class `PortList2` is slower than `PortList` in every sense but have a small size. Lookup is slower, at least, in 3 times than for `PortList` (for port 443). In the worst case (for port 995) the speed is decreasing in 10 times.

Test results:

1. Windows 10, Core i7 9700K, VS 2019, Release (x64):

```
=== Measurement of lookup performance for port number 443 ===

isSSLPort() with operator switch: duration(ms): 432, iterations: 1000000000

PortList::contains(): duration(ms): 435, iterations: 1000000000

PortList2::contains(): duration(ms): 1303, iterations: 1000000000
```

```
=== Measurement of lookup performance for port number 995 ===

isSSLPort() with operator switch: duration(ms): 429, iterations: 1000000000

PortList::contains(): duration(ms): 427, iterations: 1000000000

PortList2::contains(): duration(ms): 4517, iterations: 1000000000
```

2. Xeon E5-2630 v4, CentOS 7.7.1908 x64, g++ 8.3.1:

```
=== Measurement of lookup performance for port number 443 ===

isSSLPort() with operator switch: duration(ms): 1949, iterations: 1000000000

PortList::contains(): duration(ms): 340, iterations: 1000000000

PortList2::contains(): duration(ms): 973, iterations: 1000000000
```

```
=== Measurement of lookup performance for port number 995 ===

isSSLPort() with operator switch: duration(ms): 2594, iterations: 1000000000

PortList::contains(): duration(ms): 339, iterations: 1000000000

PortList2::contains(): duration(ms): 5186, iterations: 1000000000
```
