### PR TITLE
Fix fuzzing build

### DIFF
--- a/mk/platform.mk.fuzzing
+++ b/mk/platform.mk.fuzzing
@@ -14,7 +14,9 @@ ifeq ($(origin CC),default)
 CC := clang
 endif
 
+ifndef CXXFLAGS
 CXXFLAGS := -g -O0 -fsanitize=address,fuzzer-no-link
+endif
 
 AR := ar
 
@@ -32,4 +34,3 @@ ifndef LIB_FUZZING_ENGINE
 LIB_FUZZING_ENGINE := -fsanitize=address,fuzzer
 endif
 
-COMPILE_FOR_FUZZING := 1


### PR DESCRIPTION
Hi!

I saw a bug on the fuzzing build system that wasn't allowing OSFuzz to build the fuzzers with the different fuzzing engines and sanitizers. This PR should fix it. Also, I saw a flag that is not being used anymore, so I removed it.

As soon as commit gets to master I'll push the other changes to the OSSFuzz PR.

Thanks!