### PR TITLE
Break dispatch loop during stopCapture

### DIFF
--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -523,6 +523,7 @@ void PcapLiveDevice::stopCapture()
 	m_StopThread = true;
 	if (m_CaptureThreadStarted)
 	{
+		pcap_breakloop(m_PcapDescriptor);
 		LOG_DEBUG("Stopping capture thread, waiting for it to join...");
 		pthread_join(m_CaptureThread->pthread, NULL);
 		m_CaptureThreadStarted = false;


### PR DESCRIPTION
It's done to avoid infinite join. Note that this will always work only when used with libpcap version 1.9.0 and higher.
Linked issue: #606