### PR TITLE
Build changes to support Android platform

### DIFF
--- a/Common++/Makefile
+++ b/Common++/Makefile
@@ -38,18 +38,15 @@ INCLUDES := -I"./src" \
 ifdef BUILD_WITH_STATIC_LIBPCAP
 INCLUDES += -I"$(STATIC_LIBPCAP_INCLUDE)"
 endif
-			
+
 ifdef WIN32
 INCLUDES += -I$(MINGW_HOME)/include/ddk \
 			-I$(PCAP_SDK_HOME)/Include
 endif
-ifdef LINUX
-INCLUDES += -I/usr/include/netinet
-endif
 ifdef MAC_OS_X
 INCLUDES += -I$(MACOS_SDK_HOME)/usr/include/malloc
 endif
-			
+
 Obj/%.o: src/%.cpp
 	@echo Building file: $<
 	@$(CXX) $(DEPS) $(INCLUDES) $(PCAPPP_BUILD_FLAGS) -c -fmessage-length=0 -MMD -MP -MF"$(@:Obj/%.o=Obj/%.d)" -MT"$(@:Obj/%.o=Obj/%.d)" -o "$@" "$<"
@@ -73,7 +70,7 @@ Common++.lib: create-directories $(OBJS_FILENAMES)
 	@$(AR) -r "Lib/Release/$(LIB_PREFIX)Common++$(LIB_EXT)" $(OBJS_FILENAMES)
 	@echo Finished successfully building: $@
 	@echo ' '
-	
+
 Common++.debug: create-directories $(OBJS_FILENAMES_DEBUG)
 	@$(AR) -r "Lib/Debug/$(LIB_PREFIX)Common++$(LIB_EXT)" $(OBJS_FILENAMES_DEBUG)
 	@echo Finished successfully building: $@

--- a/Common++/header/IpUtils.h
+++ b/Common++/header/IpUtils.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 #ifdef LINUX
-#include <in.h>
+#include <netinet/in.h>
 #include <arpa/inet.h>
 #endif
 #ifdef MAC_OS_X

--- a/Packet++/Makefile
+++ b/Packet++/Makefile
@@ -41,9 +41,6 @@ ifdef WIN32
 INCLUDES += -I$(MINGW_HOME)/include/ddk \
 			-I$(PCAP_SDK_HOME)/Include
 endif
-ifdef LINUX
-INCLUDES += -I/usr/include/netinet
-endif
 
 Obj/%.o: src/%.cpp
 	@echo Building file: $<

--- a/mk/PcapPlusPlus.mk.linux
+++ b/mk/PcapPlusPlus.mk.linux
@@ -1,8 +1,5 @@
 ### LINUX ###
 
-# includes
-PCAPPP_INCLUDES += -I/usr/include/netinet
-
 # libs
 PCAPPP_LIBS += -lpcap -lpthread
 

--- a/mk/platform.mk.linux
+++ b/mk/platform.mk.linux
@@ -14,7 +14,9 @@ ifeq ($(origin CC),default)
 CC := gcc
 endif
 
+ifeq ($(origin AR),default)
 AR := ar
+endif
 
 RM := rm
 


### PR DESCRIPTION
Hi, thanks for the project.  I went through the exercise of building pcapplusplus for Android and encountered a couple of build issues.  I have been maintaining these changes myself in a downstream fork but thought you might be interested in taking these changes.  Please feel free to reject these changes if you are not interested.

In summary, the changes are as follows.

1. Removing hard-coded path to "/usr/include/netinet" for Linux.  This header should be included in the system header search path.  Also, when using the android toolchain, it sets the headers search path to use the android-specific "netinet" headers (i.e. the one packaged in the Android NDK).  Without this change, the android tool chain will pick up the header from the host which was causing build failures.
2. Also allowing "ar" tool to be set by AR variable.  Android toolchain uses its own "ar" tool and not the one on the host machine.

I verified that the build worked successfully for both Linux (using Ubuntu) and Android.  If there are other tests you want me to run, please suggest.
