### PR TITLE
Add TcpSorter to support sorting TCP segments.

### DIFF
--- a/Common++/header/Logger.h
+++ b/Common++/header/Logger.h
@@ -52,6 +52,7 @@ namespace pcpp
 		PacketLogModuleRadiusLayer, ///< RadiusLayer module (Packet++)
 		PacketLogModuleGtpLayer, ///< GtpLayer module (Packet++)
 		PacketLogModuleTcpReassembly, ///< TcpReassembly module (Packet++)
+		PacketLogModuleTcpSorter, ///< TcpSorter module (Packet++)
 		PacketLogModuleIPReassembly, ///< IPReassembly module (Packet++)
 		PcapLogModuleWinPcapLiveDevice, ///< WinPcapLiveDevice module (Pcap++)
 		PcapLogModuleRemoteDevice, ///< WinPcapRemoteDevice module (Pcap++)

--- a/Examples/TcpSorter/Makefile
+++ b/Examples/TcpSorter/Makefile
@@ -1,0 +1,45 @@
+ifeq ($(wildcard ../../mk/platform.mk),)
+  $(error platform.mk not found! Please run configure script first)
+endif
+ifeq ($(wildcard ../../mk/PcapPlusPlus.mk),)
+  $(error PcapPlusPlus.mk not found! Please run configure script first)
+endif
+
+include ../../mk/platform.mk
+include ../../mk/PcapPlusPlus.mk
+
+SOURCES := $(wildcard *.cpp)
+OBJS_FILENAMES := $(patsubst %.cpp,Obj/%.o,$(SOURCES))
+
+Obj/%.o: %.cpp
+	@echo 'Building file: $<'
+	@$(CXX) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_INCLUDES) -O0 -g -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
+
+
+UNAME := $(shell uname)
+CUR_TARGET := $(notdir $(shell pwd))
+
+.SILENT:
+
+all: dependents TcpSorter
+
+start:
+	@echo '==> Building target: $(CUR_TARGET)'
+
+create-directories:
+	@$(MKDIR) -p Obj
+	@$(MKDIR) -p Bin
+
+dependents:
+	@cd $(PCAPPLUSPLUS_HOME) && $(MAKE) libs
+
+TcpSorter: start create-directories $(OBJS_FILENAMES)
+	@$(CXX) $(PCAPPP_BUILD_FLAGS) $(PCAPPP_LIBS_DIR) -o "./Bin/TcpSorter$(BIN_EXT)" $(OBJS_FILENAMES) $(PCAPPP_LIBS)
+	@$(PCAPPP_POST_BUILD)
+	@echo 'Finished successfully building: $(CUR_TARGET)'
+	@echo ' '
+
+clean:
+	@$(RM) -rf ./Obj/*
+	@$(RM) -rf ./Bin/*
+	@echo 'Clean finished: $(CUR_TARGET)'

--- a/Examples/TcpSorter/main.cpp
+++ b/Examples/TcpSorter/main.cpp
@@ -1,0 +1,709 @@
+/**
+ * TcpSorter application
+ * =========================
+ * This is an application that captures packets transmitted as part of TCP connections, organizes the packet and stores it in a way that is convenient for protocol analysis and debugging.
+ * This application reconstructs the TCP packets by order and stores each connection in a separate file(s). TcpSorter understands TCP sequence numbers and will correctly reorder
+ * packets regardless of retransmissions, out-of-order delivery or data loss.
+ *
+ * The main purpose of it is to demonstrate the TCP packet sorting capabilities in PcapPlusPlus.
+ *
+ * Main features and capabilities:
+ *   - Captures packets from pcap/pcapng files or live traffic
+ *   - Handles TCP retransmission, out-of-order packets and packet loss
+ *   - Possibility to set a BPF filter to process only part of the traffic
+ *   - Write each connection to a separate file
+ *   - Write each side of each connection to a separate file
+ *   - Write to console only (instead of files)
+ *   - Set a directory to write files to (default is current directory)
+ *
+ * For more details about modes of operation and parameters run TcpSorter -h
+ */
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <map>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+#include "TcpSorter.h"
+#include "PcapLiveDeviceList.h"
+#include "PcapFileDevice.h"
+#include "PlatformSpecificUtils.h"
+#include "SystemUtils.h"
+#include "PcapPlusPlusVersion.h"
+#include "LRUList.h"
+#include <getopt.h>
+
+using namespace pcpp;
+
+#define EXIT_WITH_ERROR(reason, ...) do { \
+	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
+	printUsage(); \
+	exit(1); \
+	} while(0)
+
+
+#if defined(WIN32) || defined(WINx64)
+#define SEPARATOR '\\'
+#else
+#define SEPARATOR '/'
+#endif
+
+
+// unless the user chooses otherwise - default number of concurrent used file descriptors is 500
+#define DEFAULT_MAX_NUMBER_OF_CONCURRENT_OPEN_FILES 500
+#define DEFAULT_UNLIMITED_NUMBEROF_OF_CAPTURED_PACKET 0
+#define DEFAULT_MAX_IDEL_TIMEOUT 180
+#define DEFAULT_MAX_NUMBER_OF_INACTIVE_CONNECTION_SCAN 100
+#define DEFAULT_CLEAN_UP_INACTIVE_CONNECTION_PERIOD 60
+#define DEFAULT_MAX_SEGMENT_LIFE_TIME 60
+
+typedef std::shared_ptr<pcpp::PcapFileWriterDevice> SPPcapFileWriterDevice;
+
+static struct option TcpSorterOptions[] =
+{
+	{"interface",  required_argument, 0, 'i'},
+	{"input-file",  required_argument, 0, 'r'},
+	{"output-dir", required_argument, 0, 'o'},
+	{"list-interfaces", no_argument, 0, 'l'},
+	{"filter", required_argument, 0, 'e'},
+	{"max-file-desc", required_argument, 0, 'f'},
+	{"max-captured-packet", required_argument, 0, 'p'},
+	{"max-idle-timeout", required_argument, 0, 't'},
+	{"max-inactive-connection-scan", required_argument, 0, 'n'},
+	{"clean-up-inactive-connection-period", required_argument, 0, 'd'},
+	{"max-segment-lifetime", required_argument, 0, 'g'},
+
+	{"write-metadata", no_argument, 0, 'm'},
+	{"write-to-console", no_argument, 0, 'c'},
+	{"separate-sides", no_argument, 0, 's'},
+	{"should-include-empty-segment", no_argument, 0, 'x'},
+	{"help", no_argument, 0, 'h'},
+	{"version", no_argument, 0, 'v'},
+	{0, 0, 0, 0}
+};
+
+
+/**
+ * A singleton class containing the configuration as requested by the user. This singleton is used throughout the application
+ */
+class GlobalConfig
+{
+private:
+
+	/**
+	 * A private c'tor (as this is a singleton)
+	 */
+	GlobalConfig() { writeMetadata = false; outputDir = ""; separateSides = false; maxOpenFiles = DEFAULT_MAX_NUMBER_OF_CONCURRENT_OPEN_FILES; m_RecentConnsWithActivity = nullptr; }
+
+	// A least-recently-used (LRU) list of all connections seen so far. Each connection is represented by its flow key. This LRU list is used to decide which connection was seen least
+	// recently in case we reached max number of open file descriptors and we need to decide which files to close
+	LRUList<uint32_t>* m_RecentConnsWithActivity;
+
+public:
+
+	// a flag indicating whether to write a metadata file for each connection (containing several stats)
+	bool writeMetadata;
+
+	// the directory to write files to (default is current directory)
+	std::string outputDir;
+
+	// a flag indicating whether to write both side of a connection to the same file (which is the default) or write each side to a separate file
+	bool separateSides;
+
+	// max number of allowed open files in each point in time
+	size_t maxOpenFiles;
+
+
+	/**
+	 * A method getting connection parameters as input and returns a filename and file path as output.
+	 * The filename is constructed by the IPs (src and dst) and the TCP ports (src and dst)
+	 */
+	std::string getFileName(ConnectionData connData, int side, bool separareSides)
+	{
+		std::stringstream stream;
+
+		// if user chooses to write to a directory other than the current directory - add the dir path to the return value
+		if (outputDir != "")
+			stream << outputDir << SEPARATOR;
+
+		std::string sourceIP = connData.srcIP->toString();
+		std::string destIP = connData.dstIP->toString();
+
+		// for IPv6 addresses, replace ':' with '_'
+		std::replace(sourceIP.begin(), sourceIP.end(), ':', '_');
+		std::replace(destIP.begin(), destIP.end(), ':', '_');
+
+		// side == 0 means data is sent from client->server
+		if (side <= 0 || separareSides == false)
+			stream << sourceIP << "." << connData.srcPort << "-" << destIP << "." << connData.dstPort;
+		else // side == 1 means data is sent from server->client
+			stream << destIP << "." << connData.dstPort << "-" << sourceIP << "." << connData.srcPort;
+
+		// return the file path
+		return stream.str();
+	}
+
+
+	/**
+	 * Open a file writer. Inputs are the filename to open and a flag indicating whether to append to an existing file or overwrite it.
+	 * Return value is a pointer to the new file stream
+	 */
+	SPPcapFileWriterDevice openFileWriter(std::string fileName, bool reopen)
+	{
+		// open the file on the disk (with append or overwrite mode)
+		SPPcapFileWriterDevice spFileWriter = std::make_shared<PcapFileWriterDevice>(fileName.c_str());
+		spFileWriter->open(reopen);
+		return spFileWriter;
+	}
+
+
+	/**
+	 * Close a file writer
+	 */
+	void closeFileWriter(SPPcapFileWriterDevice fileWriter)
+	{
+		if (nullptr != fileWriter)
+		{
+			fileWriter->close();
+			// free the memory
+			fileWriter.reset();
+		}
+	}
+
+
+	/**
+	 * Return a pointer to the least-recently-used (LRU) list of connections
+	 */
+	LRUList<uint32_t>* getRecentConnsWithActivity()
+	{
+		// this is a lazy implementation - the instance isn't created until the user requests it for the first time.
+		// the side of the LRU list is determined by the max number of allowed open files at any point in time. Default is DEFAULT_MAX_NUMBER_OF_CONCURRENT_OPEN_FILES
+		// but the user can choose another number
+		if (m_RecentConnsWithActivity == nullptr)
+			m_RecentConnsWithActivity = new LRUList<uint32_t>(maxOpenFiles);
+
+		// return the pointer
+		return m_RecentConnsWithActivity;
+	}
+
+
+	/**
+	 * The singleton implementation of this class
+	 */
+	static GlobalConfig& getInstance()
+	{
+		static GlobalConfig instance;
+		return instance;
+	}
+};
+
+/**
+ * A struct to contain all data save on a specific connection. It contains the file streams to write to and also stats data on the connection
+ */
+struct TcpSorterData
+{
+	// shared pointer to the Pcap file writer for both sides
+	SPPcapFileWriterDevice pcapFileWriterSide[2];
+
+	// flags indicating whether the file in each side was already opened before. If the answer is yes, next time it'll be opened in append mode (and not in overwrite mode)
+	bool reopenFileWriter[2];
+
+	// a flag indicating on which side was the latest message on this connection
+	int curSide;
+
+	// stats data: num of data packets on each side, bytes seen on each side and messages seen on each side
+	int numOfDataPackets[2];
+	int numOfMessagesFromSide[2];
+
+	/**
+	 * the default c'tor
+	 */
+	TcpSorterData() { pcapFileWriterSide[0] = nullptr; pcapFileWriterSide[1] = nullptr; clear(); }
+
+	/**
+	 * The default d'tor
+	 */
+	~TcpSorterData()
+	{
+		// close files on both sides if open
+		for (int side = 0; side < 2; side++)
+		{
+			if (pcapFileWriterSide[side] != nullptr)
+				GlobalConfig::getInstance().closeFileWriter(pcapFileWriterSide[side]);
+		}
+	}
+
+	/**
+	 * Clear all data (put 0, false or nullptr - whatever relevant for each field)
+	 */
+	void clear()
+	{
+		for (int side = 0; side < 2; side++)
+		{
+			if (pcapFileWriterSide[side] != nullptr)
+			{
+				GlobalConfig::getInstance().closeFileWriter(pcapFileWriterSide[side]);
+				pcapFileWriterSide[side] = nullptr;
+			}
+
+			reopenFileWriter[side] = false;
+			numOfDataPackets[side] = 0;
+			numOfMessagesFromSide[side] = 0;
+		}
+
+
+		curSide = -1;
+	}
+};
+
+// typedef representing the connection manager and its iterator
+typedef std::map<uint32_t, TcpSorterData> TcpSorterConnMgr;
+typedef std::map<uint32_t, TcpSorterData>::iterator TcpSorterConnMgrIter;
+
+/**
+ * Print application usage
+ */
+void printUsage()
+{
+	printf("\nUsage:\n"
+			"------\n"
+			"%s [-hvlcms] [-r input_file] [-i interface] [-o output_dir] [-e bpf_filter] [-f max_files]\n"
+			"\nOptions:\n\n"
+			"    -r input_file : Input pcap/pcapng file to analyze. Required argument for reading from file\n"
+			"    -i interface  : Use the specified interface. Can be interface name (e.g eth0) or interface IPv4 address. Required argument for capturing from live interface\n"
+			"    -o output_dir : Specify output directory (default is '.')\n"
+			"    -e bpf_filter : Apply a BPF filter to capture file or live interface, meaning TCP sorter will only work on filtered packets\n"
+			"    -f max_files  : Maximum number of file descriptors to use (default: 500)\n"
+			"    -p max_packet : Maximum number of captured packets from both sides in each TCP connection (default: 0 = unlimited)\n"
+			"    -t time_out   : Maximum idle timeout in seconds for inactive TCP connection (default: 180. The value 0 = unlimited)\n"
+			"    -n max_scan   : Maximum number of inactive TCP connection scan in each batch (default: 100. The value 0 = scan all)\n"
+			"    -d clean_prd  : Time period in seconds to trigger clean up inactive TCP connection (default: 60)\n"
+			"    -g max_slt    : Maximum sgement lifetime. In TIME_WAIT state, TCP state machine wait for twice the MSS until transist to closed state. (default: 60)\n"
+			"    -x            : Exclude empty TCP packet (default: false)\n"
+			"    -m            : Write a metadata file for each connection\n"
+			"    -s            : Write each side of each connection to a separate file (default is writing both sides of each connection to the same file)\n"
+			"    -l            : Print the list of interfaces and exit\n"
+			"    -v            : Displays the current version and exists\n"
+			"    -h            : Display this help message and exit\n\n", AppName::get().c_str());
+	exit(0);
+}
+
+
+/**
+ * Print application version
+ */
+void printAppVersion()
+{
+	printf("%s %s\n", AppName::get().c_str(), getPcapPlusPlusVersionFull().c_str());
+	printf("Built: %s\n", getBuildDateTime().c_str());
+	printf("Built from: %s\n", getGitInfo().c_str());
+	exit(0);
+}
+
+
+/**
+ * Go over all interfaces and output their names
+ */
+void listInterfaces()
+{
+	const std::vector<PcapLiveDevice*>& devList = PcapLiveDeviceList::getInstance().getPcapLiveDevicesList();
+
+	printf("\nNetwork interfaces:\n");
+	for (std::vector<PcapLiveDevice*>::const_iterator iter = devList.begin(); iter != devList.end(); iter++)
+	{
+		printf("    -> Name: '%s'   IP address: %s\n", (*iter)->getName(), (*iter)->getIPv4Address().toString().c_str());
+	}
+	exit(0);
+}
+
+
+/*********************************************************************
+ *
+ * TcpSorter callback functions begins
+ *
+ * ******************************************************************/
+
+/**
+ * The callback being called by the TCP sorter module whenever new data arrives on a certain connection
+ */
+
+static void tcpPacketReadyCallback(int sideIndex, ConnectionData connData, TcpSorter::SPRawPacket spRawPacket, void* userCookie)
+{
+	// extract the connection manager from the user cookie
+	TcpSorterConnMgr* connMgr = (TcpSorterConnMgr*)userCookie;
+
+	uint32_t flowKey = connData.flowKey;
+	// check if this flow already appears in the connection manager. If not add it
+	TcpSorterConnMgrIter iter = connMgr->find(flowKey);
+	if (iter == connMgr->end())
+	{
+		connMgr->insert({flowKey, TcpSorterData()});
+		iter = connMgr->find(flowKey);
+	}
+
+	int side;
+
+	// if the user wants to write each side in a different file - set side as the sideIndex, otherwise write everything to the same file ("side 0")
+	if (GlobalConfig::getInstance().separateSides)
+		side = sideIndex;
+	else
+		side = 0;
+
+	// if the file writer on the relevant side isn't open yet (meaning it's the first data on this connection)
+	if (iter->second.pcapFileWriterSide[side] == nullptr)
+	{
+		// add the flow key of this connection to the list of open connections. If the return value isn't NULL it means that there are too many open files
+		// and we need to close the connection with least recently used file(s) in order to open a new one.
+		// The connection with the least recently used file is the return value
+		uint32_t flowKeyToCloseFiles;
+		int result = GlobalConfig::getInstance().getRecentConnsWithActivity()->put(flowKey, &flowKeyToCloseFiles);
+
+		// if result equals to 1 it means we need to close the open files in this connection (the one with the least recently used files)
+		if (result == 1)
+		{
+			// find the connection from the flow key
+			TcpSorterConnMgrIter iter2 = connMgr->find(flowKeyToCloseFiles);
+			if (iter2 != connMgr->end())
+			{
+				// close files on both sides (if they're open)
+				for (int index = 0; index < 1; index++)
+				{
+					if (iter2->second.pcapFileWriterSide[index] != nullptr)
+					{
+						// close the file
+						GlobalConfig::getInstance().closeFileWriter(iter2->second.pcapFileWriterSide[index]);
+						iter2->second.pcapFileWriterSide[index] = nullptr;
+						// set the reopen flag to true to indicate that next time this file will be opened it will be opened in append mode (and not overwrite mode)
+						iter2->second.reopenFileWriter[index] = true;
+					}
+				}
+			}
+		}
+
+		// get the file name according to the 5-tuple etc.
+		std::string fileName = GlobalConfig::getInstance().getFileName(connData, sideIndex, GlobalConfig::getInstance().separateSides) + ".pcap";
+
+		// open the file in overwrite mode (if this is the first time the file is opened) or in append mode (if it was already opened before)
+		iter->second.pcapFileWriterSide[side] = GlobalConfig::getInstance().openFileWriter(fileName, iter->second.reopenFileWriter[side]);
+	}
+	// if this messages comes on a different side than previous message seen on this connection
+	if (sideIndex != iter->second.curSide)
+	{
+		// count number of message in each side
+		iter->second.numOfMessagesFromSide[sideIndex]++;
+
+		// set side index as the current active side
+		iter->second.curSide = sideIndex;
+	}
+
+	// count number of packets and bytes in each side of the connection
+	iter->second.numOfDataPackets[sideIndex]++;
+
+	// write the new packet to the file
+	iter->second.pcapFileWriterSide[side]->writePacket(*spRawPacket);
+}
+
+/**
+ * The callback being called by the TCP sorter module whenever missing packet is found in capture
+ */
+static void tcpPacketMissingCallback(int sideIndex, ConnectionData connData, uint32_t seq, uint32_t length, void* userCookie)
+{
+	std::string sourceIP = connData.srcIP->toString();
+	std::string destIP = connData.dstIP->toString();
+	std::string dir = sideIndex == 0? " => " : " <= ";
+	std::cout<< "Found missing packet: " << "side(" << sideIndex <<"), "
+				<< sourceIP << ":" << connData.srcPort
+				<< dir
+				<< destIP <<":" << connData.dstPort
+				<< ", seq(" << seq <<"), len(" << length <<")"
+				<< std::endl;
+}
+
+/*********************************************************************
+ *
+ * TcpSorter callback functions ends
+ *
+ * ******************************************************************/
+
+/**
+ * The callback to be called when application is terminated by ctrl-c. Stops the endless while loop
+ */
+static void onApplicationInterrupted(void* cookie)
+{
+	bool* shouldStop = (bool*)cookie;
+	*shouldStop = true;
+}
+
+
+/**
+ * packet capture callback - called whenever a packet arrives on the live device (in live device capturing mode)
+ */
+static void onPacketArrives(RawPacket* packet, PcapLiveDevice* dev, void* tcpSorterCookie)
+{
+	// get a pointer to the TCP sorter instance and feed the packet arrived to it
+	TcpSorter* tcpSorter = (TcpSorter*)tcpSorterCookie;
+
+	// The libpcap engine might release the packet data after the callback function.
+	// Clone a copy of raw packet by the copy c'tor.
+	TcpSorter::SPRawPacket spRawPacket = std::make_shared<RawPacket>(*packet);
+	tcpSorter->sortPacket(spRawPacket);
+}
+
+void printSummary(TcpSorterConnMgr* connMgr)
+{
+	uint64_t numTotalConn = connMgr->size();
+	uint64_t numTotalPackets = 0;
+	uint64_t numTotalMsgs = 0;
+	for (auto iter = connMgr->begin(); iter != connMgr->end(); iter++)
+	{
+		numTotalPackets += iter->second.numOfDataPackets[0] + iter->second.numOfDataPackets[1];
+		numTotalMsgs += iter->second.numOfMessagesFromSide[0] + iter->second.numOfMessagesFromSide[1];
+	}
+
+	printf("\nSummary:\n"
+			 "----------\n");
+	printf("Total Number of Connections    : %lu\n", numTotalConn);
+	printf("Total Number of Packets        : %lu\n", numTotalPackets);
+	printf("Total Number of Messages       : %lu\n", numTotalMsgs);
+}
+
+/**
+ * The method responsible for TCP sorter on pcap/pcapng files
+ */
+void doTcpSorterOnPcapFile(std::string fileName, TcpSorter& tcpSorter, TcpSorterConnMgr* connMgr, std::string bpfFiler = "")
+{
+	// open input file (pcap or pcapng file)
+	IFileReaderDevice* reader = IFileReaderDevice::getReader(fileName.c_str());
+
+	// try to open the file device
+	if (!reader->open())
+		EXIT_WITH_ERROR("Cannot open pcap/pcapng file");
+
+	// set BPF filter if set by the user
+	if (bpfFiler != "")
+	{
+		if (!reader->setFilter(bpfFiler))
+			EXIT_WITH_ERROR("Cannot set BPF filter to pcap file");
+	}
+
+	printf("Starting reading '%s'...\n", fileName.c_str());
+
+	// run in a loop that reads one packet from the file in each iteration and feeds it to the TCP sorter instance
+	RawPacket rawPacket;
+	while (reader->getNextPacket(rawPacket))
+	{
+		TcpSorter::SPRawPacket spRawPacket = std::make_shared<RawPacket>(rawPacket);
+		tcpSorter.sortPacket(spRawPacket);
+	}
+
+	// after all packets have been read - close the connections which are still opened
+	tcpSorter.closeAllConnections();
+
+	// close the reader and free its memory
+	reader->close();
+	delete reader;
+
+	printSummary(connMgr);
+
+	printf("Done!\n");
+}
+
+
+/**
+ * The method responsible for TCP sorter on live traffic
+ */
+void doTcpSorterOnLiveTraffic(PcapLiveDevice* dev, TcpSorter& tcpSorter, TcpSorterConnMgr* connMgr, std::string bpfFiler = "")
+{
+	// try to open device
+	if (!dev->open())
+		EXIT_WITH_ERROR("Cannot open interface");
+
+	// set BPF filter if set by the user
+	if (bpfFiler != "")
+	{
+		if (!dev->setFilter(bpfFiler))
+			EXIT_WITH_ERROR("Cannot set BPF filter to interface");
+	}
+
+	printf("Starting packet capture on '%s'...\n", dev->getIPv4Address().toString().c_str());
+
+	// start capturing packets. Each packet arrived will be handled by onPacketArrives method
+	dev->startCapture(onPacketArrives, &tcpSorter);
+
+	// register the on app close event to print summary stats on app termination
+	bool shouldStop = false;
+	ApplicationEventHandler::getInstance().onApplicationInterrupted(onApplicationInterrupted, &shouldStop);
+
+	// run in an endless loop until the user presses ctrl+c
+	while(!shouldStop)
+		PCAP_SLEEP(1);
+
+	// stop capturing and close the live device
+	dev->stopCapture();
+	dev->close();
+
+	// close all connections which are still opened
+	tcpSorter.closeAllConnections();
+
+	printSummary(connMgr);
+
+	printf("Done!\n");
+}
+
+
+/**
+ * main method of this utility
+ */
+int main(int argc, char* argv[])
+{
+	AppName::init(argc, argv);
+
+	std::string interfaceNameOrIP = "";
+	std::string inputPcapFileName = "";
+	std::string bpfFilter = "";
+	std::string outputDir = "";
+	bool writeMetadata = false;
+	bool separateSides = false;
+	size_t maxOpenFiles = DEFAULT_MAX_NUMBER_OF_CONCURRENT_OPEN_FILES;
+	uint64_t maxNumCapturedPacket = DEFAULT_UNLIMITED_NUMBEROF_OF_CAPTURED_PACKET;
+	uint32_t maxIdleTimeout = DEFAULT_MAX_IDEL_TIMEOUT;
+	uint32_t maxNumInactiveConnScan = DEFAULT_MAX_NUMBER_OF_INACTIVE_CONNECTION_SCAN;
+	uint32_t cleanUpInactiveConnPeriod = DEFAULT_CLEAN_UP_INACTIVE_CONNECTION_PERIOD;
+	uint32_t maxSegmentLifeTime = DEFAULT_MAX_SEGMENT_LIFE_TIME;
+	bool shouldIncludeEmptySegments = true;
+
+	int optionIndex = 0;
+	char opt = 0;
+
+	while((opt = getopt_long (argc, argv, "i:r:o:e:f:p:t:n:d:g:mcsvhlx", TcpSorterOptions, &optionIndex)) != -1)
+	{
+		switch (opt)
+		{
+			case 0:
+				break;
+			case 'i':
+				interfaceNameOrIP = optarg;
+				break;
+			case 'r':
+				inputPcapFileName = optarg;
+				break;
+			case 'o':
+				outputDir = optarg;
+				break;
+			case 'e':
+				bpfFilter = optarg;
+				break;
+			case 's':
+				separateSides = true;
+				break;
+			case 'm':
+				writeMetadata = true;
+				break;
+			case 'x':
+				shouldIncludeEmptySegments = false;
+				break;
+			case 'f':
+				if(sscanf(optarg, "%lu", &maxOpenFiles) != 1) {
+					printf("Invalid argument for maxOpenFiles!");
+					exit(-1);
+				}
+				break;
+			case 'p':
+				if(sscanf(optarg, "%lu", &maxNumCapturedPacket) != 1) {
+					printf("Invalid argument for maxNumCapturedPacket!");
+					exit(-1);
+				}
+				break;
+			case 't':
+				if(sscanf(optarg, "%u", &maxIdleTimeout) != 1) {
+					printf("Invalid argument for maxIdelTimeout!");
+					exit(-1);
+				}
+				break;
+			case 'n':
+				if(sscanf(optarg, "%u", &maxNumInactiveConnScan) != 1) {
+					printf("Invalid argument for maxNumInactiveConnScan!");
+					exit(-1);
+				}
+				break;
+			case 'd':
+				if(sscanf(optarg, "%u", &cleanUpInactiveConnPeriod) != 1) {
+					printf("Invalid argument for cleanUpInactiveConnPeriod!");
+					exit(-1);
+				}
+				break;
+			case 'g':
+				if(sscanf(optarg, "%u", &maxSegmentLifeTime) != 1) {
+					printf("Invalid argument for maxSegmentLifeTime!");
+					exit(-1);
+				}
+				break;
+			case 'h':
+				printUsage();
+				break;
+			case 'v':
+				printAppVersion();
+				break;
+			case 'l':
+				listInterfaces();
+				break;
+			default:
+				printUsage();
+				exit(-1);
+		}
+	}
+
+	// if no interface nor input pcap file were provided - exit with error
+	if (inputPcapFileName == "" && interfaceNameOrIP == "")
+		EXIT_WITH_ERROR("Neither interface nor input pcap file were provided");
+
+	// verify output dir exists
+	if (outputDir != "" && !directoryExists(outputDir))
+		EXIT_WITH_ERROR("Output directory doesn't exist");
+
+	// set global config singleton with input configuration
+	GlobalConfig::getInstance().outputDir = outputDir;
+	GlobalConfig::getInstance().writeMetadata = writeMetadata;
+	GlobalConfig::getInstance().separateSides = separateSides;
+	GlobalConfig::getInstance().maxOpenFiles = maxOpenFiles;
+
+	// create the object which manages info on all connections
+	TcpSorterConnMgr connMgr;
+
+	TcpSorterConfiguration cfg(maxNumCapturedPacket, maxIdleTimeout,
+														 maxNumInactiveConnScan, cleanUpInactiveConnPeriod,
+														 maxSegmentLifeTime, shouldIncludeEmptySegments);
+
+	// create the TCP sorter instance
+	TcpSorter tcpSorter(tcpPacketReadyCallback, tcpPacketMissingCallback, &connMgr, cfg);
+
+	// analyze in pcap file mode
+	if (inputPcapFileName != "")
+	{
+		doTcpSorterOnPcapFile(inputPcapFileName, tcpSorter, &connMgr, bpfFilter);
+	}
+	else // analyze in live traffic mode
+	{
+		// extract pcap live device by interface name or IP address
+		PcapLiveDevice* dev = nullptr;
+		IPv4Address interfaceIP(interfaceNameOrIP);
+		if (interfaceIP.isValid())
+		{
+			dev = PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(interfaceIP);
+			if (dev == nullptr)
+				EXIT_WITH_ERROR("Couldn't find interface by provided IP");
+		}
+		else
+		{
+			dev = PcapLiveDeviceList::getInstance().getPcapLiveDeviceByName(interfaceNameOrIP);
+			if (dev == nullptr)
+				EXIT_WITH_ERROR("Couldn't find interface by provided name");
+		}
+
+		// start capturing packets and do TCP sorting
+		doTcpSorterOnLiveTraffic(dev, tcpSorter, &connMgr, bpfFilter);
+	}
+}

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ EXAMPLE_PCAPSPLITTER := Examples/PcapSplitter
 EXAMPLE_PCAPSEARCH   := Examples/PcapSearch
 EXAMPLE_ICMP_FT      := Examples/IcmpFileTransfer
 EXAMPLE_TCP_REASM    := Examples/TcpReassembly
+EXAMPLE_TCP_SORT     := Examples/TcpSorter
 EXAMPLE_IP_FRAG      := Examples/IPFragUtil
 EXAMPLE_IP_DEFRAG    := Examples/IPDefragUtil
 EXAMPLE_DPDK2        := Examples/DpdkBridge
@@ -47,6 +48,7 @@ all: libs
 	@cd $(EXAMPLE_PCAPSEARCH)        && $(MAKE) PcapSearch
 	@cd $(EXAMPLE_ICMP_FT)           && $(MAKE) IcmpFileTransfer-pitcher && $(MAKE) IcmpFileTransfer-catcher
 	@cd $(EXAMPLE_TCP_REASM)         && $(MAKE) TcpReassembly
+	@cd $(EXAMPLE_TCP_SORT)          && $(MAKE) TcpSorter
 	@cd $(EXAMPLE_IP_FRAG)           && $(MAKE) IPFragUtil
 	@cd $(EXAMPLE_IP_DEFRAG)         && $(MAKE) IPDefragUtil
 ifdef USE_DPDK
@@ -70,6 +72,7 @@ endif
 	$(CP) $(EXAMPLE_PCAPSEARCH)/Bin/* ./Dist/examples
 	$(CP) $(EXAMPLE_ICMP_FT)/Bin/* ./Dist/examples
 	$(CP) $(EXAMPLE_TCP_REASM)/Bin/* ./Dist/examples
+	$(CP) $(EXAMPLE_TCP_SORT)/Bin/* ./Dist/examples
 	$(CP) $(EXAMPLE_IP_FRAG)/Bin/* ./Dist/examples	
 	$(CP) $(EXAMPLE_IP_DEFRAG)/Bin/* ./Dist/examples	
 ifdef USE_DPDK
@@ -118,6 +121,7 @@ clean:
 	@cd $(EXAMPLE_PCAPSEARCH)        && $(MAKE) clean
 	@cd $(EXAMPLE_ICMP_FT)           && $(MAKE) clean
 	@cd $(EXAMPLE_TCP_REASM)         && $(MAKE) clean
+	@cd $(EXAMPLE_TCP_SORT)          && $(MAKE) clean
 	@cd $(EXAMPLE_IP_FRAG)           && $(MAKE) clean
 	@cd $(EXAMPLE_IP_DEFRAG)         && $(MAKE) clean
 ifdef USE_DPDK

--- a/Packet++/header/TcpSorter.h
+++ b/Packet++/header/TcpSorter.h
@@ -1,0 +1,301 @@
+#ifndef PACKETPP_TCP_SORTER
+#define PACKETPP_TCP_SORTER
+#include "Packet.h"
+#include "IpAddress.h"
+#include "TcpReassembly.h"
+#include <map>
+#include <list>
+#include <time.h>
+#include <memory>
+
+
+/**
+ *@file
+ * This is an implementation of TCP segment sort logic. It groups and sorts multiple TCP segments by order from TCP connections.<BR>
+ *
+ * __General Features:__
+ * - Manage multiple TCP connections under one pcpp#TcpSorter instance
+ * - Support TCP retransmission
+ * - Support out-of-order packets
+ * - Support detection of missing TCP packet in capture
+ * - Support two callbacks: the arrival of TCP packets and the detection of the packets missing in the packet capture.
+ * - TCP connections ends by an idle timeout.
+ * - TCP segment sort logic follows RFC 753 but disregards packet dropping logic,
+ *   such as windows size validation, time stamp validation, and etc.
+ *
+ * __Logic Description:__
+ * - The user creates an instance of the pcpp#TcpSorter class
+ * - Then the user starts feeding it with TCP packets.
+ * - The pcpp#TcpSorter instance manages all TCP connections from the packets it's being fed. For each connection it manages its 2 sides (A->B and B->A)
+ * - When a packet arrives, it is first classified to a certain TCP connection
+ * - Then it is classified to a certain side of the TCP connection. We assume such side is the sender.
+ * - If the new arrival packet has been already acknowledged by receiver's side, drop it. Otherwise, add it to the unacknowledged packet multi map in sender's side.
+ * - If ACK is set in the new arrival packet, flush the unacknowledged packets from receiver's side and set sender's ACK to receiver's SND.UNA.
+ * - When flushing the unacknowledged packets, maintain an internal expected sequence number. If the internal expected sequence number is greater than or equal to
+ *   the sequence number of the flushed packet, invoke callback function pcpp#TcpSorter#onTcpPacketReady with the raw packet. Otherwise, the missing packet is
+ *   detected from captue and invoke callback function pcpp#TcpSorter#OnTcpPacketMIssing.
+ *
+ * __Basic Usage and APIs:__
+ * - pcpp#TcpSorter c'tor - Create an instance, provide the callbacks and the user cookie to the instance
+ * - pcpp#TcpSorter#sortPacket() - Feed pcpp#TcpSorter instance with packets
+ * - pcpp#TcpSorter#closeAllConnections() - Manually close all currently opened connections
+ * - pcpp#TcpSorter#OnTcpPacketReady callback - Invoked when new data arrives on a certain connection. Contains the new data as well as connection data (5-tuple, flow key).
+ * - pcpp#TcpSorter#OnTcpPacketMIssing callback - Invoked when detect a missing packet from capture.
+ *
+ * __Additional information:__
+ *
+ * - Clean up inactive TCP connection. In case of half-closed TCP connection, it is unwise to stop sorting prematurely
+ *   once FIN bit is set in the packet. An inactive timer is setup in each TCP connection. pcpp#TcpSorter scans
+ *   a predefined random subset of all TCP connection periodically and check if inactivity of the TCP connection
+ *   passes the idle time out.
+ */
+
+#define SEQ_LT(a,b)		(static_cast<int32_t>((a)-(b)) < 0)
+#define SEQ_LEQ(a,b)		(static_cast<int32_t>((a)-(b)) <= 0)
+#define SEQ_GT(a,b)		(static_cast<int32_t>((a)-(b)) > 0)
+#define SEQ_GEQ(a,b)		(static_cast<int32_t>((a)-(b)) >= 0)
+
+/**
+ * @namespace pcpp
+ * @brief The main namespace for the PcapPlusPlus lib
+ */
+namespace pcpp
+{
+/**
+ * @struct TcpSorterConfiguration
+ * A structure for configuring the TcpSorter class
+ */
+struct TcpSorterConfiguration
+{
+	/** The maximum number of captured packets from both sides in each TCP connection.
+	 * The default value 0 means unlimited.
+	 */
+	uint64_t maxNumCapturedPacket;
+
+	/** The maximum idle timeout in seconds for inactive TCP connections
+	 * The default value 0 means it disable clean up inactive TCP connections.
+	 */
+	uint32_t maxIdleTimeout;
+
+	/** The maximum number of inactive TCP connection scanning in each batch
+	 * The default value is 100. The value 0 means scanning all.
+	 */
+	uint32_t maxNumInactiveConnScan;
+
+	/** The time period in seconds to trigger clean up inactive TCP connection
+	 * The default value is 60 seconds.
+	 */
+	uint32_t cleanUpInactiveConnPeriod;
+
+	/** The maximum segment lifetime
+	 * The default value is 60 seconds. In TIME_WAIT state, TCP state machine wait for twice the maximum segment lifetime until transit to the CLOSED state.
+	 */
+	uint32_t maxSegmentLifeTime;
+
+	/** The flag indicating to include empty segments */
+	bool shouldIncludeEmptySegments;
+
+	/**
+	 * A c'tor for TcpSorterConfiguration struct
+	 * @param[in] maxNumCapturedPacket The maximum number of captured packets from both sides in each TCP connection. The default value 0 means unlimited.
+	 * @param[in] maxIdleTimeout The maximum idle timeout in seconds for inactive TCP connections. The default value 0 means disable clean up inactive TCP connections.
+	 * @param[in] maxNumInactiveConnScan The maximum number of inactive TCP connection scanning in each batch. The default value is 100. The value 0 means scanning all.
+	 * @param[in] cleanUpInactiveConnPeriod The time period in seconds to trigger clean up inactive TCP connection. The default value is 60.
+	 * @param[in] maxSegmentLifeTime The maximum segment lifetime. The default value is 60 seconds. In TIME_WAIT state, TCP state machine wait for twice the maximum segment lifetime until transit to the CLOSED state.
+	 * @param[in] shouldIncludeEmptySegments The flag indicating to include empty segments. The default value is true.
+	 */
+	TcpSorterConfiguration(
+									uint64_t maxNumCapturedPacket       = 0,
+									uint32_t maxIdleTimeout             = 0,
+									uint32_t maxNumInactiveConnScan     = 100,
+									uint32_t cleanUpInactiveConnPeriod  = 60,
+									uint32_t maxSegmentLifeTime         = 60,
+									bool shouldIncludeEmptySegments     = true) :
+		maxNumCapturedPacket(maxNumCapturedPacket),
+		maxIdleTimeout(maxIdleTimeout),
+		maxNumInactiveConnScan(maxNumInactiveConnScan),
+		cleanUpInactiveConnPeriod(cleanUpInactiveConnPeriod),
+		maxSegmentLifeTime(maxSegmentLifeTime),
+		shouldIncludeEmptySegments(shouldIncludeEmptySegments)
+	{
+	}
+};
+
+/**
+ * @class TcpSorter
+ * A class containing the TCP packet sorting logic. Please refer to the documentation at the top of TcpSorter.h for understanding how to use this class
+ */
+class TcpSorter
+{
+public:
+
+	/**
+	 * @typedef SPRawPacket
+	 * The type for shared pointer of raw packet
+	 */
+	typedef std::shared_ptr<RawPacket> SPRawPacket;
+
+	/**
+	 * An enum for TCP state transition
+	 */
+	enum TcpConnectionState
+	{
+		CLOSED,
+		LISTEN,
+		SYN_SENT,
+		SYN_RCVD,
+		ESTABLISHED,
+		CLOSE_WAIT,
+		LAST_ACK,
+		FIN_WAIT_1,
+		FIN_WAIT_2,
+		CLOSING,
+		TIME_WAIT
+	};
+
+
+	/**
+	 * @typedef OnTcpPacketReady
+	 * A callback invoked when new TCP packet arrives on a connection
+	 * @param[in] side The side this data belongs to (MachineA->MachineB or vice versa). The value is 0 or 1 where 0 is the first side seen in the connection and 1 is the second side seen
+	 * @param[in] connData Connection meta data
+	 * @param[in] spRawPacket A shared pointer to a new arrival TCP packet
+	 * @param[in] userCookie A pointer to the cookie provided by the user in TcpSorter c'tor (or nullptr if no cookie provided)
+	 */
+	typedef void (*OnTcpPacketReady)(int side, ConnectionData connData, SPRawPacket spRawPacket, void* userCookie);
+
+	/**
+	 * @typedef OnTcpPacketMissing
+	 * A callback invoked when found TCP packet missing in capturing
+	 * @param[in] side The side this data belongs to (MachineA->MachineB or vice versa). The value is 0 or 1 where 0 is the first side seen in the connection and 1 is the second side seen
+	 * @param[in] connData Connection meta data
+	 * @param[in] seq The sequence number of the missing packet
+	 * @param[in] length The length of the missing packet
+	 * @param[in] userCookie A pointer to the cookie provided by the user in TcpSorter c'tor (or nullptr if no cookie provided)
+	 */
+	typedef void (*OnTcpPacketMissing)(int side, ConnectionData connData, uint32_t seq, uint32_t length, void* userCookie);
+
+	/**
+	 * A c'tor for TcpSorter class
+	 * @param[in] onPacketReadyCallback The callback to be invoked when new TCP packet arrives
+	 * @param[in] onPacketMissingCallback The callback to be invoked when found TCP packet is missing in capture
+	 * @param[in] userCookie A pointer to an object provided by the user. This pointer will be returned when invoking the various callbacks. This parameter is optional, default cookie is nullptr
+	 * @param[in] config Optional parameter for defining special configuration parameters. If not set the default parameters will be set
+	 */
+	TcpSorter(OnTcpPacketReady onPacketReadyCallback,
+				 OnTcpPacketMissing onPacketMissingCallback = nullptr,
+				 void* userCookie = nullptr,
+				 const TcpSorterConfiguration &config = TcpSorterConfiguration());
+
+	/**
+	 * A d'tor for this class. Close all connections.
+	 */
+	virtual ~TcpSorter();
+
+	/**
+	 * The most important method of this class which gets a raw packet from the user and processes it.
+	 * The raw packet will be added to unacknowledged packet list.
+	 * If this packet contains ACK bit,	the relevant callback will be invoked (TcpSorter#OnTcpPacketReady, TcpSorter#OnTcpPacketMissing)
+	 * @param[in] spRawPacket A shared pointer to the raw packet
+	 */
+	void sortPacket(SPRawPacket spRawPacket);
+
+	/**
+	 * Stop sorting packet and clean up all captured connection.
+	 */
+	void closeAllConnections();
+
+private:
+	/**
+	 * @struct SequenceLessThan struct provides sequence number less than comparision method.
+	 */
+	struct SequenceLessThan {
+		bool operator()(const uint32_t leftSeq, const uint32_t rightSeq) const {
+			return SEQ_LT(leftSeq, rightSeq);
+		}
+	};
+
+	/**
+	 * @typedef RawPacketMultiMap defines multi map with customized sequence comparison method.
+	 */
+	typedef std::multimap<uint32_t, SPRawPacket, SequenceLessThan> RawPacketMultiMap;
+
+	/**
+	 * @struct TcpOneSideData struct represents the packets from the sender's perspective.
+	 */
+	struct TcpOneSideData
+	{
+		RawPacketMultiMap uPacketMap; // unacknowledged raw packet map
+		IPAddress* srcIP; // source IP address
+		uint64_t acceptedPacketCount;
+		uint32_t sndUna; // send unacknowledged
+		uint32_t expSeq; // next expected sequence number for packet flushing
+		TcpConnectionState tcpState; // tcp state
+		uint16_t srcPort; // source port
+		bool gotFinOrRst;
+
+		void setSrcIP(IPAddress* sourrcIP);
+
+		TcpOneSideData() { srcIP = nullptr; srcPort = 0; sndUna = 0; gotFinOrRst = false; acceptedPacketCount = 0; tcpState = CLOSED; }
+
+		~TcpOneSideData() { if (srcIP != nullptr) delete srcIP; }
+	};
+
+	/**
+	 * @struct TcpSorterData struct represents the TCP connection
+	 */
+	struct TcpSorterData
+	{
+		TcpOneSideData twoSides[2];
+		ConnectionData connData;
+		time_t lastActiveTimeStamp;
+		int numOfSides;
+		bool hasTcp3WayHandShake;
+
+		TcpSorterData() { numOfSides = 0; lastActiveTimeStamp = 0; hasTcp3WayHandShake = false;}
+	};
+
+	typedef std::shared_ptr<TcpSorterData> SPTcpSorterData;
+	typedef std::map<uint32_t, SPTcpSorterData> ConnectionList;
+
+	// callback function
+	OnTcpPacketReady m_OnPacketReadyCallback;
+	OnTcpPacketMissing m_OnPacketMissingCallback;
+	// user defined handler
+	void* m_UserCookie;
+	// The key data structure to store TCP connection.
+	// a map: flow key -> TcpSorterData
+	ConnectionList m_ConnectionList;
+	// time stamp for recording last clean up TCP connection
+	time_t m_LastCleanupTime;
+	// configuration variables
+	uint64_t m_MaxNumCapturedPacket;
+	bool m_ShouldIncludeEmptySegments;
+	// a boolean flag to determine if all connections are closed
+	bool m_isClosed;
+	uint32_t m_MaxIdleTimeout;
+	uint32_t m_CleanUpInactiveConnPeriod;
+	uint32_t m_MaxNumInactiveConnScan;
+	uint32_t m_MaxSegmentLifeTime;
+
+	/**
+	 * @brief cleanUpInactiveTcpConnection Clean up inactive TCP connection by random sample without replacement method.
+	 * @param now time stamp now
+	 */
+	void cleanUpInactiveTcpConnection(time_t now);
+	/**
+	 * @brief closeConnection Close one TCP connection. Flush the last unacknowledged packet if any.
+	 * @param flowKey flow key of the TCP connection
+	 */
+	void closeConnection(uint32_t flowKey);
+	/**
+	 * @brief flushPacket Given sender's ACK, flush all acknowledged packets from receiver's side.
+	 * @param tcpSorterData TCP connection
+	 * @param ack sender's ACK
+	 * @param rcvIdx receiver index
+	 */
+	void flushPacket(SPTcpSorterData tcpSorterData, uint32_t ack, int rcvIdx);
+};
+
+}
+#endif // PACKETTPP_TCP_SORTER

--- a/Packet++/src/TcpSorter.cpp
+++ b/Packet++/src/TcpSorter.cpp
@@ -511,7 +511,7 @@ void TcpSorter::flushPacket(SPTcpSorterData tcpSorterData, uint32_t ack, int rcv
 		// found missing packets
 		else
 		{
-			m_OnPacketMissingCallback(rcvIdx, tcpSorterData->connData, seq, seq - expSeq, m_UserCookie);
+			m_OnPacketMissingCallback(rcvIdx, tcpSorterData->connData, expSeq, seq - expSeq, m_UserCookie);
 			// update expected sequence number with packet sequence number
 			expSeq = seq;
 			// add back packet to the front

--- a/Packet++/src/TcpSorter.cpp
+++ b/Packet++/src/TcpSorter.cpp
@@ -1,0 +1,585 @@
+#define LOG_MODULE PacketLogModuleTcpSorter
+
+#include "TcpSorter.h"
+#include "TcpLayer.h"
+#include "IPv4Layer.h"
+#include "IPv6Layer.h"
+#include "PacketUtils.h"
+#include "IpAddress.h"
+#include "Logger.h"
+#include <sstream>
+#include <random>
+#include <vector>
+#include <algorithm>
+#if defined(WIN32) || defined(PCAPPP_MINGW_ENV) //for using ntohl, ntohs, etc.
+#include <winsock2.h>
+#elif LINUX
+#include <in.h> //for using ntohl, ntohs, etc.
+#elif MAC_OS_X || FREEBSD
+#include <arpa/inet.h> //for using ntohl, ntohs, etc.
+#endif
+
+#define PURGE_FREQ_SECS 1
+
+namespace pcpp
+{
+
+TcpSorter::TcpSorter(
+							OnTcpPacketReady onPacketReadyCallback,
+							OnTcpPacketMissing onPacketMissingCallback,
+							void* userCookie,
+							const TcpSorterConfiguration &config)
+{
+	m_isClosed = false;
+	m_OnPacketReadyCallback = onPacketReadyCallback;
+	m_OnPacketMissingCallback = onPacketMissingCallback;
+	m_UserCookie = userCookie;
+	// configuration value
+	m_MaxNumCapturedPacket = config.maxNumCapturedPacket;
+	m_MaxIdleTimeout = config.maxIdleTimeout;
+	m_MaxNumInactiveConnScan = config.maxNumInactiveConnScan;
+	m_MaxSegmentLifeTime = config.maxSegmentLifeTime;
+	m_CleanUpInactiveConnPeriod = config.cleanUpInactiveConnPeriod;
+	m_ShouldIncludeEmptySegments = config.shouldIncludeEmptySegments;
+	// reset clean up timer
+	m_LastCleanupTime = time(NULL);
+}
+
+TcpSorter::~TcpSorter()
+{
+	closeAllConnections();
+}
+
+void TcpSorter::sortPacket(SPRawPacket spRawPacket)
+{
+	// stop sorting if it is closed
+	if(m_isClosed)
+	{
+		return;
+	}
+	// parse the packet
+	Packet packet(spRawPacket.get(), false);
+
+	time_t now = time(NULL);
+
+	// clean up any expired inactive TCP connection
+	if (0 != m_MaxIdleTimeout && m_LastCleanupTime + m_CleanUpInactiveConnPeriod < now)
+	{
+		cleanUpInactiveTcpConnection(now);
+		m_LastCleanupTime = now;
+	}
+
+	// get IP layer
+	Layer* ipLayer = nullptr;
+	if (packet.isPacketOfType(IPv4))
+		ipLayer = dynamic_cast<Layer*>(packet.getLayerOfType<IPv4Layer>());
+	else if (packet.isPacketOfType(IPv6))
+		ipLayer = dynamic_cast<Layer*>(packet.getLayerOfType<IPv6Layer>());
+
+	if (ipLayer == nullptr)
+		return;
+
+	// Ignore non-TCP packets
+	TcpLayer* tcpLayer = packet.getLayerOfType<TcpLayer>();
+	if (tcpLayer == nullptr)
+		return;
+
+	// Ignore the packet if it's an ICMP packet that has a TCP layer
+	// Several ICMP messages (like "destination unreachable") have TCP data as part of the ICMP message.
+	// This is not real TCP data and packet can be ignored
+	if (packet.isPacketOfType(ICMP))
+	{
+		LOG_DEBUG("Packet is of type ICMP so TCP data is probably  part of the ICMP message. Ignoring this packet");
+		return;
+	}
+
+	// set the TCP payload size
+	uint32_t tcpPayloadSize =static_cast<uint32_t>(tcpLayer->getLayerPayloadSize());
+
+	// get TCP flag
+	bool isAck = (tcpLayer->getTcpHeader()->ackFlag == 1);
+	bool isSyn = (tcpLayer->getTcpHeader()->synFlag == 1);
+	bool isFin = (tcpLayer->getTcpHeader()->finFlag == 1);
+	bool isRst = (tcpLayer->getTcpHeader()->rstFlag == 1);
+
+	// TCP connection for captured packet
+	SPTcpSorterData tcpSorterData = nullptr;
+
+	// calculate flow key for this packet
+	uint32_t flowKey = hash5Tuple(&packet);
+
+	// find the connection in the connection map
+	ConnectionList::iterator iter = m_ConnectionList.find(flowKey);
+
+	// get packet's source and dest IP address
+	IPAddress* srcIP = nullptr;
+	IPAddress* dstIP = nullptr;
+	IPv4Address srcIP4Addr = IPv4Address::Zero;
+	IPv6Address srcIP6Addr = IPv6Address::Zero;
+	IPv4Address dstIP4Addr = IPv4Address::Zero;
+	IPv6Address dstIP6Addr = IPv6Address::Zero;
+	if (ipLayer->getProtocol() == IPv4)
+	{
+		srcIP4Addr = (dynamic_cast<IPv4Layer*>(ipLayer))->getSrcIpAddress();
+		srcIP = &srcIP4Addr;
+		dstIP4Addr = (dynamic_cast<IPv4Layer*>(ipLayer))->getDstIpAddress();
+		dstIP = &dstIP4Addr;
+	}
+	else if (ipLayer->getProtocol() == IPv6)
+	{
+		srcIP6Addr = (dynamic_cast<IPv6Layer*>(ipLayer))->getSrcIpAddress();
+		srcIP = &srcIP6Addr;
+		dstIP6Addr = (dynamic_cast<IPv6Layer*>(ipLayer))->getDstIpAddress();
+		dstIP = &dstIP6Addr;
+	}
+
+	// if TCP connection doesn't exist, create one
+	if (iter == m_ConnectionList.end())
+	{
+		// The SYN flag in the first packet must be set.
+		if (! isSyn)
+		{
+			LOG_DEBUG("Ignore packet of a flow [0x%X] that doesn't start with 3 way handshake.", flowKey);
+			return;
+		}
+		// create a TcpSorterData object and add it to the active connection list
+		tcpSorterData = std::make_shared<TcpSorterData>();
+		tcpSorterData->connData.setSrcIpAddress(srcIP);
+		tcpSorterData->connData.setDstIpAddress(dstIP);
+		tcpSorterData->connData.srcPort = ntohs(tcpLayer->getTcpHeader()->portSrc);
+		tcpSorterData->connData.dstPort = ntohs(tcpLayer->getTcpHeader()->portDst);
+		tcpSorterData->connData.flowKey = flowKey;
+		timeval ts = packet.getRawPacket()->getPacketTimeStamp();
+		tcpSorterData->connData.setStartTime(ts);
+		m_ConnectionList[flowKey] = tcpSorterData;
+	}
+	else // connection already exists
+	{
+		tcpSorterData = iter->second;
+	} // end of connection exists
+
+	// sender's side index
+	int sndIdx = -1;
+
+	// get packet's source port
+	uint16_t srcPort = tcpLayer->getTcpHeader()->portSrc;
+
+	// if this is a new connection and it's the first packet we see on that connection
+	if (tcpSorterData->numOfSides == 0)
+	{
+		LOG_DEBUG("Setting side for new connection");
+
+		// open the first side of the connection, side index is 0
+		sndIdx = 0;
+		tcpSorterData->twoSides[sndIdx].setSrcIP(srcIP);
+		tcpSorterData->twoSides[sndIdx].srcPort = srcPort;
+		tcpSorterData->numOfSides++;
+	}
+	// if there is already one side in this connection (which will be at side index 0)
+	else if (tcpSorterData->numOfSides == 1)
+	{
+		// check if packet belongs to that side
+		if (tcpSorterData->twoSides[0].srcIP->equals(srcIP) && tcpSorterData->twoSides[0].srcPort == srcPort)
+		{
+			sndIdx = 0;
+		}
+		else
+		{
+			// this means packet belong to the second side which doesn't yet exist. Open a second side with side index 1
+			LOG_DEBUG("Setting second side of a connection");
+			sndIdx = 1;
+			tcpSorterData->twoSides[sndIdx].setSrcIP(srcIP);
+			tcpSorterData->twoSides[sndIdx].srcPort = srcPort;
+			tcpSorterData->numOfSides++;
+		}
+	}
+	// if there are already 2 sides open for this connection
+	else if (tcpSorterData->numOfSides == 2)
+	{
+		// check if packet matches side 0
+		if (tcpSorterData->twoSides[0].srcIP->equals(srcIP) && tcpSorterData->twoSides[0].srcPort == srcPort)
+		{
+			sndIdx = 0;
+		}
+		// check if packet matches side 1
+		else if (tcpSorterData->twoSides[1].srcIP->equals(srcIP) && tcpSorterData->twoSides[1].srcPort == srcPort)
+		{
+			sndIdx = 1;
+		}
+		// packet doesn't match either side. This case doesn't make sense but it's handled anyway. Packet will be ignored
+		else
+		{
+			LOG_ERROR("Error occurred - packet doesn't match either side of the connection!!");
+			return;
+		}
+	}
+	// there are more than 2 side - this case doesn't make sense and shouldn't happen, but handled anyway. Packet will be ignored
+	else
+	{
+		LOG_ERROR("Error occurred - connection has more than 2 sides!!");
+		return;
+	}
+
+	int rcvIdx = 1 - sndIdx;
+
+	// no further processing if accepted packe count reach maximum
+	if (0 != m_MaxNumCapturedPacket &&
+			((tcpSorterData->twoSides[rcvIdx].acceptedPacketCount +
+				tcpSorterData->twoSides[sndIdx].acceptedPacketCount) >= m_MaxNumCapturedPacket))
+	{
+		return;
+	}
+
+	// update TCP connection last active timestamp
+	tcpSorterData->lastActiveTimeStamp = now;
+
+	// extract sequence number and acknoledgement number if any
+	uint32_t seq = ntohl(tcpLayer->getTcpHeader()->sequenceNumber);
+	uint32_t ack = ntohl(tcpLayer->getTcpHeader()->ackNumber);
+
+	// Get previous TCP state
+	auto sndState = tcpSorterData->twoSides[sndIdx].tcpState;
+	auto rcvState = tcpSorterData->twoSides[rcvIdx].tcpState;
+
+	// Update TCP state
+	/** Assumption:
+	 *
+	 * Alice sends a packet to Bob. TcpSorter captures this packet.
+	 *
+	 * - If (seq + Tcp payload size) >= Alice's SND.UNA, insert the packet into
+	 *   Alice's unacknowledged packet multimap with key = (seq + Tcp payload size).
+	 *   Otherwise, drop the packet.
+	 *
+	 * - If Alice sends an ACK, Bob should flush the packets from his unacknowledged
+	 *   packet multimap with key up to Alice's ACK and set his SND.UNA to Alice's ACK
+	 *   (assuming Bob must receive ACK packet from Alice. If not, Bob would keep sending
+	 *    to Alice.).
+	 *
+	 */
+
+	// For the first packet, we have an early return for special handling.
+	/** Start of special handling. **/
+	if (sndState == CLOSED)
+	{
+		if (isSyn)
+		{
+			// isSyn && isAck
+			if (isAck)
+			{
+				// validate if the sender's ACK matches the receiver's SYN
+				if (SEQ_LEQ(tcpSorterData->twoSides[rcvIdx].sndUna, ack))
+				{
+					// passive OPEN: CLOSED => LISTEN =>  SYN_RCVD, skip LISTEN
+					tcpSorterData->twoSides[sndIdx].tcpState = SYN_RCVD;
+					// set to ISS
+					tcpSorterData->twoSides[sndIdx].expSeq = seq;
+					// flush packet in receiver side
+					flushPacket(tcpSorterData, ack, rcvIdx);
+				}
+				else
+				{
+					LOG_ERROR("Found incorrect ACK number in 3 way TCP handshake.");
+					return;
+				}
+			}
+			// isSyn && !isAck
+			else
+			{
+				// active OPEN: CLOSED => SYN_SENT or SEND: LISTEN => SYN_SENT
+				tcpSorterData->twoSides[sndIdx].tcpState = SYN_SENT;
+				// set to ISS
+				tcpSorterData->twoSides[sndIdx].expSeq = seq;
+			}
+
+			// Initialize SND.UNA with ISS. Per RFC 7413 TCP Fast Open, add TCP pay load size.
+			tcpSorterData->twoSides[sndIdx].sndUna = seq + tcpPayloadSize;
+			// Insert the packet into unack packet map.
+			tcpSorterData->twoSides[sndIdx].uPacketMap.insert({seq + tcpPayloadSize, spRawPacket});
+		} // end of isSyn is true
+
+		if (isRst)
+		{
+			// isRst && isAck
+			if (isAck)
+			{
+				if (SEQ_LEQ(tcpSorterData->twoSides[rcvIdx].sndUna, ack))
+				{
+					// force closing connection
+					tcpSorterData->twoSides[sndIdx].tcpState = CLOSED;
+					tcpSorterData->twoSides[rcvIdx].tcpState = CLOSED;
+					tcpSorterData->twoSides[sndIdx].expSeq = seq;
+					flushPacket(tcpSorterData, ack, rcvIdx);
+					tcpSorterData->twoSides[sndIdx].sndUna = seq + tcpPayloadSize;
+					tcpSorterData->twoSides[sndIdx].uPacketMap.insert({seq + tcpPayloadSize, spRawPacket});
+					closeConnection(flowKey);
+				}
+			}
+		} // end of isRst is true
+		return;
+	} // end of sender's CLOSED state
+
+	/** End of speical handling. From below, it needs to take care of sndUna, sndNxt and flush the packet in the receiver side.**/
+
+	if (sndState == SYN_RCVD)
+	{
+		if (isFin)
+		{
+			// Close: SYN_RCVD => FIN_WAIT_1
+			tcpSorterData->twoSides[sndIdx].tcpState = FIN_WAIT_1;
+		}
+	} // end of sender's SYN_RCVD state
+
+	if (sndState == SYN_SENT)
+	{
+		if (isAck)
+		{
+			if (SEQ_LEQ(tcpSorterData->twoSides[rcvIdx].sndUna, ack))
+			{
+				tcpSorterData->twoSides[sndIdx].tcpState = ESTABLISHED;
+				// change receiver side to ESTABLISHED, we assume the receiver side is going to get this ACK packet
+				if (rcvState == SYN_RCVD)
+				{
+					tcpSorterData->twoSides[rcvIdx].tcpState = ESTABLISHED;
+				}
+			}
+		}
+	} // end of sender's SYN_SENT state
+
+
+	if (sndState == ESTABLISHED)
+	{
+		if (isFin)
+		{
+			// Close: ESTABLISHED => FIN_WAIT_1
+			tcpSorterData->twoSides[sndIdx].tcpState = FIN_WAIT_1;
+		}
+
+		if (rcvState == FIN_WAIT_1 && isAck && SEQ_LEQ(tcpSorterData->twoSides[rcvIdx].sndUna, ack))
+		{
+			// the receiver side sends FIN and the sender sends ACK,
+			// ESTABLISED => CLOSE_WAIT
+			tcpSorterData->twoSides[sndIdx].tcpState = CLOSE_WAIT;
+		}
+	} // end of sendr's ESTABLISHED state
+
+	// Perhaps take care of the rest TCP states... But for now, it is OK.
+
+	// update TCP 3 way handshake boolean flag
+	if (!tcpSorterData->hasTcp3WayHandShake &&
+		 tcpSorterData->twoSides[sndIdx].tcpState == ESTABLISHED &&
+		 tcpSorterData->twoSides[rcvIdx].tcpState == ESTABLISHED)
+	{
+		tcpSorterData->hasTcp3WayHandShake = true;
+	}
+
+	// insert sender's packet to unacknowledged packet multimap only it is unacknowledged.
+	if(SEQ_GEQ(seq + tcpPayloadSize, tcpSorterData->twoSides[sndIdx].sndUna))
+	{
+		tcpSorterData->twoSides[sndIdx].uPacketMap.insert({seq + tcpPayloadSize, spRawPacket});
+	}
+
+
+	// if there is ACK in sender's side, flush acknowledged TCP packets in the receiver's side
+	if (isAck)
+	{
+		flushPacket(tcpSorterData, ack, rcvIdx);
+	}
+
+}
+
+void TcpSorter::closeConnection(uint32_t flowKey)
+{
+	auto iter = m_ConnectionList.find(flowKey);
+	if (iter != m_ConnectionList.end())
+	{
+		auto tcpSorterData = iter->second;
+		if (0 != m_MaxNumCapturedPacket &&
+				((tcpSorterData->twoSides[0].acceptedPacketCount +
+					tcpSorterData->twoSides[1].acceptedPacketCount) >= m_MaxNumCapturedPacket))
+		{
+			return;
+		}
+		// flush the remaining packet if there is only one packet left
+		auto numUnackPacketAtSide0 = tcpSorterData->twoSides[0].uPacketMap.size();
+		auto numUnackPacketAtSide1 = tcpSorterData->twoSides[1].uPacketMap.size();
+		if (1 == (numUnackPacketAtSide0 + numUnackPacketAtSide1))
+		{
+			int idx = (1 == numUnackPacketAtSide0)? 0: 1;
+			auto spRawPacket = tcpSorterData->twoSides[idx].uPacketMap.begin()->second;
+			m_OnPacketReadyCallback(idx, tcpSorterData->connData, spRawPacket, m_UserCookie);
+			tcpSorterData->twoSides[idx].uPacketMap.erase(tcpSorterData->twoSides[idx].uPacketMap.begin());
+		}
+	}
+}
+
+void TcpSorter::closeAllConnections()
+{
+	if (!m_isClosed)
+	{
+		m_isClosed = true;
+
+		for(auto it = m_ConnectionList.begin(); it != m_ConnectionList.end(); it++)
+		{
+			closeConnection(it->first);
+		}
+
+		m_ConnectionList.clear();
+	}
+}
+
+/**
+ * Given sender's ACK, flush acknowledged packets from receiver's side.
+ */
+void TcpSorter::flushPacket(SPTcpSorterData tcpSorterData, uint32_t ack, int rcvIdx)
+{
+	int sndIdx = 1 - rcvIdx;
+
+	if (tcpSorterData->twoSides[rcvIdx].uPacketMap.empty())
+	{
+		// update SND.UNA with ACK
+		tcpSorterData->twoSides[rcvIdx].sndUna = ack;
+		return;
+	}
+
+	std::list<SPRawPacket> aPacketList; // acknowledged raw packet list
+
+	auto itLowerAck = tcpSorterData->twoSides[rcvIdx].uPacketMap.lower_bound(ack);
+	// move packets up to ack (not include ack)
+	for (auto it = tcpSorterData->twoSides[rcvIdx].uPacketMap.begin();
+		  it != itLowerAck;
+		  ++it)
+	{
+		aPacketList.push_back(it->second);
+	}
+	// move packets with key = ack
+	auto equRange = tcpSorterData->twoSides[rcvIdx].uPacketMap.equal_range(ack);
+	for (auto it = equRange.first; it != equRange.second; ++it)
+	{
+		aPacketList.push_back(it->second);
+	}
+
+	uint32_t expSeq = tcpSorterData->twoSides[rcvIdx].expSeq;
+
+	// remove acknowledged packet from unacknowledged packet
+	if (!aPacketList.empty())
+	{
+		auto itUpperAck = tcpSorterData->twoSides[rcvIdx].uPacketMap.upper_bound(ack);
+		auto itBegin = tcpSorterData->twoSides[rcvIdx].uPacketMap.begin();
+		tcpSorterData->twoSides[rcvIdx].uPacketMap.erase(itBegin, itUpperAck);
+	}
+
+	while (!aPacketList.empty())
+	{
+		auto spRawPacket = aPacketList.front();
+		aPacketList.pop_front();
+		// parse the packet
+		Packet packet(spRawPacket.get(), false);
+		TcpLayer * tcpLayer = packet.getLayerOfType<TcpLayer>();
+		if (tcpLayer == nullptr)
+			continue;
+		uint32_t tcpPayloadSize =static_cast<uint32_t>(tcpLayer->getLayerPayloadSize());
+		uint32_t seq = ntohl(tcpLayer->getTcpHeader()->sequenceNumber);
+		bool isSyn = (tcpLayer->getTcpHeader()->synFlag == 1);
+		bool isFin = (tcpLayer->getTcpHeader()->finFlag == 1);
+
+		// expected sequencepacket sequence number
+		if (SEQ_GEQ(expSeq, seq))
+		{
+			if (tcpPayloadSize > 0 || ( 0 == tcpPayloadSize && m_ShouldIncludeEmptySegments))
+			{
+				if (0 == m_MaxNumCapturedPacket ||
+					 ((tcpSorterData->twoSides[rcvIdx].acceptedPacketCount +
+						tcpSorterData->twoSides[sndIdx].acceptedPacketCount) <= m_MaxNumCapturedPacket))
+				{
+					m_OnPacketReadyCallback(rcvIdx, tcpSorterData->connData, spRawPacket, m_UserCookie);
+					tcpSorterData->twoSides[rcvIdx].acceptedPacketCount++;
+				}
+			}
+
+			// advance expected sequence number only if it grows
+			if (SEQ_GT(seq + tcpPayloadSize, expSeq))
+			{
+				expSeq = seq + tcpPayloadSize;
+			}
+
+			// override for Syn or Fin packet
+			if ((isSyn || isFin) && SEQ_GT(seq + tcpPayloadSize + 1, expSeq))
+			{
+				expSeq = seq + tcpPayloadSize + 1;
+			}
+		}
+		// found missing packets
+		else
+		{
+			m_OnPacketMissingCallback(rcvIdx, tcpSorterData->connData, seq, seq - expSeq, m_UserCookie);
+			// update expected sequence number with packet sequence number
+			expSeq = seq;
+			// add back packet to the front
+			aPacketList.push_front(spRawPacket);
+		}
+	} // end of while looping acknowledged packet list
+
+	tcpSorterData->twoSides[rcvIdx].expSeq = expSeq;
+
+	// update SND.UNA with ACK
+	tcpSorterData->twoSides[rcvIdx].sndUna = ack;
+}
+
+void TcpSorter::TcpOneSideData::setSrcIP(IPAddress* sourrcIP)
+{
+	if (srcIP != nullptr)
+		delete srcIP;
+
+	srcIP = sourrcIP->clone();
+}
+
+void TcpSorter::cleanUpInactiveTcpConnection(time_t now)
+{
+	// if disable clean up
+	if (0 == m_MaxIdleTimeout)
+	{
+		return;
+	}
+
+	// collect flowKeys from TCP connection list
+	auto iterKey = m_ConnectionList.begin(), iterKeyEnd = m_ConnectionList.end();
+	std::vector<uint32_t> accessKeys;
+	for(; iterKey != iterKeyEnd; iterKey++)
+	{
+		accessKeys.push_back(iterKey->first);
+	}
+
+	// if scan partial of TCP connection list, use random sample without replacement method to get a partial list.
+	if (0 != m_MaxNumInactiveConnScan)
+	{
+		// shuffle the access keys
+		std::shuffle(accessKeys.begin(), accessKeys.end(), std::default_random_engine(static_cast<unsigned long>(now)));
+		// only keep the first m_MaxNumInactiveConnScan elements
+		if (accessKeys.size() > m_MaxNumInactiveConnScan)
+		{
+			accessKeys.resize(m_MaxNumInactiveConnScan);
+		}
+	}
+
+	auto iterAccessKey = accessKeys.begin(), iterAccessKeyEnd = accessKeys.end();
+	for(; iterAccessKey != iterAccessKeyEnd; iterAccessKey++)
+	{
+		auto it = m_ConnectionList.find(*iterAccessKey);
+		// assert accessKey can be found
+		if (m_ConnectionList.end() == it)
+		{
+			continue;
+		}
+		auto tcpSorterData = it->second;
+		// check if last active timestamp passes idel timeout
+		if (tcpSorterData->lastActiveTimeStamp + m_MaxIdleTimeout <= now)
+		{
+			// close connection
+			closeConnection(it->first);
+			// clean up expire tcpSorterData
+			m_ConnectionList.erase(*iterAccessKey);
+		}
+	}
+}
+
+} // end of namespace pcpp

--- a/mk/platform.mk.macosx
+++ b/mk/platform.mk.macosx
@@ -6,9 +6,9 @@ LIB_PREFIX := lib
 
 LIB_EXT := .a
 
-CXX := g++
+CXX := clang++
 
-CC := gcc
+CC := clang
 
 AR := ar
 
@@ -21,3 +21,5 @@ MKDIR := mkdir
 INSTALL_SCRIPT := install.sh
 
 UNINSTALL_SCRIPT := uninstall.sh
+
+PCAPPP_ENABLE_CPP_FEATURE_DETECTION := YES


### PR DESCRIPTION
I have performed online capturing test and offline pcap file test. The result looks good.

Also, I ran valgrind to check memory leak for hours. The shared pointer makes my life easier. I did find pcap library itself has memory leak when lists NIC. I didn't look deeper into the issue since I can't fix libpcap here.

Regarding to the TCP sorter logic, the TCP packet is flushed to the user once another side sends ACK. You can find more technical detail in the Doxygen header.

