### PR TITLE
Performance and readability improvements

### DIFF
--- a/Packet++/header/DnsLayer.h
+++ b/Packet++/header/DnsLayer.h
@@ -5,8 +5,6 @@
 #include "DnsResource.h"
 #include "DnsResourceData.h"
 #include "Layer.h"
-#include <vector>
-#include <map>
 
 /// @file
 
@@ -428,9 +426,11 @@ namespace pcpp
 		OsiModelLayer getOsiModelLayer() const { return OsiModelApplicationLayer; }
 
 		/**
-		 * @return A pointer to a map containing all UDP ports recognize as DNS
+		 * A static method that checks whether the port is considered as DNS
+		 * @param[in] port The port number to be checked
 		 */
-		static const std::map<uint16_t, bool>* getDNSPortMap();
+		static inline bool isDnsPort(uint16_t port);
+
 	private:
 		IDnsResource* m_ResourceList;
 		DnsQuery*     m_FirstQuery;
@@ -457,6 +457,22 @@ namespace pcpp
 		bool removeResource(IDnsResource* resourceToRemove);
 
 	};
+
+
+	// implementation of inline methods
+
+	bool DnsLayer::isDnsPort(uint16_t port)
+	{
+		switch (port)
+		{
+		case 53:
+		case 5353:
+		case 5355:
+			return true;
+		default:
+			return false;
+		}
+	}
 
 } // namespace pcpp
 

--- a/Packet++/header/GtpLayer.h
+++ b/Packet++/header/GtpLayer.h
@@ -421,6 +421,12 @@ namespace pcpp
 		 */
 		bool isGTPCMessage() const;
 
+		/**
+		 * A static method that checks whether the port is considered as GTPv1
+		 * @param[in] port The port number to be checked
+		 */
+		static bool isGTPv1Port(uint16_t port) { return port == 2152 /* GTP-U */ || port == 2123 /* GTP-C */; }
+
 
 		// implement abstract methods
 

--- a/Packet++/header/HttpLayer.h
+++ b/Packet++/header/HttpLayer.h
@@ -4,7 +4,6 @@
 #include "TextBasedProtocol.h"
 #include <string>
 #include <exception>
-#include <map>
 
 /// @file
 
@@ -75,9 +74,10 @@ namespace pcpp
 		virtual ~HttpMessage() {}
 
 		/**
-		 * @return A pointer to a map containing all TCP ports recognize as HTTP
+		 * A static method that checks whether the port is considered as HTTP
+		 * @param[in] port The port number to be checked
 		 */
-		static const std::map<uint16_t, bool>* getHTTPPortMap();
+		static bool isHttpPort(uint16_t port) { return port == 80 || port == 8080; }
 
 		// overriden methods
 
@@ -103,7 +103,6 @@ namespace pcpp
 
 
 	class HttpRequestFirstLine;
-
 
 
 

--- a/Packet++/header/RadiusLayer.h
+++ b/Packet++/header/RadiusLayer.h
@@ -282,6 +282,19 @@ namespace pcpp
 		 */
 		bool removeAllAttributes();
 
+		/**
+		 * The static method makes validation of UDP data
+		 * @param[in] udpData The pointer to the UDP payload data. It points to the first byte of RADIUS header.
+		 * @param[in] udpDataLen The payload data size
+		 * @return True if the data is valid and can represent the RADIUS packet
+		 */
+		static bool isDataValid(const uint8_t* udpData, size_t udpDataLen);
+
+		/**
+		 * A static method that checks whether the port is considered as RADIUS
+		 * @param[in] port The port number to be checked
+		 */
+		static inline bool isRadiusPort(uint16_t port);
 
 		// implement abstract methods
 
@@ -303,16 +316,24 @@ namespace pcpp
 		std::string toString() const;
 
 		OsiModelLayer getOsiModelLayer() const { return OsiModelSesionLayer; }
-
-		/**
-		 * The static method makes validation of UDP data
-		 * @param[in] udpData The pointer to the UDP payload data. It points to the first byte of RADIUS header.
-		 * @param[in] udpDataLen The payload data size
-		 * @return True if the data is valid and can represent the RADIUS packet
-		 */
-		static bool isDataValid(const uint8_t* udpData, size_t udpDataLen);
-
 	};
-}
+
+
+	// implementation of inline methods
+
+	bool RadiusLayer::isRadiusPort(uint16_t port)
+	{
+		switch (port)
+		{
+		case 1812:
+		case 1813:
+		case 3799:
+			return true;
+		default:
+			return false;
+		}
+	} // isRadiusPort
+
+} // namespace pcpp
 
 #endif // PACKETPP_RADIUS_LAYER

--- a/Packet++/header/SSLLayer.h
+++ b/Packet++/header/SSLLayer.h
@@ -176,7 +176,7 @@ namespace pcpp
 		 * A static method that checks whether the port is considered as SSL/TLS
 		 * @param[in] port The port number to be checked
 		 */
-		static bool isSSLPort(uint16_t port);
+		static inline bool isSSLPort(uint16_t port);
 
 		/**
 		 * A static methods that gets raw data of a layer and checks whether this data is a SSL/TLS record or not. This check is
@@ -253,7 +253,7 @@ namespace pcpp
 	protected:
 		SSLLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet) : Layer(data, dataLen, prevLayer, packet) { m_Protocol = SSL; }
 
-	};
+	}; // class SSLLayer
 
 
 	/**
@@ -359,7 +359,7 @@ namespace pcpp
 
 	private:
 		PointerVector<SSLHandshakeMessage> m_MessageList;
-	};
+	}; // class SSLHandshakeLayer
 
 
 	/**
@@ -391,7 +391,7 @@ namespace pcpp
 		 * There are no calculated fields for this layer
 		 */
 		void computeCalculateFields() {}
-	};
+	}; // class SSLChangeCipherSpecLayer
 
 
 	/**
@@ -433,7 +433,7 @@ namespace pcpp
 		 * There are no calculated fields for this layer
 		 */
 		void computeCalculateFields() {}
-	};
+	}; // class SSLAlertLayer
 
 
 	/**
@@ -476,7 +476,8 @@ namespace pcpp
 		 * There are no calculated fields for this layer
 		 */
 		void computeCalculateFields() {}
-	};
+	}; // class SSLApplicationDataLayer
+
 
 	template<class THandshakeMessage>
 	THandshakeMessage* SSLHandshakeLayer::getHandshakeMessageOfType() const
@@ -491,7 +492,8 @@ namespace pcpp
 
 		// element not found
 		return NULL;
-	}
+	} // getHandshakeMessageOfType
+
 
 	template<class THandshakeMessage>
 	THandshakeMessage* SSLHandshakeLayer::getNextHandshakeMessageOfType(SSLHandshakeMessage* after) const
@@ -520,7 +522,36 @@ namespace pcpp
 
 		// element not found
 		return NULL;
-	}
+	} // getNextHandshakeMessageOfType
+
+
+	// implementation of inline methods
+
+	bool SSLLayer::isSSLPort(uint16_t port)
+	{
+		if (port == 443) // HTTPS, this is likely case
+			return true;
+
+		switch (port)
+		{
+		case 0:   // default
+		case 261: // NSIIOPS
+		case 448: // DDM-SSL
+		case 465: // SMTPS
+		case 563: // NNTPS
+		case 614: // SSHELL
+		case 636: // LDAPS
+		case 989: // FTPS - data
+		case 990: // FTPS - control
+		case 992: // Telnet over TLS/SSL
+		case 993: // IMAPS
+		case 994: // IRCS
+		case 995: // POP3S
+			return true;
+		default:
+			return false;
+		}
+	} // isSSLPort
 
 } // namespace pcpp
 

--- a/Packet++/header/SipLayer.h
+++ b/Packet++/header/SipLayer.h
@@ -112,6 +112,12 @@ namespace pcpp
 		 */
 		void computeCalculateFields();
 
+		/**
+		 * A static method that checks whether the port is considered as SIP
+		 * @param[in] port The port number to be checked
+		 */
+		static bool isSipPort(uint16_t port) { return port == 5060 || port == 5061; }
+
 	protected:
 		SipLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet) : TextBasedProtocolMessage(data, dataLen, prevLayer, packet) {}
 		SipLayer() : TextBasedProtocolMessage() {}
@@ -122,7 +128,6 @@ namespace pcpp
 		char getHeaderFieldNameValueSeparator() const { return ':'; }
 		bool spacesAllowedBetweenHeaderFieldNameAndValue() const { return true; }
 	};
-
 
 
 	class SipRequestFirstLine;

--- a/Packet++/header/VxlanLayer.h
+++ b/Packet++/header/VxlanLayer.h
@@ -110,6 +110,12 @@ namespace pcpp
 		 */
 		void setVNI(uint32_t vni);
 
+		/**
+		 * A static method that checks whether the port is considered as VxLAN
+		 * @param[in] port The port number to be checked
+		 */
+		static bool isVxlanPort(uint16_t port) { return port == 4789; }
+
 
 		// implement abstract methods
 

--- a/Packet++/src/DnsLayer.cpp
+++ b/Packet++/src/DnsLayer.cpp
@@ -18,18 +18,6 @@
 namespace pcpp
 {
 
-static std::map<uint16_t, bool> createDNSPortMap()
-{
-	std::map<uint16_t, bool> result;
-	result[53] = true;
-	result[5353] = true;
-	result[5355] = true;
-	return result;
-}
-
-static const std::map<uint16_t, bool> DNSPortMap = createDNSPortMap();
-
-
 DnsLayer::DnsLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
 	: Layer(data, dataLen, prevLayer, packet)
 {
@@ -690,11 +678,6 @@ bool DnsLayer::removeAnswer(DnsResource* answerToRemove)
 	}
 
 	return res;
-}
-
-const std::map<uint16_t, bool>* DnsLayer::getDNSPortMap()
-{
-	return &DNSPortMap;
 }
 
 

--- a/Packet++/src/HttpLayer.cpp
+++ b/Packet++/src/HttpLayer.cpp
@@ -10,25 +10,8 @@
 namespace pcpp
 {
 
-static std::map<uint16_t, bool> createHTTPPortMap()
-{
-	std::map<uint16_t, bool> result;
-	result[80] = true;
-	result[8080] = true;
-	return result;
-}
-
-static const std::map<uint16_t, bool> HTTPPortMap = createHTTPPortMap();
-
-
-
 
 // -------- Class HttpMessage -----------------
-
-const std::map<uint16_t, bool>* HttpMessage::getHTTPPortMap()
-{
-	return &HTTPPortMap;
-}
 
 
 HeaderField* HttpMessage::addField(const std::string& fieldName, const std::string& fieldValue)

--- a/Packet++/src/SSLLayer.cpp
+++ b/Packet++/src/SSLLayer.cpp
@@ -15,33 +15,6 @@
 namespace pcpp
 {
 
-
-bool SSLLayer::isSSLPort(uint16_t port)
-{
-	if (port == 443) // HTTPS, this is likely case
-		return true;
-
-	switch (port)
-	{
-	case 0:   // default
-	case 261: // NSIIOPS
-	case 448: // DDM-SSL
-	case 465: // SMTPS
-	case 563: // NNTPS
-	case 614: // SSHELL
-	case 636: // LDAPS
-	case 989: // FTPS - data
-	case 990: // FTPS - control
-	case 992: // Telnet over TLS/SSL
-	case 993: // IMAPS
-	case 994: // IRCS
-	case 995: // POP3S
-		return true;
-	default:
-		return false;
-	}
-}
-
 // ----------------
 // SSLLayer methods
 // ----------------

--- a/Packet++/src/TcpLayer.cpp
+++ b/Packet++/src/TcpLayer.cpp
@@ -339,15 +339,15 @@ void TcpLayer::parseNextLayer()
 	uint16_t portDst = ntohs(tcpHder->portDst);
 	uint16_t portSrc = ntohs(tcpHder->portSrc);
 
-	if ((HttpMessage::getHTTPPortMap()->find(portDst) != HttpMessage::getHTTPPortMap()->end()) && HttpRequestFirstLine::parseMethod((char*)payload, payloadLen) != HttpRequestLayer::HttpMethodUnknown)
+	if (HttpMessage::isHttpPort(portDst) && HttpRequestFirstLine::parseMethod((char*)payload, payloadLen) != HttpRequestLayer::HttpMethodUnknown)
 		m_NextLayer = new HttpRequestLayer(payload, payloadLen, this, m_Packet);
-	else if ((HttpMessage::getHTTPPortMap()->find(portSrc) != HttpMessage::getHTTPPortMap()->end()) && HttpResponseFirstLine::parseStatusCode((char*)payload, payloadLen) != HttpResponseLayer::HttpStatusCodeUnknown)
+	else if (HttpMessage::isHttpPort(portSrc) && HttpResponseFirstLine::parseStatusCode((char*)payload, payloadLen) != HttpResponseLayer::HttpStatusCodeUnknown)
 		m_NextLayer = new HttpResponseLayer(m_Data + headerLen, m_DataLen - headerLen, this, m_Packet);
 	else if (SSLLayer::IsSSLMessage(portSrc, portDst, payload, payloadLen))
 		m_NextLayer = SSLLayer::createSSLMessage(payload, payloadLen, this, m_Packet);
-	else if (((portDst == 5060) || (portDst == 5061)) && (SipRequestFirstLine::parseMethod((char*)payload, payloadLen) != SipRequestLayer::SipMethodUnknown))
+	else if (SipLayer::isSipPort(portDst) && (SipRequestFirstLine::parseMethod((char*)payload, payloadLen) != SipRequestLayer::SipMethodUnknown))
 		m_NextLayer = new SipRequestLayer(m_Data + headerLen, m_DataLen - headerLen, this, m_Packet);
-	else if (((portDst == 5060) || (portDst == 5061)) && (SipResponseFirstLine::parseStatusCode((char*)payload, payloadLen) != SipResponseLayer::SipStatusCodeUnknown))
+	else if (SipLayer::isSipPort(portDst) && (SipResponseFirstLine::parseStatusCode((char*)payload, payloadLen) != SipResponseLayer::SipStatusCodeUnknown))
 		m_NextLayer = new SipResponseLayer(payload, payloadLen, this, m_Packet);
 	else
 		m_NextLayer = new PayloadLayer(payload, payloadLen, this, m_Packet);

--- a/Packet++/src/UdpLayer.cpp
+++ b/Packet++/src/UdpLayer.cpp
@@ -96,17 +96,17 @@ void UdpLayer::parseNextLayer()
 
 	if ((portSrc == 68 && portDst == 67) || (portSrc == 67 && portDst == 68) || (portSrc == 67 && portDst == 67))
 		m_NextLayer = new DhcpLayer(udpData, udpDataLen, this, m_Packet);
-	else if (portDst == 4789)
+	else if (VxlanLayer::isVxlanPort(portDst))
 		m_NextLayer = new VxlanLayer(udpData, udpDataLen, this, m_Packet);
-	else if ((udpDataLen >= sizeof(dnshdr)) && (DnsLayer::getDNSPortMap()->find(portDst) != DnsLayer::getDNSPortMap()->end() || DnsLayer::getDNSPortMap()->find(portSrc) != DnsLayer::getDNSPortMap()->end()))
+	else if ((udpDataLen >= sizeof(dnshdr)) && (DnsLayer::isDnsPort(portDst) || DnsLayer::isDnsPort(portSrc)))
 		m_NextLayer = new DnsLayer(udpData, udpDataLen, this, m_Packet);
-	else if ((portDst == 5060 || portDst == 5061 || portSrc == 5060 || portSrc == 5061) && (SipRequestFirstLine::parseMethod((char*)udpData, udpDataLen) != SipRequestLayer::SipMethodUnknown))
+	else if ((SipLayer::isSipPort(portDst) || SipLayer::isSipPort(portSrc)) && (SipRequestFirstLine::parseMethod((char*)udpData, udpDataLen) != SipRequestLayer::SipMethodUnknown))
 		m_NextLayer = new SipRequestLayer(udpData, udpDataLen, this, m_Packet);
-	else if ((portDst == 5060 || portDst == 5061 || portSrc == 5060 || portSrc == 5061) && (SipResponseFirstLine::parseStatusCode((char*)udpData, udpDataLen) != SipResponseLayer::SipStatusCodeUnknown))
+	else if ((SipLayer::isSipPort(portDst) || SipLayer::isSipPort(portSrc)) && (SipResponseFirstLine::parseStatusCode((char*)udpData, udpDataLen) != SipResponseLayer::SipStatusCodeUnknown))
 		m_NextLayer = new SipResponseLayer(udpData, udpDataLen, this, m_Packet);
-	else if ((portDst == 1812 || portSrc == 1812 || portDst == 1813 || portSrc == 1813 || portDst == 3799 || portSrc == 3799) && RadiusLayer::isDataValid(udpData, udpDataLen))
+	else if ((RadiusLayer::isRadiusPort(portDst) || RadiusLayer::isRadiusPort(portSrc)) && RadiusLayer::isDataValid(udpData, udpDataLen))
 		m_NextLayer = new RadiusLayer(udpData, udpDataLen, this, m_Packet);
-	else if ((portDst == 2152 || portSrc == 2152 || portDst == 2123 || portSrc == 2123) && GtpV1Layer::isGTPv1(udpData, udpDataLen))
+	else if ((GtpV1Layer::isGTPv1Port(portDst) || GtpV1Layer::isGTPv1Port(portSrc)) && GtpV1Layer::isGTPv1(udpData, udpDataLen))
 		m_NextLayer = new GtpV1Layer(udpData, udpDataLen, this, m_Packet);
 	else
 		m_NextLayer = new PayloadLayer(udpData, udpDataLen, this, m_Packet);


### PR DESCRIPTION
Significantly improved performance of detecting of `HTTP` and `DNS` layers. The static methods `getHTTPPortMap` and `getDNSPortMap` were removed (it was made in the same way as in `SSLLayer`, PR #288 ).