### PR TITLE
Recognize *.zstd file extension in IFileReaderDevice::getReader()

### DIFF
--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -78,7 +78,9 @@ IFileReaderDevice* IFileReaderDevice::getReader(const std::string& fileName)
 {
 	const char* fileExtension = strrchr(fileName.c_str(), '.');
 
-	if (fileExtension != NULL && strcmp(fileExtension, ".pcapng") == 0)
+	if (fileExtension != NULL
+		&& (strcmp(fileExtension, ".pcapng") == 0
+		|| strcmp(fileExtension, ".zstd") == 0))
 		return new PcapNgFileReaderDevice(fileName);
 
 	return new PcapFileReaderDevice(fileName);

--- a/Tests/Pcap++Test/Tests/FileTests.cpp
+++ b/Tests/Pcap++Test/Tests/FileTests.cpp
@@ -619,6 +619,13 @@ PTF_TEST_CASE(TestPcapNgFileReadWriteAdv)
 	FileReaderTeardown genericReaderTeardown2(genericReader);
 	PTF_ASSERT_NOT_NULL(dynamic_cast<pcpp::PcapNgFileReaderDevice*>(genericReader));
 
+	genericReader = pcpp::IFileReaderDevice::getReader(EXAMPLE_PCAPNG_ZSTD_WRITE_PATH);
+	FileReaderTeardown genericReaderTeardown3(genericReader);
+	PTF_ASSERT_NOT_NULL(dynamic_cast<pcpp::PcapNgFileReaderDevice*>(genericReader));
+	PTF_ASSERT_TRUE(genericReader->open());
+
+	genericReader->close();
+
 	// -------
 
 	pcpp::PcapNgFileReaderDevice readerDev5(EXAMPLE2_PCAPNG_PATH);


### PR DESCRIPTION
Fixes #639 

IFileReaderDevice::getReader() should recognize the *.zstd file extension and provide a PcapNgFileReaderDevice.