### PR TITLE
Changes in class RawPacket

### DIFF
--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -290,38 +290,32 @@ namespace pcpp
 
 		/**
 		 * Get raw data pointer
-		 * @return A pointer to the raw data
-		 */
-		const uint8_t* getRawData() const;
-
-		/**
-		 * Get read only raw data pointer
 		 * @return A read-only pointer to the raw data
 		 */
-		const uint8_t* getRawDataReadOnly() const;
+		const uint8_t* getRawData() const { return m_RawData; }
 
 		/**
 		 * Get the link layer tpye
 		 * @return the type of the link layer
 		 */
-		LinkLayerType getLinkLayerType() const;
+		LinkLayerType getLinkLayerType() const { return m_LinkLayerType; }
 
 		/**
 		 * Get raw data length in bytes
 		 * @return Raw data length in bytes
 		 */
-		int getRawDataLen() const;
+		int getRawDataLen() const { return m_RawDataLen; }
 
 		/**
 		 * Get frame length in bytes
 		 * @return frame length in bytes
 		 */
-		int getFrameLength() const;
+		int getFrameLength() const { return m_FrameLength; }
 		/**
 		 * Get raw data timestamp
 		 * @return Raw data timestamp
 		 */
-		timeval getPacketTimeStamp() const;
+		timeval getPacketTimeStamp() const { return m_TimeStamp; }
 
 		/**
 		 * Get an indication whether raw data was already set for this instance.

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -94,36 +94,6 @@ bool RawPacket::setRawData(const uint8_t* pRawData, int rawDataLen, timeval time
 	return true;
 }
 
-const uint8_t* RawPacket::getRawData() const
-{
-	return m_RawData;
-}
-
-const uint8_t* RawPacket::getRawDataReadOnly() const
-{
-	return m_RawData;
-}
-		
-LinkLayerType RawPacket::getLinkLayerType() const
-{
-	return m_LinkLayerType;
-}
-
-int RawPacket::getRawDataLen() const
-{
-	return m_RawDataLen;
-}
-
-int RawPacket::getFrameLength() const
-{
-	return m_FrameLength;
-}
-
-timeval RawPacket::getPacketTimeStamp() const
-{
-	return m_TimeStamp;
-}
-
 void RawPacket::clear()
 {
 	if (m_RawData != 0)

--- a/Pcap++/src/PfRingDevice.cpp
+++ b/Pcap++/src/PfRingDevice.cpp
@@ -789,13 +789,13 @@ bool PfRingDevice::sendPacket(const uint8_t* packetData, int packetDataLength)
 
 bool PfRingDevice::sendPacket(const RawPacket& rawPacket)
 {
-	return sendData(rawPacket.getRawDataReadOnly(), rawPacket.getRawDataLen(), true);
+	return sendData(rawPacket.getRawData(), rawPacket.getRawDataLen(), true);
 }
 
 
 bool PfRingDevice::sendPacket(const Packet& packet)
 {
-	return sendData(packet.getRawPacketReadOnly()->getRawDataReadOnly(), packet.getRawPacketReadOnly()->getRawDataLen(), true);
+	return sendData(packet.getRawPacketReadOnly()->getRawData(), packet.getRawPacketReadOnly()->getRawDataLen(), true);
 }
 
 
@@ -804,7 +804,7 @@ int PfRingDevice::sendPackets(const RawPacket* rawPacketsArr, int arrLength)
 	int packetsSent = 0;
 	for (int i = 0; i < arrLength; i++)
 	{
-		if (!sendData(rawPacketsArr[i].getRawDataReadOnly(), rawPacketsArr[i].getRawDataLen(), false))
+		if (!sendData(rawPacketsArr[i].getRawData(), rawPacketsArr[i].getRawDataLen(), false))
 			break;
 		else
 			packetsSent++;
@@ -823,7 +823,7 @@ int PfRingDevice::sendPackets(const Packet** packetsArr, int arrLength)
 	int packetsSent = 0;
 	for (int i = 0; i < arrLength; i++)
 	{
-		if (!sendData(packetsArr[i]->getRawPacketReadOnly()->getRawDataReadOnly(), packetsArr[i]->getRawPacketReadOnly()->getRawDataLen(), false))
+		if (!sendData(packetsArr[i]->getRawPacketReadOnly()->getRawData(), packetsArr[i]->getRawPacketReadOnly()->getRawDataLen(), false))
 			break;
 		else
 			packetsSent++;
@@ -842,7 +842,7 @@ int PfRingDevice::sendPackets(const RawPacketVector& rawPackets)
 	int packetsSent = 0;
 	for (RawPacketVector::ConstVectorIterator iter = rawPackets.begin(); iter != rawPackets.end(); iter++)
 	{
-		if (!sendData((*iter)->getRawDataReadOnly(), (*iter)->getRawDataLen(), false))
+		if (!sendData((*iter)->getRawData(), (*iter)->getRawDataLen(), false))
 			break;
 		else
 			packetsSent++;


### PR DESCRIPTION
- method `getRawDataReadOnly` was removed as it duplicates the `getRawData`
- implementation of simple methods was moved into the header file