### PR TITLE
Avoid the compilation warnings under Linux and OSX

### DIFF
--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
@@ -496,7 +496,7 @@ void light_write_packet(light_pcapng_t *pcapng, const light_packet_header *packe
 
 		// let all written packets has a timestamp resolution in nsec - this way we will not loose the precision;
 		// when a possibility to write interface blocks is added, the precision should be taken from them
-		light_option resolution_option = light_create_option(LIGHT_OPTION_IF_TSRESOL, sizeof(NSEC_PRECISION), &NSEC_PRECISION);
+		light_option resolution_option = light_create_option(LIGHT_OPTION_IF_TSRESOL, sizeof(NSEC_PRECISION), (uint8_t*)&NSEC_PRECISION);
 		light_add_option(NULL, iface_block_pcapng, resolution_option, LIGHT_FALSE);
 
 		blocks_to_write = iface_block_pcapng;

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -1152,12 +1152,12 @@ PTF_TEST_CASE(TestPcapNgFileReadWriteAdv)
     pcap_stat writerStatistics;
 
     readerDev.getStatistics(readerStatistics);
-    PTF_ASSERT(readerStatistics.ps_recv == 159, "Incorrect number of packets read from file. Expected: 159; read: %d", readerStatistics.ps_recv);
-    PTF_ASSERT(readerStatistics.ps_drop == 0, "Packets were not read properly from file. Number of packets dropped: %d", readerStatistics.ps_drop);
+    PTF_ASSERT(readerStatistics.ps_recv == 159, "Incorrect number of packets read from file. Expected: 159; read: %u", readerStatistics.ps_recv);
+    PTF_ASSERT(readerStatistics.ps_drop == 0, "Packets were not read properly from file. Number of packets dropped: %u", readerStatistics.ps_drop);
 
     writerDev.getStatistics(writerStatistics);
-    PTF_ASSERT(writerStatistics.ps_recv == 159, "Incorrect number of packets written to file. Expected: 159; written: %d", writerStatistics.ps_recv);
-    PTF_ASSERT(writerStatistics.ps_drop == 0, "Packets were not written properly to file. Number of packets dropped: %d", writerStatistics.ps_drop);
+    PTF_ASSERT(writerStatistics.ps_recv == 159, "Incorrect number of packets written to file. Expected: 159; written: %u", writerStatistics.ps_recv);
+    PTF_ASSERT(writerStatistics.ps_drop == 0, "Packets were not written properly to file. Number of packets dropped: %u", writerStatistics.ps_drop);
 
     readerDev.close();
     writerDev.close();
@@ -1221,26 +1221,26 @@ PTF_TEST_CASE(TestPcapNgFileReadWriteAdv)
 		if (packet1_timestamp.tv_sec < packet2_timestamp.tv_sec)
 		{
 			PTF_ASSERT((packet2_timestamp.tv_sec - packet1_timestamp.tv_sec) < 2,
-					"Timestamps are differ in packets %d in more than 2 secs: %lld and %lld; nsec are %lld and %lld",
+					"Timestamps are differ in packets %d in more than 2 secs: %ld and %ld; nsec are %ld and %ld",
 					packet_count, packet1_timestamp.tv_sec, packet2_timestamp.tv_sec, packet1_timestamp.tv_nsec, packet2_timestamp.tv_nsec);
 		}
 		else
 		{
 			PTF_ASSERT((packet1_timestamp.tv_sec - packet2_timestamp.tv_sec) < 2,
-					"Timestamps are differ in packets %d in more than 2 secs: %lld and %lld; nsec are %lld and %lld",
+					"Timestamps are differ in packets %d in more than 2 secs: %ld and %ld; nsec are %ld and %ld",
 					packet_count, packet1_timestamp.tv_sec, packet2_timestamp.tv_sec, packet1_timestamp.tv_nsec, packet2_timestamp.tv_nsec);
 		}
 
 		if (packet1_timestamp.tv_nsec < packet2_timestamp.tv_nsec)
 		{
 			PTF_ASSERT((packet2_timestamp.tv_nsec - packet1_timestamp.tv_nsec) < 100000,
-					"Timestamps are differ in packets %d in more than 100 nsecs: %ld and %ld; secs are %lld and %lld",
+					"Timestamps are differ in packets %d in more than 100 nsecs: %ld and %ld; secs are %ld and %ld",
 					packet_count,  packet1_timestamp.tv_nsec, packet2_timestamp.tv_nsec, packet1_timestamp.tv_sec, packet2_timestamp.tv_sec);
 		}
 		else
 		{
 			PTF_ASSERT((packet1_timestamp.tv_nsec - packet2_timestamp.tv_nsec) < 100000,
-					"Timestamps are differ in packets %d in more than 100 nsecs: %ld and %ld; secs are %lld and %lld",
+					"Timestamps are differ in packets %d in more than 100 nsecs: %ld and %ld; secs are %ld and %ld",
 					packet_count,  packet1_timestamp.tv_nsec, packet2_timestamp.tv_nsec, packet1_timestamp.tv_sec, packet2_timestamp.tv_sec);
 		}
 		packet_count++;


### PR DESCRIPTION
```
LightPcapNg/src/light_pcapng_ext.c:499:105: warning: passing argument 3 of ‘light_create_option’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   light_option resolution_option = light_create_option(LIGHT_OPTION_IF_TSRESOL, sizeof(NSEC_PRECISION), &NSEC_PRECISION);

==> Building target: Pcap++Test
In file included from main.cpp:46:
main.cpp: In function ‘void TestPcapNgFileReadWriteAdv(int&)’:
../PcppTestFramework/PcppTestFramework.h:87:10: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 4 has type ‘__time_t’ {aka ‘long int’} [-Wformat=]
   printf("%-30s: FAILED. assertion failed: " assertFailedFormat "\n", __FUNCTION__, ## __VA_ARGS__); \
```