### PR TITLE
Bugfix #666 - few fixes in MPLS layer

### DIFF
--- a/Packet++/header/MplsLayer.h
+++ b/Packet++/header/MplsLayer.h
@@ -23,9 +23,9 @@ namespace pcpp
 		#pragma pack(push, 1)
 		struct mpls_header
 		{
-			uint16_t    hiLabel;
-			uint8_t		misc;
-			uint8_t		ttl;
+			uint16_t hiLabel;
+			uint8_t  misc;
+			uint8_t  ttl;
 		};
 		#pragma pack(pop)
 

--- a/Packet++/src/MplsLayer.cpp
+++ b/Packet++/src/MplsLayer.cpp
@@ -36,7 +36,7 @@ void MplsLayer::setBottomOfStack(bool val)
 	if (!val)
 		getMplsHeader()->misc &= 0xFE;
 	else
-		getMplsHeader()->misc |= 0xFF;
+		getMplsHeader()->misc |= 0x1;
 }
 
 uint8_t MplsLayer::getExperimentalUseValue() const
@@ -138,7 +138,7 @@ void MplsLayer::computeCalculateFields()
 	Layer* nextLayer = getNextLayer();
 	if (nextLayer != NULL)
 	{
-		setBottomOfStack((nextLayer->getProtocol() == MPLS));
+		setBottomOfStack((nextLayer->getProtocol() != MPLS));
 	}
 }
 


### PR DESCRIPTION
- `setBottomOfStack(false)` sets the wrong value
- `computeCalculateFields()` set the wrong `BottomOfStack` value