### PR TITLE
IPv4Layer::isDataValid

### DIFF
--- a/Packet++/header/IPv4Layer.h
+++ b/Packet++/header/IPv4Layer.h
@@ -601,7 +601,7 @@ namespace pcpp
 		 * @param[in] dataLen The length of byte stream
 		 * @return True if the data is valid and can represent the IPv4 packet
 		 */
-		static bool isDataValid(const uint8_t* data, size_t dataLen);
+		static inline bool isDataValid(const uint8_t* data, size_t dataLen);
 
 	private:
 		int m_NumOfTrailingBytes;
@@ -615,6 +615,15 @@ namespace pcpp
 		void initLayer();
 		void initLayerInPacket(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet, bool setTotalLenAsDataLen);
 	};
+
+
+	// implementation of inline methods
+
+	bool IPv4Layer::isDataValid(const uint8_t* data, size_t dataLen)
+	{
+		const iphdr* hdr = reinterpret_cast<const iphdr*>(data);
+		return dataLen >= sizeof(iphdr) && hdr->ipVersion == 4 && hdr->internetHeaderLength >= 5;
+	}
 
 } // namespace pcpp
 

--- a/Packet++/src/IPv4Layer.cpp
+++ b/Packet++/src/IPv4Layer.cpp
@@ -558,13 +558,10 @@ bool IPv4Layer::removeAllOptions()
 
 bool IPv4Layer::isDataValid(const uint8_t* data, size_t dataLen)
 {
-	if (dataLen >= 20)
+	if (dataLen >= sizeof(iphdr))
 	{
 		const iphdr* hdr = reinterpret_cast<const iphdr*>(data);
-
-		return hdr->ipVersion == 4
-			&& hdr->internetHeaderLength >= 5
-			&& be16toh(hdr->totalLength) <= 65535;
+		return hdr->ipVersion == 4 && hdr->internetHeaderLength >= 5;
 	}
 	return false;
 }

--- a/Packet++/src/IPv4Layer.cpp
+++ b/Packet++/src/IPv4Layer.cpp
@@ -556,14 +556,4 @@ bool IPv4Layer::removeAllOptions()
 	return true;
 }
 
-bool IPv4Layer::isDataValid(const uint8_t* data, size_t dataLen)
-{
-	if (dataLen >= sizeof(iphdr))
-	{
-		const iphdr* hdr = reinterpret_cast<const iphdr*>(data);
-		return hdr->ipVersion == 4 && hdr->internetHeaderLength >= 5;
-	}
-	return false;
-}
-
 } // namespace pcpp


### PR DESCRIPTION
1. Removed useless check `be16toh(hdr->totalLength) <= 65535` because it's always true
2. This method became an inline