### PR TITLE
Fixing offsets and checks. Fixes issue 543/542

### DIFF
--- a/Common++/src/GeneralUtils.cpp
+++ b/Common++/src/GeneralUtils.cpp
@@ -76,6 +76,12 @@ char* cross_platform_memmem(const char* haystack, size_t haystackLen, const char
 	{
 		if (NULL != (ptr = (char*)memchr(ptr, (int)(*needle), haystackLen - (ptr - haystack))))
 		{
+			// check if there is room to do a memcmp 
+			if(needleLen > (haystackLen - (ptr - haystack)))
+			{
+				return NULL;
+			}
+
 			if (0 == memcmp(ptr, needle, needleLen))
 				return ptr;
 			else

--- a/Packet++/src/HttpLayer.cpp
+++ b/Packet++/src/HttpLayer.cpp
@@ -175,11 +175,22 @@ HttpRequestFirstLine::HttpRequestFirstLine(HttpRequestLayer* httpRequest) : m_Ht
 	{
 		m_UriOffset = -1;
 		LOG_DEBUG("Couldn't resolve HTTP request method");
+		m_IsComplete = false;
+		m_Version = HttpVersionUnknown;
+		m_VersionOffset = -1;
+		m_FirstLineEndOffset = m_HttpRequest->getDataLen();
+		return;
 	}
 	else
 		m_UriOffset = MethodEnumToString[m_Method].length() + 1;
 
 	parseVersion();
+	if(m_VersionOffset < 0)
+	{
+		m_IsComplete = false;
+		m_FirstLineEndOffset = m_HttpRequest->getDataLen();
+		return;
+	}
 
 	char* endOfFirstLine;
 	if ((endOfFirstLine = (char*)memchr((char*)(m_HttpRequest->m_Data + m_VersionOffset), '\n', m_HttpRequest->m_DataLen-(size_t)m_VersionOffset)) != NULL)


### PR DESCRIPTION
@seladb I have recreated the pull request here, I just didnt find enough free cycles to look into the fuzzing aspect, but let me paste the anonymized callstack for your reference and the analysis 

```

0   libsystem_platform.dylib        0x00007fff690f60e5 _platform_memchr$VARIANT$Base 
+ 371    svc       0x00000001073368fb pcpp::cross_platform_memmem(char const*, unsigned long, char const*, unsigned long) (in svc) 
+ 592    svc       0x00000001072d36af pcpp::HttpRequestFirstLine::parseVersion() (in svc)
+ 473    svc       0x00000001072d31ba pcpp::HttpRequestFirstLine::HttpRequestFirstLine(pcpp::HttpRequestLayer*) (in svc)
+ 2024   svc       0x00000001072d258c pcpp::HttpRequestLayer::HttpRequestLayer(unsigned char*, unsigned long, pcpp::Layer*, pcpp::Packet*) (in svc) + 60

Register context:
Thread 9 crashed with X86 Thread State (64-bit):
  rax: 0x0000000000000020  rbx: 0x00007fcd6a77cfff  rcx: 0x000000000000001f  rdx: 0x00000000000005ab
  rdi: 0x00007fcd6a77cfe0  rsi: 0x0000000000000020  rbp: 0x0000700002313330  rsp: 0x0000700002313330
   r8: 0x0000000000009448   r9: 0x000000000000944b  r10: 0x00000000fffff8ff  r11: 0x00007fcd6a597a50
  r12: 0x00007fcd6a77cfff  r13: 0x0000000000000006  r14: 0x0000000107483def  r15: 0x00000000000005ab
  rip: 0x00007fff690f60e5  rfl: 0x0000000000010202  cr2: 0x00007fcd6a77cfe0
     0x7fff690f5000 -     0x7fff690fdfef  libsystem_platform.dylib (220.100.1) the crash happens at offset 10e5

0   libsystem_platform.dylib        0x00007fff690f60e5 _platform_memchr$VARIANT$Base + 37
00000000000010c0         push       rbp                                         ; DATA XREF=__platform_memchr
00000000000010c1         mov        rbp, rsp
00000000000010c4         test       rdx, rdx
00000000000010c7         je         loc_1165
 
00000000000010cd         movq       xmm0, rsi
00000000000010d2         pxor       xmm2, xmm2
00000000000010d6         pshufb     xmm0, xmm2
00000000000010db         mov        rcx, rdi
00000000000010de         and        rdi, 0xffffffffffffffe0 <<-- this round up the address but will not cross the page boundary
00000000000010e2         and        ecx, 0x1f
00000000000010e5         movdqa     xmm1, xmmword [rdi] << --- crashed here for value 0x00007fcd6a77cfe0 which looks fairly valid until you check instruction at 10de,
00000000000010e9         movdqa     xmm2, xmmword [rdi+0x10]
```


So the pointer passed is not a valid value in memchr going up the callframe a bit:

```


// The problem happense here
 HttpRequestFirstLine::HttpRequestFirstLine
{
// ...
 m_Method = parseMethod((char*)m_HttpRequest->m_Data, m_HttpRequest->getDataLen());
 if (m_Method == HttpRequestLayer::HttpMethodUnknown)
 {
    m_UriOffset = -1; // for unknown method we end up parsing version
    LOG_DEBUG("Couldn't resolve HTTP request method");
 }
 else
    m_UriOffset = MethodEnumToString[m_Method].length() + 1;
  
parseVersion();
...
}
 
// in parseversion
void HttpRequestFirstLine::parseVersion()
{
    char* data = (char*)(m_HttpRequest->m_Data + m_UriOffset); <-- here if m_UriOffset if it is -1 we will have underflow and cross_platform_memmem might get a data pointer that is invalid, if m_data is pointing at page  // boundary, for HTTP in our case it might have for a connection over a proxy, this is a problem.
    char* verPos = cross_platform_memmem(data, m_HttpRequest->getDataLen() - m_UriOffset, " HTTP/", 6); // this function invokes memchr
    if (verPos == NULL)

```

 I hope that makes sense?  Thank you for your patience.