### PR TITLE
add explicit flush for pcapng file writers

### DIFF
--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -485,7 +485,12 @@ namespace pcpp
 		bool open(bool appendMode);
 
 		/**
-		 * Flush and close the pacp-ng file
+		 * Flush packets to the pcap-ng file
+		 */
+		void flush();
+
+		/**
+		 * Flush and close the pcap-ng file
 		 */
 		void close();
 

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -832,7 +832,7 @@ void PcapNgFileWriterDevice::flush()
 		return;
 
 	light_pcapng_flush((light_pcapng_t*)m_LightPcapNg);
-	LOG_DEBUG("File writer flushed to file '%s'", m_Filename);
+	LOG_DEBUG("File writer flushed to file '%s'", m_FileName);
 }
 
 void PcapNgFileWriterDevice::close()

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -826,6 +826,15 @@ bool PcapNgFileWriterDevice::open(bool appendMode)
 
 }
 
+void PcapNgFileWriterDevice::flush()
+{
+	if (!m_DeviceOpened || m_LightPcapNg == NULL)
+		return;
+
+	light_pcapng_flush((light_pcapng_t*)m_LightPcapNg);
+	LOG_DEBUG("File writer flushed to file '%s'", m_Filename);
+}
+
 void PcapNgFileWriterDevice::close()
 {
 	if (m_LightPcapNg == NULL)


### PR DESCRIPTION
PcapNg file writers do not have an explicit flush like Pcap file writers do. This allows for runtime tshark or Wireshark synchronization.