### PR TITLE
Remove warnings in MinGW

### DIFF
--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -1367,11 +1367,11 @@ PTF_TEST_CASE(TcpPacketNoOptionsParsing)
 
 	PTF_ASSERT_EQUAL(tcpLayer->getTcpHeader()->portDst, htobe16(60388), u16);
 	PTF_ASSERT_EQUAL(tcpLayer->getTcpHeader()->portSrc, htobe16(80), u16);
-	PTF_ASSERT_EQUAL(tcpLayer->getTcpHeader()->sequenceNumber, htobe32(0xbeab364a), hex);
-	PTF_ASSERT_EQUAL(tcpLayer->getTcpHeader()->ackNumber, htobe32(0xf9ffb58e), hex);
+	PTF_ASSERT_EQUAL(tcpLayer->getTcpHeader()->sequenceNumber, htobe32(0xbeab364a), u32);
+	PTF_ASSERT_EQUAL(tcpLayer->getTcpHeader()->ackNumber, htobe32(0xf9ffb58e), u32);
 	PTF_ASSERT_EQUAL(tcpLayer->getTcpHeader()->dataOffset, 5, u16);
 	PTF_ASSERT_EQUAL(tcpLayer->getTcpHeader()->urgentPointer, 0, u16);
-	PTF_ASSERT_EQUAL(tcpLayer->getTcpHeader()->headerChecksum, htobe16(0x4c03), hex);
+	PTF_ASSERT_EQUAL(tcpLayer->getTcpHeader()->headerChecksum, htobe16(0x4c03), u16);
 
 	// Flags
 	PTF_ASSERT_EQUAL(tcpLayer->getTcpHeader()->ackFlag, 1, u16);
@@ -7275,7 +7275,7 @@ PTF_TEST_CASE(GtpLayerParsingTest)
 	PTF_ASSERT_NOT_NULL(gtpLayer->getHeader());
 	PTF_ASSERT_EQUAL(gtpLayer->getHeader()->messageType, 0xff, hex);
 	PTF_ASSERT_EQUAL(be16toh(gtpLayer->getHeader()->messageLength), 496, u16);
-	PTF_ASSERT_EQUAL(be32toh(gtpLayer->getHeader()->teid), 2327461905, u32);
+	PTF_ASSERT_EQUAL(be32toh(gtpLayer->getHeader()->teid), 2327461905U, u32);
 	PTF_ASSERT_EQUAL(gtpLayer->getHeader()->protocolType, 1, u8);
 
 	PTF_ASSERT_EQUAL(gtpLayer->getHeaderLen(), 8, size);

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -2394,7 +2394,7 @@ PTF_TEST_CASE(TestRemoteCapture)
 	size_t capturedPacketsSize = capturedPackets.size();
 	while (iter != capturedPackets.end())
 	{
-		if ((*iter)->getRawDataLen() <= pRemoteDevice->getMtu())
+		if ((*iter)->getRawDataLen() <= (int)pRemoteDevice->getMtu())
 		{
 			packetsToSend.pushBack(capturedPackets.getAndRemoveFromVector(iter));
 		}


### PR DESCRIPTION
```
==> Building target: Packet++Test
Building file: main.cpp
main.cpp:7278:2: warning: this decimal constant is unsigned only in ISO C90
  PTF_ASSERT_EQUAL(be32toh(gtpLayer->getHeader()->teid), 2327461905, u32);
	
main.cpp: In function 'void TcpPacketNoOptionsParsing(int&)':
../PcppTestFramework/PcppTestFramework.h:103:225: warning: format '%X' expects argument of type 'unsigned int', but argument 5 has type 'u_long {aka long unsigned int}' [-Wformat=]
   printf("%-30s: FAILED (line: %d). assert equal failed: actual: " type##_PTF_PRINT_FORMAT " != expected: " type##_PTF_PRINT_FORMAT "\n", __FUNCTION__, __LINE__, type##_PTF_PRINT_TYPE(actual), type##_PTF_PRINT_TYPE(expected)); \
                                                                                                                                                                                                                                 ^
main.cpp:1370:2: note: in expansion of macro 'PTF_ASSERT_EQUAL'
  PTF_ASSERT_EQUAL(tcpLayer->getTcpHeader()->sequenceNumber, htobe32(0xbeab364a), hex);
  ^
../PcppTestFramework/PcppTestFramework.h:103:225: warning: format '%X' expects argument of type 'unsigned int', but argument 5 has type 'u_long {aka long unsigned int}' [-Wformat=]
   printf("%-30s: FAILED (line: %d). assert equal failed: actual: " type##_PTF_PRINT_FORMAT " != expected: " type##_PTF_PRINT_FORMAT "\n", __FUNCTION__, __LINE__, type##_PTF_PRINT_TYPE(actual), type##_PTF_PRINT_TYPE(expected)); \
                                                                                                                                                                                                                                 ^
main.cpp:1371:2: note: in expansion of macro 'PTF_ASSERT_EQUAL'
  PTF_ASSERT_EQUAL(tcpLayer->getTcpHeader()->ackNumber, htobe32(0xf9ffb58e), hex);
  ^
```