### PR TITLE
Lookup a layer in reverse order (enhancement)

### DIFF
--- a/Packet++/header/Packet.h
+++ b/Packet++/header/Packet.h
@@ -245,21 +245,33 @@ namespace pcpp
 
 		/**
 		 * A templated method to get a layer of a certain type (protocol). If no layer of such type is found, NULL is returned
+		 * @param[in] reverseOrder The optional paramter that indicates that the lookup should run in reverse order, the default value is false
 		 * @return A pointer to the layer of the requested type, NULL if not found
 		 */
 		template<class TLayer>
-		TLayer* getLayerOfType() const;
+		TLayer* getLayerOfType(bool reverseOrder = false) const;
 
 		/**
 		 * A templated method to get the first layer of a certain type (protocol), start searching from a certain layer.
 		 * For example: if a packet looks like: EthLayer -> VlanLayer(1) -> VlanLayer(2) -> VlanLayer(3) -> IPv4Layer
 		 * and the user put VlanLayer(2) as a parameter and wishes to search for a VlanLayer, VlanLayer(3) will be returned
 		 * If no layer of such type is found, NULL is returned
-		 * @param[in] after A pointer to the layer to start search from
+		 * @param[in] startLayer A pointer to the layer to start search from
 		 * @return A pointer to the layer of the requested type, NULL if not found
 		 */
 		template<class TLayer>
-		TLayer* getNextLayerOfType(Layer* after) const;
+		TLayer* getNextLayerOfType(Layer* startLayer) const;
+
+		/**
+		 * A templated method to get the first layer of a certain type (protocol), start searching from a certain layer.
+		 * For example: if a packet looks like: EthLayer -> VlanLayer(1) -> VlanLayer(2) -> VlanLayer(3) -> IPv4Layer
+		 * and the user put VlanLayer(2) as a parameter and wishes to search for a VlanLayer, VlanLayer(1) will be returned
+		 * If no layer of such type is found, NULL is returned
+		 * @param[in] startLayer A pointer to the layer to start search from
+		 * @return A pointer to the layer of the requested type, NULL if not found
+		 */
+		template<class TLayer>
+		TLayer* getPrevLayerOfType(Layer* startLayer) const;
 
 		/**
 		 * Check whether the packet contains a certain protocol
@@ -307,27 +319,51 @@ namespace pcpp
 	};
 
 	template<class TLayer>
-	TLayer* Packet::getLayerOfType() const
+	TLayer* Packet::getLayerOfType(bool reverse) const
 	{
-		if (dynamic_cast<TLayer*>(m_FirstLayer) != NULL)
-			return (TLayer*)m_FirstLayer;
+		if (!reverse)
+		{
+			if (dynamic_cast<TLayer*>(getFirstLayer()) != NULL)
+				return (TLayer*)getFirstLayer();
 
-		return getNextLayerOfType<TLayer>(m_FirstLayer);
+			return getNextLayerOfType<TLayer>(getFirstLayer());
+		}
+
+		// lookup in reverse order
+		if (dynamic_cast<TLayer*>(getLastLayer()) != NULL)
+			return (TLayer*)getLastLayer();
+
+		return getPrevLayerOfType<TLayer>(getLastLayer());
 	}
 
 	template<class TLayer>
-	TLayer* Packet::getNextLayerOfType(Layer* after) const
+	TLayer* Packet::getNextLayerOfType(Layer* curLayer) const
 	{
-		if (after == NULL)
+		if (curLayer == NULL)
 			return NULL;
 
-		Layer* curLayer = after->getNextLayer();
+		curLayer = curLayer->getNextLayer();
 		while ((curLayer != NULL) && (dynamic_cast<TLayer*>(curLayer) == NULL))
 		{
 			curLayer = curLayer->getNextLayer();
 		}
 
 		return (TLayer*)curLayer;
+	}
+
+	template<class TLayer>
+	TLayer* Packet::getPrevLayerOfType(Layer* curLayer) const
+	{
+		if (curLayer == NULL)
+			return NULL;
+
+		curLayer = curLayer->getPrevLayer();
+		while (curLayer != NULL && dynamic_cast<TLayer*>(curLayer) == NULL)
+		{
+			curLayer = curLayer->getPrevLayer();
+		}
+
+		return static_cast<TLayer*>(curLayer);
 	}
 
 } // namespace pcpp

--- a/Packet++/src/PacketUtils.cpp
+++ b/Packet++/src/PacketUtils.cpp
@@ -26,7 +26,7 @@ uint32_t hash5Tuple(Packet* packet)
 	uint16_t portDst = 0;
 	int srcPosition = 0;
 
-	TcpLayer* tcpLayer = packet->getLayerOfType<TcpLayer>();
+	TcpLayer* tcpLayer = packet->getLayerOfType<TcpLayer>(true); // lookup in reverse order
 	if (tcpLayer != NULL)
 	{
 		portSrc = tcpLayer->getTcpHeader()->portSrc;
@@ -34,7 +34,7 @@ uint32_t hash5Tuple(Packet* packet)
 	}
 	else
 	{
-		UdpLayer* udpLayer = packet->getLayerOfType<UdpLayer>();
+		UdpLayer* udpLayer = packet->getLayerOfType<UdpLayer>(true);
 		portSrc = udpLayer->getUdpHeader()->portSrc;
 		portDst = udpLayer->getUdpHeader()->portDst;
 	}

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -103,7 +103,7 @@ TcpReassembly::~TcpReassembly()
 void TcpReassembly::reassemblePacket(Packet& tcpData)
 {
 	// automatic cleanup
-	if(m_RemoveConnInfo == true)
+	if (m_RemoveConnInfo == true)
 	{
 		if(time(NULL) >= m_PurgeTimepoint)
 		{
@@ -123,12 +123,12 @@ void TcpReassembly::reassemblePacket(Packet& tcpData)
 		return;
 
 	// Ignore non-TCP packets
-	TcpLayer* tcpLayer = tcpData.getLayerOfType<TcpLayer>();
+	TcpLayer* tcpLayer = tcpData.getLayerOfType<TcpLayer>(true); // lookup in reverse order
 	if (tcpLayer == NULL)
 		return;
 
 	// Ignore the packet if it's an ICMP packet that has a TCP layer
-    // Several ICMP messages (like "destination unreachable") have TCP data as part of the ICMP message.
+	// Several ICMP messages (like "destination unreachable") have TCP data as part of the ICMP message.
 	// This is not real TCP data and packet can be ignored
 	if (tcpData.isPacketOfType(ICMP))
 	{

--- a/Pcap++/src/NetworkUtils.cpp
+++ b/Pcap++/src/NetworkUtils.cpp
@@ -63,7 +63,7 @@ static void arpPacketRecieved(RawPacket* rawPacket, PcapLiveDevice* device, void
 		return;
 
 	// extract the ARP layer from the packet
-	ArpLayer* arpReplyLayer = packet.getLayerOfType<ArpLayer>();
+	ArpLayer* arpReplyLayer = packet.getLayerOfType<ArpLayer>(true); // lookup in reverse order
 	if (arpReplyLayer == NULL)
 		return;
 
@@ -246,7 +246,7 @@ static void dnsResponseRecieved(RawPacket* rawPacket, PcapLiveDevice* device, vo
 		return;
 
 	// extract the DNS layer from the packet
-	DnsLayer* dnsResponseLayer = packet.getLayerOfType<DnsLayer>();
+	DnsLayer* dnsResponseLayer = packet.getLayerOfType<DnsLayer>(true); // lookup in reverse order
 	if (dnsResponseLayer == NULL)
 		return;
 

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -7561,6 +7561,32 @@ PTF_TEST_CASE(EthDot3LayerCreateEditTest)
 
 
 
+PTF_TEST_CASE(PacketLayerLookupTest)
+{
+	// reverse lookup
+	int bufferLength = 0;
+	uint8_t* buffer = readFileIntoBuffer("PacketExamples/radius_1.dat", bufferLength);
+	PTF_ASSERT_NOT_NULL(buffer);
+
+	timeval time;
+	gettimeofday(&time, NULL);
+	RawPacket rawPacket((const uint8_t*)buffer, bufferLength, time, true);
+	Packet radiusPacket(&rawPacket);
+
+	RadiusLayer* radiusLayer = radiusPacket.getLayerOfType<RadiusLayer>(true);
+	PTF_ASSERT_NOT_NULL(radiusLayer);
+
+	EthLayer* ethLayer = radiusPacket.getLayerOfType<EthLayer>(true);
+	PTF_ASSERT_NOT_NULL(ethLayer);
+
+	IPv4Layer* ipLayer = radiusPacket.getPrevLayerOfType<IPv4Layer>(radiusLayer);
+	PTF_ASSERT_NOT_NULL(ipLayer);
+
+	TcpLayer* tcpLayer = radiusPacket.getPrevLayerOfType<TcpLayer>(ipLayer);
+	PTF_ASSERT_NULL(tcpLayer);
+}
+
+
 static struct option PacketTestOptions[] =
 {
 	{"tags",  required_argument, 0, 't'},
@@ -7724,6 +7750,7 @@ int main(int argc, char* argv[]) {
 	PTF_RUN_TEST(GtpLayerEditTest, "gtp");
 	PTF_RUN_TEST(EthDot3LayerParsingTest, "eth_dot3;eth");
 	PTF_RUN_TEST(EthDot3LayerCreateEditTest, "eth_dot3;eth");
+	PTF_RUN_TEST(PacketLayerLookupTest, "packet");
 
 	PTF_END_RUNNING_TESTS;
 }

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -7563,27 +7563,63 @@ PTF_TEST_CASE(EthDot3LayerCreateEditTest)
 
 PTF_TEST_CASE(PacketLayerLookupTest)
 {
-	// reverse lookup
-	int bufferLength = 0;
-	uint8_t* buffer = readFileIntoBuffer("PacketExamples/radius_1.dat", bufferLength);
-	PTF_ASSERT_NOT_NULL(buffer);
-
 	timeval time;
 	gettimeofday(&time, NULL);
-	RawPacket rawPacket((const uint8_t*)buffer, bufferLength, time, true);
-	Packet radiusPacket(&rawPacket);
 
-	RadiusLayer* radiusLayer = radiusPacket.getLayerOfType<RadiusLayer>(true);
-	PTF_ASSERT_NOT_NULL(radiusLayer);
+	{
+		int bufferLength = 0;
+		uint8_t* buffer = readFileIntoBuffer("PacketExamples/radius_1.dat", bufferLength);
+		PTF_ASSERT_NOT_NULL(buffer);
 
-	EthLayer* ethLayer = radiusPacket.getLayerOfType<EthLayer>(true);
-	PTF_ASSERT_NOT_NULL(ethLayer);
+		RawPacket rawPacket(buffer, bufferLength, time, true);
+		Packet radiusPacket(&rawPacket);
 
-	IPv4Layer* ipLayer = radiusPacket.getPrevLayerOfType<IPv4Layer>(radiusLayer);
-	PTF_ASSERT_NOT_NULL(ipLayer);
+		RadiusLayer* radiusLayer = radiusPacket.getLayerOfType<RadiusLayer>(true);
+		PTF_ASSERT_NOT_NULL(radiusLayer);
 
-	TcpLayer* tcpLayer = radiusPacket.getPrevLayerOfType<TcpLayer>(ipLayer);
-	PTF_ASSERT_NULL(tcpLayer);
+		EthLayer* ethLayer = radiusPacket.getLayerOfType<EthLayer>(true);
+		PTF_ASSERT_NOT_NULL(ethLayer);
+
+		IPv4Layer* ipLayer = radiusPacket.getPrevLayerOfType<IPv4Layer>(radiusLayer);
+		PTF_ASSERT_NOT_NULL(ipLayer);
+
+		TcpLayer* tcpLayer = radiusPacket.getPrevLayerOfType<TcpLayer>(ipLayer);
+		PTF_ASSERT_NULL(tcpLayer);
+	}
+
+	{
+		int bufferLength = 0;
+		uint8_t* buffer = readFileIntoBuffer("PacketExamples/Vxlan1.dat", bufferLength);
+		PTF_ASSERT_NOT_NULL(buffer);
+
+		// current packet contains the following layers: Eth(1) -> IPv4(1) -> UDP -> VXLAN -> Eth(2) -> IPv4(2) -> ICMP
+		RawPacket rawPacket(buffer, bufferLength, time, true);
+		Packet vxlanPacket(&rawPacket);
+
+		// get the last IPv4 layer
+		IPv4Layer* ipLayer = vxlanPacket.getLayerOfType<IPv4Layer>(true);
+		PTF_ASSERT_NOT_NULL(ipLayer);
+		PTF_ASSERT_EQUAL(ipLayer->getSrcIpAddress(), IPv4Address("192.168.203.3"), object);
+		PTF_ASSERT_EQUAL(ipLayer->getDstIpAddress(), IPv4Address("192.168.203.5"), object);
+
+		// get the first IPv4 layer
+		ipLayer = vxlanPacket.getPrevLayerOfType<IPv4Layer>(ipLayer);
+		PTF_ASSERT_NOT_NULL(ipLayer);
+		PTF_ASSERT_EQUAL(ipLayer->getSrcIpAddress(), IPv4Address("192.168.203.1"), object);
+		PTF_ASSERT_EQUAL(ipLayer->getDstIpAddress(), IPv4Address("192.168.202.1"), object);
+
+		// try to get one more IPv4 layer
+		PTF_ASSERT_NULL(vxlanPacket.getPrevLayerOfType<IPv4Layer>(ipLayer));
+
+		// get the first layer
+		EthLayer* ethLayer = vxlanPacket.getPrevLayerOfType<EthLayer>(ipLayer);
+		PTF_ASSERT_NOT_NULL(ipLayer);
+		PTF_ASSERT_NULL(vxlanPacket.getPrevLayerOfType<EthLayer>(ethLayer));
+		PTF_ASSERT_NULL(vxlanPacket.getPrevLayerOfType<EthLayer>(vxlanPacket.getFirstLayer()));
+
+		// try to get nonexistent layer
+		PTF_ASSERT_NULL(vxlanPacket.getLayerOfType<RadiusLayer>(true));
+	}
 }
 
 

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -7613,7 +7613,7 @@ PTF_TEST_CASE(PacketLayerLookupTest)
 
 		// get the first layer
 		EthLayer* ethLayer = vxlanPacket.getPrevLayerOfType<EthLayer>(ipLayer);
-		PTF_ASSERT_NOT_NULL(ipLayer);
+		PTF_ASSERT_NOT_NULL(ethLayer);
 		PTF_ASSERT_NULL(vxlanPacket.getPrevLayerOfType<EthLayer>(ethLayer));
 		PTF_ASSERT_NULL(vxlanPacket.getPrevLayerOfType<EthLayer>(vxlanPacket.getFirstLayer()));
 


### PR DESCRIPTION
In many cases the lookup in reverse order in packet is faster than in the direct one.

This PR adds such feature and improvements in a number of modules.