### PR TITLE
Fix IPcapDevice::matchPacketWithFilter when checking empty filter.

### DIFF
--- a/Pcap++/src/PcapDevice.cpp
+++ b/Pcap++/src/PcapDevice.cpp
@@ -74,8 +74,7 @@ bool IPcapDevice::matchPacketWithFilter(std::string filterAsString, RawPacket* r
 {
 	static std::string curFilter = "";
 	static struct bpf_program prog;
-	static bool isProgCompiled = false;
-	if ( (curFilter != filterAsString) || !isProgCompiled )
+	if ( (curFilter != filterAsString) || (prog.bf_insns == nullptr) )
 	{
 		LOG_DEBUG("Compiling the filter '%s'", filterAsString.c_str());
 		pcap_freecode(&prog);
@@ -83,7 +82,6 @@ bool IPcapDevice::matchPacketWithFilter(std::string filterAsString, RawPacket* r
 		{
 			return false;
 		}
-		isProgCompiled = true;
 		curFilter = filterAsString;
 	}
 

--- a/Pcap++/src/PcapDevice.cpp
+++ b/Pcap++/src/PcapDevice.cpp
@@ -74,7 +74,8 @@ bool IPcapDevice::matchPacketWithFilter(std::string filterAsString, RawPacket* r
 {
 	static std::string curFilter = "";
 	static struct bpf_program prog;
-	if (curFilter != filterAsString)
+	static bool isProgCompiled = false;
+	if ( (curFilter != filterAsString) || !isProgCompiled )
 	{
 		LOG_DEBUG("Compiling the filter '%s'", filterAsString.c_str());
 		pcap_freecode(&prog);
@@ -82,7 +83,7 @@ bool IPcapDevice::matchPacketWithFilter(std::string filterAsString, RawPacket* r
 		{
 			return false;
 		}
-
+		isProgCompiled = true;
 		curFilter = filterAsString;
 	}
 

--- a/Pcap++/src/PcapDevice.cpp
+++ b/Pcap++/src/PcapDevice.cpp
@@ -74,7 +74,7 @@ bool IPcapDevice::matchPacketWithFilter(std::string filterAsString, RawPacket* r
 {
 	static std::string curFilter = "";
 	static struct bpf_program prog;
-	if ( (curFilter != filterAsString) || (prog.bf_insns == nullptr) )
+	if ( (curFilter != filterAsString) || (prog.bf_insns == NULL) )
 	{
 		LOG_DEBUG("Compiling the filter '%s'", filterAsString.c_str());
 		pcap_freecode(&prog);

--- a/Tests/Pcap++Test/TestDefinition.h
+++ b/Tests/Pcap++Test/TestDefinition.h
@@ -31,6 +31,7 @@ PTF_TEST_CASE(TestSendPackets);
 PTF_TEST_CASE(TestRemoteCapture);
 
 // Implemented in FilterTests.cpp
+PTF_TEST_CASE(TestPcapFilters_matchPacketWithFilter_static);
 PTF_TEST_CASE(TestPcapFiltersLive);
 PTF_TEST_CASE(TestPcapFilters_General_BPFStr);
 PTF_TEST_CASE(TestPcapFiltersOffline);

--- a/Tests/Pcap++Test/Tests/FilterTests.cpp
+++ b/Tests/Pcap++Test/Tests/FilterTests.cpp
@@ -266,10 +266,11 @@ PTF_TEST_CASE(TestPcapFilters_matchPacketWithFilter_static)
 	fileReaderDev.getNextPackets(rawPacketVec);
 	fileReaderDev.close();
 
-	//	Test empty BPFstring - the "ALL" filter
+	//	Test empty BPFstring (the "ALL" filter) in combination with a "-" (example wrong filter)
 	for (pcpp::RawPacketVector::VectorIterator iter = rawPacketVec.begin(); iter != rawPacketVec.end(); iter++)
 	{
 		PTF_ASSERT_TRUE(pcpp::IPcapDevice::matchPacketWithFilter("", *iter));
+		PTF_ASSERT_FALSE(pcpp::IPcapDevice::matchPacketWithFilter("-", *iter));
 	}
 
 	rawPacketVec.clear();

--- a/Tests/Pcap++Test/Tests/FilterTests.cpp
+++ b/Tests/Pcap++Test/Tests/FilterTests.cpp
@@ -258,6 +258,26 @@ PTF_TEST_CASE(TestPcapFilters_General_BPFStr)
 
 
 
+PTF_TEST_CASE(TestPcapFilters_matchPacketWithFilter_static)
+{
+	pcpp::RawPacketVector rawPacketVec;
+	pcpp::PcapFileReaderDevice fileReaderDev(EXAMPLE_PCAP_VLAN);
+	PTF_ASSERT_TRUE(fileReaderDev.open());
+	fileReaderDev.getNextPackets(rawPacketVec);
+	fileReaderDev.close();
+
+	//	Test empty BPFstring - the "ALL" filter
+	for (pcpp::RawPacketVector::VectorIterator iter = rawPacketVec.begin(); iter != rawPacketVec.end(); iter++)
+	{
+		PTF_ASSERT_TRUE(pcpp::IPcapDevice::matchPacketWithFilter("", *iter));
+	}
+
+	rawPacketVec.clear();
+} // TestPcapFilters_matchPacketWithFilter_static
+
+
+
+
 PTF_TEST_CASE(TestPcapFiltersOffline)
 {
 	pcpp::RawPacketVector rawPacketVec;

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -220,6 +220,7 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(TestSendPackets, "live_device;send");
 	PTF_RUN_TEST(TestRemoteCapture, "live_device;remote_capture;winpcap");
 
+	PTF_RUN_TEST(TestPcapFilters_matchPacketWithFilter_static, "no_network;filters;skip_mem_leak_check");
 	PTF_RUN_TEST(TestPcapFiltersLive, "filters");
 	PTF_RUN_TEST(TestPcapFilters_General_BPFStr, "no_network;filters;skip_mem_leak_check");
 	PTF_RUN_TEST(TestPcapFiltersOffline, "no_network;filters");


### PR DESCRIPTION
Bug:
bool IPcapDevice::matchPacketWithFilter(std::string filterAsString, RawPacket* rawPacket)
"pcap_compile_nopcap" would not be called untill first, non empty filterAsString.