### PR TITLE
Support for setting snapshot length

### DIFF
--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -195,21 +195,37 @@ namespace pcpp
 			PcapDirection direction;
 
 			/**
+			 * Set the snapshot length. Snapshot length is the amount of data for each frame that is actually captured. Note that taking
+			 * larger snapshots both increases the amount of time it takes to process packets and, effectively, decreases the amount of
+			 * packet buffering. This may cause packets to be lost. Note also that taking smaller snapshots will discard data from protocols
+			 * above the transport layer, which loses information that may be important.
+			 * You can read more here:
+			 * https://wiki.wireshark.org/SnapLen
+			*/
+			int snapshotLength;
+
+			/**
 			 * A c'tor for this struct
 			 * @param[in] mode The mode to open the device: promiscuous or non-promiscuous. Default value is promiscuous
 			 * @param[in] packetBufferTimeoutMs Buffer timeout in millisecond. Default value is 0 which means set timeout of
 			 * 1 or -1 (depends on the platform)
 			 * @param[in] packetBufferSize The packet buffer size. Default value is 0 which means use the default value
 			 * (varies between different OS's)
-			 * @param[in] direction Direction for capturing packtes. Default value is INOUT which means capture both incoming
+			 * @param[in] direction Direction for capturing packets. Default value is INOUT which means capture both incoming
 			 * and outgoing packets (not all platforms support this)
-			 */
-			DeviceConfiguration(DeviceMode mode = Promiscuous, int packetBufferTimeoutMs = 0, int packetBufferSize = 0, PcapDirection direction = PCPP_INOUT)
+			 * @param[in] snapshotLength Snapshot length for capturing packets. Default value is 0 which means use the default value.
+			 * A snapshot length of 262144 should be big enough for maximum-size Linux loopback packets (65549) and some USB packets
+			 * captured with USBPcap (> 131072, < 262144). A snapshot length of 65535 should be sufficient, on most if not all networks,
+			 * to capture all the data available from the packet.
+			*/
+			DeviceConfiguration(DeviceMode mode = Promiscuous, int packetBufferTimeoutMs = 0, int packetBufferSize = 0,
+				                PcapDirection direction = PCPP_INOUT, int snapshotLength = 0)
 			{
 				this->mode = mode;
 				this->packetBufferTimeoutMs = packetBufferTimeoutMs;
 				this->packetBufferSize = packetBufferSize;
 				this->direction = direction;
+				this->snapshotLength = snapshotLength;
 			}
 		};
 

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -241,7 +241,7 @@ pcap_t* PcapLiveDevice::doOpen(const DeviceConfiguration& config)
 		LOG_ERROR("%s", errbuf);
 		return pcap;
 	}
-	int ret = pcap_set_snaplen(pcap, DEFAULT_SNAPLEN);
+	int ret = pcap_set_snaplen(pcap, config.snapshotLength <= 0 ? DEFAULT_SNAPLEN : config.snapshotLength);
 	if (ret != 0)
 	{
 		LOG_ERROR("%s", pcap_geterr(pcap));

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -609,6 +609,10 @@ bool packetArrivesBlockingModeNoTimeoutPacketCount(RawPacket* pRawPacket, PcapLi
 	return false;
 }
 
+bool packetArrivesBlockingModeWithSnaplen(RawPacket* pRawPacket, PcapLiveDevice* dev, void* userCookie) {
+	int snaplen = *(int*)userCookie;
+	return pRawPacket->getRawDataLen() > snaplen;
+}
 
 bool packetArrivesBlockingModeStartCapture(RawPacket* pRawPacket, PcapLiveDevice* dev, void* userCookie)
 {
@@ -1640,6 +1644,17 @@ PTF_TEST_CASE(TestPcapLiveDeviceSpecialCfg)
 	liveDev->close();
 #endif 
 
+	// create a non-default configuration with a snapshot length of 10 bytes
+	int snaplen = 20;
+	PcapLiveDevice::DeviceConfiguration devConfgWithSnaplen(PcapLiveDevice::Promiscuous, 0, 0, PcapLiveDevice::PCPP_INOUT, snaplen);
+
+	liveDev->open(devConfgWithSnaplen);
+
+	// start capturing in non-default configuration witch only captures incoming traffics
+	PTF_ASSERT(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeWithSnaplen, &snaplen, 7) == -1, 
+			"The packet size should is greater than the snapshot length");
+
+	liveDev->close();
 }
 
 


### PR DESCRIPTION
see #436 for details.

The testcases are passed on my machine and on [travis CI](https://travis-ci.org/github/wongsingfo/PcapPlusPlus).

```
$ sudo ./Bin/Pcap++Test  -i 172.21.0.2
PcapPlusPlus version: v19.12+ (non-official release)
Built: May 21 2020 12:33:47
Git info: Git branch 'dev', commit '85ee32ac562c8b79ff7496fd0b829bd3f2f2872c'
Using ip: 172.21.0.2
Debug mode: off
Starting tests...
Start running tests...

......
TestPcapLiveDeviceSpecialCfg  : PASSED
...... 
```

 but I run in to some troubles when I tried [appveyor](https://ci.appveyor.com/project/wongsingfo/pcapplusplus/builds/33020929)).