### PR TITLE
Missing dnsPacketCount increment

### DIFF
--- a/Examples/Tutorials/Tutorial-LiveTraffic/main.cpp
+++ b/Examples/Tutorials/Tutorial-LiveTraffic/main.cpp
@@ -41,6 +41,8 @@ struct PacketStats
 			tcpPacketCount++;
 		if (packet.isPacketOfType(pcpp::UDP))
 			udpPacketCount++;
+		if (packet.isPacketOfType(pcpp::DNS))
+			dnsPacketCount++;
 		if (packet.isPacketOfType(pcpp::HTTP))
 			httpPacketCount++;
 		if (packet.isPacketOfType(pcpp::SSL))


### PR DESCRIPTION
Hello,
consumePacket() function is missing the dnsPacketCount increment so I added.

Best