### PR TITLE
Performance improvement in LRUList::eraseElement

### DIFF
--- a/Common++/header/LRUList.h
+++ b/Common++/header/LRUList.h
@@ -111,7 +111,7 @@ namespace pcpp
 				return;
 
 			m_CacheItemsList.erase(iter->second);
-			m_CacheItemsMap.erase(element);
+			m_CacheItemsMap.erase(iter);
 		}
 
 		/**


### PR DESCRIPTION
It's faster to remove an element by an iterator than by value