### PR TITLE
[IP addresses] performance improvements in TcpReassembly

### DIFF
--- a/Packet++/header/TcpReassembly.h
+++ b/Packet++/header/TcpReassembly.h
@@ -263,12 +263,6 @@ public:
 	TcpReassembly(OnTcpMessageReady onMessageReadyCallback, void* userCookie = NULL, OnTcpConnectionStart onConnectionStartCallback = NULL, OnTcpConnectionEnd onConnectionEndCallback = NULL, const TcpReassemblyConfiguration &config = TcpReassemblyConfiguration());
 
 	/**
-	 * A d'tor for this class. Frees all internal structures. Notice that if the d'tor is called while connections are still open, all data is lost and TcpReassembly#OnTcpConnectionEnd won't
-	 * be called for those connections
-	 */
-	~TcpReassembly();
-
-	/**
 	 * The most important method of this class which gets a packet from the user and processes it. If this packet opens a new connection, ends a connection or contains new data on an
 	 * existing connection, the relevant callback will be called (TcpReassembly#OnTcpMessageReady, TcpReassembly#OnTcpConnectionStart, TcpReassembly#OnTcpConnectionEnd)
 	 * @param[in] tcpData A reference to the packet to process
@@ -339,15 +333,16 @@ private:
 
 	struct TcpReassemblyData
 	{
+		bool closed;
 		int numOfSides;
 		int prevSide;
 		TcpOneSideData twoSides[2];
 		ConnectionData connData;
 
-		TcpReassemblyData() : numOfSides(0), prevSide(-1) {}
+		TcpReassemblyData() : closed(false), numOfSides(0), prevSide(-1) {}
 	};
 	
-	typedef std::map<uint32_t, TcpReassemblyData *> ConnectionList;
+	typedef std::map<uint32_t, TcpReassemblyData> ConnectionList;
 	typedef std::map<time_t, std::list<uint32_t> > CleanupList;
 
 	OnTcpMessageReady m_OnMessageReadyCallback;

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -21,18 +21,16 @@
 #define SEQ_GT(a,b)  ((int32_t)((a)-(b)) > 0)
 #define SEQ_GEQ(a,b) ((int32_t)((a)-(b)) >= 0)
 
-namespace
+
+namespace pcpp
 {
-	timeval timespec_to_timeval(const timespec &in)
+
+	static timeval timespecToTimeval(const timespec& in)
 	{
 		timeval out;
 		TIMESPEC_TO_TIMEVAL(&out, &in);
 		return out;
 	}
-}
-
-namespace pcpp
-{
 
 TcpReassembly::TcpReassembly(OnTcpMessageReady onMessageReadyCallback, void* userCookie, OnTcpConnectionStart onConnectionStartCallback, OnTcpConnectionEnd onConnectionEndCallback, const TcpReassemblyConfiguration &config)
 {
@@ -46,14 +44,6 @@ TcpReassembly::TcpReassembly(OnTcpMessageReady onMessageReadyCallback, void* use
 	m_PurgeTimepoint = time(NULL) + PURGE_FREQ_SECS;
 }
 
-TcpReassembly::~TcpReassembly()
-{
-	while (!m_ConnectionList.empty())
-	{
-		delete m_ConnectionList.begin()->second;
-		m_ConnectionList.erase(m_ConnectionList.begin());
-	}
-}
 
 void TcpReassembly::reassemblePacket(Packet& tcpData)
 {
@@ -134,20 +124,19 @@ void TcpReassembly::reassemblePacket(Packet& tcpData)
 
 	// find the connection in the connection map
 	ConnectionList::iterator iter = m_ConnectionList.find(flowKey);
-
 	if (iter == m_ConnectionList.end())
 	{
 		// if it's a packet of a new connection, create a TcpReassemblyData object and add it to the active connection list
-		tcpReassemblyData = new TcpReassemblyData();
+		std::pair<ConnectionList::iterator, bool> pair = m_ConnectionList.insert(std::make_pair(flowKey, TcpReassemblyData()));
+		tcpReassemblyData = &pair.first->second;
 		tcpReassemblyData->connData.setSrcIpAddress(srcIP);
 		tcpReassemblyData->connData.setDstIpAddress(dstIP);
 		tcpReassemblyData->connData.srcPort = be16toh(tcpLayer->getTcpHeader()->portSrc);
 		tcpReassemblyData->connData.dstPort = be16toh(tcpLayer->getTcpHeader()->portDst);
 		tcpReassemblyData->connData.flowKey = flowKey;
-		timeval ts = timespec_to_timeval(tcpData.getRawPacket()->getPacketTimeStamp());
+		timeval ts = timespecToTimeval(tcpData.getRawPacket()->getPacketTimeStamp());
 		tcpReassemblyData->connData.setStartTime(ts);
 
-		m_ConnectionList[flowKey] = tcpReassemblyData;
 		m_ConnectionInfo[flowKey] = tcpReassemblyData->connData;
 
 		// fire connection start callback
@@ -158,14 +147,14 @@ void TcpReassembly::reassemblePacket(Packet& tcpData)
 	{
 		// if this packet belongs to a connection that was already closed (for example: data packet that comes after FIN), ignore it.
 		// the connection is already closed when the value of mapped type is NULL
-		if (iter->second == NULL)
+		if (iter->second.closed)
 		{
 			LOG_DEBUG("Ignoring packet of already closed flow [0x%X]", flowKey);
 			return;
 		}
 
-		tcpReassemblyData = iter->second;
-		timeval currTime = timespec_to_timeval(tcpData.getRawPacket()->getPacketTimeStamp());
+		tcpReassemblyData = &iter->second;
+		timeval currTime = timespecToTimeval(tcpData.getRawPacket()->getPacketTimeStamp());
 		if (currTime.tv_sec > tcpReassemblyData->connData.endTime.tv_sec)
 		{
 			tcpReassemblyData->connData.setEndTime(currTime); 
@@ -416,7 +405,6 @@ void TcpReassembly::reassemblePacket(Packet& tcpData)
 			handleFinOrRst(tcpReassemblyData, sideIndex, flowKey);
 			return;
 		}
-
 	}
 }
 
@@ -633,7 +621,6 @@ void TcpReassembly::closeConnection(uint32_t flowKey)
 
 void TcpReassembly::closeConnectionInternal(uint32_t flowKey, ConnectionEndReason reason)
 {
-	TcpReassemblyData* tcpReassemblyData = NULL;
 	ConnectionList::iterator iter = m_ConnectionList.find(flowKey);
 	if (iter == m_ConnectionList.end())
 	{
@@ -641,24 +628,23 @@ void TcpReassembly::closeConnectionInternal(uint32_t flowKey, ConnectionEndReaso
 		return;
 	}
 
-	if (iter->second == NULL) // the connection is already closed
+	TcpReassemblyData& tcpReassemblyData = iter->second;
+
+	if (tcpReassemblyData.closed) // the connection is already closed
 		return;
 
 	LOG_DEBUG("Closing connection with flow key 0x%X", flowKey);
 
-	tcpReassemblyData = iter->second;
-
 	LOG_DEBUG("Calling checkOutOfOrderFragments on side 0");
-	checkOutOfOrderFragments(tcpReassemblyData, 0, true);
+	checkOutOfOrderFragments(&tcpReassemblyData, 0, true);
 
 	LOG_DEBUG("Calling checkOutOfOrderFragments on side 1");
-	checkOutOfOrderFragments(tcpReassemblyData, 1, true);
+	checkOutOfOrderFragments(&tcpReassemblyData, 1, true);
 
 	if (m_OnConnEnd != NULL)
-		m_OnConnEnd(tcpReassemblyData->connData, reason, m_UserCookie);
+		m_OnConnEnd(tcpReassemblyData.connData, reason, m_UserCookie);
 
-	delete tcpReassemblyData;
-	iter->second = NULL; // mark the connection as closed
+	tcpReassemblyData.closed = true; // mark the connection as closed
 	insertIntoCleanupList(flowKey);
 
 	LOG_DEBUG("Connection with flow key 0x%X is closed", flowKey);
@@ -671,25 +657,24 @@ void TcpReassembly::closeAllConnections()
 	ConnectionList::iterator iter = m_ConnectionList.begin(), iterEnd = m_ConnectionList.end();
 	for (; iter != iterEnd; ++iter)
 	{
-		if (iter->second == NULL) // the connection is already closed, skip it
+		TcpReassemblyData& tcpReassemblyData = iter->second;
+
+		if (tcpReassemblyData.closed) // the connection is already closed, skip it
 			continue;
 
-		TcpReassemblyData* tcpReassemblyData = iter->second;
-
-		uint32_t flowKey = tcpReassemblyData->connData.flowKey;
+		uint32_t flowKey = tcpReassemblyData.connData.flowKey;
 		LOG_DEBUG("Closing connection with flow key 0x%X", flowKey);
 
 		LOG_DEBUG("Calling checkOutOfOrderFragments on side 0");
-		checkOutOfOrderFragments(tcpReassemblyData, 0, true);
+		checkOutOfOrderFragments(&tcpReassemblyData, 0, true);
 
 		LOG_DEBUG("Calling checkOutOfOrderFragments on side 1");
-		checkOutOfOrderFragments(tcpReassemblyData, 1, true);
+		checkOutOfOrderFragments(&tcpReassemblyData, 1, true);
 
 		if (m_OnConnEnd != NULL)
-			m_OnConnEnd(tcpReassemblyData->connData, TcpReassemblyConnectionClosedManually, m_UserCookie);
+			m_OnConnEnd(tcpReassemblyData.connData, TcpReassemblyConnectionClosedManually, m_UserCookie);
 
-		delete tcpReassemblyData;
-		iter->second = NULL; // mark the connection as closed
+		tcpReassemblyData.closed = true; // mark the connection as closed
 		insertIntoCleanupList(flowKey);
 
 		LOG_DEBUG("Connection with flow key 0x%X is closed", flowKey);
@@ -700,7 +685,7 @@ int TcpReassembly::isConnectionOpen(const ConnectionData& connection) const
 {
 	ConnectionList::const_iterator iter = m_ConnectionList.find(connection.flowKey);
 	if (iter != m_ConnectionList.end())
-		return iter->second != NULL; // If the value of mapped type is NULL then this connection is closed
+		return iter->second.closed == false;
 
 	return -1;
 }


### PR DESCRIPTION
The mapped type of `TcpReassembly::ConnectionList` has changed from `TcpReassemblyData*` to `TcpReassemblyData`.

Notice the size of `TcpReassemblyData` has increased but in next PR I will decrease the size to previous value (the type of `numOfSides` and `prevSide` will be changed to `int8_t`).