### PR TITLE
Add lgtm.yml configuration file

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,10 @@
+extraction:
+  cpp:
+    prepare:
+      packages:
+      - "libpcap-dev"
+      - "libstdc++6"
+    configure:
+      command: "./configure-linux.sh --default"
+    index:
+      build_command: "make libs -j8"


### PR DESCRIPTION
Having this file in the root of the project will allow LGTM.com use the custom configuration to analyze C++ code of the project. I am a user of this library and am very interested to see if there are any issues we should be aware of.

Currently, C++ source code of the project on [LGTM.com](https://lgtm.com/projects/g/seladb/PcapPlusPlus/?mode=list) is not analyzed because there are some custom steps involved (outlined at [Build From Source on Linux](https://pcapplusplus.github.io/docs/install/build-source/linux)) to build from source which LGTM.com won't be able figure out automatically.

I have tested this configuration and it [worked successfully](https://lgtm.com/logs/44c380e5cc569235a4af1b120e7f208dc78b5f87/lang:cpp) analyzing the C++ source code of the project.

I have also ran the analysis locally using CodeQL CLI and there were around 30 issues found which I think would be interesting to review. Once the configuration file of this PR is in the master, next time LGTM.com will attempt to analyze the C++ code, it should pick it up and the analysis results will be available online on the project page.