### PR TITLE
Fix build warning in macOS

### DIFF
--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -667,7 +667,7 @@ std::string Packet::printPacketInfo(bool timeAsLocalTime) const
 	if (nowtm != NULL)
 	{
 		strftime(tmbuf, sizeof(tmbuf), "%Y-%m-%d %H:%M:%S", nowtm);
-		snprintf(buf, sizeof(buf), "%s.%06lu", tmbuf, timestamp.tv_usec);
+		snprintf(buf, sizeof(buf), "%s.%06lu", tmbuf, (unsigned long)timestamp.tv_usec);
 	}
 	else
 		snprintf(buf, sizeof(buf), "0000-00-00 00:00:00.000000");


### PR DESCRIPTION
Fix following build warning:  

```
src/Packet.cpp:670:49: warning: format specifies type 'unsigned long' but the argument has type '__darwin_suseconds_t' (aka 'int') [-Wformat]
                snprintf(buf, sizeof(buf), "%s.%06lu", tmbuf, timestamp.tv_usec);
                                               ~~~~~          ^~~~~~~~~~~~~~~~~
                                               %06d
1 warning generated.
```