### PR TITLE
Supporting the user defined options when DPDK is initialized

### DIFF
--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -3291,7 +3291,18 @@ PTF_TEST_CASE(TestDpdkInitDevice)
 	CoreMask coreMask = 0;
 	for (int i = 0; i < getNumOfCores(); i++)
 		coreMask |= SystemCores::IdToSystemCore[i].Mask;
-	PTF_ASSERT_TRUE(DpdkDeviceList::initDpdk(coreMask, 16383));
+
+	std::vector<DpdkOption> options;
+	options.push_back(DpdkOption());
+	std::vector<DpdkOption>::iterator memChannelsOptionIter = options.insert(options.end(), DpdkOption(DpdkOption::Type::OptionMemChannels));
+
+	LoggerPP::getInstance().supressErrors();
+	PTF_ASSERT_FALSE(DpdkDeviceList::initDpdk(coreMask, 16383, 0, options));
+	LoggerPP::getInstance().enableErrors();
+
+	memChannelsOptionIter->value = "2";
+	PTF_ASSERT_TRUE(DpdkDeviceList::initDpdk(coreMask, 16383, 0, options));
+
 	PTF_ASSERT(devList.getDpdkDeviceList().size() > 0, "No DPDK devices");
 
 	PTF_ASSERT_EQUAL(devList.getDpdkLogLevel(), LoggerPP::Normal, enum);


### PR DESCRIPTION
DpdkDeviceList::initDpdk has been enhanced by supporting the user defined options. Is this feature useful or not? I had planned to use some DPDK init options (for example: to override the number of memory channels which is hard-coded) but I'm currently not sure I will use it.

Should I test these changes in real application?