### PR TITLE
Improvements in TcpReassembly (performance increased)

### DIFF
--- a/Examples/TcpReassembly/main.cpp
+++ b/Examples/TcpReassembly/main.cpp
@@ -330,7 +330,7 @@ void listInterfaces()
 /**
  * The callback being called by the TCP reassembly module whenever new data arrives on a certain connection
  */
-static void tcpReassemblyMsgReadyCallback(int sideIndex, TcpStreamData tcpData, void* userCookie)
+static void tcpReassemblyMsgReadyCallback(int sideIndex, const TcpStreamData& tcpData, void* userCookie)
 {
 	// extract the connection manager from the user cookie
 	TcpReassemblyConnMgr* connMgr = (TcpReassemblyConnMgr*)userCookie;
@@ -412,7 +412,7 @@ static void tcpReassemblyMsgReadyCallback(int sideIndex, TcpStreamData tcpData, 
 /**
  * The callback being called by the TCP reassembly module whenever a new connection is found. This method adds the connection to the connection manager
  */
-static void tcpReassemblyConnectionStartCallback(ConnectionData connectionData, void* userCookie)
+static void tcpReassemblyConnectionStartCallback(const ConnectionData& connectionData, void* userCookie)
 {
 	// get a pointer to the connection manager
 	TcpReassemblyConnMgr* connMgr = (TcpReassemblyConnMgr*)userCookie;
@@ -433,7 +433,7 @@ static void tcpReassemblyConnectionStartCallback(ConnectionData connectionData, 
  * The callback being called by the TCP reassembly module whenever a connection is ending. This method removes the connection from the connection manager and writes the metadata file if requested
  * by the user
  */
-static void tcpReassemblyConnectionEndCallback(ConnectionData connectionData, TcpReassembly::ConnectionEndReason reason, void* userCookie)
+static void tcpReassemblyConnectionEndCallback(const ConnectionData& connectionData, TcpReassembly::ConnectionEndReason reason, void* userCookie)
 {
 	// get a pointer to the connection manager
 	TcpReassemblyConnMgr* connMgr = (TcpReassemblyConnMgr*)userCookie;

--- a/Packet++/header/TcpReassembly.h
+++ b/Packet++/header/TcpReassembly.h
@@ -205,12 +205,12 @@ public:
 	 * A getter for the connection data
 	 * @return The const reference to connection data
 	 */
-	const ConnectionData& getConnectionData() const { return m_Connection; }
+	const ConnectionData& getConnectionData() const { return *m_Connection; }
 
 private:
 	uint8_t* m_Data;
 	size_t m_DataLen;
-	ConnectionData m_Connection;
+	const ConnectionData* m_Connection;
 	bool m_DeleteDataOnDestruction;
 
 	void setDeleteDataOnDestruction(bool flag) { m_DeleteDataOnDestruction = flag; }
@@ -281,7 +281,7 @@ public:
 	 * @param[in] tcpData The TCP data itself + connection information
 	 * @param[in] userCookie A pointer to the cookie provided by the user in TcpReassembly c'tor (or NULL if no cookie provided)
 	 */
-	typedef void (*OnTcpMessageReady)(int side, TcpStreamData tcpData, void* userCookie);
+	typedef void (*OnTcpMessageReady)(int side, const TcpStreamData& tcpData, void* userCookie);
 
 	/**
 	 * @typedef OnTcpConnectionStart
@@ -289,7 +289,7 @@ public:
 	 * @param[in] connectionData Connection information
 	 * @param[in] userCookie A pointer to the cookie provided by the user in TcpReassembly c'tor (or NULL if no cookie provided)
 	 */
-	typedef void (*OnTcpConnectionStart)(ConnectionData connectionData, void* userCookie);
+	typedef void (*OnTcpConnectionStart)(const ConnectionData& connectionData, void* userCookie);
 
 	/**
 	 * @typedef OnTcpConnectionEnd
@@ -298,7 +298,7 @@ public:
 	 * @param[in] reason The reason for connection termination: FIN/RST packet or manually by the user
 	 * @param[in] userCookie A pointer to the cookie provided by the user in TcpReassembly c'tor (or NULL if no cookie provided)
 	 */
-	typedef void (*OnTcpConnectionEnd)(ConnectionData connectionData, ConnectionEndReason reason, void* userCookie);
+	typedef void (*OnTcpConnectionEnd)(const ConnectionData& connectionData, ConnectionEndReason reason, void* userCookie);
 
 	/**
 	 * A c'tor for this class

--- a/Packet++/header/TcpReassembly.h
+++ b/Packet++/header/TcpReassembly.h
@@ -152,48 +152,23 @@ class TcpReassembly;
  */
 class TcpStreamData
 {
-	friend class TcpReassembly;
-
 public:
-
 	/**
-	 * A c'tor for this class that basically zeros all members
-	 */
-	TcpStreamData();
-
-	/**
-	 * A c'tor for this class that get data from outside and set the internal members. Notice that when this class is destroyed it also frees the TCP data it stores
-	 * @param[in] tcpData A buffer containing the TCP data piece
+	 * A c'tor for this class that get data from outside and set the internal members
+	 * @param[in] tcpData A pointer to buffer containing the TCP data piece
 	 * @param[in] tcpDataLength The length of the buffer
 	 * @param[in] connData TCP connection information for this TCP data
 	 */
-	TcpStreamData(uint8_t* tcpData, size_t tcpDataLength, const ConnectionData& connData);
-
-	/**
-	 * A d'tor for this class
-	 */
-	~TcpStreamData();
-
-	/**
-	 * A copy c'tor for this class. Notice the data buffer is copied from the source instance to this instance, so even if the source instance is destroyed the data in this instance
-	 * stays valid. When this instance is destroyed it also frees the data buffer
-	 * @param[in] other The instance to copy from
-	 */
-	TcpStreamData(TcpStreamData& other);
-
-	/**
-	 * Overload of the assignment operator. Notice the data buffer is copied from the source instance to this instance, so even if the source instance is destroyed the data in this instance
-	 * stays valid. When this instance is destroyed it also frees the data buffer
-	 * @param[in] other The instance to copy from
-	 * @return A reference to this instance
-	 */
-	TcpStreamData& operator=(const TcpStreamData& other);
+	TcpStreamData(const uint8_t* tcpData, size_t tcpDataLength, const ConnectionData& connData)
+		: m_Data(tcpData), m_DataLen(tcpDataLength), m_Connection(connData)
+	{
+	}
 
 	/**
 	 * A getter for the data buffer
 	 * @return A pointer to the buffer
 	 */
-	uint8_t* getData() const { return m_Data; }
+	const uint8_t* getData() const { return m_Data; }
 
 	/**
 	 * A getter for buffer length
@@ -205,16 +180,12 @@ public:
 	 * A getter for the connection data
 	 * @return The const reference to connection data
 	 */
-	const ConnectionData& getConnectionData() const { return *m_Connection; }
+	const ConnectionData& getConnectionData() const { return m_Connection; }
 
 private:
-	uint8_t* m_Data;
+	const uint8_t* m_Data;
 	size_t m_DataLen;
-	const ConnectionData* m_Connection;
-	bool m_DeleteDataOnDestruction;
-
-	void setDeleteDataOnDestruction(bool flag) { m_DeleteDataOnDestruction = flag; }
-	void copyData(const TcpStreamData& other);
+	const ConnectionData& m_Connection;
 };
 
 

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -79,7 +79,7 @@ TcpStreamData::TcpStreamData(uint8_t* tcpData, size_t tcpDataLength, const Conne
 {
 	m_Data = tcpData;
 	m_DataLen = tcpDataLength;
-	m_Connection = connData;
+	m_Connection = &connData;
 	m_DeleteDataOnDestruction = true;
 }
 

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -4488,7 +4488,7 @@ void saveStringToFile(std::string& str, std::string fileName)
     outfile.close();
 }
 
-void tcpReassemblyMsgReadyCallback(int sideIndex, TcpStreamData tcpData, void* userCookie)
+void tcpReassemblyMsgReadyCallback(int sideIndex, const TcpStreamData& tcpData, void* userCookie)
 {
 	TcpReassemblyMultipleConnStats::Stats &stats = ((TcpReassemblyMultipleConnStats*)userCookie)->stats;
 
@@ -4511,7 +4511,7 @@ void tcpReassemblyMsgReadyCallback(int sideIndex, TcpStreamData tcpData, void* u
 	//printf("\n***** got %d bytes from side %d conn 0x%X *****\n", tcpData.getDataLength(), sideIndex, tcpData.getConnectionData().flowKey);
 }
 
-void tcpReassemblyConnectionStartCallback(ConnectionData connectionData, void* userCookie)
+void tcpReassemblyConnectionStartCallback(const ConnectionData& connectionData, void* userCookie)
 {
 	TcpReassemblyMultipleConnStats::Stats &stats = ((TcpReassemblyMultipleConnStats*)userCookie)->stats;
 
@@ -4532,7 +4532,7 @@ void tcpReassemblyConnectionStartCallback(ConnectionData connectionData, void* u
 	//printf("conn 0x%X started\n", connectionData.flowKey);
 }
 
-void tcpReassemblyConnectionEndCallback(ConnectionData connectionData, TcpReassembly::ConnectionEndReason reason, void* userCookie)
+void tcpReassemblyConnectionEndCallback(const ConnectionData& connectionData, TcpReassembly::ConnectionEndReason reason, void* userCookie)
 {
 	TcpReassemblyMultipleConnStats::Stats &stats = ((TcpReassemblyMultipleConnStats*)userCookie)->stats;
 


### PR DESCRIPTION
1. The signatures of callback function have been changed because passing the arguments by value is useless and gives performance overhead.
2. The type of `TcpStreamData::m_Connection` has been changed from `ConnectionData` to `const ConnectionData*` to avoid data copying
3. The private method `TcpReassembly::prepareMissingDataMessage` has been replaced by the new static function which is optimized on speed (no dynamic memory allocation).