### PR TITLE
Performance and readability improvements in TcpReassembly

### DIFF
--- a/Packet++/header/TcpReassembly.h
+++ b/Packet++/header/TcpReassembly.h
@@ -327,12 +327,6 @@ public:
 	TcpReassembly(OnTcpMessageReady onMessageReadyCallback, void* userCookie = NULL, OnTcpConnectionStart onConnectionStartCallback = NULL, OnTcpConnectionEnd onConnectionEndCallback = NULL, const TcpReassemblyConfiguration &config = TcpReassemblyConfiguration());
 
 	/**
-	 * A d'tor for this class. Frees all internal structures. Notice that if the d'tor is called while connections are still open, all data is lost and TcpReassembly#OnTcpConnectionEnd won't
-	 * be called for those connections
-	 */
-	~TcpReassembly();
-
-	/**
 	 * The most important method of this class which gets a packet from the user and processes it. If this packet opens a new connection, ends a connection or contains new data on an
 	 * existing connection, the relevant callback will be called (TcpReassembly#OnTcpMessageReady, TcpReassembly#OnTcpConnectionStart, TcpReassembly#OnTcpConnectionEnd)
 	 * @param[in] tcpData A reference to the packet to process
@@ -405,15 +399,16 @@ private:
 
 	struct TcpReassemblyData
 	{
+		bool closed;
 		int numOfSides;
 		int prevSide;
 		TcpOneSideData twoSides[2];
 		ConnectionData connData;
 
-		TcpReassemblyData() { numOfSides = 0; prevSide = -1; }
+		TcpReassemblyData() : closed(false), numOfSides(0), prevSide(-1) {}
 	};
 	
-	typedef std::map<uint32_t, TcpReassemblyData *> ConnectionList;
+	typedef std::map<uint32_t, TcpReassemblyData> ConnectionList;
 	typedef std::map<time_t, std::list<uint32_t> > CleanupList;
 
 	OnTcpMessageReady m_OnMessageReadyCallback;

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -52,7 +52,7 @@ TcpReassembly::ReassemblyStatus TcpReassembly::reassemblePacket(Packet& tcpData)
 	// automatic cleanup
 	if (m_RemoveConnInfo == true)
 	{
-		if(time(NULL) >= m_PurgeTimepoint)
+		if (time(NULL) >= m_PurgeTimepoint)
 		{
 			purgeClosedConnections();
 			m_PurgeTimepoint = time(NULL) + PURGE_FREQ_SECS;
@@ -730,11 +730,11 @@ uint32_t TcpReassembly::purgeClosedConnections(uint32_t maxNumToClean)
 {
 	uint32_t count = 0;
 
-	if(maxNumToClean == 0)
+	if (maxNumToClean == 0)
 		maxNumToClean = m_MaxNumToClean;
 
 	CleanupList::iterator iterTime = m_CleanupList.begin(), iterTimeEnd = m_CleanupList.upper_bound(time(NULL));
-	while(iterTime != iterTimeEnd && count < maxNumToClean)
+	while (iterTime != iterTimeEnd && count < maxNumToClean)
 	{
 		CleanupList::mapped_type& keysList = iterTime->second;
 
@@ -746,7 +746,7 @@ uint32_t TcpReassembly::purgeClosedConnections(uint32_t maxNumToClean)
 			keysList.pop_front();
 		}
 
-		if(keysList.empty())
+		if (keysList.empty())
 			m_CleanupList.erase(iterTime++);
 		else
 			++iterTime;


### PR DESCRIPTION
The main goal of this PR is to change the type of items stored in `ConnectionList`. I also made the readability improvements.