### PR TITLE
Improvements in TcpReassembly

### DIFF
--- a/Packet++/header/TcpReassembly.h
+++ b/Packet++/header/TcpReassembly.h
@@ -167,7 +167,7 @@ public:
 	 * @param[in] tcpDataLength The length of the buffer
 	 * @param[in] connData TCP connection information for this TCP data
 	 */
-	TcpStreamData(uint8_t* tcpData, size_t tcpDataLength, ConnectionData connData);
+	TcpStreamData(uint8_t* tcpData, size_t tcpDataLength, const ConnectionData& connData);
 
 	/**
 	 * A d'tor for this class
@@ -203,15 +203,9 @@ public:
 
 	/**
 	 * A getter for the connection data
-	 * @return The connection data
-	 */
-	ConnectionData getConnectionData() const { return m_Connection; }
-
-	/**
-	 * A getter for the connection data
 	 * @return The const reference to connection data
 	 */
-	const ConnectionData& getConnectionDataRef() const { return m_Connection; }
+	const ConnectionData& getConnectionData() const { return m_Connection; }
 
 private:
 	uint8_t* m_Data;

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -75,7 +75,7 @@ TcpStreamData::TcpStreamData()
 	m_DeleteDataOnDestruction = false;
 }
 
-TcpStreamData::TcpStreamData(uint8_t* tcpData, size_t tcpDataLength, ConnectionData connData)
+TcpStreamData::TcpStreamData(uint8_t* tcpData, size_t tcpDataLength, const ConnectionData& connData)
 {
 	m_Data = tcpData;
 	m_DataLen = tcpDataLength;


### PR DESCRIPTION
- Changed the signature of method `getConnectionData` and removed unnecessary method `getConnectionDataRef`
- Сhanged the type of `connData` parameter in constructor of `TcpStreamData` from `ConnectionData connData` to `const ConnectionData& connData`. It avoids one unnecessary copying.

I attached the screenshot with results of `perf report` before and after the changes applied:

![screenshots](https://user-images.githubusercontent.com/43776630/69144336-1e8f1d80-0adc-11ea-8e0b-b9d22c981b23.png)
