### PR TITLE
Regression Tests for each Sanitizer

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,11 +28,23 @@ task:
     - cd ../Pcap++Test && Bin/Pcap++Test -n
 
 task:
-  name: Regression Tests Linux
+  name: Regression Tests Linux (Address Sanitizer)
   container:
     image: seladb/ubuntu1804:latest
   configure_script:
-    - ./configure-fuzzing.sh --default
+    - ./configure-fuzzing.sh --sanitizer address
+    - ldconfig
+  build_script:
+    - make fuzzers
+  test_script:
+    - cd Tests/Fuzzers/RegressionTests && ./run_tests.sh
+
+task:
+  name: Regression Tests Linux (Undefined Behavior Sanitizer)
+  container:
+    image: seladb/ubuntu1804:latest
+  configure_script:
+    - ./configure-fuzzing.sh --sanitizer undefined
     - ldconfig
   build_script:
     - make fuzzers

--- a/mk/platform.mk.fuzzing
+++ b/mk/platform.mk.fuzzing
@@ -15,7 +15,7 @@ CC := clang
 endif
 
 ifndef CXXFLAGS
-CXXFLAGS := -g -O0 -fsanitize=address,fuzzer-no-link
+CXXFLAGS := -g -O0 -fsanitize=fuzzer-no-link
 endif
 
 AR := ar
@@ -31,6 +31,6 @@ INSTALL_SCRIPT := install.sh
 UNINSTALL_SCRIPT := uninstall.sh
 
 ifndef LIB_FUZZING_ENGINE
-LIB_FUZZING_ENGINE := -fsanitize=address,fuzzer
+LIB_FUZZING_ENGINE := -fsanitize=fuzzer
 endif
 


### PR DESCRIPTION
Today I noticed that I forgot to add regression tests for all the different Sanitizers that are run in OSS-Fuzz (`address`, `memory` and `undefiend`), so I added the option of selecting the sanitizer on the `configure-fuzzing.sh` file and created two more regression tests for `memory` and `undefined.

The workflow after fixing a bug related to fuzzing is exactly the same, just put the sample that triggers the bug in the regression samples dir: `Tests/Fuzzers/RegressionTests/regression_samples/`

This PR does not affect the fuzzers already running on OSS-Fuzz, it is purely to add robustness to the regression tests.