### PR TITLE
#428 fix pcap setdirection bug

### DIFF
--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -280,18 +280,26 @@ pcap_t* PcapLiveDevice::doOpen(const DeviceConfiguration& config)
 	}
 #endif
 
+	ret = pcap_activate(pcap);
+	if (ret != 0)
+	{
+		LOG_ERROR("%s", pcap_geterr(pcap));
+		pcap_close(pcap);
+		pcap = NULL;
+	}
+
 #ifdef HAS_SET_DIRECTION_ENABLED
 	pcap_direction_t directionToSet = directionTypeMap(config.direction);
 	ret = pcap_setdirection(pcap, directionToSet);
-	if (ret != 0)
+	if (ret == 0)
 	{
 		if (config.direction == PCPP_IN)
 		{
-		  LOG_DEBUG("Only incoming traffics will be captured");
+			LOG_DEBUG("Only incoming traffics will be captured");
 		}
-		else if (config.direction == PCPP_OUT) 
+		else if (config.direction == PCPP_OUT)
 		{
-		  LOG_DEBUG("Only outgoing traffics will be captured");
+			LOG_DEBUG("Only outgoing traffics will be captured");
 		}
 		else
 		{
@@ -303,13 +311,6 @@ pcap_t* PcapLiveDevice::doOpen(const DeviceConfiguration& config)
 		LOG_ERROR("Failed to set direction for capturing packets, error code: '%d', error message: '%s'", ret, pcap_geterr(pcap));
 	}
 #endif
-	ret = pcap_activate(pcap);
-	if (ret != 0)
-	{
-		LOG_ERROR("%s", pcap_geterr(pcap));
-		pcap_close(pcap);
-		pcap = NULL;
-	}
 
 	if (pcap)
 	{

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,9 @@ environment:
   NPCAP_PASSWORD:
     secure: 8sWBrDudyutFv+4Eq6teJA==
   matrix:
+    - compiler: mingw32
+      pcap_lib: npcap
+    - compiler: mingw-w64
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       compiler: vs2017
       platform: x86

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,6 @@ environment:
   NPCAP_PASSWORD:
     secure: 8sWBrDudyutFv+4Eq6teJA==
   matrix:
-    - compiler: mingw32
-      pcap_lib: npcap
-    - compiler: mingw-w64
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       compiler: vs2017
       platform: x86


### PR DESCRIPTION
Hi,

as documented [here](https://github.com/seladb/PcapPlusPlus/issues/428), I have found a bug with the implementation of pcap_setdirection.

I have fixed the two addressed problems with this pull request.

As has been discussed, I have excluded the failing mingw32 and mingw64 builds (see [here](https://github.com/seladb/PcapPlusPlus/issues/427) )

All other builds are succeeding. (see [Travis](https://travis-ci.org/github/maruu/PcapPlusPlus/builds/683292315) and [AppVeyor](https://ci.appveyor.com/project/maruu/pcapplusplus/builds/32655583) ) Please let me know if you need more information on this.