### PR TITLE
Add RoCEv1 ether type

### DIFF
--- a/Packet++/header/EthLayer.h
+++ b/Packet++/header/EthLayer.h
@@ -58,6 +58,8 @@ namespace pcpp
 #define PCPP_ETHERTYPE_MPLS      0x8847
 	/** Point-to-point protocol (PPP) */
 #define PCPP_ETHERTYPE_PPP       0x880B
+    /** RDMA over Converged Ethernet (RoCEv1) */
+#define PCPP_ETHERTYPE_ROCEV1    0x8915
 
 
 	/**


### PR DESCRIPTION
0x8915 is [RDMA over Converged Ethernet (RoCE)](https://en.wikipedia.org/wiki/RDMA_over_Converged_Ethernet#RoCE_v1:~:text=The%20RoCE%20v1%20protocol%20is%20an%20Ethernet%20link%20layer%20protocol%20with%20Ethertype%200x8915
)


