### PR TITLE
Performance improvements in TcpReassembly

### DIFF
--- a/Packet++/header/IPv4Layer.h
+++ b/Packet++/header/IPv4Layer.h
@@ -569,6 +569,18 @@ namespace pcpp
 		 */
 		bool removeAllOptions();
 
+		/**
+		 * This method overrides the method of base class (Layer) to improve performance in some cases
+		 * @return A pointer for the layer payload, meaning the first byte after the header
+		 */
+		virtual uint8_t* getLayerPayload() const { return getData() + getHeaderLen(); }
+
+		/**
+		 * This method overrides the method of base class (Layer) to improve performance in some cases
+		 * @return The size in bytes of the payload
+		 */
+		virtual size_t getLayerPayloadSize() const { return getDataLen() - getHeaderLen(); }
+
 
 		// implement abstract methods
 

--- a/Packet++/header/IPv6Layer.h
+++ b/Packet++/header/IPv6Layer.h
@@ -143,6 +143,18 @@ namespace pcpp
 		 */
 		bool isFragment() const;
 
+		/**
+		 * This method overrides the method of base class (Layer) to improve performance in some cases
+		 * @return A pointer for the layer payload, meaning the first byte after the header
+		 */
+		virtual uint8_t* getLayerPayload() const { return getData() + getHeaderLen(); }
+
+		/**
+		 * This method overrides the method of base class (Layer) to improve performance in some cases
+		 * @return The size in bytes of the payload
+		 */
+		virtual size_t getLayerPayloadSize() const { return getDataLen() - getHeaderLen(); }
+
 
 		// implement abstract methods
 

--- a/Packet++/header/Layer.h
+++ b/Packet++/header/Layer.h
@@ -103,12 +103,12 @@ namespace pcpp
 		/**
 		 * @return A pointer for the layer payload, meaning the first byte after the header
 		 */
-		uint8_t* getLayerPayload() const { return m_Data + getHeaderLen(); }
+		virtual uint8_t* getLayerPayload() const { return m_Data + getHeaderLen(); }
 
 		/**
 		 * @return The size in bytes of the payload
 		 */
-		size_t getLayerPayloadSize() const { return m_DataLen - getHeaderLen(); }
+		virtual size_t getLayerPayloadSize() const { return m_DataLen - getHeaderLen(); }
 
 		/**
 		 * Raw data in layers can come from one of sources:

--- a/Packet++/header/TcpLayer.h
+++ b/Packet++/header/TcpLayer.h
@@ -437,6 +437,19 @@ namespace pcpp
 		 */
 		uint16_t calculateChecksum(bool writeResultToPacket);
 
+		/**
+		 * This method overrides the method of base class (Layer) to improve performance in some cases
+		 * @return A pointer for the layer payload, meaning the first byte after the header
+		 */
+		virtual uint8_t* getLayerPayload() const { return getData() + getHeaderLen(); }
+
+		/**
+		 * This method overrides the method of base class (Layer) to improve performance in some cases
+		 * @return The size in bytes of the payload
+		 */
+		virtual size_t getLayerPayloadSize() const { return getDataLen() - getHeaderLen(); }
+
+
 		// implement abstract methods
 
 		/**


### PR DESCRIPTION
1. `getLayerPayload` and `getLayerPayloadSize` have been made virtual in class `Layer`. In some cases it is useful to override these methods in derived class, because an implementation in base class uses the calling of virtual methods of derived class.

2. The new inline methods `getLayerPayload` and `getLayerPayloadSize` have been added in `IPv4Layer`, `IPv6Layer` and `TcpLayer`.  These override corresponding methods of the base class. It improves the performance of methods of `TcpReassembly` class.