### PR TITLE
Linux: remove hardcoded netinet include folder

### DIFF
--- a/Common++/Makefile
+++ b/Common++/Makefile
@@ -43,9 +43,6 @@ ifdef WIN32
 INCLUDES += -I$(MINGW_HOME)/include/ddk \
 			-I$(PCAP_SDK_HOME)/Include
 endif
-ifdef LINUX
-INCLUDES += -I/usr/include/netinet
-endif
 ifdef MAC_OS_X
 INCLUDES += -I$(MACOS_SDK_HOME)/usr/include/malloc
 endif

--- a/Packet++/Makefile
+++ b/Packet++/Makefile
@@ -46,9 +46,6 @@ ifdef WIN32
 INCLUDES += -I$(MINGW_HOME)/include/ddk \
 			-I$(PCAP_SDK_HOME)/Include
 endif
-ifdef LINUX
-INCLUDES += -I/usr/include/netinet
-endif
 
 Obj/%.o: src/%.cpp Obj/%.d
 	@echo Building file: $<

--- a/Pcap++/Makefile
+++ b/Pcap++/Makefile
@@ -54,9 +54,6 @@ ifdef WIN32
 INCLUDES += -I$(MINGW_HOME)/include/ddk \
 			-I$(PCAP_SDK_HOME)/Include
 endif
-ifdef LINUX
-INCLUDES += -I/usr/include/netinet
-endif
 ifdef PF_RING_HOME
 INCLUDES += -I$(PF_RING_HOME)/userland/lib -I$(PF_RING_HOME)/kernel
 endif


### PR DESCRIPTION
Hi @seladb,

Is there any reason to include this folder?
inet is provided by the libC no?  

When I tried both native and cross compilation under Linux, I didn't need it and it's polluting the cross compilation 