### PR TITLE
Cosmetic changes in unit tests

### DIFF
--- a/Tests/Packet++Test/Tests/DhcpTests.cpp
+++ b/Tests/Packet++Test/Tests/DhcpTests.cpp
@@ -26,9 +26,9 @@ PTF_TEST_CASE(DhcpParsingTest)
 	PTF_ASSERT_EQUAL(dhcpLayer->getDhcpHeader()->hops, 1, u8);
 	PTF_ASSERT_EQUAL(dhcpLayer->getDhcpHeader()->transactionID, be32toh(0x7771cf85), u32);
 	PTF_ASSERT_EQUAL(dhcpLayer->getClientIpAddress(), pcpp::IPv4Address::Zero, object);
-	PTF_ASSERT_EQUAL(dhcpLayer->getYourIpAddress(), pcpp::IPv4Address(std::string("10.10.8.235")), object);
-	PTF_ASSERT_EQUAL(dhcpLayer->getServerIpAddress(), pcpp::IPv4Address(std::string("172.22.178.234")), object);
-	PTF_ASSERT_EQUAL(dhcpLayer->getGatewayIpAddress(), pcpp::IPv4Address(std::string("10.10.8.240")), object);
+	PTF_ASSERT_EQUAL(dhcpLayer->getYourIpAddress(), pcpp::IPv4Address("10.10.8.235"), object);
+	PTF_ASSERT_EQUAL(dhcpLayer->getServerIpAddress(), pcpp::IPv4Address("172.22.178.234"), object);
+	PTF_ASSERT_EQUAL(dhcpLayer->getGatewayIpAddress(), pcpp::IPv4Address("10.10.8.240"), object);
 	PTF_ASSERT_EQUAL(dhcpLayer->getClientHardwareAddress(), pcpp::MacAddress(std::string("00:0e:86:11:c0:75")), object);
 
 	PTF_ASSERT_EQUAL(dhcpLayer->getOptionsCount(), 12, size);
@@ -67,8 +67,8 @@ PTF_TEST_CASE(DhcpParsingTest)
 		PTF_ASSERT_FALSE(dhcpLayer->getOptionData(optTypeArr[i]).isNull());
 	}
 
-	PTF_ASSERT_EQUAL(dhcpLayer->getOptionData(pcpp::DHCPOPT_SUBNET_MASK).getValueAsIpAddr(), pcpp::IPv4Address(std::string("255.255.255.0")), object);
-	PTF_ASSERT_EQUAL(dhcpLayer->getOptionData(pcpp::DHCPOPT_DHCP_SERVER_IDENTIFIER).getValueAsIpAddr(), pcpp::IPv4Address(std::string("172.22.178.234")), object);
+	PTF_ASSERT_EQUAL(dhcpLayer->getOptionData(pcpp::DHCPOPT_SUBNET_MASK).getValueAsIpAddr(), pcpp::IPv4Address("255.255.255.0"), object);
+	PTF_ASSERT_EQUAL(dhcpLayer->getOptionData(pcpp::DHCPOPT_DHCP_SERVER_IDENTIFIER).getValueAsIpAddr(), pcpp::IPv4Address("172.22.178.234"), object);
 	PTF_ASSERT_EQUAL(dhcpLayer->getOptionData(pcpp::DHCPOPT_DHCP_LEASE_TIME).getValueAs<uint32_t>(), htobe32(43200), u32);
 	PTF_ASSERT_EQUAL(dhcpLayer->getOptionData(pcpp::DHCPOPT_TFTP_SERVER_NAME).getValueAsString(), "172.22.178.234", string);
 
@@ -134,8 +134,8 @@ PTF_TEST_CASE(DhcpCreationTest)
 {
 	pcpp::EthLayer ethLayer(pcpp::MacAddress("00:13:72:25:fa:cd"), pcpp::MacAddress("00:e0:b1:49:39:02"));
 
-	pcpp::IPv4Address srcIp(std::string("172.22.178.234"));
-	pcpp::IPv4Address dstIp(std::string("10.10.8.240"));
+	pcpp::IPv4Address srcIp("172.22.178.234");
+	pcpp::IPv4Address dstIp("10.10.8.240");
 	pcpp::IPv4Layer ipLayer(srcIp, dstIp);
 	ipLayer.getIPv4Header()->ipId = htobe16(20370);
 	ipLayer.getIPv4Header()->timeToLive = 128;
@@ -147,14 +147,14 @@ PTF_TEST_CASE(DhcpCreationTest)
 	dhcpLayer.getDhcpHeader()->hops = 1;
 	dhcpLayer.getDhcpHeader()->transactionID = htobe32(0x7771cf85);
 	dhcpLayer.getDhcpHeader()->secondsElapsed = htobe16(10);
-	pcpp::IPv4Address yourIP(std::string("10.10.8.235"));
-	pcpp::IPv4Address serverIP(std::string("172.22.178.234"));
-	pcpp::IPv4Address gatewayIP(std::string("10.10.8.240"));
+	pcpp::IPv4Address yourIP("10.10.8.235");
+	pcpp::IPv4Address serverIP("172.22.178.234");
+	pcpp::IPv4Address gatewayIP("10.10.8.240");
 	dhcpLayer.setYourIpAddress(yourIP);
 	dhcpLayer.setServerIpAddress(serverIP);
 	dhcpLayer.setGatewayIpAddress(gatewayIP);
 
-	pcpp::DhcpOption subnetMaskOpt = dhcpLayer.addOption(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_SUBNET_MASK, pcpp::IPv4Address(std::string("255.255.255.0"))));
+	pcpp::DhcpOption subnetMaskOpt = dhcpLayer.addOption(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_SUBNET_MASK, pcpp::IPv4Address("255.255.255.0")));
 	PTF_ASSERT_FALSE(subnetMaskOpt.isNull());
 
 	uint8_t sipServersData[] = { 0x01, 0xac, 0x16, 0xb2, 0xea };
@@ -175,7 +175,7 @@ PTF_TEST_CASE(DhcpCreationTest)
 	pcpp::DhcpOption authOpt = dhcpLayer.addOptionAfter(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_AUTHENTICATION, authOptData, 31), pcpp::DHCPOPT_DHCP_CLIENT_IDENTIFIER);
 	PTF_ASSERT_FALSE(authOpt.isNull());
 
-	pcpp::DhcpOption dhcpServerIdOpt = dhcpLayer.addOptionAfter(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_DHCP_SERVER_IDENTIFIER, pcpp::IPv4Address(std::string("172.22.178.234"))), pcpp::DHCPOPT_SUBNET_MASK);
+	pcpp::DhcpOption dhcpServerIdOpt = dhcpLayer.addOptionAfter(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_DHCP_SERVER_IDENTIFIER, pcpp::IPv4Address("172.22.178.234")), pcpp::DHCPOPT_SUBNET_MASK);
 	PTF_ASSERT_FALSE(dhcpServerIdOpt.isNull());
 
 	pcpp::Packet newPacket(6);
@@ -184,7 +184,7 @@ PTF_TEST_CASE(DhcpCreationTest)
 	PTF_ASSERT_TRUE(newPacket.addLayer(&udpLayer));
 	PTF_ASSERT_TRUE(newPacket.addLayer(&dhcpLayer));
 
-	pcpp::DhcpOption routerOpt = dhcpLayer.addOptionAfter(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_ROUTERS, pcpp::IPv4Address(std::string("10.10.8.254"))), pcpp::DHCPOPT_DHCP_SERVER_IDENTIFIER);
+	pcpp::DhcpOption routerOpt = dhcpLayer.addOptionAfter(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_ROUTERS, pcpp::IPv4Address("10.10.8.254")), pcpp::DHCPOPT_DHCP_SERVER_IDENTIFIER);
 	PTF_ASSERT_FALSE(routerOpt.isNull());
 
 	pcpp::DhcpOption tftpServerOpt = dhcpLayer.addOptionAfter(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_TFTP_SERVER_NAME, std::string("172.22.178.234")), pcpp::DHCPOPT_ROUTERS);
@@ -192,8 +192,8 @@ PTF_TEST_CASE(DhcpCreationTest)
 
 	pcpp::DhcpOption dnsOpt = dhcpLayer.addOptionAfter(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_DOMAIN_NAME_SERVERS, NULL, 8), pcpp::DHCPOPT_ROUTERS);
 	PTF_ASSERT_FALSE(dnsOpt.isNull());
-	pcpp::IPv4Address dns1IP = pcpp::IPv4Address(std::string("143.209.4.1"));
-	pcpp::IPv4Address dns2IP = pcpp::IPv4Address(std::string("143.209.5.1"));
+	pcpp::IPv4Address dns1IP("143.209.4.1");
+	pcpp::IPv4Address dns2IP("143.209.5.1");
 	dnsOpt.setValueIpAddr(dns1IP);
 	dnsOpt.setValueIpAddr(dns2IP, 4);
 
@@ -232,12 +232,12 @@ PTF_TEST_CASE(DhcpEditTest)
 	PTF_ASSERT_TRUE(dhcpLayer->removeOption(pcpp::DHCPOPT_DHCP_MAX_MESSAGE_SIZE));
 
 	pcpp::DhcpOption opt = dhcpLayer->getOptionData(pcpp::DHCPOPT_SUBNET_MASK);
-	pcpp::IPv4Address newSubnet(std::string("255.255.255.0"));
+	pcpp::IPv4Address newSubnet("255.255.255.0");
 	opt.setValueIpAddr(newSubnet);
 
 	PTF_ASSERT_TRUE(dhcpLayer->setMesageType(pcpp::DHCP_ACK));
 
-	pcpp::IPv4Address newRouter(std::string("192.168.2.1"));
+	pcpp::IPv4Address newRouter("192.168.2.1");
 
 	opt = dhcpLayer->addOptionAfter(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_ROUTERS, newRouter), pcpp::DHCPOPT_SUBNET_MASK);
 	PTF_ASSERT_FALSE(opt.isNull());

--- a/Tests/Packet++Test/Tests/DnsTests.cpp
+++ b/Tests/Packet++Test/Tests/DnsTests.cpp
@@ -57,7 +57,7 @@ PTF_TEST_CASE(DnsLayerParsingTest)
 	PTF_ASSERT_EQUAL(firstAuthority->getName(), "Yaels-iPhone.local", string);
 	PTF_ASSERT_EQUAL(firstAuthority->getDataLength(), 4, size);
 	PTF_ASSERT_EQUAL(firstAuthority->getData()->toString(), "10.0.0.2", string);
-	PTF_ASSERT_EQUAL(firstAuthority->getData().castAs<pcpp::IPv4DnsResourceData>()->getIpAddress(), pcpp::IPv4Address(std::string("10.0.0.2")), object);
+	PTF_ASSERT_EQUAL(firstAuthority->getData().castAs<pcpp::IPv4DnsResourceData>()->getIpAddress(), pcpp::IPv4Address("10.0.0.2"), object);
 	PTF_ASSERT_EQUAL(firstAuthority->getSize(), 16, size);
 
 	pcpp::DnsResource* secondAuthority = dnsLayer->getNextAuthority(firstAuthority);
@@ -123,7 +123,7 @@ PTF_TEST_CASE(DnsLayerParsingTest)
 
 	curAnswer = dnsLayer->getNextAnswer(curAnswer);
 	int answerCount = 2;
-	pcpp::IPv4Address subnet(std::string("212.199.219.0"));
+	pcpp::IPv4Address subnet("212.199.219.0");
 	std::string subnetMask = "255.255.255.0";
 	while (curAnswer != NULL)
 	{

--- a/Tests/Packet++Test/Tests/EthAndArpTests.cpp
+++ b/Tests/Packet++Test/Tests/EthAndArpTests.cpp
@@ -92,7 +92,7 @@ PTF_TEST_CASE(EthAndArpPacketParsing)
 	PTF_ASSERT_EQUAL(arpLayer->getArpHeader()->hardwareSize, 6, u8);
 	PTF_ASSERT_EQUAL(arpLayer->getArpHeader()->protocolSize, 4, u8);
 	PTF_ASSERT_EQUAL(arpLayer->getArpHeader()->opcode, htobe16(pcpp::ARP_REPLY), u16);
-	PTF_ASSERT_EQUAL(arpLayer->getSenderIpAddr(), pcpp::IPv4Address(std::string("10.0.0.138")), object);
+	PTF_ASSERT_EQUAL(arpLayer->getSenderIpAddr(), pcpp::IPv4Address("10.0.0.138"), object);
 	PTF_ASSERT_EQUAL(arpLayer->getTargetMacAddress(), pcpp::MacAddress("6c:f0:49:b2:de:6e"), object);
 } // EthAndArpPacketParsing
 
@@ -103,7 +103,7 @@ PTF_TEST_CASE(ArpPacketCreation)
 	pcpp::MacAddress dstMac("ff:ff:ff:ff:ff:ff:");
 	pcpp::EthLayer ethLayer(srcMac, dstMac, PCPP_ETHERTYPE_ARP);
 
-	pcpp::ArpLayer arpLayer(pcpp::ARP_REQUEST, srcMac, srcMac, pcpp::IPv4Address(std::string("10.0.0.1")), pcpp::IPv4Address(std::string("10.0.0.138")));
+	pcpp::ArpLayer arpLayer(pcpp::ARP_REQUEST, srcMac, srcMac, pcpp::IPv4Address("10.0.0.1"), pcpp::IPv4Address("10.0.0.138"));
 
 	pcpp::Packet arpRequestPacket(1);
 	PTF_ASSERT_TRUE(arpRequestPacket.addLayer(&ethLayer));

--- a/Tests/Packet++Test/Tests/GreTests.cpp
+++ b/Tests/Packet++Test/Tests/GreTests.cpp
@@ -150,7 +150,7 @@ PTF_TEST_CASE(GreCreationTest)
 	// GREv1 packet creation
 
 	pcpp::EthLayer ethLayer(pcpp::MacAddress("00:90:4b:1f:a4:f7"), pcpp::MacAddress("00:0d:ed:7b:48:f4"));
-	pcpp::IPv4Layer ipLayer(pcpp::IPv4Address(std::string("192.168.2.65")), pcpp::IPv4Address(std::string("192.168.2.254")));
+	pcpp::IPv4Layer ipLayer(pcpp::IPv4Address("192.168.2.65"), pcpp::IPv4Address("192.168.2.254"));
 	ipLayer.getIPv4Header()->ipId = htobe16(1660);
 	ipLayer.getIPv4Header()->timeToLive = 128;
 
@@ -181,10 +181,10 @@ PTF_TEST_CASE(GreCreationTest)
 	// GREv0 packet creation
 
 	pcpp::EthLayer ethLayer2(pcpp::MacAddress("00:01:01:00:00:01"), pcpp::MacAddress("00:01:01:00:00:02"));
-	pcpp::IPv4Layer ipLayer2(pcpp::IPv4Address(std::string("127.0.0.1")), pcpp::IPv4Address(std::string("127.0.0.1")));
+	pcpp::IPv4Layer ipLayer2(pcpp::IPv4Address("127.0.0.1"), pcpp::IPv4Address("127.0.0.1"));
 	ipLayer2.getIPv4Header()->ipId = htobe16(1);
 	ipLayer2.getIPv4Header()->timeToLive = 64;
-	pcpp::IPv4Layer ipLayer3(pcpp::IPv4Address(std::string("127.0.0.1")), pcpp::IPv4Address(std::string("127.0.0.1")));
+	pcpp::IPv4Layer ipLayer3(pcpp::IPv4Address("127.0.0.1"), pcpp::IPv4Address("127.0.0.1"));
 	ipLayer3.getIPv4Header()->ipId = htobe16(46845);
 	ipLayer3.getIPv4Header()->timeToLive = 64;
 

--- a/Tests/Packet++Test/Tests/IPv4Tests.cpp
+++ b/Tests/Packet++Test/Tests/IPv4Tests.cpp
@@ -30,8 +30,8 @@ PTF_TEST_CASE(IPv4PacketCreation)
 	PTF_ASSERT_EQUAL(rawPacket->getRawDataLen(), 14, int);
 
 
-	pcpp::IPv4Address ipSrc(std::string("1.1.1.1"));
-	pcpp::IPv4Address ipDst(std::string("20.20.20.20"));
+	pcpp::IPv4Address ipSrc("1.1.1.1");
+	pcpp::IPv4Address ipDst("20.20.20.20");
 	pcpp::IPv4Layer ip4Layer(ipSrc, ipDst);
 	ip4Layer.getIPv4Header()->protocol = pcpp::PACKETPP_IPPROTO_TCP;
 	PTF_ASSERT_TRUE(ip4Packet.addLayer(&ip4Layer));
@@ -73,8 +73,8 @@ PTF_TEST_CASE(IPv4PacketParsing)
 	PTF_ASSERT_EQUAL(be16toh(ethLayer->getEthHeader()->etherType), PCPP_ETHERTYPE_IP, u16);
 
 	pcpp::IPv4Layer* ipv4Layer = ip4Packet.getLayerOfType<pcpp::IPv4Layer>();
-	pcpp::IPv4Address ip4addr1(std::string("10.0.0.4"));
-	pcpp::IPv4Address ip4addr2(std::string("1.1.1.1"));
+	pcpp::IPv4Address ip4addr1("10.0.0.4");
+	pcpp::IPv4Address ip4addr2("1.1.1.1");
 	PTF_ASSERT_EQUAL(ipv4Layer->getIPv4Header()->protocol, 1, u8);
 	PTF_ASSERT_EQUAL(ipv4Layer->getIPv4Header()->ipVersion, 4, u8);
 	PTF_ASSERT_EQUAL(ipv4Layer->getIPv4Header()->ipSrc, ip4addr1.toInt(), u32);
@@ -240,9 +240,9 @@ PTF_TEST_CASE(IPv4OptionsParsingTest)
 	PTF_ASSERT_EQUAL(opt.getTotalSize(), 39, size);
 	std::vector<pcpp::IPv4Address> ipAddrs = opt.getValueAsIpList();
 	PTF_ASSERT_EQUAL(ipAddrs.size(), 3, size);
-	PTF_ASSERT_EQUAL(ipAddrs.at(0), pcpp::IPv4Address(std::string("1.2.3.4")), object);
-	PTF_ASSERT_EQUAL(ipAddrs.at(1), pcpp::IPv4Address(std::string("10.0.0.138")), object);
-	PTF_ASSERT_EQUAL(ipAddrs.at(2), pcpp::IPv4Address(std::string("10.0.0.138")), object);
+	PTF_ASSERT_EQUAL(ipAddrs.at(0), pcpp::IPv4Address("1.2.3.4"), object);
+	PTF_ASSERT_EQUAL(ipAddrs.at(1), pcpp::IPv4Address("10.0.0.138"), object);
+	PTF_ASSERT_EQUAL(ipAddrs.at(2), pcpp::IPv4Address("10.0.0.138"), object);
 	pcpp::IPv4Option opt2 = ipLayer->getOption(pcpp::IPV4OPT_RecordRoute);
 	PTF_ASSERT_FALSE(opt2.isNull());
 	PTF_ASSERT_TRUE(opt2 == opt);
@@ -262,8 +262,8 @@ PTF_TEST_CASE(IPv4OptionsParsingTest)
 	PTF_ASSERT_EQUAL(tsValue.ipAddresses.size(), 3, size);
 	PTF_ASSERT_EQUAL(tsValue.timestamps.at(0), htobe32(70037668), u32);
 	PTF_ASSERT_EQUAL(tsValue.timestamps.at(2), htobe32(77233718), u32);
-	PTF_ASSERT_EQUAL(tsValue.ipAddresses.at(0), pcpp::IPv4Address(std::string("10.0.0.6")), object);
-	PTF_ASSERT_EQUAL(tsValue.ipAddresses.at(1), pcpp::IPv4Address(std::string("10.0.0.138")), object);
+	PTF_ASSERT_EQUAL(tsValue.ipAddresses.at(0), pcpp::IPv4Address("10.0.0.6"), object);
+	PTF_ASSERT_EQUAL(tsValue.ipAddresses.at(1), pcpp::IPv4Address("10.0.0.138"), object);
 	opt = ipLayer->getNextOption(opt);
 	PTF_ASSERT_TRUE(opt.isNull());
 
@@ -374,9 +374,9 @@ PTF_TEST_CASE(IPv4OptionsEditTest)
 
 	ipLayer = ipOpt4.getLayerOfType<pcpp::IPv4Layer>();
 	std::vector<pcpp::IPv4Address> ipListValue;
-	ipListValue.push_back(pcpp::IPv4Address(std::string("1.2.3.4")));
-	ipListValue.push_back(pcpp::IPv4Address(std::string("10.0.0.138")));
-	ipListValue.push_back(pcpp::IPv4Address(std::string("10.0.0.138")));
+	ipListValue.push_back(pcpp::IPv4Address("1.2.3.4"));
+	ipListValue.push_back(pcpp::IPv4Address("10.0.0.138"));
+	ipListValue.push_back(pcpp::IPv4Address("10.0.0.138"));
 	for (int i = 0; i < 6; i++)
 		ipListValue.push_back(pcpp::IPv4Address::Zero);
 	PTF_ASSERT_FALSE(ipLayer->addOption(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_RecordRoute, ipListValue)).isNull());
@@ -392,9 +392,9 @@ PTF_TEST_CASE(IPv4OptionsEditTest)
 	PTF_ASSERT_TRUE(ipLayer->addOption(pcpp::IPv4OptionBuilder(tsOption)).isNull());
 	pcpp::LoggerPP::getInstance().enableErrors();
 	tsOption.type = pcpp::IPv4TimestampOptionValue::TimestampAndIP;
-	tsOption.ipAddresses.push_back(pcpp::IPv4Address(std::string("10.0.0.6")));
-	tsOption.ipAddresses.push_back(pcpp::IPv4Address(std::string("10.0.0.138")));
-	tsOption.ipAddresses.push_back(pcpp::IPv4Address(std::string("10.0.0.138")));
+	tsOption.ipAddresses.push_back(pcpp::IPv4Address("10.0.0.6"));
+	tsOption.ipAddresses.push_back(pcpp::IPv4Address("10.0.0.138"));
+	tsOption.ipAddresses.push_back(pcpp::IPv4Address("10.0.0.138"));
 	tsOption.ipAddresses.push_back(pcpp::IPv4Address::Zero);
 	pcpp::LoggerPP::getInstance().supressErrors();
 	PTF_ASSERT_TRUE(ipLayer->addOption(pcpp::IPv4OptionBuilder(tsOption)).isNull());
@@ -413,7 +413,7 @@ PTF_TEST_CASE(IPv4OptionsEditTest)
 	PTF_ASSERT_EQUAL(tsOption.timestamps.size(), 3, size);
 	PTF_ASSERT_EQUAL(tsOption.timestamps.at(1), htobe32(77233718), u32);
 	PTF_ASSERT_EQUAL(tsOption.ipAddresses.size(), 3, size);
-	PTF_ASSERT_EQUAL(tsOption.ipAddresses.at(2), pcpp::IPv4Address(std::string("10.0.0.138")), object);
+	PTF_ASSERT_EQUAL(tsOption.ipAddresses.at(2), pcpp::IPv4Address("10.0.0.138"), object);
 	ipOpt5.computeCalculateFields();
 	PTF_ASSERT_EQUAL(ipOpt5.getRawPacket()->getRawDataLen(), bufferLength55, int);
 	PTF_ASSERT_BUF_COMPARE(ipOpt5.getRawPacket()->getRawData(), buffer55, ipOpt5.getRawPacket()->getRawDataLen());
@@ -447,7 +447,7 @@ PTF_TEST_CASE(IPv4OptionsEditTest)
 
 	tsOption.clear();
 	tsOption.type = pcpp::IPv4TimestampOptionValue::TimestampAndIP;
-	tsOption.ipAddresses.push_back(pcpp::IPv4Address(std::string("10.0.0.6")));
+	tsOption.ipAddresses.push_back(pcpp::IPv4Address("10.0.0.6"));
 	tsOption.ipAddresses.push_back(pcpp::IPv4Address::Zero);
 	tsOption.timestamps.push_back(70037668);
 	tsOption.timestamps.push_back(70037669);

--- a/Tests/Packet++Test/Tests/IcmpTests.cpp
+++ b/Tests/Packet++Test/Tests/IcmpTests.cpp
@@ -160,7 +160,7 @@ PTF_TEST_CASE(IcmpParsingTest)
 	PTF_ASSERT_NOT_NULL(icmpLayer->getNextLayer());
 	PTF_ASSERT_EQUAL(icmpLayer->getNextLayer()->getProtocol(), pcpp::IPv4, u64);
 	pcpp::IPv4Layer* ipLayer = (pcpp::IPv4Layer*)icmpLayer->getNextLayer();
-	PTF_ASSERT_EQUAL(ipLayer->getSrcIpAddress(), pcpp::IPv4Address(std::string("10.0.1.2")), object);
+	PTF_ASSERT_EQUAL(ipLayer->getSrcIpAddress(), pcpp::IPv4Address("10.0.1.2"), object);
 	PTF_ASSERT_NOT_NULL(ipLayer->getNextLayer());
 	PTF_ASSERT_EQUAL(ipLayer->getNextLayer()->getProtocol(), pcpp::UDP, u64);
 
@@ -174,7 +174,7 @@ PTF_TEST_CASE(IcmpParsingTest)
 	PTF_ASSERT_NOT_NULL(icmpLayer->getNextLayer());
 	PTF_ASSERT_EQUAL(icmpLayer->getNextLayer()->getProtocol(), pcpp::IPv4, u64);
 	ipLayer = (pcpp::IPv4Layer*)icmpLayer->getNextLayer();
-	PTF_ASSERT_EQUAL(ipLayer->getDstIpAddress(), pcpp::IPv4Address(std::string("10.0.0.111")), object);
+	PTF_ASSERT_EQUAL(ipLayer->getDstIpAddress(), pcpp::IPv4Address("10.0.0.111"), object);
 	PTF_ASSERT_NOT_NULL(ipLayer->getNextLayer());
 	PTF_ASSERT_EQUAL(ipLayer->getNextLayer()->getProtocol(), pcpp::ICMP, u64);
 
@@ -240,7 +240,7 @@ PTF_TEST_CASE(IcmpParsingTest)
 	PTF_ASSERT_NULL(routerAdvData->getRouterAddress(100));
 	pcpp::icmp_router_address_structure* routerAddr = routerAdvData->getRouterAddress(0);
 	PTF_ASSERT_NOT_NULL(routerAddr);
-	PTF_ASSERT_EQUAL(pcpp::IPv4Address(routerAddr->routerAddress), pcpp::IPv4Address(std::string("192.168.144.2")), object);
+	PTF_ASSERT_EQUAL(pcpp::IPv4Address(routerAddr->routerAddress), pcpp::IPv4Address("192.168.144.2"), object);
 	PTF_ASSERT_EQUAL(routerAddr->preferenceLevel, 0x80, u32);
 
 	icmpLayer = icmpRouterAdv2.getLayerOfType<pcpp::IcmpLayer>();
@@ -254,7 +254,7 @@ PTF_TEST_CASE(IcmpParsingTest)
 	PTF_ASSERT_NULL(routerAdvData->getRouterAddress(20));
 	routerAddr = routerAdvData->getRouterAddress(0);
 	PTF_ASSERT_NOT_NULL(routerAddr);
-	PTF_ASSERT_EQUAL(pcpp::IPv4Address(routerAddr->routerAddress), pcpp::IPv4Address(std::string("14.80.84.66")), object);
+	PTF_ASSERT_EQUAL(pcpp::IPv4Address(routerAddr->routerAddress), pcpp::IPv4Address("14.80.84.66"), object);
 	PTF_ASSERT_EQUAL(routerAddr->preferenceLevel, 0, u32);
 } // IcmpParsingTest
 
@@ -283,7 +283,7 @@ PTF_TEST_CASE(IcmpCreationTest)
 
 	pcpp::EthLayer ethLayer(pcpp::MacAddress("11:22:33:44:55:66"), pcpp::MacAddress("66:55:44:33:22:11"));
 
-	pcpp::IPv4Layer ipLayer(pcpp::IPv4Address(std::string("1.1.1.1")), pcpp::IPv4Address(std::string("2.2.2.2")));
+	pcpp::IPv4Layer ipLayer(pcpp::IPv4Address("1.1.1.1"), pcpp::IPv4Address("2.2.2.2"));
 
 	uint8_t data[48] = { 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a,
 			0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f,
@@ -324,7 +324,7 @@ PTF_TEST_CASE(IcmpCreationTest)
 	PTF_ASSERT_TRUE(timeExceededPacket.addLayer(&ethLayer3));
 	PTF_ASSERT_TRUE(timeExceededPacket.addLayer(&ipLayer3));
 	PTF_ASSERT_TRUE(timeExceededPacket.addLayer(&timeExceededLayer));
-	pcpp::IPv4Layer ipLayerForTimeExceeded(pcpp::IPv4Address(std::string("10.0.0.6")), pcpp::IPv4Address(std::string("8.8.8.8")));
+	pcpp::IPv4Layer ipLayerForTimeExceeded(pcpp::IPv4Address("10.0.0.6"), pcpp::IPv4Address("8.8.8.8"));
 	ipLayerForTimeExceeded.getIPv4Header()->fragmentOffset = 0x40;
 	ipLayerForTimeExceeded.getIPv4Header()->timeToLive = 1;
 	ipLayerForTimeExceeded.getIPv4Header()->ipId = be16toh(2846);
@@ -346,7 +346,7 @@ PTF_TEST_CASE(IcmpCreationTest)
 	PTF_ASSERT_TRUE(destUnreachablePacket.addLayer(&ethLayer4));
 	PTF_ASSERT_TRUE(destUnreachablePacket.addLayer(&ipLayer4));
 	PTF_ASSERT_TRUE(destUnreachablePacket.addLayer(&destUnreachableLayer));
-	pcpp::IPv4Layer ipLayerForDestUnreachable(pcpp::IPv4Address(std::string("10.0.1.2")), pcpp::IPv4Address(std::string("172.16.0.2")));
+	pcpp::IPv4Layer ipLayerForDestUnreachable(pcpp::IPv4Address("10.0.1.2"), pcpp::IPv4Address("172.16.0.2"));
 	ipLayerForDestUnreachable.getIPv4Header()->timeToLive = 1;
 	ipLayerForDestUnreachable.getIPv4Header()->ipId = be16toh(230);
 	pcpp::UdpLayer udpLayerForDestUnreachable(49182, 33446);
@@ -380,8 +380,8 @@ PTF_TEST_CASE(IcmpCreationTest)
 	PTF_ASSERT_NOT_NULL(addressMaskRequestLayer.setAddressMaskRequestData(45068, 1536, pcpp::IPv4Address::Zero));
 	PTF_ASSERT_TRUE(addressMaskRequestPacket.addLayer(&addressMaskRequestLayer));
 	addressMaskRequestPacket.computeCalculateFields();
-	PTF_ASSERT_EQUAL(addressMaskRequestPacket.getRawPacket()->getRawDataLen(), bufferLength14-14, int);
-	PTF_ASSERT_BUF_COMPARE(addressMaskRequestPacket.getRawPacket()->getRawData()+34, buffer14+34, bufferLength14-34-14);
+	PTF_ASSERT_EQUAL(addressMaskRequestPacket.getRawPacket()->getRawDataLen(), bufferLength14 - 14, int);
+	PTF_ASSERT_BUF_COMPARE(addressMaskRequestPacket.getRawPacket()->getRawData() + 34, buffer14 + 34, bufferLength14 - 34 - 14);
 
 	// Redirect creation
 	pcpp::EthLayer ethLayer7(ethLayer);
@@ -394,12 +394,12 @@ PTF_TEST_CASE(IcmpCreationTest)
 	PTF_ASSERT_TRUE(redirectPacket.addLayer(&ethLayer7));
 	PTF_ASSERT_TRUE(redirectPacket.addLayer(&ipLayer7));
 	PTF_ASSERT_TRUE(redirectPacket.addLayer(&redirectLayer));
-	pcpp::IPv4Layer ipLayerForRedirect(pcpp::IPv4Address(std::string("10.2.10.2")), pcpp::IPv4Address(std::string("10.3.71.7")));
+	pcpp::IPv4Layer ipLayerForRedirect(pcpp::IPv4Address("10.2.10.2"), pcpp::IPv4Address("10.3.71.7"));
 	ipLayerForRedirect.getIPv4Header()->ipId = be16toh(14848);
 	ipLayerForRedirect.getIPv4Header()->timeToLive = 31;
 	pcpp::IcmpLayer icmpLayerForRedirect;
 	icmpLayerForRedirect.setEchoRequestData(512, 12544, 0, NULL, 0);
-	PTF_ASSERT_NOT_NULL(redirectLayer.setRedirectData(1, pcpp::IPv4Address(std::string("10.2.99.98")), &ipLayerForRedirect, &icmpLayerForRedirect));
+	PTF_ASSERT_NOT_NULL(redirectLayer.setRedirectData(1, pcpp::IPv4Address("10.2.99.98"), &ipLayerForRedirect, &icmpLayerForRedirect));
 	redirectPacket.computeCalculateFields();
 	PTF_ASSERT_EQUAL(redirectPacket.getRawPacket()->getRawDataLen(), bufferLength5+8, int);
 
@@ -412,11 +412,11 @@ PTF_TEST_CASE(IcmpCreationTest)
 	PTF_ASSERT_TRUE(routerAdvPacket.addLayer(&ipLayer8));
 	PTF_ASSERT_TRUE(routerAdvPacket.addLayer(&routerAdvLayer));
 	pcpp::icmp_router_address_structure addr1;
-	addr1.setRouterAddress(pcpp::IPv4Address(std::string("192.168.144.2")), (uint32_t)0x08000000);
+	addr1.setRouterAddress(pcpp::IPv4Address("192.168.144.2"), (uint32_t)0x08000000);
 	pcpp::icmp_router_address_structure addr2;
-	addr2.setRouterAddress(pcpp::IPv4Address(std::string("1.1.1.1")), (uint32_t)1000);
+	addr2.setRouterAddress(pcpp::IPv4Address("1.1.1.1"), (uint32_t)1000);
 	pcpp::icmp_router_address_structure addr3;
-	addr3.setRouterAddress(pcpp::IPv4Address(std::string("10.0.0.138")), (uint32_t)30000);
+	addr3.setRouterAddress(pcpp::IPv4Address("10.0.0.138"), (uint32_t)30000);
 	std::vector<pcpp::icmp_router_address_structure> routerAddresses;
 	routerAddresses.push_back(addr1);
 	routerAddresses.push_back(addr2);
@@ -510,7 +510,7 @@ PTF_TEST_CASE(IcmpEditTest)
 
 	// convert echo request to dest unreachable
 
-	pcpp::IPv4Layer ipLayerForDestUnreachable(pcpp::IPv4Address(std::string("10.0.0.7")), pcpp::IPv4Address(std::string("10.0.0.111")));
+	pcpp::IPv4Layer ipLayerForDestUnreachable(pcpp::IPv4Address("10.0.0.7"), pcpp::IPv4Address("10.0.0.111"));
 	ipLayerForDestUnreachable.getIPv4Header()->fragmentOffset = 0x0040;
 	ipLayerForDestUnreachable.getIPv4Header()->timeToLive = 64;
 	ipLayerForDestUnreachable.getIPv4Header()->ipId = be16toh(10203);
@@ -523,7 +523,7 @@ PTF_TEST_CASE(IcmpEditTest)
 	PTF_ASSERT_NOT_NULL(icmpLayer->getNextLayer());
 	PTF_ASSERT_EQUAL(icmpLayer->getNextLayer()->getProtocol(), pcpp::IPv4, u64);
 	pcpp::IPv4Layer* ipLayer = (pcpp::IPv4Layer*)icmpLayer->getNextLayer();
-	PTF_ASSERT_EQUAL(ipLayer->getDstIpAddress(), pcpp::IPv4Address(std::string("10.0.0.111")), object);
+	PTF_ASSERT_EQUAL(ipLayer->getDstIpAddress(), pcpp::IPv4Address("10.0.0.111"), object);
 	PTF_ASSERT_NOT_NULL(ipLayer->getNextLayer());
 	PTF_ASSERT_EQUAL(ipLayer->getNextLayer()->getProtocol(), pcpp::ICMP, u64);
 	icmpLayer = (pcpp::IcmpLayer*)ipLayer->getNextLayer();

--- a/Tests/Packet++Test/Tests/IgmpTests.cpp
+++ b/Tests/Packet++Test/Tests/IgmpTests.cpp
@@ -37,7 +37,7 @@ PTF_TEST_CASE(IgmpParsingTest)
 	PTF_ASSERT_NOT_NULL(igmpv2Layer);
 
 	PTF_ASSERT_EQUAL(igmpv2Layer->getType(), pcpp::IgmpType_MembershipReportV2, enum);
-	PTF_ASSERT_EQUAL(igmpv2Layer->getGroupAddress(), pcpp::IPv4Address(std::string("239.255.255.250")), object);
+	PTF_ASSERT_EQUAL(igmpv2Layer->getGroupAddress(), pcpp::IPv4Address("239.255.255.250"), object);
 	PTF_ASSERT_EQUAL(igmpv2Layer->toString(), "IGMPv2 Layer, Membership Report message", string);
 } // IgmpParsingTest
 
@@ -52,10 +52,10 @@ PTF_TEST_CASE(IgmpCreateAndEditTest)
 	pcpp::EthLayer ethLayer1(srcMac1, dstMac1);
 	pcpp::EthLayer ethLayer2(srcMac2, dstMac2);
 
-	pcpp::IPv4Address srcIp1(std::string("10.0.200.151"));
-	pcpp::IPv4Address dstIp1(std::string("224.0.0.1"));
-	pcpp::IPv4Address srcIp2(std::string("10.60.2.7"));
-	pcpp::IPv4Address dstIp2(std::string("239.255.255.250"));
+	pcpp::IPv4Address srcIp1("10.0.200.151");
+	pcpp::IPv4Address dstIp1("224.0.0.1");
+	pcpp::IPv4Address srcIp2("10.60.2.7");
+	pcpp::IPv4Address dstIp2("239.255.255.250");
 	pcpp::IPv4Layer ipLayer1(srcIp1, dstIp1);
 	pcpp::IPv4Layer ipLayer2(srcIp2, dstIp2);
 
@@ -65,7 +65,7 @@ PTF_TEST_CASE(IgmpCreateAndEditTest)
 	ipLayer2.getIPv4Header()->timeToLive = 1;
 
 	pcpp::IgmpV1Layer igmpV1Layer(pcpp::IgmpType_MembershipQuery);
-	pcpp::IgmpV2Layer igmpV2Layer(pcpp::IgmpType_MembershipReportV2, pcpp::IPv4Address(std::string("239.255.255.250")));
+	pcpp::IgmpV2Layer igmpV2Layer(pcpp::IgmpType_MembershipReportV2, pcpp::IPv4Address("239.255.255.250"));
 
 	pcpp::Packet igmpv1Packet(1);
 	igmpv1Packet.addLayer(&ethLayer1);
@@ -92,7 +92,7 @@ PTF_TEST_CASE(IgmpCreateAndEditTest)
 
 	pcpp::IgmpV1Layer* igmpLayer = igmpv1Packet.getLayerOfType<pcpp::IgmpV1Layer>();
 	igmpLayer->setType(pcpp::IgmpType_MembershipReportV2);
-	igmpLayer->setGroupAddress(pcpp::IPv4Address(std::string("239.255.255.250")));
+	igmpLayer->setGroupAddress(pcpp::IPv4Address("239.255.255.250"));
 	igmpv1Packet.computeCalculateFields();
 
 	PTF_ASSERT_BUF_COMPARE(igmpLayer->getData(), igmpV2Layer.getData(), igmpLayer->getHeaderLen());
@@ -167,17 +167,17 @@ PTF_TEST_CASE(Igmpv3QueryCreateAndEditTest)
 {
 	pcpp::EthLayer ethLayer(pcpp::MacAddress("00:01:01:00:00:01"), pcpp::MacAddress("01:00:5e:00:00:09"));
 
-	pcpp::IPv4Address srcIp(std::string("127.0.0.1"));
-	pcpp::IPv4Address dstIp(std::string("224.0.0.9"));
+	pcpp::IPv4Address srcIp("127.0.0.1");
+	pcpp::IPv4Address dstIp("224.0.0.9");
 	pcpp::IPv4Layer ipLayer(srcIp, dstIp);
 
 	ipLayer.getIPv4Header()->ipId = htobe16(36760);
 	ipLayer.getIPv4Header()->timeToLive = 1;
 
-	pcpp::IPv4Address multicastAddr(std::string("224.0.0.11"));
+	pcpp::IPv4Address multicastAddr("224.0.0.11");
 	pcpp::IgmpV3QueryLayer igmpV3QueryLayer(multicastAddr, 1, 0x0f);
 
-	pcpp::IPv4Address srcAddr1(std::string("192.168.20.222"));
+	pcpp::IPv4Address srcAddr1("192.168.20.222");
 	PTF_ASSERT_TRUE(igmpV3QueryLayer.addSourceAddress(srcAddr1));
 
 	pcpp::Packet igmpv3QueryPacket(33);
@@ -185,13 +185,13 @@ PTF_TEST_CASE(Igmpv3QueryCreateAndEditTest)
 	PTF_ASSERT_TRUE(igmpv3QueryPacket.addLayer(&ipLayer));
 	PTF_ASSERT_TRUE(igmpv3QueryPacket.addLayer(&igmpV3QueryLayer));
 
-	pcpp::IPv4Address srcAddr2(std::string("1.2.3.4"));
+	pcpp::IPv4Address srcAddr2("1.2.3.4");
 	PTF_ASSERT_TRUE(igmpV3QueryLayer.addSourceAddress(srcAddr2));
 
-	pcpp::IPv4Address srcAddr3(std::string("10.20.30.40"));
+	pcpp::IPv4Address srcAddr3("10.20.30.40");
 	PTF_ASSERT_TRUE(igmpV3QueryLayer.addSourceAddressAtIndex(srcAddr3, 0));
 
-	pcpp::IPv4Address srcAddr4(std::string("100.200.255.255"));
+	pcpp::IPv4Address srcAddr4("100.200.255.255");
 
 	pcpp::LoggerPP::getInstance().supressErrors();
 	PTF_ASSERT_FALSE(igmpV3QueryLayer.addSourceAddressAtIndex(srcAddr4, -1));
@@ -203,7 +203,7 @@ PTF_TEST_CASE(Igmpv3QueryCreateAndEditTest)
 
 	PTF_ASSERT_TRUE(igmpV3QueryLayer.addSourceAddressAtIndex(srcAddr4, 2));
 
-	pcpp::IPv4Address srcAddr5(std::string("11.22.33.44"));
+	pcpp::IPv4Address srcAddr5("11.22.33.44");
 	PTF_ASSERT_TRUE(igmpV3QueryLayer.addSourceAddressAtIndex(srcAddr5, 4));
 
 	igmpv3QueryPacket.computeCalculateFields();
@@ -229,7 +229,7 @@ PTF_TEST_CASE(Igmpv3QueryCreateAndEditTest)
 	PTF_ASSERT_TRUE(igmpV3QueryLayer.removeSourceAddressAtIndex(1));
 	PTF_ASSERT_TRUE(igmpV3QueryLayer.removeSourceAddressAtIndex(1));
 
-	igmpV3QueryLayer.setGroupAddress(pcpp::IPv4Address(std::string("224.0.0.9")));
+	igmpV3QueryLayer.setGroupAddress(pcpp::IPv4Address("224.0.0.9"));
 
 	igmpv3QueryPacket.computeCalculateFields();
 
@@ -251,8 +251,8 @@ PTF_TEST_CASE(Igmpv3ReportCreateAndEditTest)
 {
 	pcpp::EthLayer ethLayer(pcpp::MacAddress("00:01:01:00:00:02"), pcpp::MacAddress("01:00:5e:00:00:16"));
 
-	pcpp::IPv4Address srcIp(std::string("127.0.0.1"));
-	pcpp::IPv4Address dstIp(std::string("224.0.0.22"));
+	pcpp::IPv4Address srcIp("127.0.0.1");
+	pcpp::IPv4Address dstIp("224.0.0.22");
 	pcpp::IPv4Layer ipLayer(srcIp, dstIp);
 
 	ipLayer.getIPv4Header()->ipId = htobe16(3941);
@@ -261,41 +261,41 @@ PTF_TEST_CASE(Igmpv3ReportCreateAndEditTest)
 	pcpp::IgmpV3ReportLayer igmpV3ReportLayer;
 
 	std::vector<pcpp::IPv4Address> srcAddrVec1;
-	srcAddrVec1.push_back(pcpp::IPv4Address(std::string("192.168.20.222")));
-	pcpp::igmpv3_group_record* groupRec = igmpV3ReportLayer.addGroupRecord(1, pcpp::IPv4Address(std::string("224.0.0.9")), srcAddrVec1);
+	srcAddrVec1.push_back(pcpp::IPv4Address("192.168.20.222"));
+	pcpp::igmpv3_group_record* groupRec = igmpV3ReportLayer.addGroupRecord(1, pcpp::IPv4Address("224.0.0.9"), srcAddrVec1);
 	PTF_ASSERT_NOT_NULL(groupRec);
-	PTF_ASSERT_EQUAL(groupRec->getSourceAddressAtIndex(0), pcpp::IPv4Address(std::string("192.168.20.222")), object);
+	PTF_ASSERT_EQUAL(groupRec->getSourceAddressAtIndex(0), pcpp::IPv4Address("192.168.20.222"), object);
 
 	std::vector<pcpp::IPv4Address> srcAddrVec2;
-	srcAddrVec2.push_back(pcpp::IPv4Address(std::string("1.2.3.4")));
-	srcAddrVec2.push_back(pcpp::IPv4Address(std::string("11.22.33.44")));
-	srcAddrVec2.push_back(pcpp::IPv4Address(std::string("111.222.33.44")));
-	groupRec = igmpV3ReportLayer.addGroupRecord(2, pcpp::IPv4Address(std::string("4.3.2.1")), srcAddrVec2);
+	srcAddrVec2.push_back(pcpp::IPv4Address("1.2.3.4"));
+	srcAddrVec2.push_back(pcpp::IPv4Address("11.22.33.44"));
+	srcAddrVec2.push_back(pcpp::IPv4Address("111.222.33.44"));
+	groupRec = igmpV3ReportLayer.addGroupRecord(2, pcpp::IPv4Address("4.3.2.1"), srcAddrVec2);
 	PTF_ASSERT_NOT_NULL(groupRec);
 	PTF_ASSERT_EQUAL(groupRec->getSourceAddressCount(), 3, u16);
 
 	std::vector<pcpp::IPv4Address> srcAddrVec3;
-	srcAddrVec3.push_back(pcpp::IPv4Address(std::string("12.34.56.78")));
-	srcAddrVec3.push_back(pcpp::IPv4Address(std::string("88.77.66.55")));
-	srcAddrVec3.push_back(pcpp::IPv4Address(std::string("44.33.22.11")));
-	srcAddrVec3.push_back(pcpp::IPv4Address(std::string("255.255.255.255")));
-	groupRec = igmpV3ReportLayer.addGroupRecordAtIndex(3, pcpp::IPv4Address(std::string("1.1.1.1")), srcAddrVec3, 0);
+	srcAddrVec3.push_back(pcpp::IPv4Address("12.34.56.78"));
+	srcAddrVec3.push_back(pcpp::IPv4Address("88.77.66.55"));
+	srcAddrVec3.push_back(pcpp::IPv4Address("44.33.22.11"));
+	srcAddrVec3.push_back(pcpp::IPv4Address("255.255.255.255"));
+	groupRec = igmpV3ReportLayer.addGroupRecordAtIndex(3, pcpp::IPv4Address("1.1.1.1"), srcAddrVec3, 0);
 	PTF_ASSERT_NOT_NULL(groupRec);
 	PTF_ASSERT_EQUAL(groupRec->getRecordLen(), 24, size);
 
 	std::vector<pcpp::IPv4Address> srcAddrVec4;
-	srcAddrVec4.push_back(pcpp::IPv4Address(std::string("13.24.57.68")));
-	srcAddrVec4.push_back(pcpp::IPv4Address(std::string("31.42.75.86")));
+	srcAddrVec4.push_back(pcpp::IPv4Address("13.24.57.68"));
+	srcAddrVec4.push_back(pcpp::IPv4Address("31.42.75.86"));
 
 	pcpp::LoggerPP::getInstance().supressErrors();
-	PTF_ASSERT_NULL(igmpV3ReportLayer.addGroupRecordAtIndex(4, pcpp::IPv4Address(std::string("1.3.5.7")), srcAddrVec4, -1));
-	PTF_ASSERT_NULL(igmpV3ReportLayer.addGroupRecordAtIndex(4, pcpp::IPv4Address(std::string("1.3.5.7")), srcAddrVec4, 4));
-	PTF_ASSERT_NULL(igmpV3ReportLayer.addGroupRecordAtIndex(4, pcpp::IPv4Address(std::string("1.3.5.7")), srcAddrVec4, 100));
+	PTF_ASSERT_NULL(igmpV3ReportLayer.addGroupRecordAtIndex(4, pcpp::IPv4Address("1.3.5.7"), srcAddrVec4, -1));
+	PTF_ASSERT_NULL(igmpV3ReportLayer.addGroupRecordAtIndex(4, pcpp::IPv4Address("1.3.5.7"), srcAddrVec4, 4));
+	PTF_ASSERT_NULL(igmpV3ReportLayer.addGroupRecordAtIndex(4, pcpp::IPv4Address("1.3.5.7"), srcAddrVec4, 100));
 	pcpp::LoggerPP::getInstance().enableErrors();
 
-	groupRec = igmpV3ReportLayer.addGroupRecordAtIndex(4, pcpp::IPv4Address(std::string("1.3.5.7")), srcAddrVec4, 1);
+	groupRec = igmpV3ReportLayer.addGroupRecordAtIndex(4, pcpp::IPv4Address("1.3.5.7"), srcAddrVec4, 1);
 	PTF_ASSERT_NOT_NULL(groupRec);
-	groupRec = igmpV3ReportLayer.addGroupRecordAtIndex(5, pcpp::IPv4Address(std::string("2.4.6.8")), srcAddrVec4, 4);
+	groupRec = igmpV3ReportLayer.addGroupRecordAtIndex(5, pcpp::IPv4Address("2.4.6.8"), srcAddrVec4, 4);
 	PTF_ASSERT_NOT_NULL(groupRec);
 
 

--- a/Tests/Packet++Test/Tests/PacketTests.cpp
+++ b/Tests/Packet++Test/Tests/PacketTests.cpp
@@ -32,8 +32,8 @@ PTF_TEST_CASE(InsertDataToPacket)
 	pcpp::EthLayer ethLayer(srcMac, dstMac, PCPP_ETHERTYPE_IP);
 	PTF_ASSERT_TRUE(ip4Packet.addLayer(&ethLayer));
 
-	pcpp::IPv4Address ipSrc(std::string("1.1.1.1"));
-	pcpp::IPv4Address ipDst(std::string("20.20.20.20"));
+	pcpp::IPv4Address ipSrc("1.1.1.1");
+	pcpp::IPv4Address ipDst("20.20.20.20");
 	pcpp::IPv4Layer ip4Layer(ipSrc, ipDst);
 	ip4Layer.getIPv4Header()->protocol = pcpp::PACKETPP_IPPROTO_TCP;
 	PTF_ASSERT_TRUE(ip4Packet.addLayer(&ip4Layer));
@@ -198,8 +198,8 @@ PTF_TEST_CASE(RemoveLayerTest)
 	pcpp::EthLayer ethLayer(srcMac, dstMac, PCPP_ETHERTYPE_IP);
 	PTF_ASSERT_TRUE(testPacket.addLayer(&ethLayer));
 
-	pcpp::IPv4Address ipSrc(std::string("1.1.1.1"));
-	pcpp::IPv4Address ipDst(std::string("20.20.20.20"));
+	pcpp::IPv4Address ipSrc("1.1.1.1");
+	pcpp::IPv4Address ipDst("20.20.20.20");
 	pcpp::IPv4Layer ip4Layer(ipSrc, ipDst);
 	ip4Layer.getIPv4Header()->protocol = pcpp::PACKETPP_IPPROTO_TCP;
 	PTF_ASSERT_TRUE(testPacket.addLayer(&ip4Layer));
@@ -804,7 +804,7 @@ PTF_TEST_CASE(PacketTrailerTest)
 	// rebuild packet starting from trailer
 	pcpp::EthLayer newEthLayer(pcpp::MacAddress("30:46:9a:23:fb:fa"), pcpp::MacAddress("6c:f0:49:b2:de:6e"), PCPP_ETHERTYPE_IP);
 	PTF_ASSERT_TRUE(trailerIPv4Packet.insertLayer(NULL, &newEthLayer));
-	pcpp::IPv4Layer newIp4Layer(pcpp::IPv4Address(std::string("173.194.78.104")), pcpp::IPv4Address(std::string("10.0.0.1")));
+	pcpp::IPv4Layer newIp4Layer(pcpp::IPv4Address("173.194.78.104"), pcpp::IPv4Address("10.0.0.1"));
 	newIp4Layer.getIPv4Header()->ipId = htobe16(40382);
 	newIp4Layer.getIPv4Header()->timeToLive = 46;
 	trailerIPv4Packet.insertLayer(&newEthLayer, &newIp4Layer);

--- a/Tests/Packet++Test/Tests/RadiusTests.cpp
+++ b/Tests/Packet++Test/Tests/RadiusTests.cpp
@@ -104,7 +104,7 @@ PTF_TEST_CASE(RadiusLayerCreationTest)
 	PTF_ASSERT_TRUE(newRadiusPacket.addLayer(&udpLayer));
 
 	pcpp::RadiusLayer radiusLayer(11, 5, "f050649184625d36f14c9075b7a48b83");
-	pcpp::RadiusAttribute radiusNewAttr = radiusLayer.addAttribute(pcpp::RadiusAttributeBuilder(8, pcpp::IPv4Address(std::string("255.255.255.254"))));
+	pcpp::RadiusAttribute radiusNewAttr = radiusLayer.addAttribute(pcpp::RadiusAttributeBuilder(8, pcpp::IPv4Address("255.255.255.254")));
 	PTF_ASSERT_FALSE(radiusNewAttr.isNull());
 	PTF_ASSERT_EQUAL(radiusNewAttr.getType(), 8, u8);
 	PTF_ASSERT_EQUAL(radiusNewAttr.getDataSize(), 4, size);

--- a/Tests/Packet++Test/Tests/SipSdpTests.cpp
+++ b/Tests/Packet++Test/Tests/SipSdpTests.cpp
@@ -483,7 +483,7 @@ PTF_TEST_CASE(SdpLayerParsingTest)
 	PTF_ASSERT_EQUAL(sdpLayer->getFieldByName(PCPP_SDP_MEDIA_ATTRIBUTE_FIELD, 4)->getFieldValue(), "SendRecv", string);
 	PTF_ASSERT_NULL(sdpLayer->getFieldByName(PCPP_SDP_MEDIA_ATTRIBUTE_FIELD, 5));
 
-	PTF_ASSERT_EQUAL(sdpLayer->getOwnerIPv4Address(), pcpp::IPv4Address(std::string("200.57.7.196")), object);
+	PTF_ASSERT_EQUAL(sdpLayer->getOwnerIPv4Address(), pcpp::IPv4Address("200.57.7.196"), object);
 	PTF_ASSERT_EQUAL(sdpLayer->getMediaPort("audio"), 40376, u16);
 
 	PTF_ASSERT_TRUE(sdpPacket2.isPacketOfType(pcpp::SDP));
@@ -499,7 +499,7 @@ PTF_TEST_CASE(SdpLayerParsingTest)
 	PTF_ASSERT_NOT_NULL(sdpLayer->getFieldByName(PCPP_SDP_SESSION_NAME_FIELD));
 	PTF_ASSERT_EQUAL(sdpLayer->getFieldByName(PCPP_SDP_SESSION_NAME_FIELD)->getFieldValue(), "Phone-Call", string);
 
-	PTF_ASSERT_EQUAL(sdpLayer->getOwnerIPv4Address(), pcpp::IPv4Address(std::string("10.33.6.100")), object);
+	PTF_ASSERT_EQUAL(sdpLayer->getOwnerIPv4Address(), pcpp::IPv4Address("10.33.6.100"), object);
 	PTF_ASSERT_EQUAL(sdpLayer->getMediaPort("audio"), 6010, u16);
 	PTF_ASSERT_EQUAL(sdpLayer->getMediaPort("image"), 6012, u16);
 } // SdpLayerParsingTest
@@ -530,7 +530,7 @@ PTF_TEST_CASE(SdpLayerCreationTest)
 	pcpp::SipResponseLayer sipLayer = *(sdpPacket.getLayerOfType<pcpp::SipResponseLayer>());
 	PTF_ASSERT_TRUE(newSdpPacket.addLayer(&sipLayer));
 
-	pcpp::SdpLayer newSdpLayer("IPP", 782647527, 782647407, pcpp::IPv4Address(std::string("10.33.6.100")), "Phone-Call", 0, 0);
+	pcpp::SdpLayer newSdpLayer("IPP", 782647527, 782647407, pcpp::IPv4Address("10.33.6.100"), "Phone-Call", 0, 0);
 
 	std::vector<std::string> audioAttributes;
 	audioAttributes.push_back("rtpmap:8 PCMA/8000");

--- a/Tests/Packet++Test/Tests/SllNullLoopbackTests.cpp
+++ b/Tests/Packet++Test/Tests/SllNullLoopbackTests.cpp
@@ -48,7 +48,7 @@ PTF_TEST_CASE(SllPacketCreationTest)
 	sllLayer.getSllHeader()->link_layer_addr[6] = 0xf6;
 	sllLayer.getSllHeader()->link_layer_addr[7] = 0x7f;
 
-	pcpp::IPv4Layer ipLayer(pcpp::IPv4Address(std::string("130.217.250.13")), pcpp::IPv4Address(std::string("130.217.250.128")));
+	pcpp::IPv4Layer ipLayer(pcpp::IPv4Address(std::string("130.217.250.13")), pcpp::IPv4Address("130.217.250.128"));
 	ipLayer.getIPv4Header()->fragmentOffset = 0x40;
 	ipLayer.getIPv4Header()->ipId = htobe16(63242);
 	ipLayer.getIPv4Header()->timeToLive = 64;
@@ -111,12 +111,12 @@ PTF_TEST_CASE(NullLoopbackTest)
 	nextLayer = nullLoopbackLayer->getNextLayer();
 	PTF_ASSERT_NOT_NULL(nextLayer);
 	PTF_ASSERT_EQUAL(nextLayer->getProtocol(), pcpp::IPv4, u64);
-	PTF_ASSERT_EQUAL(((pcpp::IPv4Layer*)nextLayer)->getSrcIpAddress(), pcpp::IPv4Address(std::string("172.16.1.117")), object);
+	PTF_ASSERT_EQUAL(((pcpp::IPv4Layer*)nextLayer)->getSrcIpAddress(), pcpp::IPv4Address("172.16.1.117"), object);
 	PTF_ASSERT_EQUAL(nullLoopbackLayer->getFamily(), PCPP_BSD_AF_INET, u32);
 
 	pcpp::Packet newNullPacket(1);
 	pcpp::NullLoopbackLayer newNullLoopbackLayer(PCPP_BSD_AF_INET);
-	pcpp::IPv4Layer newIp4Layer(pcpp::IPv4Address(std::string("172.16.1.117")), pcpp::IPv4Address(std::string("172.16.1.255")));
+	pcpp::IPv4Layer newIp4Layer(pcpp::IPv4Address("172.16.1.117"), pcpp::IPv4Address("172.16.1.255"));
 	newIp4Layer.getIPv4Header()->ipId = htobe16(49513);
 	newIp4Layer.getIPv4Header()->timeToLive = 64;
 

--- a/Tests/Packet++Test/Tests/TcpTests.cpp
+++ b/Tests/Packet++Test/Tests/TcpTests.cpp
@@ -158,8 +158,8 @@ PTF_TEST_CASE(TcpPacketCreation)
 	pcpp::MacAddress srcMac("30:46:9a:23:fb:fa");
 	pcpp::MacAddress dstMac("08:00:27:19:1c:78");
 	pcpp::EthLayer ethLayer(srcMac, dstMac, PCPP_ETHERTYPE_IP);
-	pcpp::IPv4Address dstIP(std::string("10.0.0.6"));
-	pcpp::IPv4Address srcIP(std::string("212.199.202.9"));
+	pcpp::IPv4Address dstIP("10.0.0.6");
+	pcpp::IPv4Address srcIP("212.199.202.9");
 	pcpp::IPv4Layer ipLayer(srcIP, dstIP);
 	ipLayer.getIPv4Header()->ipId = htobe16(20300);
 	ipLayer.getIPv4Header()->fragmentOffset = htobe16(0x4000);
@@ -212,8 +212,8 @@ PTF_TEST_CASE(TcpPacketCreation2)
 	pcpp::MacAddress srcMac("08:00:27:19:1c:78");
 	pcpp::MacAddress dstMac("30:46:9a:23:fb:fa");
 	pcpp::EthLayer ethLayer(srcMac, dstMac, PCPP_ETHERTYPE_IP);
-	pcpp::IPv4Address dstIP(std::string("23.44.242.127"));
-	pcpp::IPv4Address srcIP(std::string("10.0.0.6"));
+	pcpp::IPv4Address dstIP("23.44.242.127");
+	pcpp::IPv4Address srcIP("10.0.0.6");
 	pcpp::IPv4Layer ipLayer(srcIP, dstIP);
 	ipLayer.getIPv4Header()->ipId = htobe16(1556);
 	ipLayer.getIPv4Header()->fragmentOffset = 0x40;

--- a/Tests/Packet++Test/Tests/VlanMplsTests.cpp
+++ b/Tests/Packet++Test/Tests/VlanMplsTests.cpp
@@ -51,7 +51,7 @@ PTF_TEST_CASE(VlanParseAndCreation)
 	pcpp::EthLayer ethLayer(macSrc, macDest, PCPP_ETHERTYPE_VLAN);
 	pcpp::VlanLayer firstVlanLayer(666, 1, 5, PCPP_ETHERTYPE_VLAN);
 	pcpp::VlanLayer secondVlanLayer(200, 0, 2, PCPP_ETHERTYPE_ARP);
-	pcpp::ArpLayer arpLayer(pcpp::ARP_REQUEST, macSrc, pcpp::MacAddress("00:00:00:00:00:00"), pcpp::IPv4Address(std::string("192.168.2.200")), pcpp::IPv4Address(std::string("192.168.2.254")));
+	pcpp::ArpLayer arpLayer(pcpp::ARP_REQUEST, macSrc, pcpp::MacAddress("00:00:00:00:00:00"), pcpp::IPv4Address("192.168.2.200"), pcpp::IPv4Address("192.168.2.254"));
 	PTF_ASSERT_TRUE(arpWithVlanNew.addLayer(&ethLayer));
 	PTF_ASSERT_TRUE(arpWithVlanNew.addLayer(&firstVlanLayer));
 	PTF_ASSERT_TRUE(arpWithVlanNew.addLayer(&secondVlanLayer));


### PR DESCRIPTION
The source code was simplified. An explicit `std::string` was removed in many places.