### PR TITLE
fix build when "make libs" is used, pkgconfig update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,6 @@ ifdef PF_RING_HOME
 	@cd $(EXAMPLE_PF_RING1)          && $(MAKE) PfRingTrafficFilter
 endif
 	@$(MKDIR) -p Dist/examples
-	@$(MKDIR) -p Dist/mk
 	$(CP) $(EXAMPLE_ARPSPOOF)/Bin/* ./Dist/examples
 	$(CP) $(EXAMPLE_ARPING)/Bin/* ./Dist/examples
 	$(CP) $(EXAMPLE_DNSSPOOF)/Bin/* ./Dist/examples
@@ -81,7 +80,6 @@ endif
 ifdef PF_RING_HOME
 	$(CP) $(EXAMPLE_PF_RING1)/Bin/* ./Dist/examples
 endif
-	$(CP) mk/PcapPlusPlus.mk ./Dist/mk
 	@echo Finished successfully building PcapPlusPlus
 
 # PcapPlusPlus libs only
@@ -98,6 +96,8 @@ libs:
 	@$(CP) $(COMMONPP_HOME)/header/* ./Dist/header
 	@$(CP) $(PACKETPP_HOME)/header/* ./Dist/header
 	@$(CP) $(PCAPPP_HOME)/header/* ./Dist/header
+	@$(MKDIR) -p Dist/mk
+	$(CP) mk/PcapPlusPlus.mk ./Dist/mk
 	@echo Finished successfully building PcapPlusPlus libs
 	@echo ' '
 

--- a/mk/install.sh.template
+++ b/mk/install.sh.template
@@ -13,8 +13,11 @@ mkdir -p $INSTALL_DIR/include/pcapplusplus
 cp header/* $INSTALL_DIR/include/pcapplusplus
 
 # copy examples
-mkdir -p $INSTALL_DIR/bin
-cp examples/* $INSTALL_DIR/bin
+if [ -d "examples/" ]
+then
+  mkdir -p $INSTALL_DIR/bin
+  cp examples/* $INSTALL_DIR/bin
+fi
 
 # create template makefile 
 cp mk/PcapPlusPlus.mk PcapPlusPlus.mk
@@ -35,7 +38,7 @@ printf 'Version: '>>PcapPlusPlus.pc
 grep '#define PCAPPLUSPLUS_VERSION ' header/PcapPlusPlusVersion.h | cut -d " " -f3 | tr -d "\"" | tr -d '\n'>>PcapPlusPlus.pc
 printf '\n'>>PcapPlusPlus.pc
 echo 'URL: https://pcapplusplus.github.io'>>PcapPlusPlus.pc
-printf 'Libs: '>>PcapPlusPlus.pc
+printf 'Libs: -L${libdir} '>>PcapPlusPlus.pc
 grep PCAPPP_LIBS PcapPlusPlus.mk | cut -d " " -f3- | tr -d '\r' | tr '\n' ' '>>PcapPlusPlus.pc
 printf '\nCFlags: '>>PcapPlusPlus.pc
 grep PCAPPP_INCLUDES PcapPlusPlus.mk | cut -d " " -f3- | tr -d '\r' | tr '\n' ' '>>PcapPlusPlus.pc


### PR DESCRIPTION
This PR addresses failures when "make libs" is used instead of "make" for build and install

- in this case the examples directory is not created, so that needs to be checked on install
- the Dist/mk directory is also required during install, but was not being made during "make libs", only "make"

Finally, -L was added to pkgconfig Libs, which was needed on OSX.

