### PR TITLE
get the full timestamp resolution from a standard pcap file

### DIFF
--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -132,7 +132,7 @@ bool PcapFileReaderDevice::open()
 	}
 
 	char errbuf[PCAP_ERRBUF_SIZE];
-	m_PcapDescriptor = pcap_open_offline(m_FileName.c_str(), errbuf);
+	m_PcapDescriptor = pcap_open_offline_with_tstamp_precision(m_FileName.c_str(), PCAP_TSTAMP_PRECISION_NANO, errbuf);
 	if (m_PcapDescriptor == NULL)
 	{
 		LOG_ERROR("Cannot open file reader device for filename '%s': %s", m_FileName.c_str(), errbuf);
@@ -183,7 +183,8 @@ bool PcapFileReaderDevice::getNextPacket(RawPacket& rawPacket)
 
 	uint8_t* pMyPacketData = new uint8_t[pkthdr.caplen];
 	memcpy(pMyPacketData, pPacketData, pkthdr.caplen);
-	if (!rawPacket.setRawData(pMyPacketData, pkthdr.caplen, pkthdr.ts, static_cast<LinkLayerType>(m_PcapLinkLayerType), pkthdr.len))
+	timespec ts = { pkthdr.ts.tv_sec, pkthdr.ts.tv_usec }; //because we opened with nano second precision 'tv_usec' is actually nanos
+	if (!rawPacket.setRawData(pMyPacketData, pkthdr.caplen, ts, static_cast<LinkLayerType>(m_PcapLinkLayerType), pkthdr.len))
 	{
 		LOG_ERROR("Couldn't set data to raw packet");
 		return false;

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -135,7 +135,7 @@ bool PcapFileReaderDevice::open()
 #if defined(PCAP_TSTAMP_PRECISION_NANO)
 	m_PcapDescriptor = pcap_open_offline_with_tstamp_precision(m_FileName.c_str(), PCAP_TSTAMP_PRECISION_NANO, errbuf);
 #else
-    m_PcapDescriptor = pcap_open_offline(m_FileName.c_str(), errbuf);
+	m_PcapDescriptor = pcap_open_offline(m_FileName.c_str(), errbuf);
 #endif
 	if (m_PcapDescriptor == NULL)
 	{
@@ -190,7 +190,7 @@ bool PcapFileReaderDevice::getNextPacket(RawPacket& rawPacket)
 #if defined(PCAP_TSTAMP_PRECISION_NANO)
 	timespec ts = { pkthdr.ts.tv_sec, pkthdr.ts.tv_usec }; //because we opened with nano second precision 'tv_usec' is actually nanos
 #else
-    struct timeval ts = pkthdr.ts;
+	struct timeval ts = pkthdr.ts;
 #endif
 	if (!rawPacket.setRawData(pMyPacketData, pkthdr.caplen, ts, static_cast<LinkLayerType>(m_PcapLinkLayerType), pkthdr.len))
 	{


### PR DESCRIPTION
pcap_open_offline_with_tstamp_precision() and pcap_fopen_offline_with_tstamp_precision() became available in libpcap release 1.5.1.

libpcap will read the magic number from the pcap file header and scale the timestamp up, down, or pass it through depending on how you opened it.  The existing method of opening a pcap file truncates the nanos from a pcap file even if the magic number indicates the scale is nanos.  If you open with PCAP_TSTAMP_PRECISION_NANO you can always use a timespec for setting RawPacket data.

this is pretty basic and I didn't find any tests that exercise this feature.  I have limited time but I will make any changes requested when possible; I don't want to maintain a fork for this feature.