### PR TITLE
Add RawPacket timestamp public setters

### DIFF
--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -344,6 +344,20 @@ namespace pcpp
 		timespec getPacketTimeStamp() const { return m_TimeStamp; }
 
 		/**
+		 * Set raw packet timestamp with usec precision
+		 * @param[in] timestamp The timestamp to set (with usec precision)
+		 * @return True if timestamp was set successfully, false otherwise
+		 */
+		virtual bool setPacketTimeStamp(timeval timestamp);
+
+		/**
+		 * Set raw packet timestamp with nsec precision
+		 * @param[in] timestamp The timestamp to set (with nsec precision)
+		 * @return True if timestamp was set successfully, false otherwise
+		 */
+		virtual bool setPacketTimeStamp(timespec timestamp);
+
+		/**
 		 * Get an indication whether raw data was already set for this instance.
 		 * @return True if raw data was set for this instance. Raw data can be set using the non-default constructor, using setRawData(), using
 		 * the copy constructor or using the assignment operator. Returns false otherwise, for example: if the instance was created using the

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -187,4 +187,17 @@ bool RawPacket::removeData(int atIndex, size_t numOfBytesToRemove)
 	return true;
 }
 
+bool RawPacket::setPacketTimeStamp(timeval timestamp)
+{
+	timespec nsec_time;
+	TIMEVAL_TO_TIMESPEC(&timestamp, &nsec_time);
+	return setPacketTimeStamp(nsec_time);
+}
+
+bool RawPacket::setPacketTimeStamp(timespec timestamp)
+{
+	m_TimeStamp = timestamp;
+	return true;
+}
+
 } // namespace pcpp

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -7640,6 +7640,40 @@ PTF_TEST_CASE(PacketLayerLookupTest)
 	}
 }
 
+PTF_TEST_CASE(RawPacketTimeStampSetterTest)
+{
+	int bufferLength = 0;
+	uint8_t* buffer = readFileIntoBuffer("PacketExamples/IPv6UdpPacket.dat", bufferLength);
+	PTF_ASSERT(!(buffer == NULL), "cannot read file");
+
+	timeval time;
+	timeval usec_test_time;
+	timespec nsec_test_time;
+	timespec expected_ts;
+	gettimeofday(&time, NULL);
+	//initialize test RawPacket instance
+	RawPacket rawPacket((const uint8_t*)buffer, bufferLength, time, true);
+
+	//test usec-precision setter
+	usec_test_time.tv_sec = 1583840642; //10.03.2020 15:44
+	usec_test_time.tv_usec = 111222;
+	expected_ts.tv_sec = usec_test_time.tv_sec;
+	expected_ts.tv_nsec = usec_test_time.tv_usec * 1000;
+
+	PTF_ASSERT_TRUE(rawPacket.setPacketTimeStamp(usec_test_time));
+	PTF_ASSERT_EQUAL(rawPacket.getPacketTimeStamp().tv_sec, expected_ts.tv_sec, u32);
+	PTF_ASSERT_EQUAL(rawPacket.getPacketTimeStamp().tv_nsec, expected_ts.tv_nsec, u32);
+
+	//test nsec-precision setter
+	nsec_test_time.tv_sec = 1583842105; //10.03.2020 16:08
+	nsec_test_time.tv_nsec = 111222987;
+	expected_ts = nsec_test_time;
+
+	PTF_ASSERT_TRUE(rawPacket.setPacketTimeStamp(nsec_test_time));
+	PTF_ASSERT_EQUAL(rawPacket.getPacketTimeStamp().tv_sec, expected_ts.tv_sec, u32);
+	PTF_ASSERT_EQUAL(rawPacket.getPacketTimeStamp().tv_nsec, expected_ts.tv_nsec, u32);
+}
+
 
 static struct option PacketTestOptions[] =
 {
@@ -7806,6 +7840,7 @@ int main(int argc, char* argv[]) {
 	PTF_RUN_TEST(EthDot3LayerParsingTest, "eth_dot3;eth");
 	PTF_RUN_TEST(EthDot3LayerCreateEditTest, "eth_dot3;eth");
 	PTF_RUN_TEST(PacketLayerLookupTest, "packet");
+	PTF_RUN_TEST(RawPacketTimeStampSetterTest, "packet");
 
 	PTF_END_RUNNING_TESTS;
 }


### PR DESCRIPTION
This PR allows to change RawPacket timestamp value after object creation. It maybe very helpful in case of imprecise timestamps, gathered from underlying capture engines.

Two setter functions were added: (legacy) timeval setter, and timespec setter.
Both setters are virtual, allowing some special processing in RawPacket subclasses.

Actually as the change is very small and straightforward, I don't know if the test-related commit is really needed (maybe cherry-pick RawPacket-relater only).   