### PR TITLE
Adding RPCAP support on linux.

### DIFF
--- a/Pcap++/header/PcapRemoteDevice.h
+++ b/Pcap++/header/PcapRemoteDevice.h
@@ -1,8 +1,6 @@
 #ifndef PCAPPP_PCAP_REMOTE_DEVICE
 #define PCAPPP_PCAP_REMOTE_DEVICE
 
-#if defined(WIN32) || defined(WINx64) || defined(PCAPPP_MINGW_ENV)
-
 #include <vector>
 #include "PcapLiveDevice.h"
 
@@ -141,7 +139,5 @@ namespace pcpp
 	};
 
 } // namespace pcpp
-
-#endif // WIN32 || WINx64
 
 #endif /* PCAPPP_PCAP_REMOTE_DEVICE */

--- a/Pcap++/header/PcapRemoteDeviceList.h
+++ b/Pcap++/header/PcapRemoteDeviceList.h
@@ -1,8 +1,6 @@
 #ifndef PCAPP_PCAP_REMOTE_DEVICE_LIST
 #define PCAPP_PCAP_REMOTE_DEVICE_LIST
 
-#if defined(WIN32) || defined(WINx64) || defined(PCAPPP_MINGW_ENV)
-
 #include "IpAddress.h"
 #include "PcapRemoteDevice.h"
 
@@ -146,7 +144,5 @@ namespace pcpp
 	};
 
 } // namespace pcpp
-
-#endif // WIN32 || WINx64
 
 #endif /* PCAPP_PCAP_REMOTE_DEVICE_LIST */

--- a/Pcap++/src/PcapRemoteDevice.cpp
+++ b/Pcap++/src/PcapRemoteDevice.cpp
@@ -1,5 +1,3 @@
-#if defined(WIN32) || defined(WINx64) || defined(PCAPPP_MINGW_ENV)
-
 #define LOG_MODULE PcapLogModuleRemoteDevice
 
 #include "PcapRemoteDevice.h"
@@ -136,5 +134,3 @@ MacAddress PcapRemoteDevice::getMacAddress() const
 }
 
 } // namespace pcpp
-
-#endif // WIN32 || WINx64

--- a/Pcap++/src/PcapRemoteDeviceList.cpp
+++ b/Pcap++/src/PcapRemoteDeviceList.cpp
@@ -1,11 +1,12 @@
-#if defined(WIN32) || defined(WINx64) || defined(PCAPPP_MINGW_ENV)
-
 #define LOG_MODULE PcapLogModuleRemoteDevice
 
 #include "PcapRemoteDeviceList.h"
 #include "Logger.h"
 #include "IpUtils.h"
+
+#if defined(WIN32) || defined(WINx64) || defined(PCAPPP_MINGW_ENV)
 #include <ws2tcpip.h>
+#endif // WIN32 || WINx64
 
 namespace pcpp
 {
@@ -230,5 +231,3 @@ PcapRemoteDeviceList::~PcapRemoteDeviceList()
 }
 
 } // namespace pcpp
-
-#endif // WIN32 || WINx64


### PR DESCRIPTION
Works with the latest version of libpcap from [libpcap repository](https://github.com/the-tcpdump-group/libpcap/). TODO: integrate propely ( check libpcap version before building?), add proper error management.