### PR TITLE
Update DnsLayer.cpp

### DIFF
--- a/Packet++/src/DnsLayer.cpp
+++ b/Packet++/src/DnsLayer.cpp
@@ -131,7 +131,7 @@ void DnsLayer::parseResources()
 	uint16_t numOfAuthority = be16toh(getDnsHeader()->numberOfAuthority);
 	uint16_t numOfAdditional = be16toh(getDnsHeader()->numberOfAdditional);
 
-	uint16_t numOfOtherResources = numOfQuestions + numOfAnswers + numOfAuthority + numOfAdditional;
+	uint32_t numOfOtherResources = numOfQuestions + numOfAnswers + numOfAuthority + numOfAdditional;
 
 	if (numOfOtherResources > 300)
 	{


### PR DESCRIPTION
change numOfOtherResources's type from uint16_t to uint32_t .  Solved  the bug of DNS resources number more than 65535 and  less than 65835.