### PR TITLE
PcapLiveDevice: fix compilation on Alpine Linux (musl libc)

### DIFF
--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -22,7 +22,7 @@
 #else
 #include <arpa/inet.h>
 #include <sys/ioctl.h>
-#include <sys/sysctl.h>
+#include <linux/sysctl.h>
 #include <net/if.h>
 #endif
 #if defined(MAC_OS_X) || defined(FREEBSD)


### PR DESCRIPTION
I had to fix the path to sysctl.h on Alpine Linux 3.10 in order to get it to compile.