### PR TITLE
Decreased memory consumption in TcpReassembly

### DIFF
--- a/Examples/TcpReassembly/main.cpp
+++ b/Examples/TcpReassembly/main.cpp
@@ -222,7 +222,7 @@ struct TcpReassemblyData
 	bool reopenFileStreams[2];
 
 	// a flag indicating on which side was the latest message on this connection
-	int curSide;
+	int8_t curSide;
 
 	// stats data: num of data packets on each side, bytes seen on each side and messages seen on each side
 	int numOfDataPackets[2];
@@ -338,7 +338,7 @@ void listInterfaces()
 /**
  * The callback being called by the TCP reassembly module whenever new data arrives on a certain connection
  */
-static void tcpReassemblyMsgReadyCallback(int sideIndex, const TcpStreamData& tcpData, void* userCookie)
+static void tcpReassemblyMsgReadyCallback(int8_t sideIndex, const TcpStreamData& tcpData, void* userCookie)
 {
 	// extract the connection manager from the user cookie
 	TcpReassemblyConnMgr* connMgr = (TcpReassemblyConnMgr*)userCookie;

--- a/Examples/TcpReassembly/main.cpp
+++ b/Examples/TcpReassembly/main.cpp
@@ -351,7 +351,7 @@ static void tcpReassemblyMsgReadyCallback(int8_t sideIndex, const TcpStreamData&
 		iter = connMgr->find(tcpData.getConnectionData().flowKey);
 	}
 
-	int side;
+	int8_t side;
 
 	// if the user wants to write each side in a different file - set side as the sideIndex, otherwise write everything to the same file ("side 0")
 	if (GlobalConfig::getInstance().separateSides)

--- a/Packet++/header/TcpReassembly.h
+++ b/Packet++/header/TcpReassembly.h
@@ -297,7 +297,7 @@ public:
 	 * @param[in] tcpData The TCP data itself + connection information
 	 * @param[in] userCookie A pointer to the cookie provided by the user in TcpReassembly c'tor (or NULL if no cookie provided)
 	 */
-	typedef void (*OnTcpMessageReady)(int side, const TcpStreamData& tcpData, void* userCookie);
+	typedef void (*OnTcpMessageReady)(int8_t side, const TcpStreamData& tcpData, void* userCookie);
 
 	/**
 	 * @typedef OnTcpConnectionStart
@@ -405,8 +405,8 @@ private:
 
 	struct TcpReassemblyData
 	{
-		int numOfSides;
-		int prevSide;
+		int8_t numOfSides;
+		int8_t prevSide;
 		TcpOneSideData twoSides[2];
 		ConnectionData connData;
 
@@ -428,11 +428,11 @@ private:
 	uint32_t m_MaxNumToClean;
 	time_t m_PurgeTimepoint;
 
-	void checkOutOfOrderFragments(TcpReassemblyData* tcpReassemblyData, int sideIndex, bool cleanWholeFragList);
+	void checkOutOfOrderFragments(TcpReassemblyData* tcpReassemblyData, int8_t sideIndex, bool cleanWholeFragList);
 
 	std::string prepareMissingDataMessage(uint32_t missingDataLen);
 
-	void handleFinOrRst(TcpReassemblyData* tcpReassemblyData, int sideIndex, uint32_t flowKey);
+	void handleFinOrRst(TcpReassemblyData* tcpReassemblyData, int8_t sideIndex, uint32_t flowKey);
 
 	void closeConnectionInternal(uint32_t flowKey, ConnectionEndReason reason);
 

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -204,7 +204,7 @@ TcpReassembly::ReassemblyStatus TcpReassembly::reassemblePacket(Packet& tcpData)
 		}
 	}
 
-	int sideIndex = -1;
+	int8_t sideIndex = -1;
 	bool first = false;
 
 	// calculate packet's source port
@@ -479,7 +479,7 @@ std::string TcpReassembly::prepareMissingDataMessage(uint32_t missingDataLen)
 	return missingDataTextStream.str();
 }
 
-void TcpReassembly::handleFinOrRst(TcpReassemblyData* tcpReassemblyData, int sideIndex, uint32_t flowKey)
+void TcpReassembly::handleFinOrRst(TcpReassemblyData* tcpReassemblyData, int8_t sideIndex, uint32_t flowKey)
 {
 	// if this side already saw a FIN or RST packet, do nothing and return
 	if (tcpReassemblyData->twoSides[sideIndex].gotFinOrRst)
@@ -498,7 +498,7 @@ void TcpReassembly::handleFinOrRst(TcpReassemblyData* tcpReassemblyData, int sid
 		checkOutOfOrderFragments(tcpReassemblyData, sideIndex, true);
 }
 
-void TcpReassembly::checkOutOfOrderFragments(TcpReassemblyData* tcpReassemblyData, int sideIndex, bool cleanWholeFragList)
+void TcpReassembly::checkOutOfOrderFragments(TcpReassemblyData* tcpReassemblyData, int8_t sideIndex, bool cleanWholeFragList)
 {
 	bool foundSomething = false;
 

--- a/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
+++ b/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
@@ -20,7 +20,7 @@ struct TcpReassemblyStats
 {
 	std::string reassembledData;
 	int numOfDataPackets;
-	int curSide;
+	int8_t curSide;
 	int numOfMessagesFromSide[2];
 	bool connectionsStarted;
 	bool connectionsEnded;
@@ -73,7 +73,7 @@ static std::string readFileIntoString(std::string fileName)
 // tcpReassemblyMsgReadyCallback()
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-static void tcpReassemblyMsgReadyCallback(int sideIndex, const pcpp::TcpStreamData& tcpData, void* userCookie)
+static void tcpReassemblyMsgReadyCallback(int8_t sideIndex, const pcpp::TcpStreamData& tcpData, void* userCookie)
 {
 	TcpReassemblyMultipleConnStats::Stats &stats = ((TcpReassemblyMultipleConnStats*)userCookie)->stats;
 


### PR DESCRIPTION
Current changes save 4 bytes per connection and give the way for next optimization (in a different PR).
Notice that the signature of callback function 'OnTcpMessageReady' has changed.