### PR TITLE
Modernize PcapPlusPlus examples

### DIFF
--- a/Examples/ArpSpoofing/main.cpp
+++ b/Examples/ArpSpoofing/main.cpp
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <iostream>
 #include <fstream>
 #include <memory>
 #include <MacAddress.h>
@@ -13,8 +14,13 @@
 #include <Logger.h>
 #include <getopt.h>
 
-using namespace std;
-using namespace pcpp;
+
+#define EXIT_WITH_ERROR(reason) do { \
+	printUsage(); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
+	exit(1); \
+	} while(0)
+
 
 static struct option L3FwdOptions[] =
 {
@@ -30,18 +36,21 @@ static struct option L3FwdOptions[] =
 /**
  * Print application usage
  */
-void printUsage() {
-	printf("\nUsage:\n"
-			"------\n"
-			"%s [-hv] -i interface_ip -c victim_ip -g gateway_ip\n"
-			"\nOptions:\n\n"
-			"    -i interface_ip   : The IPv4 address of interface to use\n"
-			"    -c victim_ip      : The IPv4 address of the victim\n"
-			"    -g gateway_ip     : The IPv4 address of the gateway\n"
-			"    -h                : Displays this help message and exits\n"
-			"    -v                : Displays the current version and exists\n", AppName::get().c_str());
-			
-	exit(0);
+void printUsage() 
+{
+	std::cout << std::endl
+		<< "Usage:" << std::endl
+		<< "------" << std::endl
+		<< pcpp::AppName::get() << " [-hv] -i interface_ip -c victim_ip -g gateway_ip" << std::endl
+		<< std::endl
+		<< "Options:" << std::endl
+		<< std::endl
+		<< "    -i interface_ip   : The IPv4 address of interface to use" << std::endl
+		<< "    -c victim_ip      : The IPv4 address of the victim" << std::endl
+		<< "    -g gateway_ip     : The IPv4 address of the gateway" << std::endl
+		<< "    -h                : Displays this help message and exits" << std::endl
+		<< "    -v                : Displays the current version and exists" << std::endl
+		<< std::endl;
 }
 
 
@@ -50,22 +59,23 @@ void printUsage() {
  */
 void printAppVersion()
 {
-	printf("%s %s\n", AppName::get().c_str(), getPcapPlusPlusVersionFull().c_str());
-	printf("Built: %s\n", getBuildDateTime().c_str());
-	printf("Built from: %s\n", getGitInfo().c_str());
+	std::cout
+		<< pcpp::AppName::get() << " " << pcpp::getPcapPlusPlusVersionFull() << std::endl
+		<< "Built: " << pcpp::getBuildDateTime() << std::endl
+		<< "Built from: " << pcpp::getGitInfo() << std::endl;
 	exit(0);
 }
 
 
-MacAddress getMacAddress(const IPv4Address& ipAddr, PcapLiveDevice* pDevice)
+pcpp::MacAddress getMacAddress(const pcpp::IPv4Address& ipAddr, pcpp::PcapLiveDevice* pDevice)
 {
 	// Create an ARP packet and change its fields
-	Packet arpRequest(500);
+	pcpp::Packet arpRequest(500);
 
-	MacAddress macSrc = pDevice->getMacAddress();
-	MacAddress macDst(0xff, 0xff, 0xff, 0xff, 0xff, 0xff);
-	EthLayer ethLayer(macSrc, macDst, (uint16_t)PCPP_ETHERTYPE_ARP);
-	ArpLayer arpLayer(ARP_REQUEST,
+	pcpp::MacAddress macSrc = pDevice->getMacAddress();
+	pcpp::MacAddress macDst(0xff, 0xff, 0xff, 0xff, 0xff, 0xff);
+	pcpp::EthLayer ethLayer(macSrc, macDst, (uint16_t)PCPP_ETHERTYPE_ARP);
+	pcpp::ArpLayer arpLayer(pcpp::ARP_REQUEST,
 						pDevice->getMacAddress(),
 						pDevice->getMacAddress(),
 						pDevice->getIPv4Address(),
@@ -77,63 +87,61 @@ MacAddress getMacAddress(const IPv4Address& ipAddr, PcapLiveDevice* pDevice)
 	arpRequest.computeCalculateFields();
 
 	//setup arp reply filter
-	ArpFilter arpFilter(ARP_REPLY);
+	pcpp::ArpFilter arpFilter(pcpp::ARP_REPLY);
 	if (!pDevice->setFilter(arpFilter))
 	{
-		printf("Could not set ARP filter on device\n");
-		return MacAddress("");
+		std::cerr << "Could not set ARP filter on device" << std::endl;
+		return pcpp::MacAddress("");
 	}
 
 	//send the arp request and wait for arp reply
 	pDevice->sendPacket(&arpRequest);
-	RawPacketVector capturedPackets;
+	pcpp::RawPacketVector capturedPackets;
 	pDevice->startCapture(capturedPackets);
-	multiPlatformSleep(2);
+	pcpp::multiPlatformSleep(2);
 	pDevice->stopCapture();
 
 	if (capturedPackets.size() < 1)
 	{
-		printf("No arp reply was captured. Couldn't retrieve MAC address for IP %s\n", ipAddr.toString().c_str());
-		return MacAddress("");
+		std::cerr << "No arp reply was captured. Couldn't retrieve MAC address for IP " << ipAddr << std::endl;
+		return pcpp::MacAddress("");
 	}
 
 	//parse arp reply and extract the MAC address
-	Packet arpReply(capturedPackets.front());
-	if (arpReply.isPacketOfType(ARP))
+	pcpp::Packet arpReply(capturedPackets.front());
+	if (arpReply.isPacketOfType(pcpp::ARP))
 	{
-		return arpReply.getLayerOfType<ArpLayer>()->getSenderMacAddress();
+		return arpReply.getLayerOfType<pcpp::ArpLayer>()->getSenderMacAddress();
 	}
-	printf("No arp reply was captured. Couldn't retrieve MAC address for IP %s\n", ipAddr.toString().c_str());
-	return MacAddress("");
+	std::cerr << "No arp reply was captured. Couldn't retrieve MAC address for IP " << ipAddr << std::endl;
+	return pcpp::MacAddress("");
 }
 
 
-bool doArpSpoofing(PcapLiveDevice* pDevice, const IPv4Address& gatewayAddr, const IPv4Address& victimAddr)
+void doArpSpoofing(pcpp::PcapLiveDevice* pDevice, const pcpp::IPv4Address& gatewayAddr, const pcpp::IPv4Address& victimAddr)
 {
 	// Get the gateway MAC address
-	MacAddress gatewayMacAddr = getMacAddress(gatewayAddr, pDevice);
+	pcpp::MacAddress gatewayMacAddr = getMacAddress(gatewayAddr, pDevice);
 	if (!gatewayMacAddr.isValid())
 	{
-		printf("Failed to find gateway MAC address. Exiting...\n");
-		return false;
+		EXIT_WITH_ERROR("Failed to find gateway MAC address");
 	}
-	printf("Got gateway MAC address: %s\n", gatewayMacAddr.toString().c_str());
+	std::cout << "Got gateway MAC address: " << gatewayMacAddr << std::endl;
 
 	// Get the victim MAC address
-	MacAddress victimMacAddr = getMacAddress(victimAddr, pDevice);
+	pcpp::MacAddress victimMacAddr = getMacAddress(victimAddr, pDevice);
 	if (!victimMacAddr.isValid())
 	{
-		printf("Failed to find victim MAC address. Exiting...\n");
-		return false;
+		EXIT_WITH_ERROR("Failed to find victim MAC address");
 	}
-	printf("Got victim MAC address: %s\n", victimMacAddr.toString().c_str());
+	std::cout << "Got victim MAC address: " << victimMacAddr << std::endl;
 
-	MacAddress deviceMacAddress = pDevice->getMacAddress();
+	pcpp::MacAddress deviceMacAddress = pDevice->getMacAddress();
 
 	// Create ARP reply for the gateway
-	Packet gwArpReply(500);
-	EthLayer gwEthLayer(deviceMacAddress, gatewayMacAddr, (uint16_t)PCPP_ETHERTYPE_ARP);
-	ArpLayer gwArpLayer(ARP_REPLY,
+	pcpp::Packet gwArpReply(500);
+	pcpp::EthLayer gwEthLayer(deviceMacAddress, gatewayMacAddr, (uint16_t)PCPP_ETHERTYPE_ARP);
+	pcpp::ArpLayer gwArpLayer(pcpp::ARP_REPLY,
 						pDevice->getMacAddress(),
 						gatewayMacAddr,
 						victimAddr,
@@ -143,9 +151,9 @@ bool doArpSpoofing(PcapLiveDevice* pDevice, const IPv4Address& gatewayAddr, cons
 	gwArpReply.computeCalculateFields();
 
 	// Create ARP reply for the victim
-	Packet victimArpReply(500);
-	EthLayer victimEthLayer(deviceMacAddress, victimMacAddr, (uint16_t)PCPP_ETHERTYPE_ARP);
-	ArpLayer victimArpLayer(ARP_REPLY,
+	pcpp::Packet victimArpReply(500);
+	pcpp::EthLayer victimEthLayer(deviceMacAddress, victimMacAddr, (uint16_t)PCPP_ETHERTYPE_ARP);
+	pcpp::ArpLayer victimArpLayer(pcpp::ARP_REPLY,
 							pDevice->getMacAddress(),
 							victimMacAddr,
 							gatewayAddr,
@@ -155,27 +163,25 @@ bool doArpSpoofing(PcapLiveDevice* pDevice, const IPv4Address& gatewayAddr, cons
 	victimArpReply.computeCalculateFields();
 
 	// Send ARP replies to gateway and to victim every 5 seconds
-	printf("Sending ARP replies to victim and to gateway every 5 seconds...\n\n");
-	while(true)
+	std::cout << "Sending ARP replies to victim and to gateway every 5 seconds..." << std::endl << std::endl;
+	while(1)
 	{
 		pDevice->sendPacket(&gwArpReply);
-		printf("Sent ARP reply: %s [gateway] is at MAC address %s [me]\n", gatewayAddr.toString().c_str(), deviceMacAddress.toString().c_str());
+		std::cout << "Sent ARP reply: " << gatewayAddr << " [gateway] is at MAC address " << deviceMacAddress << " [me]" << std::endl;
 		pDevice->sendPacket(&victimArpReply);
-		printf("Sent ARP reply: %s [victim] is at MAC address %s [me]\n\n", victimAddr.toString().c_str(), deviceMacAddress.toString().c_str());
-		multiPlatformSleep(5);
+		std::cout << "Sent ARP reply: " << victimAddr << " [victim] is at MAC address " << deviceMacAddress << " [me]" << std::endl;
+		pcpp::multiPlatformSleep(5);
 	}
-
-	return true;
 }
 
 
 int main(int argc, char* argv[])
 {
-	AppName::init(argc, argv);
+	pcpp::AppName::init(argc, argv);
 
 	//Get arguments from user for incoming interface and outgoing interface
 
-	string iface = "", victim = "", gateway = "";
+	std::string iface = "", victim = "", gateway = "";
 	int optionIndex = 0;
 	char opt = 0;
 	while((opt = getopt_long (argc, argv, "i:c:g:hv", L3FwdOptions, &optionIndex)) != -1)
@@ -195,6 +201,7 @@ int main(int argc, char* argv[])
 				break;
 			case 'h':
 				printUsage();
+				exit(0);
 				break;
 			case 'v':
 				printAppVersion();
@@ -208,42 +215,37 @@ int main(int argc, char* argv[])
 	//Both incoming and outgoing interfaces must be provided by user
 	if(iface == "" || victim == "" || gateway == "")
 	{
-		printUsage();
-		exit(-1);
+		EXIT_WITH_ERROR("Please specify both interface IP, victim IP and gateway IP");
 	}
 
 	//Currently supports only IPv4 addresses
-	IPv4Address ifaceAddr(iface);
-	IPv4Address victimAddr(victim);
-	IPv4Address gatewayAddr(gateway);
+	pcpp::IPv4Address ifaceAddr(iface);
+	pcpp::IPv4Address victimAddr(victim);
+	pcpp::IPv4Address gatewayAddr(gateway);
 
-	PcapLiveDevice* pIfaceDevice = PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ifaceAddr);
+	pcpp::PcapLiveDevice* pIfaceDevice = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ifaceAddr);
 
 	//Verifying interface is valid
 	if (pIfaceDevice == NULL)
 	{
-		printf("Cannot find interface. Exiting...\n");
-		exit(-1);
+		EXIT_WITH_ERROR("Cannot find interface");
 	}
 
 	if (!victimAddr.isValid())
 	{
-		printf("Victim address not valid. Exiting...\n");
-		exit(-1);
+		EXIT_WITH_ERROR("Victim address is not valid");
 	}
 
 	if (!gatewayAddr.isValid())
 	{
-		printf("Gateway address not valid. Exiting...\n");
-		exit(-1);
+		EXIT_WITH_ERROR("Gateway address is not valid");
 	}
 
 	//Opening interface device
 	if (!pIfaceDevice->open())
 	{
-		printf("Cannot open interface. Exiting...\n");
-		exit(-1);
+		EXIT_WITH_ERROR("Cannot open interface");
 	}
 
-	return (!doArpSpoofing(pIfaceDevice, gatewayAddr, victimAddr));
+	doArpSpoofing(pIfaceDevice, gatewayAddr, victimAddr);
 }

--- a/Examples/Arping/main.cpp
+++ b/Examples/Arping/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <stdlib.h>
+#include <iostream>
 #include <MacAddress.h>
 #include <IpAddress.h>
 #include <Logger.h>
@@ -17,15 +18,15 @@
 #include <SystemUtils.h>
 
 
-#define EXIT_WITH_ERROR_AND_PRINT_USAGE(reason, ...) do { \
-	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
+#define EXIT_WITH_ERROR(reason) do { \
 	printUsage(); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
-	} while (0)
+	} while(0)
+
 
 #define DEFAULT_MAX_TRIES	1000000
 
-using namespace pcpp;
 
 static struct option ArpingOptions[] =
 {
@@ -46,19 +47,23 @@ static struct option ArpingOptions[] =
  * Print application usage
  */
 void printUsage() {
-	printf("\nUsage:\n"
-			"------\n"
-			"%s [-hvl] [-c count] [-w timeout] [-s mac_sddr] [-S ip_addr] -i interface -T ip_addr\n"
-			"\nOptions:\n\n"
-			"    -h           : Displays this help message and exits\n"
-			"    -v           : Displays the current version and exists\n"
-			"    -l           : Print the list of interfaces and exists\n"
-			"    -c count     : Send 'count' requests\n"
-			"    -i interface : Use the specified interface. Can be interface name (e.g eth0) or interface IPv4 address\n"
-			"    -s mac_addr  : Set source MAC address\n"
-			"    -S ip_addr   : Set source IP address\n"
-			"    -T ip_addr   : Set target IP address\n"
-			"    -w timeout   : How long to wait for a reply (in seconds)\n", AppName::get().c_str());
+	std::cout << std::endl
+		<< "Usage:" << std::endl
+		<< "------" << std::endl
+		<< pcpp::AppName::get() << " [-hvl] [-c count] [-w timeout] [-s mac_addr] [-S ip_addr] -i interface -T ip_addr" << std::endl
+		<< std::endl
+		<< "Options:" << std::endl
+		<< std::endl
+		<< "    -h           : Displays this help message and exits" << std::endl
+		<< "    -v           : Displays the current version and exists" << std::endl
+		<< "    -l           : Print the list of interfaces and exists" << std::endl
+		<< "    -c count     : Send 'count' requests" << std::endl
+		<< "    -i interface : Use the specified interface. Can be interface name (e.g eth0) or interface IPv4 address" << std::endl
+		<< "    -s mac_addr  : Set source MAC address" << std::endl
+		<< "    -S ip_addr   : Set source IP address" << std::endl
+		<< "    -T ip_addr   : Set target IP address" << std::endl
+		<< "    -w timeout   : How long to wait for a reply (in seconds)" << std::endl
+		<< std::endl;
 }
 
 
@@ -67,9 +72,10 @@ void printUsage() {
  */
 void printAppVersion()
 {
-	printf("%s %s\n", AppName::get().c_str(), getPcapPlusPlusVersionFull().c_str());
-	printf("Built: %s\n", getBuildDateTime().c_str());
-	printf("Built from: %s\n", getGitInfo().c_str());
+	std::cout
+		<< pcpp::AppName::get() << " " << pcpp::getPcapPlusPlusVersionFull() << std::endl
+		<< "Built: " << pcpp::getBuildDateTime() << std::endl
+		<< "Built from: " << pcpp::getGitInfo() << std::endl;
 	exit(0);
 }
 
@@ -79,12 +85,12 @@ void printAppVersion()
  */
 void listInterfaces()
 {
-	const std::vector<PcapLiveDevice*>& devList = PcapLiveDeviceList::getInstance().getPcapLiveDevicesList();
+	const std::vector<pcpp::PcapLiveDevice*>& devList = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDevicesList();
 
-	printf("\nNetwork interfaces:\n");
-	for (std::vector<PcapLiveDevice*>::const_iterator iter = devList.begin(); iter != devList.end(); iter++)
+	std::cout << std::endl << "Network interfaces:" << std::endl;
+	for (std::vector<pcpp::PcapLiveDevice*>::const_iterator iter = devList.begin(); iter != devList.end(); iter++)
 	{
-		printf("    -> Name: '%s'   IP address: %s\n", (*iter)->getName().c_str(), (*iter)->getIPv4Address().toString().c_str());
+		std::cout << "    -> Name: '" << (*iter)->getName() << "'   IP address: " << (*iter)->getIPv4Address().toString() << std::endl;
 	}
 	exit(0);
 }
@@ -95,16 +101,16 @@ void listInterfaces()
  */
 int main(int argc, char* argv[])
 {
-	AppName::init(argc, argv);
+	pcpp::AppName::init(argc, argv);
 
 	int maxTries = DEFAULT_MAX_TRIES;
-	MacAddress sourceMac;
-	IPv4Address sourceIP;
-	IPv4Address targetIP;
+	pcpp::MacAddress sourceMac;
+	pcpp::IPv4Address sourceIP;
+	pcpp::IPv4Address targetIP;
 	bool targetIpProvided = false;
 	std::string ifaceNameOrIP;
 	bool ifaceNameOrIpProvided = false;
-	int timeoutSec = NetworkUtils::DefaultTimeout;
+	int timeoutSec = pcpp::NetworkUtils::DefaultTimeout;
 	int optionIndex = 0;
 	char opt = 0;
 
@@ -119,13 +125,13 @@ int main(int argc, char* argv[])
 				ifaceNameOrIpProvided = true;
 				break;
 			case 's':
-				sourceMac = MacAddress(optarg);
+				sourceMac = pcpp::MacAddress(optarg);
 				break;
 			case 'S':
-				sourceIP = IPv4Address(static_cast<char const *>(optarg));
+				sourceIP = pcpp::IPv4Address(static_cast<char const *>(optarg));
 				break;
 			case 'T':
-				targetIP = IPv4Address(static_cast<char const *>(optarg));
+				targetIP = pcpp::IPv4Address(static_cast<char const *>(optarg));
 				targetIpProvided = true;
 				break;
 			case 'c':
@@ -151,77 +157,79 @@ int main(int argc, char* argv[])
 
 	// verify that interface name or IP were provided
 	if (!ifaceNameOrIpProvided)
-		EXIT_WITH_ERROR_AND_PRINT_USAGE("You must provide at least interface name or interface IP (-i switch)");
+		EXIT_WITH_ERROR("You must provide at least interface name or interface IP (-i switch)");
 
 	// verify target IP was provided
 	if (!targetIpProvided)
-		EXIT_WITH_ERROR_AND_PRINT_USAGE("You must provide target IP (-T switch)");
+		EXIT_WITH_ERROR("You must provide target IP (-T switch)");
 
 	// verify target IP is value
 	if (!targetIP.isValid())
-		EXIT_WITH_ERROR_AND_PRINT_USAGE("Target IP is not valid");
+		EXIT_WITH_ERROR("Target IP is not valid");
 
 
-	PcapLiveDevice* dev = NULL;
+	pcpp::PcapLiveDevice* dev = NULL;
 
 	// Search interface by name or IP
 	if (!ifaceNameOrIP.empty())
 	{
-		dev = PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(ifaceNameOrIP);
+		dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(ifaceNameOrIP);
 		if (dev == NULL)
-			EXIT_WITH_ERROR_AND_PRINT_USAGE("Couldn't find interface by provided IP address or name");
+			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 	}
 	else
-		EXIT_WITH_ERROR_AND_PRINT_USAGE("Interface name or IP empty");
+		EXIT_WITH_ERROR("Interface name or IP empty");
 
 	// open device in promiscuous mode
 	if (!dev->open())
-		EXIT_WITH_ERROR_AND_PRINT_USAGE("Couldn't open interface device '%s'", dev->getName().c_str());
+		EXIT_WITH_ERROR("Couldn't open interface device '" << dev->getName() << "'");
 
 	// verify source MAC is valud
 	if (!sourceMac.isValid())
-		EXIT_WITH_ERROR_AND_PRINT_USAGE("Source MAC address is invalid");
+		EXIT_WITH_ERROR("Source MAC address is invalid");
 
 	// if source MAC not provided - use the interface MAC address
-	if (sourceMac == MacAddress::Zero)
+	if (sourceMac == pcpp::MacAddress::Zero)
 		sourceMac = dev->getMacAddress();
 
 	// if source MAC is still invalid, it means it couldn't be extracted from interface
-	if (!sourceMac.isValid() || sourceMac == MacAddress::Zero)
-		EXIT_WITH_ERROR_AND_PRINT_USAGE("MAC address couldn't be extracted from interface");
+	if (!sourceMac.isValid() || sourceMac == pcpp::MacAddress::Zero)
+		EXIT_WITH_ERROR("MAC address couldn't be extracted from interface");
 
-	if (!sourceIP.isValid() || sourceIP == IPv4Address::Zero)
+	if (!sourceIP.isValid() || sourceIP == pcpp::IPv4Address::Zero)
 		sourceIP = dev->getIPv4Address();
 
-	if (!sourceIP.isValid() || sourceIP == IPv4Address::Zero)
-		EXIT_WITH_ERROR_AND_PRINT_USAGE("Source IPv4 address wasn't supplied and couldn't be retrieved from interface");
+	if (!sourceIP.isValid() || sourceIP == pcpp::IPv4Address::Zero)
+		EXIT_WITH_ERROR("Source IPv4 address wasn't supplied and couldn't be retrieved from interface");
 
 	// let's go
 	double arpResonseTimeMS = 0;
 	int i = 1;
 	char errString[1000];
-	LoggerPP::getInstance().setErrorString(errString, 1000);
+	pcpp::LoggerPP::getInstance().setErrorString(errString, 1000);
 	while (i <= maxTries)
 	{
 		// reset error string
 		memset(errString, 0, 1000);
 
 		// use the getMacAddress utility to send an ARP request and resolve the MAC address
-		MacAddress result = NetworkUtils::getInstance().getMacAddress(targetIP, dev, arpResonseTimeMS, sourceMac, sourceIP, timeoutSec);
+		pcpp::MacAddress result = pcpp::NetworkUtils::getInstance().getMacAddress(targetIP, dev, arpResonseTimeMS, sourceMac, sourceIP, timeoutSec);
 
 		// failed fetching MAC address
-		if (result == MacAddress::Zero)
+		if (result == pcpp::MacAddress::Zero)
 		{
-			printf("Arping  index=%d : %s\n", i, errString);
+			std::cout << "Arping  index=" << i << " : " << errString << std::endl;
 		}
 		else // Succeeded fetching MAC address
 		{
 			// output ARP ping data
-			printf("Reply from %s [%s]  %.3fms  index=%d\n",
-					targetIP.toString().c_str(),
-					result.toString().c_str(),
-					arpResonseTimeMS,
-					i);
+			std::cout.precision(3);
+			std::cout
+				<< "Reply from " << targetIP << " "
+				<< "[" << result << "]  "
+				<< std::fixed << arpResonseTimeMS << "ms  "
+				<< "index=" << i
+				<< std::endl;
 		}
 
 		i++;

--- a/Examples/DpdkBridge/AppWorkerThread.h
+++ b/Examples/DpdkBridge/AppWorkerThread.h
@@ -7,14 +7,13 @@
 #include "DpdkDeviceList.h"
 #include "PcapFileDevice.h"
 
-using namespace pcpp;
 
 /**
  * The worker thread class which does all the work. It's initialized with pointers to the RX and TX devices, then it runs in
  * an endless loop which reads packets from the RX device and sends them to the TX device.
  * The endless loop is interrupted only when the thread is asked to stop (calling its stop() method)
  */
-class AppWorkerThread : public DpdkWorkerThread
+class AppWorkerThread : public pcpp::DpdkWorkerThread
 {
 private:
 	AppWorkerConfig& m_WorkerConfig;
@@ -38,8 +37,8 @@ public:
 	{
 		m_CoreId = coreId;
 		m_Stop = false;
-		DpdkDevice* rxDevice = m_WorkerConfig.RxDevice;
-		DpdkDevice* txDevice = m_WorkerConfig.TxDevice;
+		pcpp::DpdkDevice* rxDevice = m_WorkerConfig.RxDevice;
+		pcpp::DpdkDevice* txDevice = m_WorkerConfig.TxDevice;
 
 		// if no DPDK devices were assigned to this worker/core don't enter the main loop and exit
 		if (!rxDevice || !txDevice)
@@ -48,7 +47,7 @@ public:
 		}
 
 		#define MAX_RECEIVE_BURST 64
-		MBufRawPacket* packetArr[MAX_RECEIVE_BURST] = {};
+		pcpp::MBufRawPacket* packetArr[MAX_RECEIVE_BURST] = {};
 
 		// main loop, runs until be told to stop
 		while (!m_Stop)

--- a/Examples/DpdkBridge/Common.h
+++ b/Examples/DpdkBridge/Common.h
@@ -13,23 +13,22 @@
 #include <sstream>
 #include <stdlib.h>
 
-using namespace std;
-using namespace pcpp;
 
 /**
  * Macros for exiting the application with error
  */
 
-#define EXIT_WITH_ERROR(reason, ...) do { \
-	printf("Application terminated in error: " reason "\n", ## __VA_ARGS__); \
+#define EXIT_WITH_ERROR(reason) do { \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while(0)
 
-#define EXIT_WITH_ERROR_AND_PRINT_USAGE(reason, ...) do { \
-	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
+
+#define EXIT_WITH_ERROR_AND_PRINT_USAGE(reason) do { \
 	printUsage(); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
-	} while (0)
+	} while(0)
 
 
 /**
@@ -40,9 +39,9 @@ using namespace pcpp;
 struct AppWorkerConfig
 {
 	uint32_t CoreId;
-	DpdkDevice* RxDevice;
+	pcpp::DpdkDevice* RxDevice;
 	uint16_t RxQueues;
-	DpdkDevice* TxDevice;
+	pcpp::DpdkDevice* TxDevice;
 
 	AppWorkerConfig() : CoreId(MAX_NUM_OF_CORES+1), RxDevice(NULL), RxQueues(1), TxDevice(NULL)
 	{

--- a/Examples/DpdkBridge/main.cpp
+++ b/Examples/DpdkBridge/main.cpp
@@ -79,21 +79,6 @@ void printUsage()
 		<< "                                                 To see all available DPDK ports use the -l switch" << std::endl
 		<< "    -q|--queue-quantity QUEUE_QTY              : Quantity of RX queues to be opened for each DPDK device. Default value is 1" << std::endl
 		<< std::endl;
-
-
-	printf("\nUsage:\n"
-			"------\n"
-			"%s [-hlv] [-c CORE_MASK] [-m POOL_SIZE] [-q QUEUE_QTY] -d PORT_1,PORT_2\n"
-			"\nOptions:\n\n"
-			"    -h|--help                                  : Displays this help message and exits\n"
-			"    -l|--list                                  : Print the list of DPDK ports and exits\n"
-			"    -v|--version                               : Displays the current version and exits\n"
-			"    -c|--core-mask CORE_MASK                   : Core mask of cores to use. For example: use 7 (binary 0111) to use cores 0,1,2.\n"
-			"                                                 Default is using all cores except management core\n"
-			"    -m|--mbuf-pool-size POOL_SIZE              : DPDK mBuf pool size to initialize DPDK with. Default value is 4095\n\n"
-			"    -d|--dpdk-ports PORT_1,PORT_2              : A comma-separated list of two DPDK port numbers to be bridged.\n"
-			"                                                 To see all available DPDK ports use the -l switch\n"
-			"    -q|--queue-quantity QUEUE_QTY              : Quantity of RX queues to be opened for each DPDK device. Default value is 1\n", pcpp::AppName::get().c_str());
 }
 
 

--- a/Examples/DpdkExample-FilterTraffic/AppWorkerThread.h
+++ b/Examples/DpdkExample-FilterTraffic/AppWorkerThread.h
@@ -21,7 +21,7 @@ private:
 	uint32_t m_CoreId;
 	PacketStats m_Stats;
 	PacketMatchingEngine& m_PacketMatchingEngine;
-	map<uint32_t, bool> m_FlowTable;
+	std::map<uint32_t, bool> m_FlowTable;
 
 public:
 	AppWorkerThread(AppWorkerConfig& workerConfig, PacketMatchingEngine& matchingEngine) :
@@ -76,7 +76,7 @@ public:
 			for (InputDataConfig::iterator iter = m_WorkerConfig.InDataCfg.begin(); iter != m_WorkerConfig.InDataCfg.end(); iter++)
 			{
 				// for each DPDK device go over all RX queues configured for this worker/core
-				for (vector<int>::iterator iter2 = iter->second.begin(); iter2 != iter->second.end(); iter2++)
+				for (std::vector<int>::iterator iter2 = iter->second.begin(); iter2 != iter->second.end(); iter2++)
 				{
 					pcpp::DpdkDevice* dev = iter->first;
 
@@ -95,7 +95,7 @@ public:
 
 						// hash the packet by 5-tuple and look in the flow table to see whether this packet belongs to an existing or new flow
 						uint32_t hash = pcpp::hash5Tuple(&parsedPacket);
-						map<uint32_t, bool>::const_iterator iter = m_FlowTable.find(hash);
+						std::map<uint32_t, bool>::const_iterator iter = m_FlowTable.find(hash);
 
 						// if packet belongs to an already existing flow
 						if (iter != m_FlowTable.end() && iter->second)

--- a/Examples/DpdkExample-FilterTraffic/Common.h
+++ b/Examples/DpdkExample-FilterTraffic/Common.h
@@ -13,24 +13,24 @@
 #include <sstream>
 #include <stdlib.h>
 
-using namespace std;
 
 /**
  * Macros for exiting the application with error
  */
 
-#define EXIT_WITH_ERROR(reason, ...) do { \
-	printf("Application terminated in error: " reason "\n", ## __VA_ARGS__); \
+#define EXIT_WITH_ERROR(reason) do { \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while(0)
 
-#define EXIT_WITH_ERROR_AND_PRINT_USAGE(reason, ...) do { \
-	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
-	printUsage(); \
-	exit(1); \
-	} while (0)
 
-typedef map<pcpp::DpdkDevice*, vector<int> > InputDataConfig;
+#define EXIT_WITH_ERROR_AND_PRINT_USAGE(reason) do { \
+	printUsage(); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
+	exit(1); \
+	} while(0)
+
+typedef std::map<pcpp::DpdkDevice*, std::vector<int> > InputDataConfig;
 
 
 /**
@@ -44,7 +44,7 @@ struct AppWorkerConfig
 	InputDataConfig InDataCfg;
 	pcpp::DpdkDevice* SendPacketsTo;
 	bool WriteMatchedPacketsToFile;
-	string PathToWritePackets;
+	std::string PathToWritePackets;
 
 	AppWorkerConfig() : CoreId(MAX_NUM_OF_CORES+1), SendPacketsTo(NULL), WriteMatchedPacketsToFile(false), PathToWritePackets("")
 	{

--- a/Examples/DpdkExample-FilterTraffic/main.cpp
+++ b/Examples/DpdkExample-FilterTraffic/main.cpp
@@ -40,7 +40,6 @@
 #include <sstream>
 #include <unistd.h>
 
-using namespace pcpp;
 
 #define DEFAULT_MBUF_POOL_SIZE 4095
 
@@ -69,26 +68,33 @@ static struct option FilterTrafficOptions[] =
  */
 void printUsage()
 {
-	printf("\nUsage:\n"
-                 "------\n"
-                        "%s [-hvl] [-s PORT] [-f FILENAME] [-i IPV4_ADDR] [-I IPV4_ADDR] [-p PORT] [-P PORT] [-r PROTOCOL]\n"
-			"                     [-c CORE_MASK] [-m POOL_SIZE] -d PORT_1,PORT_3,...,PORT_N\n"
-			"\nOptions:\n\n"
-			"    -h|--help                                  : Displays this help message and exits\n"
-                        "    -v|--version                               : Displays the current version and exits\n"
-			"    -l|--list                                  : Print the list of DPDK ports and exists\n"
-			"    -d|--dpdk-ports PORT_1,PORT_3,...,PORT_N   : A comma-separated list of DPDK port numbers to receive packets from.\n"
-			"                                                 To see all available DPDK ports use the -l switch\n"
-			"    -s|--send-matched-packets PORT             : DPDK port to send matched packets to\n"
-			"    -f|--save-matched-packets FILEPATH         : Save matched packets to pcap files under FILEPATH. Packets matched by core X will be saved under 'FILEPATH/CoreX.pcap'\n"
-			"    -i|--match-source-ip      IPV4_ADDR        : Match source IPv4 address\n"
-			"    -I|--match-dest-ip        IPV4_ADDR        : Match destination IPv4 address\n"
-			"    -p|--match-source-port    PORT             : Match source TCP/UDP port\n"
-			"    -P|--match-dest-port      PORT             : Match destination TCP/UDP port\n"
-			"    -r|--match-protocol       PROTOCOL         : Match protocol. Valid values are 'TCP' or 'UDP'\n"
-			"    -c|--core-mask            CORE_MASK        : Core mask of cores to use. For example: use 7 (binary 0111) to use cores 0,1,2.\n"
-			"                                                 Default is using all cores except management core\n"
-			"    -m|--mbuf-pool-size       POOL_SIZE        : DPDK mBuf pool size to initialize DPDK with. Default value is 4095\n\n", AppName::get().c_str());
+	std::cout << std::endl
+		<< "Usage:" << std::endl
+		<< "------" << std::endl
+		<< pcpp::AppName::get() << " [-hvl] [-s PORT] [-f FILENAME] [-i IPV4_ADDR] [-I IPV4_ADDR] [-p PORT] [-P PORT] [-r PROTOCOL]" << std::endl
+		<< "                  [-c CORE_MASK] [-m POOL_SIZE] -d PORT_1,PORT_3,...,PORT_N" << std::endl
+		<< std::endl
+		<< "Options:" << std::endl
+		<< std::endl
+		<< "    -h|--help                                  : Displays this help message and exits" << std::endl
+		<< "    -v|--version                               : Displays the current version and exits" << std::endl
+		<< "    -l|--list                                  : Print the list of DPDK ports and exists" << std::endl
+		<< "    -d|--dpdk-ports PORT_1,PORT_3,...,PORT_N   : A comma-separated list of DPDK port numbers to receive" << std::endl 
+		<< "                                                 packets from. To see all available DPDK ports use the -l switch" << std::endl
+		<< "    -s|--send-matched-packets PORT             : DPDK port to send matched packets to" << std::endl
+		<< "    -f|--save-matched-packets FILEPATH         : Save matched packets to pcap files under FILEPATH. Packets" << std::endl
+		<< "                                                 matched by core X will be saved under 'FILEPATH/CoreX.pcap'" << std::endl
+		<< "    -i|--match-source-ip      IPV4_ADDR        : Match source IPv4 address" << std::endl
+		<< "    -I|--match-dest-ip        IPV4_ADDR        : Match destination IPv4 address" << std::endl
+		<< "    -p|--match-source-port    PORT             : Match source TCP/UDP port" << std::endl
+		<< "    -P|--match-dest-port      PORT             : Match destination TCP/UDP port" << std::endl
+		<< "    -r|--match-protocol       PROTOCOL         : Match protocol. Valid values are 'TCP' or 'UDP'" << std::endl
+		<< "    -c|--core-mask            CORE_MASK        : Core mask of cores to use." << std::endl
+		<< "                                                 For example: use 7 (binary 0111) to use cores 0,1,2." << std::endl
+		<< "                                                 Default is using all cores except management core" << std::endl
+		<< "    -m|--mbuf-pool-size       POOL_SIZE        : DPDK mBuf pool size to initialize DPDK with." << std::endl
+		<< "                                                 Default value is 4095" << std::endl
+		<< std::endl;
 }
 
 
@@ -97,9 +103,10 @@ void printUsage()
  */
 void printAppVersion()
 {
-	printf("%s %s\n", AppName::get().c_str(), getPcapPlusPlusVersionFull().c_str());
-	printf("Built: %s\n", getBuildDateTime().c_str());
-	printf("Built from: %s\n", getGitInfo().c_str());
+	std::cout
+		<< pcpp::AppName::get() << " " << pcpp::getPcapPlusPlusVersionFull() << std::endl
+		<< "Built: " << pcpp::getBuildDateTime() << std::endl
+		<< "Built from: " << pcpp::getGitInfo() << std::endl;
 	exit(0);
 }
 
@@ -109,26 +116,27 @@ void printAppVersion()
  */
 void listDpdkPorts()
 {
-	CoreMask coreMaskToUse = getCoreMaskForAllMachineCores();
+	pcpp::CoreMask coreMaskToUse = pcpp::getCoreMaskForAllMachineCores();
 
 	// initialize DPDK
-	if (!DpdkDeviceList::initDpdk(coreMaskToUse, DEFAULT_MBUF_POOL_SIZE))
+	if (!pcpp::DpdkDeviceList::initDpdk(coreMaskToUse, DEFAULT_MBUF_POOL_SIZE))
 	{
 		EXIT_WITH_ERROR("couldn't initialize DPDK");
 	}
 
-	printf("DPDK port list:\n");
+	std::cout << "DPDK port list:" << std::endl;
 
 	// go over all available DPDK devices and print info for each one
-	vector<DpdkDevice*> deviceList = DpdkDeviceList::getInstance().getDpdkDeviceList();
-	for (vector<DpdkDevice*>::iterator iter = deviceList.begin(); iter != deviceList.end(); iter++)
+	std::vector<pcpp::DpdkDevice*> deviceList = pcpp::DpdkDeviceList::getInstance().getDpdkDeviceList();
+	for (std::vector<pcpp::DpdkDevice*>::iterator iter = deviceList.begin(); iter != deviceList.end(); iter++)
 	{
-		DpdkDevice* dev = *iter;
-		printf("    Port #%d: MAC address='%s'; PCI address='%s'; PMD='%s'\n",
-				dev->getDeviceId(),
-				dev->getMacAddress().toString().c_str(),
-				dev->getPciAddress().c_str(),
-				dev->getPMDName().c_str());
+		pcpp::DpdkDevice* dev = *iter;
+		std::cout << "   "
+			<< " Port #" << dev->getDeviceId() << ":"
+			<< " MAC address='" << dev->getMacAddress() << "';"
+			<< " PCI address='" << dev->getPciAddress() << "';"
+			<< " PMD='" << dev->getPMDName() << "'"
+			<< std::endl;
 	}
 }
 
@@ -137,18 +145,18 @@ void listDpdkPorts()
  * Prepare the configuration for each core. Configuration includes: which DpdkDevices and which RX queues to receive packets from, where to send the matched
  * packets, etc.
  */
-void prepareCoreConfiguration(vector<DpdkDevice*>& dpdkDevicesToUse, vector<SystemCore>& coresToUse,
-		bool writePacketsToDisk, string packetFilePath, DpdkDevice* sendPacketsTo,
+void prepareCoreConfiguration(std::vector<pcpp::DpdkDevice*>& dpdkDevicesToUse, std::vector<pcpp::SystemCore>& coresToUse,
+		bool writePacketsToDisk, std::string packetFilePath, pcpp::DpdkDevice* sendPacketsTo,
 		AppWorkerConfig workerConfigArr[], int workerConfigArrLen)
 {
 	// create a list of pairs of DpdkDevice and RX queues for all RX queues in all requested devices
 	int totalNumOfRxQueues = 0;
-	vector<pair<DpdkDevice*, int> > deviceAndRxQVec;
-	for (vector<DpdkDevice*>::iterator iter = dpdkDevicesToUse.begin(); iter != dpdkDevicesToUse.end(); iter++)
+	std::vector<std::pair<pcpp::DpdkDevice*, int> > deviceAndRxQVec;
+	for (std::vector<pcpp::DpdkDevice*>::iterator iter = dpdkDevicesToUse.begin(); iter != dpdkDevicesToUse.end(); iter++)
 	{
 		for (int rxQueueIndex = 0; rxQueueIndex < (*iter)->getTotalNumOfRxQueues(); rxQueueIndex++)
 		{
-			pair<DpdkDevice*, int> curPair(*iter, rxQueueIndex);
+			std::pair<pcpp::DpdkDevice*, int> curPair(*iter, rxQueueIndex);
 			deviceAndRxQVec.push_back(curPair);
 		}
 		totalNumOfRxQueues += (*iter)->getTotalNumOfRxQueues();
@@ -160,10 +168,10 @@ void prepareCoreConfiguration(vector<DpdkDevice*>& dpdkDevicesToUse, vector<Syst
 
 	// prepare the configuration for every core: divide the devices and RX queue for each device with the various cores
 	int i = 0;
-	vector<pair<DpdkDevice*, int> >::iterator pairVecIter = deviceAndRxQVec.begin();
-	for (vector<SystemCore>::iterator iter = coresToUse.begin(); iter != coresToUse.end(); iter++)
+	std::vector<std::pair<pcpp::DpdkDevice*, int> >::iterator pairVecIter = deviceAndRxQVec.begin();
+	for (std::vector<pcpp::SystemCore>::iterator iter = coresToUse.begin(); iter != coresToUse.end(); iter++)
 	{
-		printf("Using core %d\n", iter->Id);
+		std::cout << "Using core " << (int)iter->Id << std::endl;
 		workerConfigArr[i].CoreId = iter->Id;
 		workerConfigArr[i].WriteMatchedPacketsToFile = writePacketsToDisk;
 
@@ -187,20 +195,20 @@ void prepareCoreConfiguration(vector<DpdkDevice*>& dpdkDevicesToUse, vector<Syst
 		}
 
 		// print configuration for core
-		printf("   Core configuration:\n");
+		std::cout << "   Core configuration:" << std::endl;
 		for (InputDataConfig::iterator iter = workerConfigArr[i].InDataCfg.begin(); iter != workerConfigArr[i].InDataCfg.end(); iter++)
 		{
-			printf("      DPDK device#%d: ", iter->first->getDeviceId());
-			for (vector<int>::iterator iter2 = iter->second.begin(); iter2 != iter->second.end(); iter2++)
+			std::cout << "      DPDK device#" << iter->first->getDeviceId() << ": ";
+			for (std::vector<int>::iterator iter2 = iter->second.begin(); iter2 != iter->second.end(); iter2++)
 			{
-				printf("RX-Queue#%d;  ", *iter2);
+				std::cout << "RX-Queue#" << *iter2 << ";  ";
 
 			}
-			printf("\n");
+			std::cout << std::endl;
 		}
 		if (workerConfigArr[i].InDataCfg.size() == 0)
 		{
-			printf("      None\n");
+			std::cout << "      None" << std::endl;
 		}
 		i++;
 	}
@@ -210,7 +218,7 @@ void prepareCoreConfiguration(vector<DpdkDevice*>& dpdkDevicesToUse, vector<Syst
 struct FiltetTrafficArgs
 {
 	bool shouldStop;
-	std::vector<DpdkWorkerThread*>* workerThreadsVector;
+	std::vector<pcpp::DpdkWorkerThread*>* workerThreadsVector;
 
 	FiltetTrafficArgs() : shouldStop(false), workerThreadsVector(NULL) {}
 };
@@ -222,20 +230,20 @@ void onApplicationInterrupted(void* cookie)
 {
 	FiltetTrafficArgs* args = (FiltetTrafficArgs*)cookie;
 
-	printf("\n\nApplication stopped\n");
+	std::cout << std::endl << std::endl << "Application stopped" << std::endl;
 
 	// stop worker threads
-	DpdkDeviceList::getInstance().stopDpdkWorkerThreads();
+	pcpp::DpdkDeviceList::getInstance().stopDpdkWorkerThreads();
 
 	// create table printer
 	std::vector<std::string> columnNames;
 	std::vector<int> columnWidths;
 	PacketStats::getStatsColumns(columnNames, columnWidths);
-	TablePrinter printer(columnNames, columnWidths);
+	pcpp::TablePrinter printer(columnNames, columnWidths);
 
 	// print final stats for every worker thread plus sum of all threads and free worker threads memory
 	PacketStats aggregatedStats;
-	for (std::vector<DpdkWorkerThread*>::iterator iter = args->workerThreadsVector->begin(); iter != args->workerThreadsVector->end(); iter++)
+	for (std::vector<pcpp::DpdkWorkerThread*>::iterator iter = args->workerThreadsVector->begin(); iter != args->workerThreadsVector->end(); iter++)
 	{
 		AppWorkerThread* thread = (AppWorkerThread*)(*iter);
 		PacketStats threadStats = thread->getStats();
@@ -257,15 +265,15 @@ void onApplicationInterrupted(void* cookie)
  */
 int main(int argc, char* argv[])
 {
-	AppName::init(argc, argv);
+	pcpp::AppName::init(argc, argv);
 
 	std::vector<int> dpdkPortVec;
 
 	bool writePacketsToDisk = false;
 
-	string packetFilePath = "";
+	std::string packetFilePath = "";
 
-	CoreMask coreMaskToUse = getCoreMaskForAllMachineCores();
+	pcpp::CoreMask coreMaskToUse = pcpp::getCoreMaskForAllMachineCores();
 
 	int sendPacketsToPort = -1;
 
@@ -274,11 +282,11 @@ int main(int argc, char* argv[])
 
 	uint32_t mBufPoolSize = DEFAULT_MBUF_POOL_SIZE;
 
-	IPv4Address 	srcIPToMatch = IPv4Address::Zero;
-	IPv4Address 	dstIPToMatch = IPv4Address::Zero;
-	uint16_t 		srcPortToMatch = 0;
-	uint16_t 		dstPortToMatch = 0;
-	ProtocolType	protocolToMatch = UnknownProtocol;
+	pcpp::IPv4Address 	srcIPToMatch = pcpp::IPv4Address::Zero;
+	pcpp::IPv4Address 	dstIPToMatch = pcpp::IPv4Address::Zero;
+	uint16_t 			srcPortToMatch = 0;
+	uint16_t 			dstPortToMatch = 0;
+	pcpp::ProtocolType	protocolToMatch = pcpp::UnknownProtocol;
 
 	while((opt = getopt_long (argc, argv, "d:c:s:f:m:i:I:p:P:r:hvl", FilterTrafficOptions, &optionIndex)) != -1)
 	{
@@ -290,9 +298,9 @@ int main(int argc, char* argv[])
 			}
 			case 'd':
 			{
-				string portListAsString = string(optarg);
-				stringstream stream(portListAsString);
-				string portAsString;
+				std::string portListAsString = std::string(optarg);
+				std::stringstream stream(portListAsString);
+				std::string portAsString;
 				int port;
 				// break comma-separated string into string list
 				while(getline(stream, portAsString, ','))
@@ -327,7 +335,7 @@ int main(int argc, char* argv[])
 			}
 			case 'f':
 			{
-				packetFilePath = string(optarg);
+				packetFilePath = std::string(optarg);
 				writePacketsToDisk = true;
 				if (packetFilePath.empty())
 				{
@@ -342,7 +350,7 @@ int main(int argc, char* argv[])
 			}
 			case 'i':
 			{
-				srcIPToMatch = IPv4Address(optarg);
+				srcIPToMatch = pcpp::IPv4Address(optarg);
 				if (!srcIPToMatch.isValid())
 				{
 					EXIT_WITH_ERROR_AND_PRINT_USAGE("Source IP to match isn't a valid IP address");
@@ -351,7 +359,7 @@ int main(int argc, char* argv[])
 			}
 			case 'I':
 			{
-				dstIPToMatch = IPv4Address(optarg);
+				dstIPToMatch = pcpp::IPv4Address(optarg);
 				if (!dstIPToMatch.isValid())
 				{
 					EXIT_WITH_ERROR_AND_PRINT_USAGE("Destination IP to match isn't a valid IP address");
@@ -378,11 +386,11 @@ int main(int argc, char* argv[])
 			}
 			case 'r':
 			{
-				string protocol = string(optarg);
+				std::string protocol = std::string(optarg);
 				if (protocol == "TCP")
-					protocolToMatch = TCP;
+					protocolToMatch = pcpp::TCP;
 				else if (protocol == "UDP")
-					protocolToMatch = UDP;
+					protocolToMatch = pcpp::UDP;
 				else
 				{
 					EXIT_WITH_ERROR_AND_PRINT_USAGE("Protocol to match isn't TCP or UDP");
@@ -419,8 +427,8 @@ int main(int argc, char* argv[])
 	}
 
 	// extract core vector from core mask
-	vector<SystemCore> coresToUse;
-	createCoreVectorFromCoreMask(coreMaskToUse, coresToUse);
+	std::vector<pcpp::SystemCore> coresToUse;
+	pcpp::createCoreVectorFromCoreMask(coreMaskToUse, coresToUse);
 
 	// need minimum of 2 cores to start - 1 management core + 1 (or more) worker thread(s)
 	if (coresToUse.size() < 2)
@@ -429,44 +437,44 @@ int main(int argc, char* argv[])
 	}
 
 	// initialize DPDK
-	if (!DpdkDeviceList::initDpdk(coreMaskToUse, mBufPoolSize))
+	if (!pcpp::DpdkDeviceList::initDpdk(coreMaskToUse, mBufPoolSize))
 	{
 		EXIT_WITH_ERROR("Couldn't initialize DPDK");
 	}
 
 	// removing DPDK master core from core mask because DPDK worker threads cannot run on master core
-	coreMaskToUse = coreMaskToUse & ~(DpdkDeviceList::getInstance().getDpdkMasterCore().Mask);
+	coreMaskToUse = coreMaskToUse & ~(pcpp::DpdkDeviceList::getInstance().getDpdkMasterCore().Mask);
 
 	// re-calculate cores to use after removing master core
 	coresToUse.clear();
 	createCoreVectorFromCoreMask(coreMaskToUse, coresToUse);
 
 	// collect the list of DPDK devices
-	vector<DpdkDevice*> dpdkDevicesToUse;
-	for (vector<int>::iterator iter = dpdkPortVec.begin(); iter != dpdkPortVec.end(); iter++)
+	std::vector<pcpp::DpdkDevice*> dpdkDevicesToUse;
+	for (std::vector<int>::iterator iter = dpdkPortVec.begin(); iter != dpdkPortVec.end(); iter++)
 	{
-		DpdkDevice* dev = DpdkDeviceList::getInstance().getDeviceByPort(*iter);
+		pcpp::DpdkDevice* dev = pcpp::DpdkDeviceList::getInstance().getDeviceByPort(*iter);
 		if (dev == NULL)
 		{
-			EXIT_WITH_ERROR("DPDK device for port %d doesn't exist", *iter);
+			EXIT_WITH_ERROR("DPDK device for port " << *iter << " doesn't exist");
 		}
 		dpdkDevicesToUse.push_back(dev);
 	}
 
 	// go over all devices and open them
-	for (vector<DpdkDevice*>::iterator iter = dpdkDevicesToUse.begin(); iter != dpdkDevicesToUse.end(); iter++)
+	for (std::vector<pcpp::DpdkDevice*>::iterator iter = dpdkDevicesToUse.begin(); iter != dpdkDevicesToUse.end(); iter++)
 	{
 		if (!(*iter)->openMultiQueues((*iter)->getTotalNumOfRxQueues(), (*iter)->getTotalNumOfTxQueues()))
 		{
-			EXIT_WITH_ERROR("Couldn't open DPDK device #%d, PMD '%s'", (*iter)->getDeviceId(), (*iter)->getPMDName().c_str());
+			EXIT_WITH_ERROR("Couldn't open DPDK device #" << (*iter)->getDeviceId() << ", PMD '" << (*iter)->getPMDName() << "'");
 		}
 	}
 
 	// get DPDK device to send packets to (or NULL if doesn't exist)
-	DpdkDevice* sendPacketsTo = DpdkDeviceList::getInstance().getDeviceByPort(sendPacketsToPort);
+	pcpp::DpdkDevice* sendPacketsTo = pcpp::DpdkDeviceList::getInstance().getDeviceByPort(sendPacketsToPort);
 	if (sendPacketsTo != NULL && !sendPacketsTo->isOpened() &&  !sendPacketsTo->open())
 	{
-		EXIT_WITH_ERROR("Could not open port#%d for sending matched packets", sendPacketsToPort);
+		EXIT_WITH_ERROR("Could not open port#" << sendPacketsToPort << " for sending matched packets");
 	}
 
 	// prepare configuration for every core
@@ -476,9 +484,9 @@ int main(int argc, char* argv[])
 	PacketMatchingEngine matchingEngine(srcIPToMatch, dstIPToMatch, srcPortToMatch, dstPortToMatch, protocolToMatch);
 
 	// create worker thread for every core
-	vector<DpdkWorkerThread*> workerThreadVec;
+	std::vector<pcpp::DpdkWorkerThread*> workerThreadVec;
 	int i = 0;
-	for (vector<SystemCore>::iterator iter = coresToUse.begin(); iter != coresToUse.end(); iter++)
+	for (std::vector<pcpp::SystemCore>::iterator iter = coresToUse.begin(); iter != coresToUse.end(); iter++)
 	{
 		AppWorkerThread* newWorker = new AppWorkerThread(workerConfigArr[i], matchingEngine);
 		workerThreadVec.push_back(newWorker);
@@ -486,7 +494,7 @@ int main(int argc, char* argv[])
 	}
 
 	// start all worker threads
-	if (!DpdkDeviceList::getInstance().startDpdkWorkerThreads(coreMaskToUse, workerThreadVec))
+	if (!pcpp::DpdkDeviceList::getInstance().startDpdkWorkerThreads(coreMaskToUse, workerThreadVec))
 	{
 		EXIT_WITH_ERROR("Couldn't start worker threads");
 	}
@@ -494,7 +502,7 @@ int main(int argc, char* argv[])
 	// register the on app close event to print summary stats on app termination
 	FiltetTrafficArgs args;
 	args.workerThreadsVector = &workerThreadVec;
-	ApplicationEventHandler::getInstance().onApplicationInterrupted(onApplicationInterrupted, &args);
+	pcpp::ApplicationEventHandler::getInstance().onApplicationInterrupted(onApplicationInterrupted, &args);
 
 	// infinite loop (until program is terminated)
 	while (!args.shouldStop)

--- a/Examples/HttpAnalyzer/main.cpp
+++ b/Examples/HttpAnalyzer/main.cpp
@@ -45,6 +45,7 @@
 			<< std::right << std::setw(15) << std::fixed << std::showpoint << std::setprecision(3) << counter \
 			<< " [" << measurement << "]" << std::endl;
 
+
 #define DEFAULT_CALC_RATES_PERIOD_SEC 2
 
 
@@ -444,7 +445,7 @@ void analyzeHttpFromPcapFile(std::string pcapFileName, uint16_t dstPort)
 /**
  * activate HTTP analysis from live traffic
  */
-void analyzeHttpFromLiveTraffic(pcpp::PcapLiveDevice* dev, bool printRatesPeriodicaly, int printRatePeriod, std::string savePacketsToFileName, uint16_t dstPort)
+void analyzeHttpFromLiveTraffic(pcpp::PcapLiveDevice* dev, bool printRatesPeriodically, int printRatePeriod, std::string savePacketsToFileName, uint16_t dstPort)
 {
 	// open the device
 	if (!dev->open())
@@ -482,7 +483,7 @@ void analyzeHttpFromLiveTraffic(pcpp::PcapLiveDevice* dev, bool printRatesPeriod
 		pcpp::multiPlatformSleep(printRatePeriod);
 
 		// calculate rates
-		if (printRatesPeriodicaly)
+		if (printRatesPeriodically)
 		{
 			collector.calcRates();
 			printCurrentRates(collector);
@@ -519,7 +520,7 @@ int main(int argc, char* argv[])
 
 	std::string interfaceNameOrIP = "";
 	std::string port = "80";
-	bool printRatesPeriodicaly = true;
+	bool printRatesPeriodically = true;
 	int printRatePeriod = DEFAULT_CALC_RATES_PERIOD_SEC;
 	std::string savePacketsToFileName = "";
 
@@ -551,7 +552,7 @@ int main(int argc, char* argv[])
 				printRatePeriod = atoi(optarg);
 				break;
 			case 'd':
-				printRatesPeriodicaly = false;
+				printRatesPeriodically = false;
 				break;
 			case 'h':
 				printUsage();
@@ -598,6 +599,6 @@ int main(int argc, char* argv[])
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 
 		// start capturing and analyzing traffic
-		analyzeHttpFromLiveTraffic(dev, printRatesPeriodicaly, printRatePeriod, savePacketsToFileName, nPort);
+		analyzeHttpFromLiveTraffic(dev, printRatesPeriodically, printRatePeriod, savePacketsToFileName, nPort);
 	}
 }

--- a/Examples/HttpAnalyzer/main.cpp
+++ b/Examples/HttpAnalyzer/main.cpp
@@ -18,6 +18,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <iomanip>
 #include <algorithm>
 #include "PcapLiveDeviceList.h"
 #include "PcapFilter.h"
@@ -30,29 +31,22 @@
 #include <iostream>
 #include <sstream>
 
-#define EXIT_WITH_ERROR(reason, ...) do { \
-	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
+
+#define EXIT_WITH_ERROR(reason) do { \
 	printUsage(); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while(0)
 
 
-#define PRINT_STAT_LINE(description, counter, measurement, type) \
-		printf("%-40s %14" type " [%s]\n", description ":", counter,  measurement)
-
-#define PRINT_STAT_LINE_INT(description, counter, measurement) \
-		PRINT_STAT_LINE(description, counter, measurement, "d")
-
-#define PRINT_STAT_LINE_DOUBLE(description, counter, measurement) \
-		PRINT_STAT_LINE(description, counter, measurement, ".3f")
-
-#define PRINT_STAT_HEADLINE(description) \
-		printf("\n" description "\n--------------------\n\n")
-
+#define PRINT_STAT_LINE(description, counter, measurement) \
+		std::cout \
+			<< std::left << std::setw(40) << (std::string(description) + ":") \
+			<< std::right << std::setw(15) << std::fixed << std::showpoint << std::setprecision(3) << counter \
+			<< " [" << measurement << "]" << std::endl;
 
 #define DEFAULT_CALC_RATES_PERIOD_SEC 2
 
-using namespace pcpp;
 
 static struct option HttpAnalyzerOptions[] =
 {
@@ -72,7 +66,7 @@ static struct option HttpAnalyzerOptions[] =
 struct HttpPacketArrivedData
 {
 	HttpStatsCollector* statsCollector;
-	PcapFileWriterDevice* pcapWriter;
+	pcpp::PcapFileWriterDevice* pcapWriter;
 };
 
 
@@ -81,25 +75,32 @@ struct HttpPacketArrivedData
  */
 void printUsage()
 {
-	printf("\nUsage: PCAP file mode:\n"
-			"----------------------\n"
-			"%s [-vh] -f input_file\n"
-			"\nOptions:\n\n"
-			"    -f             : The input pcap/pcapng file to analyze. Required argument for this mode\n"
-			"    -v             : Displays the current version and exists\n"
-			"    -h             : Displays this help message and exits\n\n"
-			"Usage: Live traffic mode:\n"
-			"-------------------------\n"
-			"%s [-hvld] [-o output_file] [-r calc_period] [-p dst_port] -i interface\n"
-			"\nOptions:\n\n"
-			"    -i interface   : Use the specified interface. Can be interface name (e.g eth0) or interface IPv4 address\n"
-			"    -p dst_port    : Use the specified port (optional parameter, the default is 80)\n"
-			"    -o output_file : Save all captured HTTP packets to a pcap file. Notice this may cause performance degradation\n"
-			"    -r calc_period : The period in seconds to calculate rates. If not provided default is 2 seconds\n"
-			"    -d             : Disable periodic rates calculation\n"
-			"    -h             : Displays this help message and exits\n"
-			"    -v             : Displays the current version and exists\n"
-			"    -l             : Print the list of interfaces and exists\n", AppName::get().c_str(), AppName::get().c_str());
+	std::cout << std::endl
+		<< "Usage: PCAP file mode:" << std::endl
+		<< "----------------------" << std::endl
+		<< pcpp::AppName::get() << " [-vh] -f input_file" << std::endl
+		<< std::endl
+		<< "Options:" << std::endl
+		<< std::endl
+		<< "    -f             : The input pcap/pcapng file to analyze. Required argument for this mode" << std::endl
+		<< "    -v             : Displays the current version and exists" << std::endl
+		<< "    -h             : Displays this help message and exits" << std::endl
+		<< std::endl
+		<< "Usage: Live traffic mode:" << std::endl
+		<< "-------------------------" << std::endl
+		<< pcpp::AppName::get() << " [-hvld] [-o output_file] [-r calc_period] [-p dst_port] -i interface" << std::endl
+		<< std::endl
+		<< "Options:" << std::endl
+		<< std::endl
+		<< "    -i interface   : Use the specified interface. Can be interface name (e.g eth0) or interface IPv4 address" << std::endl
+		<< "    -p dst_port    : Use the specified port (optional parameter, the default is 80)" << std::endl
+		<< "    -o output_file : Save all captured HTTP packets to a pcap file. Notice this may cause performance degradation" << std::endl
+		<< "    -r calc_period : The period in seconds to calculate rates. If not provided default is 2 seconds" << std::endl
+		<< "    -d             : Disable periodic rates calculation" << std::endl
+		<< "    -h             : Displays this help message and exits" << std::endl
+		<< "    -v             : Displays the current version and exists" << std::endl
+		<< "    -l             : Print the list of interfaces and exists" << std::endl
+		<< std::endl;
 }
 
 
@@ -108,9 +109,10 @@ void printUsage()
  */
 void printAppVersion()
 {
-	printf("%s %s\n", AppName::get().c_str(), getPcapPlusPlusVersionFull().c_str());
-	printf("Built: %s\n", getBuildDateTime().c_str());
-	printf("Built from: %s\n", getGitInfo().c_str());
+	std::cout
+		<< pcpp::AppName::get() << " " << pcpp::getPcapPlusPlusVersionFull() << std::endl
+		<< "Built: " << pcpp::getBuildDateTime() << std::endl
+		<< "Built from: " << pcpp::getGitInfo() << std::endl;
 	exit(0);
 }
 
@@ -120,24 +122,36 @@ void printAppVersion()
  */
 void listInterfaces()
 {
-	const std::vector<PcapLiveDevice*>& devList = PcapLiveDeviceList::getInstance().getPcapLiveDevicesList();
+	const std::vector<pcpp::PcapLiveDevice*>& devList = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDevicesList();
 
-	printf("\nNetwork interfaces:\n");
-	for (std::vector<PcapLiveDevice*>::const_iterator iter = devList.begin(); iter != devList.end(); iter++)
+	std::cout << std::endl << "Network interfaces:" << std::endl;
+	for (std::vector<pcpp::PcapLiveDevice*>::const_iterator iter = devList.begin(); iter != devList.end(); iter++)
 	{
-		printf("    -> Name: '%s'   IP address: %s\n", (*iter)->getName().c_str(), (*iter)->getIPv4Address().toString().c_str());
+		std::cout << "    -> Name: '" << (*iter)->getName() << "'   IP address: " << (*iter)->getIPv4Address().toString() << std::endl;
 	}
 	exit(0);
+}
+
+
+void printStatsHeadline(std::string description)
+{
+	std::string underline;
+	for (size_t i = 0; i < description.length(); i++)
+	{
+		underline += "-";
+	}
+
+	std::cout << std::endl << description << std::endl << underline << std::endl << std::endl;
 }
 
 
 /**
  * packet capture callback - called whenever a packet arrives
  */
-void httpPacketArrive(RawPacket* packet, PcapLiveDevice* dev, void* cookie)
+void httpPacketArrive(pcpp::RawPacket* packet, pcpp::PcapLiveDevice* dev, void* cookie)
 {
 	// parse the packet
-	Packet parsedPacket(packet);
+	pcpp::Packet parsedPacket(packet);
 
 	HttpPacketArrivedData* data  = (HttpPacketArrivedData*)cookie;
 
@@ -163,11 +177,11 @@ void printMethods(HttpRequestStats& reqStatscollector)
 	std::vector<int> columnsWidths;
 	columnsWidths.push_back(9);
 	columnsWidths.push_back(5);
-	TablePrinter printer(columnNames, columnsWidths);
+	pcpp::TablePrinter printer(columnNames, columnsWidths);
 
 
 	// go over the method count table and print each method and count
-	for(std::map<HttpRequestLayer::HttpMethod, int>::iterator iter = reqStatscollector.methodCount.begin();
+	for(std::map<pcpp::HttpRequestLayer::HttpMethod, int>::iterator iter = reqStatscollector.methodCount.begin();
 			iter != reqStatscollector.methodCount.end();
 			iter++)
 	{
@@ -175,40 +189,40 @@ void printMethods(HttpRequestStats& reqStatscollector)
 
 		switch (iter->first)
 		{
-		case HttpRequestLayer::HttpGET:
-			values << "GET" << "|" << reqStatscollector.methodCount[HttpRequestLayer::HttpGET];
+		case pcpp::HttpRequestLayer::HttpGET:
+			values << "GET" << "|" << reqStatscollector.methodCount[pcpp::HttpRequestLayer::HttpGET];
 			printer.printRow(values.str(), '|');
 			break;
-		case HttpRequestLayer::HttpPOST:
-			values << "POST" << "|" << reqStatscollector.methodCount[HttpRequestLayer::HttpPOST];
+		case pcpp::HttpRequestLayer::HttpPOST:
+			values << "POST" << "|" << reqStatscollector.methodCount[pcpp::HttpRequestLayer::HttpPOST];
 			printer.printRow(values.str(), '|');
 			break;
-		case HttpRequestLayer::HttpCONNECT:
-			values << "CONNECT" << "|" << reqStatscollector.methodCount[HttpRequestLayer::HttpCONNECT];
+		case pcpp::HttpRequestLayer::HttpCONNECT:
+			values << "CONNECT" << "|" << reqStatscollector.methodCount[pcpp::HttpRequestLayer::HttpCONNECT];
 			printer.printRow(values.str(), '|');
 			break;
-		case HttpRequestLayer::HttpDELETE:
-			values << "DELETE" << "|" << reqStatscollector.methodCount[HttpRequestLayer::HttpDELETE];
+		case pcpp::HttpRequestLayer::HttpDELETE:
+			values << "DELETE" << "|" << reqStatscollector.methodCount[pcpp::HttpRequestLayer::HttpDELETE];
 			printer.printRow(values.str(), '|');
 			break;
-		case HttpRequestLayer::HttpHEAD:
-			values << "HEAD" << "|" << reqStatscollector.methodCount[HttpRequestLayer::HttpHEAD];
+		case pcpp::HttpRequestLayer::HttpHEAD:
+			values << "HEAD" << "|" << reqStatscollector.methodCount[pcpp::HttpRequestLayer::HttpHEAD];
 			printer.printRow(values.str(), '|');
 			break;
-		case HttpRequestLayer::HttpOPTIONS:
-			values << "OPTIONS" << "|" << reqStatscollector.methodCount[HttpRequestLayer::HttpOPTIONS];
+		case pcpp::HttpRequestLayer::HttpOPTIONS:
+			values << "OPTIONS" << "|" << reqStatscollector.methodCount[pcpp::HttpRequestLayer::HttpOPTIONS];
 			printer.printRow(values.str(), '|');
 			break;
-		case HttpRequestLayer::HttpPATCH:
-			values << "PATCH" << "|" << reqStatscollector.methodCount[HttpRequestLayer::HttpPATCH];
+		case pcpp::HttpRequestLayer::HttpPATCH:
+			values << "PATCH" << "|" << reqStatscollector.methodCount[pcpp::HttpRequestLayer::HttpPATCH];
 			printer.printRow(values.str(), '|');
 			break;
-		case HttpRequestLayer::HttpPUT:
-			values << "PUT" << "|" << reqStatscollector.methodCount[HttpRequestLayer::HttpPUT];
+		case pcpp::HttpRequestLayer::HttpPUT:
+			values << "PUT" << "|" << reqStatscollector.methodCount[pcpp::HttpRequestLayer::HttpPUT];
 			printer.printRow(values.str(), '|');
 			break;
-		case HttpRequestLayer::HttpTRACE:
-			values << "TRACE" << "|" << reqStatscollector.methodCount[HttpRequestLayer::HttpTRACE];
+		case pcpp::HttpRequestLayer::HttpTRACE:
+			values << "TRACE" << "|" << reqStatscollector.methodCount[pcpp::HttpRequestLayer::HttpTRACE];
 			printer.printRow(values.str(), '|');
 			break;
 		default:
@@ -243,7 +257,7 @@ void printHostnames(HttpRequestStats& reqStatscollector)
 	std::vector<int> columnsWidths;
 	columnsWidths.push_back(40);
 	columnsWidths.push_back(5);
-	TablePrinter printer(columnNames, columnsWidths);
+	pcpp::TablePrinter printer(columnNames, columnsWidths);
 
 	// sort the hostname count map so the most popular hostnames will be first
 	// since it's not possible to sort a std::map you must copy it to a std::vector and sort it then
@@ -274,7 +288,7 @@ void printStatusCodes(HttpResponseStats& resStatscollector)
 	std::vector<int> columnsWidths;
 	columnsWidths.push_back(28);
 	columnsWidths.push_back(5);
-	TablePrinter printer(columnNames, columnsWidths);
+	pcpp::TablePrinter printer(columnNames, columnsWidths);
 
 	// go over the status code map and print each item
 	for(std::map<std::string, int>::iterator iter = resStatscollector.statusCodeCount.begin();
@@ -300,7 +314,7 @@ void printContentTypes(HttpResponseStats& resStatscollector)
 	std::vector<int> columnsWidths;
 	columnsWidths.push_back(30);
 	columnsWidths.push_back(5);
-	TablePrinter printer(columnNames, columnsWidths);
+	pcpp::TablePrinter printer(columnNames, columnsWidths);
 
 	// go over the status code map and print each item
 	for(std::map<std::string, int>::iterator iter = resStatscollector.contentTypeCount.begin();
@@ -319,46 +333,46 @@ void printContentTypes(HttpResponseStats& resStatscollector)
  */
 void printStatsSummary(HttpStatsCollector& collector)
 {
-	PRINT_STAT_HEADLINE("General stats");
-	PRINT_STAT_LINE_DOUBLE("Sample time", collector.getGeneralStats().sampleTime, "Seconds");
-	PRINT_STAT_LINE_INT("Number of HTTP packets", collector.getGeneralStats().numOfHttpPackets, "Packets");
-	PRINT_STAT_LINE_DOUBLE("Rate of HTTP packets", collector.getGeneralStats().httpPacketRate.totalRate, "Packets/sec");
-	PRINT_STAT_LINE_INT("Number of HTTP flows", collector.getGeneralStats().numOfHttpFlows, "Flows");
-	PRINT_STAT_LINE_DOUBLE("Rate of HTTP flows", collector.getGeneralStats().httpFlowRate.totalRate, "Flows/sec");
-	PRINT_STAT_LINE_INT("Number of HTTP pipelining flows", collector.getGeneralStats().numOfHttpPipeliningFlows, "Flows");
-	PRINT_STAT_LINE_INT("Number of HTTP transactions", collector.getGeneralStats().numOfHttpTransactions, "Transactions");
-	PRINT_STAT_LINE_DOUBLE("Rate of HTTP transactions", collector.getGeneralStats().httpTransactionsRate.totalRate, "Transactions/sec");
-	PRINT_STAT_LINE_INT("Total HTTP data", collector.getGeneralStats().amountOfHttpTraffic, "Bytes");
-	PRINT_STAT_LINE_DOUBLE("Rate of HTTP data", collector.getGeneralStats().httpTrafficRate.totalRate, "Bytes/sec");
-	PRINT_STAT_LINE_DOUBLE("Average packets per flow", collector.getGeneralStats().averageNumOfPacketsPerFlow, "Packets");
-	PRINT_STAT_LINE_DOUBLE("Average transactions per flow", collector.getGeneralStats().averageNumOfHttpTransactionsPerFlow, "Transactions");
-	PRINT_STAT_LINE_DOUBLE("Average data per flow", collector.getGeneralStats().averageAmountOfDataPerFlow, "Bytes");
+	printStatsHeadline("General stats");
+	PRINT_STAT_LINE("Sample time", collector.getGeneralStats().sampleTime, "Seconds");
+	PRINT_STAT_LINE("Number of HTTP packets", collector.getGeneralStats().numOfHttpPackets, "Packets");
+	PRINT_STAT_LINE("Rate of HTTP packets", collector.getGeneralStats().httpPacketRate.totalRate, "Packets/sec");
+	PRINT_STAT_LINE("Number of HTTP flows", collector.getGeneralStats().numOfHttpFlows, "Flows");
+	PRINT_STAT_LINE("Rate of HTTP flows", collector.getGeneralStats().httpFlowRate.totalRate, "Flows/sec");
+	PRINT_STAT_LINE("Number of HTTP pipelining flows", collector.getGeneralStats().numOfHttpPipeliningFlows, "Flows");
+	PRINT_STAT_LINE("Number of HTTP transactions", collector.getGeneralStats().numOfHttpTransactions, "Transactions");
+	PRINT_STAT_LINE("Rate of HTTP transactions", collector.getGeneralStats().httpTransactionsRate.totalRate, "Transactions/sec");
+	PRINT_STAT_LINE("Total HTTP data", collector.getGeneralStats().amountOfHttpTraffic, "Bytes");
+	PRINT_STAT_LINE("Rate of HTTP data", collector.getGeneralStats().httpTrafficRate.totalRate, "Bytes/sec");
+	PRINT_STAT_LINE("Average packets per flow", collector.getGeneralStats().averageNumOfPacketsPerFlow, "Packets");
+	PRINT_STAT_LINE("Average transactions per flow", collector.getGeneralStats().averageNumOfHttpTransactionsPerFlow, "Transactions");
+	PRINT_STAT_LINE("Average data per flow", collector.getGeneralStats().averageAmountOfDataPerFlow, "Bytes");
 
-	PRINT_STAT_HEADLINE("HTTP request stats");
-	PRINT_STAT_LINE_INT("Number of HTTP requests", collector.getRequestStats().numOfMessages, "Requests");
-	PRINT_STAT_LINE_DOUBLE("Rate of HTTP requests", collector.getRequestStats().messageRate.totalRate, "Requests/sec");
-	PRINT_STAT_LINE_INT("Total data in headers", collector.getRequestStats().totalMessageHeaderSize, "Bytes");
-	PRINT_STAT_LINE_DOUBLE("Average header size", collector.getRequestStats().averageMessageHeaderSize, "Bytes");
+	printStatsHeadline("HTTP request stats");
+	PRINT_STAT_LINE("Number of HTTP requests", collector.getRequestStats().numOfMessages, "Requests");
+	PRINT_STAT_LINE("Rate of HTTP requests", collector.getRequestStats().messageRate.totalRate, "Requests/sec");
+	PRINT_STAT_LINE("Total data in headers", collector.getRequestStats().totalMessageHeaderSize, "Bytes");
+	PRINT_STAT_LINE("Average header size", collector.getRequestStats().averageMessageHeaderSize, "Bytes");
 
-	PRINT_STAT_HEADLINE("HTTP response stats");
-	PRINT_STAT_LINE_INT("Number of HTTP responses", collector.getResponseStats().numOfMessages, "Responses");
-	PRINT_STAT_LINE_DOUBLE("Rate of HTTP responses", collector.getResponseStats().messageRate.totalRate, "Responses/sec");
-	PRINT_STAT_LINE_INT("Total data in headers", collector.getResponseStats().totalMessageHeaderSize, "Bytes");
-	PRINT_STAT_LINE_DOUBLE("Average header size", collector.getResponseStats().averageMessageHeaderSize, "Bytes");
-	PRINT_STAT_LINE_INT("Num of responses with content-length", collector.getResponseStats().numOfMessagesWithContentLength, "Responses");
-	PRINT_STAT_LINE_INT("Total body size (may be compressed)", collector.getResponseStats().totalConentLengthSize, "Bytes");
-	PRINT_STAT_LINE_DOUBLE("Average body size", collector.getResponseStats().averageContentLengthSize, "Bytes");
+	printStatsHeadline("HTTP response stats");
+	PRINT_STAT_LINE("Number of HTTP responses", collector.getResponseStats().numOfMessages, "Responses");
+	PRINT_STAT_LINE("Rate of HTTP responses", collector.getResponseStats().messageRate.totalRate, "Responses/sec");
+	PRINT_STAT_LINE("Total data in headers", collector.getResponseStats().totalMessageHeaderSize, "Bytes");
+	PRINT_STAT_LINE("Average header size", collector.getResponseStats().averageMessageHeaderSize, "Bytes");
+	PRINT_STAT_LINE("Num of responses with content-length", collector.getResponseStats().numOfMessagesWithContentLength, "Responses");
+	PRINT_STAT_LINE("Total body size (may be compressed)", collector.getResponseStats().totalConentLengthSize, "Bytes");
+	PRINT_STAT_LINE("Average body size", collector.getResponseStats().averageContentLengthSize, "Bytes");
 
-	PRINT_STAT_HEADLINE("HTTP request methods");
+	printStatsHeadline("HTTP request methods");
 	printMethods(collector.getRequestStats());
 
-	PRINT_STAT_HEADLINE("Hostnames count");
+	printStatsHeadline("Hostnames count");
 	printHostnames(collector.getRequestStats());
 
-	PRINT_STAT_HEADLINE("Status code count");
+	printStatsHeadline("Status code count");
 	printStatusCodes(collector.getResponseStats());
 
-	PRINT_STAT_HEADLINE("Content-type count");
+	printStatsHeadline("Content-type count");
 	printContentTypes(collector.getResponseStats());
 }
 
@@ -368,13 +382,13 @@ void printStatsSummary(HttpStatsCollector& collector)
  */
 void printCurrentRates(HttpStatsCollector& collector)
 {
-	PRINT_STAT_HEADLINE("Current HTTP rates");
-	PRINT_STAT_LINE_DOUBLE("Rate of HTTP packets", collector.getGeneralStats().httpPacketRate.currentRate, "Packets/sec");
-	PRINT_STAT_LINE_DOUBLE("Rate of HTTP flows", collector.getGeneralStats().httpFlowRate.currentRate, "Flows/sec");
-	PRINT_STAT_LINE_DOUBLE("Rate of HTTP transactions", collector.getGeneralStats().httpTransactionsRate.currentRate, "Transactions/sec");
-	PRINT_STAT_LINE_DOUBLE("Rate of HTTP data", collector.getGeneralStats().httpTrafficRate.currentRate, "Bytes/sec");
-	PRINT_STAT_LINE_DOUBLE("Rate of HTTP requests", collector.getRequestStats().messageRate.currentRate, "Requests/sec");
-	PRINT_STAT_LINE_DOUBLE("Rate of HTTP responses", collector.getResponseStats().messageRate.currentRate, "Responses/sec");
+	printStatsHeadline("Current HTTP rates");
+	PRINT_STAT_LINE("Rate of HTTP packets", collector.getGeneralStats().httpPacketRate.currentRate, "Packets/sec");
+	PRINT_STAT_LINE("Rate of HTTP flows", collector.getGeneralStats().httpFlowRate.currentRate, "Flows/sec");
+	PRINT_STAT_LINE("Rate of HTTP transactions", collector.getGeneralStats().httpTransactionsRate.currentRate, "Transactions/sec");
+	PRINT_STAT_LINE("Rate of HTTP data", collector.getGeneralStats().httpTrafficRate.currentRate, "Bytes/sec");
+	PRINT_STAT_LINE("Rate of HTTP requests", collector.getRequestStats().messageRate.currentRate, "Requests/sec");
+	PRINT_STAT_LINE("Rate of HTTP responses", collector.getResponseStats().messageRate.currentRate, "Responses/sec");
 }
 
 
@@ -394,29 +408,29 @@ void onApplicationInterrupted(void* cookie)
 void analyzeHttpFromPcapFile(std::string pcapFileName, uint16_t dstPort)
 {
 	// open input file (pcap or pcapng file)
-	IFileReaderDevice* reader = IFileReaderDevice::getReader(pcapFileName);
+	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader(pcapFileName);
 
 	if (!reader->open())
 		EXIT_WITH_ERROR("Could not open input pcap file");
 
 	// set a port  filter on the reader device to process only HTTP packets
-	PortFilter httpPortFilter(dstPort, SRC_OR_DST);
+	pcpp::PortFilter httpPortFilter(dstPort, pcpp::SRC_OR_DST);
 	if (!reader->setFilter(httpPortFilter))
 		EXIT_WITH_ERROR("Could not set up filter on file");
 
 	// read the input file packet by packet and give it to the HttpStatsCollector for collecting stats
 	HttpStatsCollector collector(dstPort);
-	RawPacket rawPacket;
+	pcpp::RawPacket rawPacket;
 	while(reader->getNextPacket(rawPacket))
 	{
-		Packet parsedPacket(&rawPacket);
+		pcpp::Packet parsedPacket(&rawPacket);
 		collector.collectStats(&parsedPacket);
 	}
 
 	// print stats summary
-	printf("\n\n");
-	printf("STATS SUMMARY\n");
-	printf("=============\n");
+	std::cout << std::endl << std::endl
+		<< "STATS SUMMARY" << std::endl
+		<< "=============" << std::endl;
 	printStatsSummary(collector);
 
 	// close input file
@@ -430,21 +444,21 @@ void analyzeHttpFromPcapFile(std::string pcapFileName, uint16_t dstPort)
 /**
  * activate HTTP analysis from live traffic
  */
-void analyzeHttpFromLiveTraffic(PcapLiveDevice* dev, bool printRatesPeriodicaly, int printRatePeriod, std::string savePacketsToFileName, uint16_t dstPort)
+void analyzeHttpFromLiveTraffic(pcpp::PcapLiveDevice* dev, bool printRatesPeriodicaly, int printRatePeriod, std::string savePacketsToFileName, uint16_t dstPort)
 {
 	// open the device
 	if (!dev->open())
 		EXIT_WITH_ERROR("Could not open the device");
 
-	PortFilter httpPortFilter(dstPort, SRC_OR_DST);
+	pcpp::PortFilter httpPortFilter(dstPort, pcpp::SRC_OR_DST);
 	if (!dev->setFilter(httpPortFilter))
 		EXIT_WITH_ERROR("Could not set up filter on device");
 
 	// if needed to save the captured packets to file - open a writer device
-	PcapFileWriterDevice* pcapWriter = NULL;
+	pcpp::PcapFileWriterDevice* pcapWriter = NULL;
 	if (savePacketsToFileName != "")
 	{
-		pcapWriter = new PcapFileWriterDevice(savePacketsToFileName);
+		pcapWriter = new pcpp::PcapFileWriterDevice(savePacketsToFileName);
 		if (!pcapWriter->open())
 		{
 			EXIT_WITH_ERROR("Could not open pcap file for writing");
@@ -461,11 +475,11 @@ void analyzeHttpFromLiveTraffic(PcapLiveDevice* dev, bool printRatesPeriodicaly,
 
 	// register the on app close event to print summary stats on app termination
 	bool shouldStop = false;
-	ApplicationEventHandler::getInstance().onApplicationInterrupted(onApplicationInterrupted, &shouldStop);
+	pcpp::ApplicationEventHandler::getInstance().onApplicationInterrupted(onApplicationInterrupted, &shouldStop);
 
 	while(!shouldStop)
 	{
-		multiPlatformSleep(printRatePeriod);
+		pcpp::multiPlatformSleep(printRatePeriod);
 
 		// calculate rates
 		if (printRatesPeriodicaly)
@@ -483,8 +497,9 @@ void analyzeHttpFromLiveTraffic(PcapLiveDevice* dev, bool printRatesPeriodicaly,
 	collector.calcRates();
 
 	// print stats summary
-	printf("\n\nSTATS SUMMARY\n");
-	printf("=============\n");
+		std::cout << std::endl << std::endl
+		<< "STATS SUMMARY" << std::endl
+		<< "=============" << std::endl;
 	printStatsSummary(collector);
 
 	// close and free the writer device
@@ -500,7 +515,7 @@ void analyzeHttpFromLiveTraffic(PcapLiveDevice* dev, bool printRatesPeriodicaly,
  */
 int main(int argc, char* argv[])
 {
-	AppName::init(argc, argv);
+	pcpp::AppName::init(argc, argv);
 
 	std::string interfaceNameOrIP = "";
 	std::string port = "80";
@@ -578,7 +593,7 @@ int main(int argc, char* argv[])
 	}
 	else // analyze in live traffic mode
 	{
-		PcapLiveDevice* dev = PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
+		pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
 		if (dev == NULL)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 

--- a/Examples/IPFragUtil/main.cpp
+++ b/Examples/IPFragUtil/main.cpp
@@ -20,6 +20,7 @@
 	exit(1); \
 	} while(0)
 
+
 static struct option FragUtilOptions[] =
 {
 	{"output-file", required_argument, 0, 'o'},

--- a/Examples/IPFragUtil/main.cpp
+++ b/Examples/IPFragUtil/main.cpp
@@ -13,11 +13,10 @@
 #include "SystemUtils.h"
 #include "getopt.h"
 
-using namespace pcpp;
 
-#define EXIT_WITH_ERROR(reason, ...) do { \
-	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
+#define EXIT_WITH_ERROR(reason) do { \
 	printUsage(); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while(0)
 
@@ -58,19 +57,23 @@ struct FragStats
  */
 void printUsage()
 {
-	printf("\nUsage:\n"
-			"-------\n"
-			"%s input_file -s frag_size -o output_file [-d ip_ids] [-f bpf_filter] [-a] [-h] [-v]\n"
-			"\nOptions:\n\n"
-			"    input_file      : Input pcap/pcapng file\n"
-			"    -s frag_size    : Size of each fragment\n"
-			"    -o output_file  : Output file. Output file type (pcap/pcapng) will match the input file type\n"
-			"    -d ip_ids       : Fragment only packets that match this comma-separated list of IP IDs in decimal format\n"
-			"    -f bpf_filter   : Fragment only packets that match bpf_filter. Filter should be provided in Berkeley Packet Filter (BPF)\n"
-			"                      syntax (http://biot.com/capstats/bpf.html) i.e: 'ip net 1.1.1.1'\n"
-			"    -a              : Copy all packets (those who were fragmented and those who weren't) to output file\n"
-			"    -v              : Displays the current version and exits\n"
-			"    -h              : Displays this help message and exits\n", AppName::get().c_str());
+	std::cout << std::endl
+		<< "Usage:" << std::endl
+		<< "------" << std::endl
+		<< pcpp::AppName::get() << " input_file -s frag_size -o output_file [-d ip_ids] [-f bpf_filter] [-a] [-h] [-v]" << std::endl
+		<< std::endl
+		<< "Options:" << std::endl
+		<< std::endl
+		<< "    input_file      : Input pcap/pcapng file" << std::endl
+		<< "    -s frag_size    : Size of each fragment" << std::endl
+		<< "    -o output_file  : Output file. Output file type (pcap/pcapng) will match the input file type" << std::endl
+		<< "    -d ip_ids       : Fragment only packets that match this comma-separated list of IP IDs in decimal format" << std::endl
+		<< "    -f bpf_filter   : Fragment only packets that match bpf_filter. Filter should be provided in Berkeley Packet Filter (BPF)" << std::endl
+		<< "                      syntax (http://biot.com/capstats/bpf.html) i.e: 'ip net 1.1.1.1'" << std::endl
+		<< "    -a              : Copy all packets (those who were fragmented and those who weren't) to output file" << std::endl
+		<< "    -v              : Displays the current version and exits" << std::endl
+		<< "    -h              : Displays this help message and exits" << std::endl
+		<< std::endl;
 }
 
 
@@ -79,9 +82,10 @@ void printUsage()
  */
 void printAppVersion()
 {
-	printf("%s %s\n", AppName::get().c_str(), getPcapPlusPlusVersionFull().c_str());
-	printf("Built: %s\n", getBuildDateTime().c_str());
-	printf("Built from: %s\n", getGitInfo().c_str());
+	std::cout
+		<< pcpp::AppName::get() << " " << pcpp::getPcapPlusPlusVersionFull() << std::endl
+		<< "Built: " << pcpp::getBuildDateTime() << std::endl
+		<< "Built from: " << pcpp::getGitInfo() << std::endl;
 	exit(0);
 }
 
@@ -89,7 +93,7 @@ void printAppVersion()
 /**
  * Set fragment parameters in an IPv4 fragment packet
  */
-void setIPv4FragmentParams(IPv4Layer* fragIpLayer, size_t fragOffset, bool lastFrag)
+void setIPv4FragmentParams(pcpp::IPv4Layer* fragIpLayer, size_t fragOffset, bool lastFrag)
 {
 	// calculate the fragment offset field
 	uint16_t fragOffsetValue = pcpp::hostToNet16((uint16_t)(fragOffset/8));
@@ -109,10 +113,10 @@ void setIPv4FragmentParams(IPv4Layer* fragIpLayer, size_t fragOffset, bool lastF
 /**
  * Add IPv6 fragmentation extension to an IPv6 fragment packet and set fragmentation parameters
  */
-void setIPv6FragmentParams(IPv6Layer* fragIpLayer, size_t fragOffset, bool lastFrag, uint32_t fragId)
+void setIPv6FragmentParams(pcpp::IPv6Layer* fragIpLayer, size_t fragOffset, bool lastFrag, uint32_t fragId)
 {
-	IPv6FragmentationHeader fragHeader(fragId, fragOffset, lastFrag);
-	fragIpLayer->addExtension<IPv6FragmentationHeader>(fragHeader);
+	pcpp::IPv6FragmentationHeader fragHeader(fragId, fragOffset, lastFrag);
+	fragIpLayer->addExtension<pcpp::IPv6FragmentationHeader>(fragHeader);
 }
 
 
@@ -139,30 +143,30 @@ uint32_t generateRandomNumber()
  * If the packet payload size is smaller or equal than the request fragment size the packet isn't fragmented, but the packet is copied
  * and pushed into the result vector
  */
-void splitIPPacketToFragmentsBySize(RawPacket* rawPacket, size_t fragmentSize, RawPacketVector& resultFragments)
+void splitIPPacketToFragmentsBySize(pcpp::RawPacket* rawPacket, size_t fragmentSize, pcpp::RawPacketVector& resultFragments)
 {
 	// parse raw packet
-	Packet packet(rawPacket);
+	pcpp::Packet packet(rawPacket);
 
 	// check if IPv4/6
-	ProtocolType ipProto = UnknownProtocol;
-	if (packet.isPacketOfType(IPv4))
-		ipProto = IPv4;
-	else if (packet.isPacketOfType(IPv6))
-		ipProto = IPv6;
+	pcpp::ProtocolType ipProto = pcpp::UnknownProtocol;
+	if (packet.isPacketOfType(pcpp::IPv4))
+		ipProto = pcpp::IPv4;
+	else if (packet.isPacketOfType(pcpp::IPv6))
+		ipProto = pcpp::IPv6;
 	else
 		return;
 
-	Layer* ipLayer = NULL;
-	if (ipProto == IPv4)
-		ipLayer = packet.getLayerOfType<IPv4Layer>();
+	pcpp::Layer* ipLayer = NULL;
+	if (ipProto == pcpp::IPv4)
+		ipLayer = packet.getLayerOfType<pcpp::IPv4Layer>();
 	else // ipProto == IPv6
-		ipLayer = packet.getLayerOfType<IPv6Layer>();
+		ipLayer = packet.getLayerOfType<pcpp::IPv6Layer>();
 
 	// if packet payload size is less than the requested fragment size, don't fragment and return
 	if (ipLayer->getLayerPayloadSize() <= fragmentSize)
 	{
-		RawPacket* copyOfRawPacket = new RawPacket(*rawPacket);
+		pcpp::RawPacket* copyOfRawPacket = new pcpp::RawPacket(*rawPacket);
 		resultFragments.pushBack(copyOfRawPacket);
 		return;
 	}
@@ -186,28 +190,28 @@ void splitIPPacketToFragmentsBySize(RawPacket* rawPacket, size_t fragmentSize, R
 
 		// create the fragment packet
 		// first, duplicate the input packet and create a new parsed packet out of it
-		RawPacket* newFragRawPacket = new RawPacket(*packet.getRawPacket());
-		Packet newFrag(newFragRawPacket);
+		pcpp::RawPacket* newFragRawPacket = new pcpp::RawPacket(*packet.getRawPacket());
+		pcpp::Packet newFrag(newFragRawPacket);
 
 		// find the IPv4/6 layer of the new fragment
-		Layer* fragIpLayer = NULL;
-		if (ipProto == IPv4)
-			fragIpLayer = newFrag.getLayerOfType<IPv4Layer>();
+		pcpp::Layer* fragIpLayer = NULL;
+		if (ipProto == pcpp::IPv4)
+			fragIpLayer = newFrag.getLayerOfType<pcpp::IPv4Layer>();
 		else // ipProto == IPv6
-			fragIpLayer = newFrag.getLayerOfType<IPv6Layer>();
+			fragIpLayer = newFrag.getLayerOfType<pcpp::IPv6Layer>();
 
 		// delete all layers above IP layer
 		newFrag.removeAllLayersAfter(fragIpLayer);
 
 		// create a new PayloadLayer with the fragmented data and add it to the new fragment packet
-		PayloadLayer newPayload(ipLayer->getLayerPayload() + curOffset, curFragSize, false);
+		pcpp::PayloadLayer newPayload(ipLayer->getLayerPayload() + curOffset, curFragSize, false);
 		newFrag.addLayer(&newPayload);
 
 		// set fragment parameters in IPv4/6 layer
-		if (ipProto == IPv4)
-			setIPv4FragmentParams((IPv4Layer*)fragIpLayer, curOffset, lastFrag);
+		if (ipProto == pcpp::IPv4)
+			setIPv4FragmentParams((pcpp::IPv4Layer*)fragIpLayer, curOffset, lastFrag);
 		else // ipProto == IPv6
-			setIPv6FragmentParams((IPv6Layer*)fragIpLayer, curOffset, lastFrag, randomNum);
+			setIPv6FragmentParams((pcpp::IPv6Layer*)fragIpLayer, curOffset, lastFrag, randomNum);
 
 		// compute all calculated fields of the new fragment
 		newFrag.computeCalculateFields();
@@ -226,7 +230,7 @@ void splitIPPacketToFragmentsBySize(RawPacket* rawPacket, size_t fragmentSize, R
  * This method reads packets from the input file, decided which packets pass the filters set by the user, fragment packets who pass them,
  * and write the result packets to the output file
  */
-void processPackets(IFileReaderDevice* reader, IFileWriterDevice* writer,
+void processPackets(pcpp::IFileReaderDevice* reader, pcpp::IFileWriterDevice* writer,
 		int fragSize,
 		bool filterByBpf, std::string bpfFilter,
 		bool filterByIpID, std::map<uint16_t, bool> ipIDs,
@@ -235,8 +239,8 @@ void processPackets(IFileReaderDevice* reader, IFileWriterDevice* writer,
 {
 	stats.clear();
 
-	RawPacket rawPacket;
-	BPFStringFilter filter(bpfFilter);
+	pcpp::RawPacket rawPacket;
+	pcpp::BPFStringFilter filter(bpfFilter);
 
 	// read all packet from input file
 	while (reader->getNextPacket(rawPacket))
@@ -250,7 +254,7 @@ void processPackets(IFileReaderDevice* reader, IFileWriterDevice* writer,
 		if (filterByBpf)
 		{
 			// check if packet matches the BPF filter supplied by the user
-			if (IPcapDevice::matchPacketWithFilter(filter, &rawPacket))
+			if (pcpp::IPcapDevice::matchPacketWithFilter(filter, &rawPacket))
 			{
 				stats.ipPacketsMatchBpfFilter++;
 			}
@@ -260,18 +264,18 @@ void processPackets(IFileReaderDevice* reader, IFileWriterDevice* writer,
 			}
 		}
 
-		ProtocolType ipProto = UnknownProtocol;
+		pcpp::ProtocolType ipProto = pcpp::UnknownProtocol;
 
 		// check if packet is of type IPv4
-		Packet parsedPacket(&rawPacket);
-		if (parsedPacket.isPacketOfType(IPv4))
+		pcpp::Packet parsedPacket(&rawPacket);
+		if (parsedPacket.isPacketOfType(pcpp::IPv4))
 		{
-			ipProto = IPv4;
+			ipProto = pcpp::IPv4;
 			stats.ipv4Packets++;
 		}
-		else if (parsedPacket.isPacketOfType(IPv6)) // check if packet is of type IPv6
+		else if (parsedPacket.isPacketOfType(pcpp::IPv6)) // check if packet is of type IPv6
 		{
-			ipProto = IPv6;
+			ipProto = pcpp::IPv6;
 			stats.ipv6Packets++;
 		}
 		else // if not - set the packet as not marked for fragmentation
@@ -283,7 +287,7 @@ void processPackets(IFileReaderDevice* reader, IFileWriterDevice* writer,
 		if (filterByIpID)
 		{
 			// get the IPv4 layer
-			IPv4Layer* ipLayer = parsedPacket.getLayerOfType<IPv4Layer>();
+			pcpp::IPv4Layer* ipLayer = parsedPacket.getLayerOfType<pcpp::IPv4Layer>();
 			if (ipLayer != NULL)
 			{
 				// check if packet ID matches one of the IP IDs requested by the user
@@ -302,7 +306,7 @@ void processPackets(IFileReaderDevice* reader, IFileWriterDevice* writer,
 		if (fragPacket)
 		{
 			// call the method who splits the packet into fragments
-			RawPacketVector resultFrags;
+			pcpp::RawPacketVector resultFrags;
 			splitIPPacketToFragmentsBySize(&rawPacket, (size_t)fragSize, resultFrags);
 
 			// if result list contains only 1 packet it means packet wasn't fragmented - update stats accordingly
@@ -312,7 +316,7 @@ void processPackets(IFileReaderDevice* reader, IFileWriterDevice* writer,
 			}
 			else if (resultFrags.size() > 1) // packet was fragmented
 			{
-				if (ipProto == IPv4)
+				if (ipProto == pcpp::IPv4)
 					stats.ipv4PacketsFragmented++;
 				else // ipProto == IPv6
 					stats.ipv6PacketsFragmented++;
@@ -365,7 +369,7 @@ void printStats(const FragStats& stats, bool filterByIpID, bool filterByBpf)
  */
 int main(int argc, char* argv[])
 {
-	AppName::init(argc, argv);
+	pcpp::AppName::init(argc, argv);
 
 	int optionIndex = 0;
 	char opt = 0;
@@ -429,7 +433,7 @@ int main(int argc, char* argv[])
 			{
 				filterByBpfFilter = true;
 				bpfFilter = optarg;
-				BPFStringFilter filter(bpfFilter);
+				pcpp::BPFStringFilter filter(bpfFilter);
 				if (!filter.verifyFilter())
 					EXIT_WITH_ERROR("Illegal BPF filter");
 				break;
@@ -462,7 +466,7 @@ int main(int argc, char* argv[])
     {
     	paramIndex++;
     	if (paramIndex > expectedParams)
-    		EXIT_WITH_ERROR("Unexpected parameter: %s", argv[i]);
+    		EXIT_WITH_ERROR("Unexpected parameter: " << argv[i]);
 
     	switch (paramIndex)
     	{
@@ -473,7 +477,7 @@ int main(int argc, char* argv[])
 			}
 
 			default:
-				EXIT_WITH_ERROR("Unexpected parameter: %s", argv[i]);
+				EXIT_WITH_ERROR("Unexpected parameter: " << argv[i]);
     	}
     }
 
@@ -494,24 +498,24 @@ int main(int argc, char* argv[])
     }
 
     // create a reader device from input file
-    IFileReaderDevice* reader = IFileReaderDevice::getReader(inputFile);
+    pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader(inputFile);
 
 	if (!reader->open())
 	{
-		EXIT_WITH_ERROR("Error opening input file\n");
+		EXIT_WITH_ERROR("Error opening input file");
 	}
 
 
 	// create a writer device for output file in the same file type as input file
-	IFileWriterDevice* writer = NULL;
+	pcpp::IFileWriterDevice* writer = NULL;
 
-	if (dynamic_cast<PcapFileReaderDevice*>(reader) != NULL)
+	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != NULL)
 	{
-		writer = new PcapFileWriterDevice(outputFile, ((PcapFileReaderDevice*)reader)->getLinkLayerType());
+		writer = new pcpp::PcapFileWriterDevice(outputFile, ((pcpp::PcapFileReaderDevice*)reader)->getLinkLayerType());
 	}
-	else if (dynamic_cast<PcapNgFileReaderDevice*>(reader) != NULL)
+	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != NULL)
 	{
-		writer = new PcapNgFileWriterDevice(outputFile);
+		writer = new pcpp::PcapNgFileWriterDevice(outputFile);
 	}
 	else
 	{
@@ -520,7 +524,7 @@ int main(int argc, char* argv[])
 
 	if (!writer->open())
 	{
-		EXIT_WITH_ERROR("Error opening output file\n");
+		EXIT_WITH_ERROR("Error opening output file");
 	}
 
 	// run the fragmentation process

--- a/Examples/IcmpFileTransfer/Common.cpp
+++ b/Examples/IcmpFileTransfer/Common.cpp
@@ -1,5 +1,6 @@
 #include "Common.h"
 #include <stdlib.h>
+#include <iostream>
 #include <vector>
 #include <getopt.h>
 #include "EthLayer.h"
@@ -8,8 +9,6 @@
 #include "PcapLiveDeviceList.h"
 #include "SystemUtils.h"
 #include "PcapPlusPlusVersion.h"
-
-using namespace pcpp;
 
 
 #if defined(WIN32) || defined(WINx64)
@@ -35,9 +34,9 @@ static struct option IcmpFTOptions[] =
 };
 
 
-#define EXIT_WITH_ERROR_PRINT_USAGE(reason, ...) do { \
-	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
+#define EXIT_WITH_ERROR_PRINT_USAGE(reason) do { \
 	printUsage(thisSide, otherSide); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while(0)
 
@@ -47,44 +46,58 @@ void printUsage(std::string thisSide, std::string otherSide)
 	std::string messagesPerSecShort = (thisSide == "pitcher") ? "[-p messages_per_sec] " : "";
 	std::string messagesPerSecLong = (thisSide == "pitcher") ? "    -p messages_per_sec  : Set number of messages to be sent per seconds. Default is max possible speed\n" : "";
 
-	printf("\nUsage:\n"
-			"-------\n"
-			"%s [-h] [-v] [-l] -i %s_interface -d %s_ip -s file_path -r %s[-b block_size]\n"
-			"\nOptions:\n\n"
-			"    -i %s_interface : Use the specified interface. Can be interface name (e.g eth0) or interface IPv4 address\n"
-			"    -d %s_ip        : %s IPv4 address\n"
-			"    -s file_path         : Send file mode: send file_path to %s\n"
-			"    -r                   : Receive file mode: receive file from %s\n"
-			"%s"
-			"    -b block_size        : Set the size of data chunk sent in each ICMP message (in bytes). Default is %d bytes. Relevant only\n"
-			"                           in send file mode (when -s is set)\n"
-			"    -l                   : Print the list of interfaces and exit\n"
-			"    -v                   : Displays the current version and exists\n"
-			"    -h                   : Display this help message and exit\n",
-			AppName::get().c_str(), thisSide.c_str(), otherSide.c_str(), messagesPerSecShort.c_str(), thisSide.c_str(), otherSide.c_str(), otherSide.c_str(), otherSide.c_str(), otherSide.c_str(),
-			messagesPerSecLong.c_str(), DEFAULT_BLOCK_SIZE);
-	exit(0);
+	std::string thisSideInterface = thisSide + "_interface";
+	std::string otherSideIP = otherSide + "_ip";
+
+	std::cout << std::endl
+		<< "Usage:" << std::endl
+		<< "------" << std::endl
+		<< pcpp::AppName::get() << " [-h] [-v] [-l] -i " << thisSideInterface << " -d " << otherSideIP << " -s file_path -r " << messagesPerSecShort << "[-b block_size]" << std::endl
+		<< std::endl
+		<< "Options:" << std::endl
+		<< std::endl
+		<< "    -i " << thisSideInterface << " : Use the specified interface. Can be interface name (e.g eth0) or interface IPv4 address" << std::endl
+		<< "    -d " << otherSideIP << "        : " << otherSide << " IPv4 address" << std::endl
+		<< "    -s file_path         : Send file mode: send file_path to " << otherSide << std::endl
+		<< "    -r                   : Receive file mode: receive file from " << otherSide << std::endl
+		<< messagesPerSecLong
+		<< "    -b block_size        : Set the size of data chunk sent in each ICMP message (in bytes). Default is " << DEFAULT_BLOCK_SIZE << " bytes. Relevant only" << std::endl
+		<< "                           in send file mode (when -s is set)" << std::endl
+		<< "    -l                   : Print the list of interfaces and exit" << std::endl
+		<< "    -v                   : Displays the current version and exists" << std::endl
+		<< "    -h                   : Display this help message and exit" << std::endl
+		<< std::endl;
 }
 
+
+/**
+ * Print application version
+ */
 void printAppVersion()
 {
-	printf("%s %s\n", AppName::get().c_str(), getPcapPlusPlusVersionFull().c_str());
-	printf("Built: %s\n", getBuildDateTime().c_str());
-	printf("Built from: %s\n", getGitInfo().c_str());
+	std::cout
+		<< pcpp::AppName::get() << " " << pcpp::getPcapPlusPlusVersionFull() << std::endl
+		<< "Built: " << pcpp::getBuildDateTime() << std::endl
+		<< "Built from: " << pcpp::getGitInfo() << std::endl;
 	exit(0);
 }
 
+
+/**
+ * Go over all interfaces and output their names
+ */
 void listInterfaces()
 {
-	const std::vector<PcapLiveDevice*>& devList = PcapLiveDeviceList::getInstance().getPcapLiveDevicesList();
+	const std::vector<pcpp::PcapLiveDevice*>& devList = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDevicesList();
 
-	printf("\nNetwork interfaces:\n");
-	for (std::vector<PcapLiveDevice*>::const_iterator iter = devList.begin(); iter != devList.end(); iter++)
+	std::cout << std::endl << "Network interfaces:" << std::endl;
+	for (std::vector<pcpp::PcapLiveDevice*>::const_iterator iter = devList.begin(); iter != devList.end(); iter++)
 	{
-		printf("    -> Name: '%s'   IP address: %s\n", (*iter)->getName().c_str(), (*iter)->getIPv4Address().toString().c_str());
+		std::cout << "    -> Name: '" << (*iter)->getName() << "'   IP address: " << (*iter)->getIPv4Address().toString() << std::endl;
 	}
 	exit(0);
 }
+
 
 void readCommandLineArguments(int argc, char* argv[],
 		std::string thisSide, std::string otherSide,
@@ -137,6 +150,7 @@ void readCommandLineArguments(int argc, char* argv[],
 				break;
 			case 'h':
 				printUsage(thisSide, otherSide);
+				exit(0);
 				break;
 			case 'v':
 				printAppVersion();
@@ -152,12 +166,12 @@ void readCommandLineArguments(int argc, char* argv[],
 
 	// extract my IP address by interface name or IP address string
 	if (interfaceNameOrIP.empty())
-		EXIT_WITH_ERROR_PRINT_USAGE("Please provide %s interface name or IP", thisSide.c_str());
+		EXIT_WITH_ERROR_PRINT_USAGE("Please provide " << thisSide << " interface name or IP");
 
-	IPv4Address interfaceIP(interfaceNameOrIP);
+	pcpp::IPv4Address interfaceIP(interfaceNameOrIP);
 	if (!interfaceIP.isValid())
 	{
-		PcapLiveDevice* dev = PcapLiveDeviceList::getInstance().getPcapLiveDeviceByName(interfaceNameOrIP);
+		pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByName(interfaceNameOrIP);
 		if (dev == NULL)
 			EXIT_WITH_ERROR_PRINT_USAGE("Cannot find interface by provided name");
 
@@ -168,11 +182,11 @@ void readCommandLineArguments(int argc, char* argv[],
 
 	// validate pitcher/catcher IP address
 	if (otherSideIPAsString.empty())
-		EXIT_WITH_ERROR_PRINT_USAGE("Please provide %s IP address", otherSide.c_str());
+		EXIT_WITH_ERROR_PRINT_USAGE("Please provide " << otherSide << " IP address");
 
-	IPv4Address tempIP = IPv4Address(otherSideIPAsString);
+	pcpp::IPv4Address tempIP = pcpp::IPv4Address(otherSideIPAsString);
 	if (!tempIP.isValid())
-		EXIT_WITH_ERROR_PRINT_USAGE("Invalid %s IP address", otherSide.c_str());
+		EXIT_WITH_ERROR_PRINT_USAGE("Invalid " << otherSide << " IP address");
 	otherSideIP = tempIP;
 
 	// verify only one of sender and receiver switches are set
@@ -195,9 +209,9 @@ void readCommandLineArguments(int argc, char* argv[],
 		EXIT_WITH_ERROR_PRINT_USAGE("message_per_sec must be a positive value greate or equal to 1");
 }
 
-bool sendIcmpMessage(PcapLiveDevice* dev,
-		MacAddress srcMacAddr, MacAddress dstMacAddr,
-		IPv4Address srcIPAddr, IPv4Address dstIPAddr,
+bool sendIcmpMessage(pcpp::PcapLiveDevice* dev,
+		pcpp::MacAddress srcMacAddr, pcpp::MacAddress dstMacAddr,
+		pcpp::IPv4Address srcIPAddr, pcpp::IPv4Address dstIPAddr,
 		size_t icmpMsgId,
 		uint64_t msgType,
 		uint8_t* data, size_t dataLen,
@@ -213,23 +227,23 @@ bool sendIcmpMessage(PcapLiveDevice* dev,
 	// create the different layers
 
 	// Eth first
-	EthLayer ethLayer(srcMacAddr, dstMacAddr, PCPP_ETHERTYPE_IP);
+	pcpp::EthLayer ethLayer(srcMacAddr, dstMacAddr, PCPP_ETHERTYPE_IP);
 
 	// then IPv4 (IPv6 is not supported)
-	IPv4Layer ipLayer(srcIPAddr, dstIPAddr);
+	pcpp::IPv4Layer ipLayer(srcIPAddr, dstIPAddr);
 	ipLayer.getIPv4Header()->timeToLive = 128;
 	// set and increment the IP ID
 	ipLayer.getIPv4Header()->ipId = pcpp::hostToNet16(ipID++);
 
 	// then ICMP
-	IcmpLayer icmpLayer;
+	pcpp::IcmpLayer icmpLayer;
 	if (sendRequest && icmpLayer.setEchoRequestData(icmpMsgId, 0, msgType, data, dataLen) == NULL)
 		EXIT_WITH_ERROR("Cannot set ICMP echo request data");
 	else if (!sendRequest && icmpLayer.setEchoReplyData(icmpMsgId, 0, msgType, data, dataLen) == NULL)
 		EXIT_WITH_ERROR("Cannot set ICMP echo response data");
 
 	// create an new packet and add all layers to it
-	Packet packet;
+	pcpp::Packet packet;
 	packet.addLayer(&ethLayer);
 	packet.addLayer(&ipLayer);
 	packet.addLayer(&icmpLayer);
@@ -239,9 +253,9 @@ bool sendIcmpMessage(PcapLiveDevice* dev,
 	return dev->sendPacket(&packet);
 }
 
-bool sendIcmpRequest(PcapLiveDevice* dev,
-		MacAddress srcMacAddr, const MacAddress dstMacAddr,
-		IPv4Address srcIPAddr, const IPv4Address dstIPAddr,
+bool sendIcmpRequest(pcpp::PcapLiveDevice* dev,
+		pcpp::MacAddress srcMacAddr, const pcpp::MacAddress dstMacAddr,
+		pcpp::IPv4Address srcIPAddr, const pcpp::IPv4Address dstIPAddr,
 		size_t icmpMsgId,
 		uint64_t msgType,
 		uint8_t* data, size_t dataLen)
@@ -249,9 +263,9 @@ bool sendIcmpRequest(PcapLiveDevice* dev,
 	return sendIcmpMessage(dev, srcMacAddr, dstMacAddr, srcIPAddr, dstIPAddr, icmpMsgId, msgType, data, dataLen, true);
 }
 
-bool sendIcmpResponse(PcapLiveDevice* dev,
-		MacAddress srcMacAddr, MacAddress dstMacAddr,
-		IPv4Address srcIPAddr, IPv4Address dstIPAddr,
+bool sendIcmpResponse(pcpp::PcapLiveDevice* dev,
+		pcpp::MacAddress srcMacAddr, pcpp::MacAddress dstMacAddr,
+		pcpp::IPv4Address srcIPAddr, pcpp::IPv4Address dstIPAddr,
 		size_t icmpMsgId,
 		uint64_t msgType,
 		uint8_t* data, size_t dataLen)

--- a/Examples/IcmpFileTransfer/Common.h
+++ b/Examples/IcmpFileTransfer/Common.h
@@ -16,14 +16,14 @@
 
 #define ONE_MBYTE 1048576
 
-#define EXIT_WITH_ERROR(reason, ...) do { \
-	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
+#define EXIT_WITH_ERROR(reason) do { \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while(0)
 
-#define EXIT_WITH_ERROR_AND_RUN_COMMAND(reason, command, ...) do { \
+#define EXIT_WITH_ERROR_AND_RUN_COMMAND(reason, command) do { \
 	command; \
-	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while(0)
 

--- a/Examples/PcapPrinter/main.cpp
+++ b/Examples/PcapPrinter/main.cpp
@@ -21,7 +21,6 @@
 #include <SystemUtils.h>
 #include <getopt.h>
 
-using namespace pcpp;
 
 static struct option PcapPrinterOptions[] =
 {
@@ -35,12 +34,11 @@ static struct option PcapPrinterOptions[] =
 };
 
 
-#define EXIT_WITH_ERROR(reason, ...) do { \
-	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
+#define EXIT_WITH_ERROR(reason) do { \
 	printUsage(); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while(0)
-
 
 
 /**
@@ -48,40 +46,47 @@ static struct option PcapPrinterOptions[] =
  */
 void printUsage()
 {
-	printf("\nUsage:\n"
-			"-------\n"
-			"%s pcap_file [-h] [-v] [-o output_file] [-c packet_count] [-i filter] [-s]\n"
-			"\nOptions:\n\n"
-			"    pcap_file      : Input pcap/pcapng file name\n"
-			"    -o output_file : Save output to text file (default output is stdout)\n"
-			"    -c packet_count: Print only first packet_count number of packet\n"
-			"    -i filter      : Apply a BPF filter, meaning only filtered packets will be printed\n"
-			"    -s             : Print only file summary and exit\n"
-			"    -v             : Display the current version and exit\n"
-			"    -h             : Display this help message and exit\n", AppName::get().c_str());
+	std::cout << std::endl
+		<< "Usage:" << std::endl
+		<< "------" << std::endl
+		<< pcpp::AppName::get() << " pcap_file [-h] [-v] [-o output_file] [-c packet_count] [-i filter] [-s]" << std::endl
+		<< std::endl
+		<< "Options:" << std::endl
+		<< std::endl
+		<< "    pcap_file      : Input pcap/pcapng file name" << std::endl
+		<< "    -o output_file : Save output to text file (default output is stdout)" << std::endl
+		<< "    -c packet_count: Print only first packet_count number of packet" << std::endl
+		<< "    -i filter      : Apply a BPF filter, meaning only filtered packets will be printed" << std::endl
+		<< "    -s             : Print only file summary and exit" << std::endl
+		<< "    -v             : Display the current version and exit" << std::endl
+		<< "    -h             : Display this help message and exit" << std::endl
+		<< std::endl;
 }
+
 
 /**
  * Print application version
  */
 void printAppVersion()
 {
-	printf("%s %s\n", AppName::get().c_str(), getPcapPlusPlusVersionFull().c_str());
-	printf("Built: %s\n", getBuildDateTime().c_str());
-	printf("Built from: %s\n", getGitInfo().c_str());
+	std::cout
+		<< pcpp::AppName::get() << " " << pcpp::getPcapPlusPlusVersionFull() << std::endl
+		<< "Built: " << pcpp::getBuildDateTime() << std::endl
+		<< "Built from: " << pcpp::getGitInfo() << std::endl;
 	exit(0);
 }
 
-std::string linkLayerToString(LinkLayerType linkLayer)
+
+std::string linkLayerToString(pcpp::LinkLayerType linkLayer)
 {
 
-	if (linkLayer == LINKTYPE_ETHERNET)
+	if (linkLayer == pcpp::LINKTYPE_ETHERNET)
 		return "Ethernet";
-	else if (linkLayer == LINKTYPE_LINUX_SLL)
+	else if (linkLayer == pcpp::LINKTYPE_LINUX_SLL)
 		return "Linux cooked capture";
-	else if (linkLayer == LINKTYPE_NULL)
+	else if (linkLayer == pcpp::LINKTYPE_NULL)
 		return "Null/Loopback";
-	else if (linkLayer == LINKTYPE_RAW || linkLayer == LINKTYPE_DLT_RAW1 || linkLayer == LINKTYPE_DLT_RAW2)
+	else if (linkLayer == pcpp::LINKTYPE_RAW || linkLayer == pcpp::LINKTYPE_DLT_RAW1 || linkLayer == pcpp::LINKTYPE_DLT_RAW2)
 	{
 		std::ostringstream stream;
 		stream << "Raw IP (" << linkLayer << ")";
@@ -93,10 +98,11 @@ std::string linkLayerToString(LinkLayerType linkLayer)
 	return stream.str();
 }
 
+
 /**
 * print file summary based on the reader type
 */
-std::string printFileSummary(IFileReaderDevice* reader)
+std::string printFileSummary(pcpp::IFileReaderDevice* reader)
 {
 	std::ostringstream stream;
 	stream << "File summary:" << std::endl;
@@ -104,15 +110,15 @@ std::string printFileSummary(IFileReaderDevice* reader)
 	stream << "   File name: " << reader->getFileName() << std::endl;
 	stream << "   File size: " << reader->getFileSize() << " bytes" << std::endl;
 	
-	if (dynamic_cast<PcapFileReaderDevice*>(reader) != NULL)
+	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != NULL)
 	{
-		PcapFileReaderDevice* pcapReader = dynamic_cast<PcapFileReaderDevice*>(reader);
-		LinkLayerType linkLayer = pcapReader->getLinkLayerType();
+		pcpp::PcapFileReaderDevice* pcapReader = dynamic_cast<pcpp::PcapFileReaderDevice*>(reader);
+		pcpp::LinkLayerType linkLayer = pcapReader->getLinkLayerType();
 		stream << "   Link layer type: " << linkLayerToString(linkLayer) << std::endl;
 	}
-	else if (dynamic_cast<PcapNgFileReaderDevice*>(reader) != NULL)
+	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != NULL)
 	{ 
-		PcapNgFileReaderDevice* pcapNgReader = dynamic_cast<PcapNgFileReaderDevice*>(reader);
+		pcpp::PcapNgFileReaderDevice* pcapNgReader = dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader);
 		if (pcapNgReader->getOS() != "")
 			stream << "   OS: " << pcapNgReader->getOS() << std::endl;
 
@@ -135,15 +141,15 @@ std::string printFileSummary(IFileReaderDevice* reader)
 /**
 * print all requested packets in a pcap file
 */
-int printPcapPackets(PcapFileReaderDevice* reader, std::ostream* out, int packetCount)
+int printPcapPackets(pcpp::PcapFileReaderDevice* reader, std::ostream* out, int packetCount)
 {
 	// read packets from the file until end-of-file or until reached user requested packet count
 	int packetCountSoFar = 0;
-	RawPacket rawPacket;
+	pcpp::RawPacket rawPacket;
 	while (reader->getNextPacket(rawPacket) && packetCountSoFar != packetCount)
 	{
 		// parse the raw packet into a parsed packet
-		Packet parsedPacket(&rawPacket);
+		pcpp::Packet parsedPacket(&rawPacket);
 
 		// print packet to string
 		(*out) << parsedPacket.toString() << std::endl;
@@ -159,11 +165,11 @@ int printPcapPackets(PcapFileReaderDevice* reader, std::ostream* out, int packet
 /**
 * print all requested packets in a pcap-ng file
 */
-int printPcapNgPackets(PcapNgFileReaderDevice* reader, std::ostream* out, int packetCount)
+int printPcapNgPackets(pcpp::PcapNgFileReaderDevice* reader, std::ostream* out, int packetCount)
 {
 	// read packets from the file until end-of-file or until reached user requested packet count
 	int packetCountSoFar = 0;
-	RawPacket rawPacket;
+	pcpp::RawPacket rawPacket;
 	std::string packetComment = "";
 	while (reader->getNextPacket(rawPacket, packetComment) && packetCountSoFar != packetCount)
 	{
@@ -172,7 +178,7 @@ int printPcapNgPackets(PcapNgFileReaderDevice* reader, std::ostream* out, int pa
 			(*out) << "Packet Comment: " << packetComment << std::endl;
 
 		// parse the raw packet into a parsed packet
-		Packet parsedPacket(&rawPacket);
+		pcpp::Packet parsedPacket(&rawPacket);
 
 		// print packet to string
 		(*out) << "Link layer type: " << linkLayerToString(rawPacket.getLinkLayerType()) << std::endl;
@@ -191,7 +197,7 @@ int printPcapNgPackets(PcapNgFileReaderDevice* reader, std::ostream* out, int pa
  */
 int main(int argc, char* argv[])
 {
-	AppName::init(argc, argv);
+	pcpp::AppName::init(argc, argv);
 
 	std::string inputPcapFileName = "";
 	std::string outputPcapFileName = "";
@@ -258,7 +264,7 @@ int main(int argc, char* argv[])
 	}
 
 	// open a pcap/pcapng file for reading
-	IFileReaderDevice* reader = IFileReaderDevice::getReader(inputPcapFileName);
+	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader(inputPcapFileName);
 
 	if (!reader->open())
 	{
@@ -272,7 +278,7 @@ int main(int argc, char* argv[])
 		if (!reader->setFilter(filter))
 		{
 			delete reader;
-			EXIT_WITH_ERROR("Couldn't set filter '%s'", filter.c_str());
+			EXIT_WITH_ERROR("Couldn't set filter '" << filter << "'");
 		}
 			
 	}
@@ -290,17 +296,17 @@ int main(int argc, char* argv[])
 	int printedPacketCount = 0;
 
 	// if the file is a pcap file
-	if (dynamic_cast<PcapFileReaderDevice*>(reader) != NULL)
+	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != NULL)
 	{
 		// print all requested packets in the pcap file
-		PcapFileReaderDevice* pcapReader = dynamic_cast<PcapFileReaderDevice*>(reader);
+		pcpp::PcapFileReaderDevice* pcapReader = dynamic_cast<pcpp::PcapFileReaderDevice*>(reader);
 		printedPacketCount = printPcapPackets(pcapReader, out, packetCount);
 	}
 	// if the file is a pcap-ng file
-	else if (dynamic_cast<PcapNgFileReaderDevice*>(reader) != NULL)
+	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != NULL)
 	{
 		// print all requested packets in the pcap-ng file
-		PcapNgFileReaderDevice* pcapNgReader = dynamic_cast<PcapNgFileReaderDevice*>(reader);
+		pcpp::PcapNgFileReaderDevice* pcapNgReader = dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader);
 		printedPacketCount = printPcapNgPackets(pcapNgReader, out, packetCount);
 	}
 	

--- a/Examples/PcapSearch/main.cpp
+++ b/Examples/PcapSearch/main.cpp
@@ -39,8 +39,6 @@
 #include <getopt.h>
 
 
-using namespace pcpp;
-
 static struct option PcapSearchOptions[] =
 {
 	{"input-dir",  required_argument, 0, 'd'},
@@ -54,9 +52,9 @@ static struct option PcapSearchOptions[] =
 };
 
 
-#define EXIT_WITH_ERROR(reason, ...) do { \
-	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
+#define EXIT_WITH_ERROR(reason) do { \
 	printUsage(); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while(0)
 
@@ -72,24 +70,29 @@ static struct option PcapSearchOptions[] =
 
 char errorString[ERROR_STRING_LEN];
 
+
 /**
  * Print application usage
  */
 void printUsage()
 {
-	printf("\nUsage:\n"
-			"-------\n"
-			"%s [-h] [-v] [-n] [-r file_name] [-e extension_list] -d directory -s search_criteria\n"
-			"\nOptions:\n\n"
-			"    -d directory        : Input directory\n"
-			"    -n                  : Don't include sub-directories (default is include them)\n"
-			"    -s search_criteria  : Criteria to search in Berkeley Packet Filter (BPF) syntax (http://biot.com/capstats/bpf.html)\n"
-			"                          i.e: 'ip net 1.1.1.1'\n"
-			"    -r file_name        : Write a detailed search report to a file\n"
-			"    -e extension_list   : Set file extensions to search. The default is searching '.pcap' and '.pcapng' files.\n"
-			"                          extension_list should be a comma-separated list of extensions, for example: pcap,net,dmp\n"
-			"    -v                  : Displays the current version and exists\n"
-			"    -h                  : Displays this help message and exits\n", AppName::get().c_str());
+	std::cout << std::endl
+		<< "Usage:" << std::endl
+		<< "------" << std::endl
+		<< pcpp::AppName::get() << " [-h] [-v] [-n] [-r file_name] [-e extension_list] -d directory -s search_criteria" << std::endl
+		<< std::endl
+		<< "Options:" << std::endl
+		<< std::endl
+		<< "    -d directory        : Input directory" << std::endl
+		<< "    -n                  : Don't include sub-directories (default is include them)" << std::endl
+		<< "    -s search_criteria  : Criteria to search in Berkeley Packet Filter (BPF) syntax (http://biot.com/capstats/bpf.html)" << std::endl
+		<< "                          i.e: 'ip net 1.1.1.1'" << std::endl
+		<< "    -r file_name        : Write a detailed search report to a file" << std::endl
+		<< "    -e extension_list   : Set file extensions to search. The default is searching '.pcap' and '.pcapng' files." << std::endl
+		<< "                          extension_list should be a comma-separated list of extensions, for example: pcap,net,dmp" << std::endl
+		<< "    -v                  : Displays the current version and exists" << std::endl
+		<< "    -h                  : Displays this help message and exits" << std::endl
+		<< std::endl;
 }
 
 
@@ -98,9 +101,10 @@ void printUsage()
  */
 void printAppVersion()
 {
-	printf("%s %s\n", AppName::get().c_str(), getPcapPlusPlusVersionFull().c_str());
-	printf("Built: %s\n", getBuildDateTime().c_str());
-	printf("Built from: %s\n", getGitInfo().c_str());
+	std::cout
+		<< pcpp::AppName::get() << " " << pcpp::getPcapPlusPlusVersionFull() << std::endl
+		<< "Built: " << pcpp::getBuildDateTime() << std::endl
+		<< "Built from: " << pcpp::getGitInfo() << std::endl;
 	exit(0);
 }
 
@@ -120,7 +124,7 @@ std::string getExtension(std::string fileName)
 int searchPcap(std::string pcapFilePath, std::string searchCriteria, std::ofstream* detailedReportFile)
 {
 	// create the pcap/pcap-ng reader
-	IFileReaderDevice* reader = IFileReaderDevice::getReader(pcapFilePath);
+	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader(pcapFilePath);
 
 	// if the reader fails to open
 	if (!reader->open())
@@ -154,7 +158,7 @@ int searchPcap(std::string pcapFilePath, std::string searchCriteria, std::ofstre
 	}
 
 	int packetCount = 0;
-	RawPacket rawPacket;
+	pcpp::RawPacket rawPacket;
 
 	// read packets from the file. Since we already set the filter, only packets that matches the filter will be read
 	while (reader->getNextPacket(rawPacket))
@@ -163,7 +167,7 @@ int searchPcap(std::string pcapFilePath, std::string searchCriteria, std::ofstre
 		if (detailedReportFile != NULL)
 		{
 			// parse the packet
-			Packet parsedPacket(&rawPacket);
+			pcpp::Packet parsedPacket(&rawPacket);
 
 			// print layer by layer by layer as we want to add a few spaces before each layer
 			std::vector<std::string> packetLayers;
@@ -281,7 +285,7 @@ void searchDirectories(std::string directory, bool includeSubDirectories, std::s
 		totalFilesSearched++;
 		if (packetsFound > 0)
 		{
-			printf("%d packets found in '%s'\n", packetsFound, iter->c_str());
+			std::cout << packetsFound << " packets found in '" << *iter << "'" << std::endl;
 			totalPacketsFound += packetsFound;
 		}
 	}
@@ -294,7 +298,7 @@ void searchDirectories(std::string directory, bool includeSubDirectories, std::s
  */
 int main(int argc, char* argv[])
 {
-	AppName::init(argc, argv);
+	pcpp::AppName::init(argc, argv);
 
 	std::string inputDirectory = "";
 
@@ -382,7 +386,7 @@ int main(int argc, char* argv[])
 	}
 
 	// verify the search criteria is a valid BPF filter
-	BPFStringFilter filter(searchCriteria);
+	pcpp::BPFStringFilter filter(searchCriteria);
 	if(!filter.verifyFilter())
 	{
 		EXIT_WITH_ERROR("Search criteria isn't valid");
@@ -396,7 +400,7 @@ int main(int argc, char* argv[])
 		detailedReportFile->open(detailedReportFileName.c_str());
 		if (detailedReportFile->fail())
 		{
-			EXIT_WITH_ERROR("Couldn't open detailed report file '%s' for writing", detailedReportFileName.c_str());
+			EXIT_WITH_ERROR("Couldn't open detailed report file '" << detailedReportFileName << "' for writing");
 		}
 
 		// in cases where the user requests a detailed report, all errors will be written to the report also. That's why we need to save the error messages
@@ -405,7 +409,7 @@ int main(int argc, char* argv[])
 	}
 
 
-	printf("Searching...\n");
+	std::cout << "Searching..." << std::endl;
 	int totalDirSearched = 0;
 	int totalFilesSearched = 0;
 	int totalPacketsFound = 0;
@@ -414,14 +418,20 @@ int main(int argc, char* argv[])
 	searchDirectories(inputDirectory, includeSubDirectories, searchCriteria, detailedReportFile, extensionsToSearch, totalDirSearched, totalFilesSearched, totalPacketsFound);
 
 	// after search is done, close the report file and delete its instance
-	printf("\n\nDone! Searched %d files in %d directories, %d packets were matched to search criteria\n", totalFilesSearched, totalDirSearched, totalPacketsFound);
+	std::cout << std::endl << std::endl
+		<< "Done! Searched " 
+		<< totalFilesSearched << " files in "
+		<< totalDirSearched << " directories, "
+		<< totalPacketsFound << " packets were matched to search criteria"
+		<< std::endl;
+
 	if (detailedReportFile != NULL)
 	{
 		if (detailedReportFile->is_open())
 			detailedReportFile->close();
 
 		delete detailedReportFile;
-		printf("Detailed report written to '%s'\n", detailedReportFileName.c_str());
+		std::cout << "Detailed report written to '" << detailedReportFileName << "'" << std::endl;
 	}
 
 	return 0;

--- a/Examples/PcapSplitter/main.cpp
+++ b/Examples/PcapSplitter/main.cpp
@@ -61,8 +61,6 @@
 #include <PcapPlusPlusVersion.h>
 
 
-using namespace pcpp;
-
 static struct option PcapSplitterOptions[] =
 {
 	{"input-file",  required_argument, 0, 'f'},
@@ -76,9 +74,9 @@ static struct option PcapSplitterOptions[] =
 };
 
 
-#define EXIT_WITH_ERROR(reason, ...) do { \
-	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
+#define EXIT_WITH_ERROR(reason) do { \
 	printUsage(); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while(0)
 
@@ -94,63 +92,69 @@ static struct option PcapSplitterOptions[] =
 #define SPLIT_BY_BPF_FILTER    "bpf-filter"
 #define SPLIT_BY_ROUND_ROBIN   "round-robin"
 
+
 #if defined(WIN32) || defined(WINx64)
 #define SEPARATOR '\\'
 #else
 #define SEPARATOR '/'
 #endif
 
+
 /**
  * Print application usage
  */
 void printUsage()
 {
-	printf("\nUsage:\n"
-			"-------\n"
-			"%s [-h] [-v] [-i filter] -f pcap_file -o output_dir -m split_method [-p split_param]\n"
-			"\nOptions:\n\n"
-			"    -f pcap_file    : Input pcap file name\n"
-			"    -o output_dir   : The directory where the output files shall be written\n"
-			"    -m split_method : The method to split with. Can take one of the following params:\n"
-			"                      'file-size'    - split files by size in bytes\n"
-			"                      'packet-count' - split files by packet count\n"
-			"                      'client-ip'    - split files by client IP, meaning all connections with\n"
-			"                                       the same client IP will be in the same file\n"
-			"                      'server-ip'    - split files by server IP, meaning all connections with\n"
-			"                                       the same server IP will be in the same file\n"
-			"                      'server-port'  - split files by server port, meaning all connections with\n"
-			"                                       the same server port will be in the same file\n"
-			"                      'client-port'  - split files by client port, meaning all connections with\n"
-			"                                       the same client port will be in the same file\n"
-			"                      'ip-src-dst'   - split files by IP src and dst (2-tuple), meaning all connections\n"
-			"                                       with the same IPs will be in the same file\n"
-			"                      'connection'   - split files by connection (5-tuple), meaning all packets\n"
-			"                                       of a connection will be in the same file\n"
-			"                      'bpf-filter'   - split file into two files: one that contains all packets\n"
-			"                                       matching the given BPF filter (file #0) and one that contains\n"
-			"                                       the rest of the packets (file #1)\n"
-			"                      'round-robin'  - split the file in a round-robin manner - each packet to a\n"
-			"                                       different file\n"
-			"    -p split-param  : The relevant parameter for the split method:\n"
-			"                      'method = file-size'    => split-param is the max size per file (in bytes).\n"
-			"                                                 split-param is required for this method\n"
-			"                      'method = packet-count' => split-param is the number of packet per file.\n"
-			"                                                 split-param is required for this method\n"
-			"                      'method = client-ip'    => split-param is max number of files to open.\n"
-			"                                                 If not provided the default is unlimited number of files\n"
-			"                      'method = server-ip'    => split-param is max number of files to open.\n"
-			"                                                 If not provided the default is unlimited number of files\n"
-			"                      'method = server-port'  => split-param is max number of files to open.\n"
-			"                                                 If not provided the default is unlimited number of files\n"
-			"                      'method = ip-src-dst'   => split-param is max number of files to open.\n"
-			"                                                 If not provided the default is unlimited number of files\n"
-			"                      'method = connection'   => split-param is max number of files to open.\n"
-			"                                                 If not provided the default is unlimited number of files\n"
-			"                      'method = bpf-filter'   => split-param is the BPF filter to match upon\n"
-			"                      'method = round-robin'  => split-param is number of files to round-robin packets between\n"
-			"    -i filter       : Apply a BPF filter, meaning only filtered packets will be counted in the split\n"
-			"    -v              : Displays the current version and exists\n"
-			"    -h              : Displays this help message and exits\n", AppName::get().c_str());
+	std::cout << std::endl
+		<< "Usage:" << std::endl
+		<< "------" << std::endl
+		<< pcpp::AppName::get() << " [-h] [-v] [-i filter] -f pcap_file -o output_dir -m split_method [-p split_param]" << std::endl
+		<< std::endl
+		<< "Options:" << std::endl
+		<< std::endl
+		<< "    -f pcap_file    : Input pcap file name" << std::endl
+		<< "    -o output_dir   : The directory where the output files shall be written" << std::endl
+		<< "    -m split_method : The method to split with. Can take one of the following params:" << std::endl
+		<< "                      'file-size'    - split files by size in bytes" << std::endl
+		<< "                      'packet-count' - split files by packet count" << std::endl
+		<< "                      'client-ip'    - split files by client IP, meaning all connections with" << std::endl
+		<< "                                       the same client IP will be in the same file" << std::endl
+		<< "                      'server-ip'    - split files by server IP, meaning all connections with" << std::endl
+		<< "                                       the same server IP will be in the same file" << std::endl
+		<< "                      'server-port'  - split files by server port, meaning all connections with" << std::endl
+		<< "                                       the same server port will be in the same file" << std::endl
+		<< "                      'client-port'  - split files by client port, meaning all connections with" << std::endl
+		<< "                                       the same client port will be in the same file" << std::endl
+		<< "                      'ip-src-dst'   - split files by IP src and dst (2-tuple), meaning all connections" << std::endl
+		<< "                                       with the same IPs will be in the same file" << std::endl
+		<< "                      'connection'   - split files by connection (5-tuple), meaning all packets" << std::endl
+		<< "                                       of a connection will be in the same file" << std::endl
+		<< "                      'bpf-filter'   - split file into two files: one that contains all packets" << std::endl
+		<< "                                       matching the given BPF filter (file #0) and one that contains" << std::endl
+		<< "                                       the rest of the packets (file #1)" << std::endl
+		<< "                      'round-robin'  - split the file in a round-robin manner - each packet to a" << std::endl
+		<< "                                       different file" << std::endl
+		<< "    -p split-param  : The relevant parameter for the split method:" << std::endl
+		<< "                      'method = file-size'    => split-param is the max size per file (in bytes)." << std::endl
+		<< "                                                 split-param is required for this method" << std::endl
+		<< "                      'method = packet-count' => split-param is the number of packet per file." << std::endl
+		<< "                                                 split-param is required for this method" << std::endl
+		<< "                      'method = client-ip'    => split-param is max number of files to open." << std::endl
+		<< "                                                 If not provided the default is unlimited number of files" << std::endl
+		<< "                      'method = server-ip'    => split-param is max number of files to open." << std::endl
+		<< "                                                 If not provided the default is unlimited number of files" << std::endl
+		<< "                      'method = server-port'  => split-param is max number of files to open." << std::endl
+		<< "                                                 If not provided the default is unlimited number of files" << std::endl
+		<< "                      'method = ip-src-dst'   => split-param is max number of files to open." << std::endl
+		<< "                                                 If not provided the default is unlimited number of files" << std::endl
+		<< "                      'method = connection'   => split-param is max number of files to open." << std::endl
+		<< "                                                 If not provided the default is unlimited number of files" << std::endl
+		<< "                      'method = bpf-filter'   => split-param is the BPF filter to match upon" << std::endl
+		<< "                      'method = round-robin'  => split-param is number of files to round-robin packets between" << std::endl
+		<< "    -i filter       : Apply a BPF filter, meaning only filtered packets will be counted in the split" << std::endl
+		<< "    -v              : Displays the current version and exists" << std::endl
+		<< "    -h              : Displays this help message and exits" << std::endl
+		<< std::endl;
 }
 
 
@@ -159,9 +163,10 @@ void printUsage()
  */
 void printAppVersion()
 {
-	printf("%s %s\n", AppName::get().c_str(), getPcapPlusPlusVersionFull().c_str());
-	printf("Built: %s\n", getBuildDateTime().c_str());
-	printf("Built from: %s\n", getGitInfo().c_str());
+	std::cout
+		<< pcpp::AppName::get() << " " << pcpp::getPcapPlusPlusVersionFull() << std::endl
+		<< "Built: " << pcpp::getBuildDateTime() << std::endl
+		<< "Built from: " << pcpp::getGitInfo() << std::endl;
 	exit(0);
 }
 
@@ -205,12 +210,13 @@ std::string getFileNameWithoutExtension(const std::string& path)
 	return("");
 }
 
+
 /**
  * main method of this utility
  */
 int main(int argc, char* argv[])
 {
-	AppName::init(argc, argv);
+	pcpp::AppName::init(argc, argv);
 
 	std::string inputPcapFileName = "";
 	std::string outputPcapDir = "";
@@ -334,7 +340,7 @@ int main(int argc, char* argv[])
 		splitter = new RoundRobinSplitter(paramAsInt);
 	}
 	else
-		EXIT_WITH_ERROR("Unknown method '%s'", method.c_str());
+		EXIT_WITH_ERROR("Unknown method '" << method << "'");
 
 
 	// verify splitter param is legal, otherwise return an error
@@ -342,45 +348,45 @@ int main(int argc, char* argv[])
 	if (!splitter->isSplitterParamLegal(errorStr))
 	{
 		delete splitter;
-		EXIT_WITH_ERROR("%s", errorStr.c_str());
+		EXIT_WITH_ERROR(errorStr);
 	}
 
 	// prepare the output file format: /requested-path/original-file-name-[4-digit-number-starting-at-0000].pcap
 	std::string outputPcapFileName = outputPcapDir + std::string(1, SEPARATOR) + getFileNameWithoutExtension(inputPcapFileName) + "-";
 
 	// open a pcap file for reading
-	IFileReaderDevice* reader = IFileReaderDevice::getReader(inputPcapFileName);
-	bool isReaderPcapng = (dynamic_cast<PcapNgFileReaderDevice*>(reader) != NULL);
+	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader(inputPcapFileName);
+	bool isReaderPcapng = (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != NULL);
 
 	if (reader == NULL || !reader->open())
 	{
-		EXIT_WITH_ERROR("Error opening input pcap file\n");
+		EXIT_WITH_ERROR("Error opening input pcap file");
 	}
 
 	// set a filter if provided
 	if (filter != "")
 	{
 		if (!reader->setFilter(filter))
-			EXIT_WITH_ERROR("Couldn't set filter '%s'", filter.c_str());
+			EXIT_WITH_ERROR("Couldn't set filter '" << filter << "'");
 	}
 
-	printf("Started...\n");
+	std::cout << "Started..." << std::endl;
 
 	// determine output file extension
 	std::string outputFileExtenison = (isReaderPcapng ? ".pcapng" : ".pcap");
 
 	int packetCountSoFar = 0;
 	int numOfFiles = 0;
-	RawPacket rawPacket;
+	pcpp::RawPacket rawPacket;
 
 	// prepare a map of file number to IFileWriterDevice
-	std::map<int, IFileWriterDevice*> outputFiles;
+	std::map<int, pcpp::IFileWriterDevice*> outputFiles;
 
 	// read all packets from input file, for each packet do:
 	while (reader->getNextPacket(rawPacket))
 	{
 		// parse the raw packet into a parsed packet
-		Packet parsedPacket(&rawPacket);
+		pcpp::Packet parsedPacket(&rawPacket);
 
 		std::vector<int> filesToClose;
 
@@ -397,12 +403,12 @@ int main(int argc, char* argv[])
 			if (isReaderPcapng)
 			{
 				// if reader is pcapng, create a pcapng writer
-				outputFiles[fileNum] = new PcapNgFileWriterDevice(fileName);
+				outputFiles[fileNum] = new pcpp::PcapNgFileWriterDevice(fileName);
 			}
 			else
 			{
 				// if reader is pcap, create a pcap writer
-				outputFiles[fileNum] = new PcapFileWriterDevice(fileName, rawPacket.getLinkLayerType());
+				outputFiles[fileNum] = new pcpp::PcapFileWriterDevice(fileName, rawPacket.getLinkLayerType());
 			}
 
 			// open the writer
@@ -423,12 +429,12 @@ int main(int argc, char* argv[])
 			if (isReaderPcapng)
 			{
 				// if reader is pcapng, create a pcapng writer
-				outputFiles[fileNum] = new PcapNgFileWriterDevice(fileName);
+				outputFiles[fileNum] = new pcpp::PcapNgFileWriterDevice(fileName);
 			}
 			else
 			{
 				// if reader is pcap, create a pcap writer
-				outputFiles[fileNum] = new PcapFileWriterDevice(fileName, rawPacket.getLinkLayerType());
+				outputFiles[fileNum] = new pcpp::PcapFileWriterDevice(fileName, rawPacket.getLinkLayerType());
 			}
 
 			// open the writer in __append__ mode
@@ -467,7 +473,7 @@ int main(int argc, char* argv[])
 	delete splitter;
 
 	// close the writer files which are still open
-	for(std::map<int, IFileWriterDevice*>::iterator it = outputFiles.begin(); it != outputFiles.end(); ++it)
+	for(std::map<int, pcpp::IFileWriterDevice*>::iterator it = outputFiles.begin(); it != outputFiles.end(); ++it)
 	{
 		if (it->second != NULL)
 		{

--- a/Examples/PfRingExample-FilterTraffic/Common.h
+++ b/Examples/PfRingExample-FilterTraffic/Common.h
@@ -12,20 +12,19 @@
 #include <sstream>
 #include <stdlib.h>
 
-using namespace std;
 
 /**
  * Macros for exiting the application with error
  */
 
-#define EXIT_WITH_ERROR(reason, ...) do { \
-	printf("Application terminated in error: " reason "\n", ## __VA_ARGS__); \
+#define EXIT_WITH_ERROR(reason) do { \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while(0)
 
-#define EXIT_WITH_ERROR_AND_PRINT_USAGE(reason, ...) do { \
-	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
+#define EXIT_WITH_ERROR_AND_PRINT_USAGE(reason) do { \
 	printUsage(); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while (0)
 

--- a/Examples/TLSFingerprinting/main.cpp
+++ b/Examples/TLSFingerprinting/main.cpp
@@ -40,9 +40,9 @@ static struct option TLSFingerprintingOptions[] =
 	{0, 0, 0, 0}
 };
 
-#define EXIT_WITH_ERROR(reason, ...) do { \
-	printUsage();\
-	printf("\nERROR: " reason "\n\n", ## __VA_ARGS__); \
+#define EXIT_WITH_ERROR(reason) do { \
+	printUsage(); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while(0)
 
@@ -399,7 +399,7 @@ void doTlsFingerprintingOnPcapFile(const std::string& inputPcapFileName, std::st
 	std::ofstream outputFile(outputFileName.c_str());
 	if (!outputFile)
 	{
-		EXIT_WITH_ERROR("Cannot open output file '%s'", outputFileName.c_str());
+		EXIT_WITH_ERROR("Cannot open output file '" << outputFileName << "'");
 	}
 
 	// write the column headers to the output file
@@ -481,7 +481,7 @@ void doTlsFingerprintingOnLiveTraffic(const std::string& interfaceNameOrIP, std:
 	std::ofstream outputFile(outputFileName.c_str());
 	if (!outputFile)
 	{
-		EXIT_WITH_ERROR("Cannot open output file '%s'", outputFileName.c_str());
+		EXIT_WITH_ERROR("Cannot open output file '" << outputFileName << "'");
 	}
 
 	// write the column headers to the output file

--- a/Examples/TcpReassembly/main.cpp
+++ b/Examples/TcpReassembly/main.cpp
@@ -286,7 +286,7 @@ typedef std::map<uint32_t, TcpReassemblyData>::iterator TcpReassemblyConnMgrIter
  */
 void printUsage()
 {
-		std::cout << std::endl
+	std::cout << std::endl
 		<< "Usage:" << std::endl
 		<< "------" << std::endl
 		<< pcpp::AppName::get() << " [-hvlcms] [-r input_file] [-i interface] [-o output_dir] [-e bpf_filter] [-f max_files]" << std::endl

--- a/Examples/TcpReassembly/main.cpp
+++ b/Examples/TcpReassembly/main.cpp
@@ -37,11 +37,10 @@
 #include "LRUList.h"
 #include <getopt.h>
 
-using namespace pcpp;
 
-#define EXIT_WITH_ERROR(reason, ...) do { \
-	printf("\nError: " reason "\n\n", ## __VA_ARGS__); \
+#define EXIT_WITH_ERROR(reason) do { \
 	printUsage(); \
+	std::cout << std::endl << "ERROR: " << reason << std::endl << std::endl; \
 	exit(1); \
 	} while(0)
 
@@ -88,7 +87,7 @@ private:
 
 	// A least-recently-used (LRU) list of all connections seen so far. Each connection is represented by its flow key. This LRU list is used to decide which connection was seen least
 	// recently in case we reached max number of open file descriptors and we need to decide which files to close
-	LRUList<uint32_t>* m_RecentConnsWithActivity;
+	pcpp::LRUList<uint32_t>* m_RecentConnsWithActivity;
 
 public:
 
@@ -112,7 +111,7 @@ public:
 	 * A method getting connection parameters as input and returns a filename and file path as output.
 	 * The filename is constructed by the IPs (src and dst) and the TCP ports (src and dst)
 	 */
-	std::string getFileName(ConnectionData connData, int side, bool separareSides)
+	std::string getFileName(pcpp::ConnectionData connData, int side, bool separareSides)
 	{
 		std::stringstream stream;
 
@@ -177,13 +176,13 @@ public:
 	/**
 	 * Return a pointer to the least-recently-used (LRU) list of connections
 	 */
-	LRUList<uint32_t>* getRecentConnsWithActivity()
+	pcpp::LRUList<uint32_t>* getRecentConnsWithActivity()
 	{
 		// This is a lazy implementation - the instance isn't created until the user requests it for the first time.
 		// the side of the LRU list is determined by the max number of allowed open files at any point in time. Default is DEFAULT_MAX_NUMBER_OF_CONCURRENT_OPEN_FILES
 		// but the user can choose another number
 		if (m_RecentConnsWithActivity == NULL)
-			m_RecentConnsWithActivity = new LRUList<uint32_t>(maxOpenFiles);
+			m_RecentConnsWithActivity = new pcpp::LRUList<uint32_t>(maxOpenFiles);
 
 		// return the pointer
 		return m_RecentConnsWithActivity;
@@ -287,21 +286,25 @@ typedef std::map<uint32_t, TcpReassemblyData>::iterator TcpReassemblyConnMgrIter
  */
 void printUsage()
 {
-	printf("\nUsage:\n"
-			"------\n"
-			"%s [-hvlcms] [-r input_file] [-i interface] [-o output_dir] [-e bpf_filter] [-f max_files]\n"
-			"\nOptions:\n\n"
-			"    -r input_file : Input pcap/pcapng file to analyze. Required argument for reading from file\n"
-			"    -i interface  : Use the specified interface. Can be interface name (e.g eth0) or interface IPv4 address. Required argument for capturing from live interface\n"
-			"    -o output_dir : Specify output directory (default is '.')\n"
-			"    -e bpf_filter : Apply a BPF filter to capture file or live interface, meaning TCP reassembly will only work on filtered packets\n"
-			"    -f max_files  : Maximum number of file descriptors to use\n"
-			"    -c            : Write all output to console (nothing will be written to files)\n"
-			"    -m            : Write a metadata file for each connection\n"
-			"    -s            : Write each side of each connection to a separate file (default is writing both sides of each connection to the same file)\n"
-			"    -l            : Print the list of interfaces and exit\n"
-			"    -v            : Display the current version and exit\n"
-			"    -h            : Display this help message and exit\n\n", AppName::get().c_str());
+		std::cout << std::endl
+		<< "Usage:" << std::endl
+		<< "------" << std::endl
+		<< pcpp::AppName::get() << " [-hvlcms] [-r input_file] [-i interface] [-o output_dir] [-e bpf_filter] [-f max_files]" << std::endl
+		<< std::endl
+		<< "Options:" << std::endl
+		<< std::endl
+		<< "    -r input_file : Input pcap/pcapng file to analyze. Required argument for reading from file" << std::endl
+		<< "    -i interface  : Use the specified interface. Can be interface name (e.g eth0) or interface IPv4 address. Required argument for capturing from live interface" << std::endl
+		<< "    -o output_dir : Specify output directory (default is '.')" << std::endl
+		<< "    -e bpf_filter : Apply a BPF filter to capture file or live interface, meaning TCP reassembly will only work on filtered packets" << std::endl
+		<< "    -f max_files  : Maximum number of file descriptors to use" << std::endl
+		<< "    -c            : Write all output to console (nothing will be written to files)" << std::endl
+		<< "    -m            : Write a metadata file for each connection" << std::endl
+		<< "    -s            : Write each side of each connection to a separate file (default is writing both sides of each connection to the same file)" << std::endl
+		<< "    -l            : Print the list of interfaces and exit" << std::endl
+		<< "    -v            : Display the current version and exit" << std::endl
+		<< "    -h            : Display this help message and exit" << std::endl
+		<< std::endl;
 }
 
 
@@ -310,9 +313,10 @@ void printUsage()
  */
 void printAppVersion()
 {
-	printf("%s %s\n", AppName::get().c_str(), getPcapPlusPlusVersionFull().c_str());
-	printf("Built: %s\n", getBuildDateTime().c_str());
-	printf("Built from: %s\n", getGitInfo().c_str());
+	std::cout
+		<< pcpp::AppName::get() << " " << pcpp::getPcapPlusPlusVersionFull() << std::endl
+		<< "Built: " << pcpp::getBuildDateTime() << std::endl
+		<< "Built from: " << pcpp::getGitInfo() << std::endl;
 	exit(0);
 }
 
@@ -322,12 +326,12 @@ void printAppVersion()
  */
 void listInterfaces()
 {
-	const std::vector<PcapLiveDevice*>& devList = PcapLiveDeviceList::getInstance().getPcapLiveDevicesList();
+	const std::vector<pcpp::PcapLiveDevice*>& devList = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDevicesList();
 
-	printf("\nNetwork interfaces:\n");
-	for (std::vector<PcapLiveDevice*>::const_iterator iter = devList.begin(); iter != devList.end(); iter++)
+	std::cout << std::endl << "Network interfaces:" << std::endl;
+	for (std::vector<pcpp::PcapLiveDevice*>::const_iterator iter = devList.begin(); iter != devList.end(); iter++)
 	{
-		printf("    -> Name: '%s'   IP address: %s\n", (*iter)->getName().c_str(), (*iter)->getIPv4Address().toString().c_str());
+		std::cout << "    -> Name: '" << (*iter)->getName() << "'   IP address: " << (*iter)->getIPv4Address().toString() << std::endl;
 	}
 	exit(0);
 }
@@ -336,7 +340,7 @@ void listInterfaces()
 /**
  * The callback being called by the TCP reassembly module whenever new data arrives on a certain connection
  */
-static void tcpReassemblyMsgReadyCallback(int8_t sideIndex, const TcpStreamData& tcpData, void* userCookie)
+static void tcpReassemblyMsgReadyCallback(int8_t sideIndex, const pcpp::TcpStreamData& tcpData, void* userCookie)
 {
 	// extract the connection manager from the user cookie
 	TcpReassemblyConnMgr* connMgr = (TcpReassemblyConnMgr*)userCookie;
@@ -418,7 +422,7 @@ static void tcpReassemblyMsgReadyCallback(int8_t sideIndex, const TcpStreamData&
 /**
  * The callback being called by the TCP reassembly module whenever a new connection is found. This method adds the connection to the connection manager
  */
-static void tcpReassemblyConnectionStartCallback(const ConnectionData& connectionData, void* userCookie)
+static void tcpReassemblyConnectionStartCallback(const pcpp::ConnectionData& connectionData, void* userCookie)
 {
 	// get a pointer to the connection manager
 	TcpReassemblyConnMgr* connMgr = (TcpReassemblyConnMgr*)userCookie;
@@ -439,7 +443,7 @@ static void tcpReassemblyConnectionStartCallback(const ConnectionData& connectio
  * The callback being called by the TCP reassembly module whenever a connection is ending. This method removes the connection from the connection manager and writes the metadata file if requested
  * by the user
  */
-static void tcpReassemblyConnectionEndCallback(const ConnectionData& connectionData, TcpReassembly::ConnectionEndReason reason, void* userCookie)
+static void tcpReassemblyConnectionEndCallback(const pcpp::ConnectionData& connectionData, pcpp::TcpReassembly::ConnectionEndReason reason, void* userCookie)
 {
 	// get a pointer to the connection manager
 	TcpReassemblyConnMgr* connMgr = (TcpReassemblyConnMgr*)userCookie;
@@ -487,10 +491,10 @@ static void onApplicationInterrupted(void* cookie)
 /**
  * packet capture callback - called whenever a packet arrives on the live device (in live device capturing mode)
  */
-static void onPacketArrives(RawPacket* packet, PcapLiveDevice* dev, void* tcpReassemblyCookie)
+static void onPacketArrives(pcpp::RawPacket* packet, pcpp::PcapLiveDevice* dev, void* tcpReassemblyCookie)
 {
 	// get a pointer to the TCP reassembly instance and feed the packet arrived to it
-	TcpReassembly* tcpReassembly = (TcpReassembly*)tcpReassemblyCookie;
+	pcpp::TcpReassembly* tcpReassembly = (pcpp::TcpReassembly*)tcpReassemblyCookie;
 	tcpReassembly->reassemblePacket(packet);
 }
 
@@ -498,10 +502,10 @@ static void onPacketArrives(RawPacket* packet, PcapLiveDevice* dev, void* tcpRea
 /**
  * The method responsible for TCP reassembly on pcap/pcapng files
  */
-void doTcpReassemblyOnPcapFile(std::string fileName, TcpReassembly& tcpReassembly, std::string bpfFilter = "")
+void doTcpReassemblyOnPcapFile(std::string fileName, pcpp::TcpReassembly& tcpReassembly, std::string bpfFilter = "")
 {
 	// open input file (pcap or pcapng file)
-	IFileReaderDevice* reader = IFileReaderDevice::getReader(fileName);
+	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader(fileName);
 
 	// try to open the file device
 	if (!reader->open())
@@ -514,10 +518,10 @@ void doTcpReassemblyOnPcapFile(std::string fileName, TcpReassembly& tcpReassembl
 			EXIT_WITH_ERROR("Cannot set BPF filter to pcap file");
 	}
 
-	printf("Starting reading '%s'...\n", fileName.c_str());
+	std::cout << "Starting reading '" << fileName << "'..." << std::endl;
 
 	// run in a loop that reads one packet from the file in each iteration and feeds it to the TCP reassembly instance
-	RawPacket rawPacket;
+	pcpp::RawPacket rawPacket;
 	while (reader->getNextPacket(rawPacket))
 	{
 		tcpReassembly.reassemblePacket(&rawPacket);
@@ -533,14 +537,14 @@ void doTcpReassemblyOnPcapFile(std::string fileName, TcpReassembly& tcpReassembl
 	reader->close();
 	delete reader;
 
-	printf("Done! processed %d connections\n", (int)numOfConnectionsProcessed);
+	std::cout << "Done! processed " << numOfConnectionsProcessed << " connections" << std::endl;
 }
 
 
 /**
  * The method responsible for TCP reassembly on live traffic
  */
-void doTcpReassemblyOnLiveTraffic(PcapLiveDevice* dev, TcpReassembly& tcpReassembly, std::string bpfFilter = "")
+void doTcpReassemblyOnLiveTraffic(pcpp::PcapLiveDevice* dev, pcpp::TcpReassembly& tcpReassembly, std::string bpfFilter = "")
 {
 	// try to open device
 	if (!dev->open())
@@ -553,18 +557,18 @@ void doTcpReassemblyOnLiveTraffic(PcapLiveDevice* dev, TcpReassembly& tcpReassem
 			EXIT_WITH_ERROR("Cannot set BPF filter to interface");
 	}
 
-	printf("Starting packet capture on '%s'...\n", dev->getIPv4Address().toString().c_str());
+	std::cout << "Starting packet capture on '" << dev->getIPv4Address() << "'..." << std::endl;
 
 	// start capturing packets. Each packet arrived will be handled by onPacketArrives method
 	dev->startCapture(onPacketArrives, &tcpReassembly);
 
 	// register the on app close event to print summary stats on app termination
 	bool shouldStop = false;
-	ApplicationEventHandler::getInstance().onApplicationInterrupted(onApplicationInterrupted, &shouldStop);
+	pcpp::ApplicationEventHandler::getInstance().onApplicationInterrupted(onApplicationInterrupted, &shouldStop);
 
 	// run in an endless loop until the user presses ctrl+c
 	while(!shouldStop)
-		multiPlatformSleep(1);
+		pcpp::multiPlatformSleep(1);
 
 	// stop capturing and close the live device
 	dev->stopCapture();
@@ -573,7 +577,7 @@ void doTcpReassemblyOnLiveTraffic(PcapLiveDevice* dev, TcpReassembly& tcpReassem
 	// close all connections which are still opened
 	tcpReassembly.closeAllConnections();
 
-	printf("Done! processed %d connections\n", (int)tcpReassembly.getConnectionInformation().size());
+	std::cout << "Done! processed " << tcpReassembly.getConnectionInformation().size() << " connections" << std::endl;
 }
 
 
@@ -582,7 +586,7 @@ void doTcpReassemblyOnLiveTraffic(PcapLiveDevice* dev, TcpReassembly& tcpReassem
  */
 int main(int argc, char* argv[])
 {
-	AppName::init(argc, argv);
+	pcpp::AppName::init(argc, argv);
 
 	std::string interfaceNameOrIP;
 	std::string inputPcapFileName;
@@ -647,7 +651,7 @@ int main(int argc, char* argv[])
 		EXIT_WITH_ERROR("Neither interface nor input pcap file were provided");
 
 	// verify output dir exists
-	if (!outputDir.empty() && !directoryExists(outputDir))
+	if (!outputDir.empty() && !pcpp::directoryExists(outputDir))
 		EXIT_WITH_ERROR("Output directory doesn't exist");
 
 	// set global config singleton with input configuration
@@ -661,7 +665,7 @@ int main(int argc, char* argv[])
 	TcpReassemblyConnMgr connMgr;
 
 	// create the TCP reassembly instance
-	TcpReassembly tcpReassembly(tcpReassemblyMsgReadyCallback, &connMgr, tcpReassemblyConnectionStartCallback, tcpReassemblyConnectionEndCallback);
+	pcpp::TcpReassembly tcpReassembly(tcpReassemblyMsgReadyCallback, &connMgr, tcpReassemblyConnectionStartCallback, tcpReassemblyConnectionEndCallback);
 
 	// analyze in pcap file mode
 	if (!inputPcapFileName.empty())
@@ -671,7 +675,7 @@ int main(int argc, char* argv[])
 	else // analyze in live traffic mode
 	{
 		// extract pcap live device by interface name or IP address
-		PcapLiveDevice* dev = PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
+		pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
 		if (dev == NULL)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 

--- a/Pcap++/src/WinPcapLiveDevice.cpp
+++ b/Pcap++/src/WinPcapLiveDevice.cpp
@@ -92,7 +92,6 @@ int WinPcapLiveDevice::sendPackets(RawPacket* rawPacketsArr, int arrLength)
 		for (int i = 0; i < arrLength; i++)
 		{
 			dataSize += rawPacketsArr[i].getRawDataLen();
-			//printf("dataSize = %d\n", dataSize);
 			if (dataSize > res)
 			{
 				return packetsSent;

--- a/Tests/ExamplesTest/expected_output/httpanalyzer_manyprotocols.txt
+++ b/Tests/ExamplesTest/expected_output/httpanalyzer_manyprotocols.txt
@@ -4,7 +4,7 @@ STATS SUMMARY
 =============
 
 General stats
---------------------
+-------------
 
 Sample time:                                      0.013 [Seconds]
 Number of HTTP packets:                            3252 [Packets]
@@ -21,7 +21,7 @@ Average transactions per flow:                    1.443 [Transactions]
 Average data per flow:                        18713.481 [Bytes]
 
 HTTP request stats
---------------------
+------------------
 
 Number of HTTP requests:                            153 [Requests]
 Rate of HTTP requests:                            0.000 [Requests/sec]
@@ -29,7 +29,7 @@ Total data in headers:                            92730 [Bytes]
 Average header size:                            606.078 [Bytes]
 
 HTTP response stats
---------------------
+-------------------
 
 Number of HTTP responses:                           162 [Responses]
 Rate of HTTP responses:                           0.000 [Responses/sec]
@@ -50,7 +50,7 @@ HTTP request methods
 ---------------------
 
 Hostnames count
---------------------
+---------------
 
 ----------------------------------------------------
 | Hostname                                 | Count |
@@ -100,7 +100,7 @@ Hostnames count
 ----------------------------------------------------
 
 Status code count
---------------------
+-----------------
 
 ----------------------------------------
 | Status Code                  | Count |
@@ -116,7 +116,7 @@ Status code count
 ----------------------------------------
 
 Content-type count
---------------------
+------------------
 
 ------------------------------------------
 | Content-type                   | Count |

--- a/Tests/ExamplesTest/expected_output/httpanalyzer_sanity.txt
+++ b/Tests/ExamplesTest/expected_output/httpanalyzer_sanity.txt
@@ -4,7 +4,7 @@ STATS SUMMARY
 =============
 
 General stats
---------------------
+-------------
 
 Sample time:                                      0.002 [Seconds]
 Number of HTTP packets:                             222 [Packets]
@@ -21,7 +21,7 @@ Average transactions per flow:                    6.333 [Transactions]
 Average data per flow:                         7384.333 [Bytes]
 
 HTTP request stats
---------------------
+------------------
 
 Number of HTTP requests:                             57 [Requests]
 Rate of HTTP requests:                            0.000 [Requests/sec]
@@ -29,7 +29,7 @@ Total data in headers:                            22441 [Bytes]
 Average header size:                            393.702 [Bytes]
 
 HTTP response stats
---------------------
+-------------------
 
 Number of HTTP responses:                            58 [Responses]
 Rate of HTTP responses:                           0.000 [Responses/sec]
@@ -49,7 +49,7 @@ HTTP request methods
 ---------------------
 
 Hostnames count
---------------------
+---------------
 
 ----------------------------------------------------
 | Hostname                                 | Count |
@@ -63,7 +63,7 @@ Hostnames count
 ----------------------------------------------------
 
 Status code count
---------------------
+-----------------
 
 ----------------------------------------
 | Status Code                  | Count |
@@ -74,7 +74,7 @@ Status code count
 ----------------------------------------
 
 Content-type count
---------------------
+------------------
 
 ------------------------------------------
 | Content-type                   | Count |

--- a/Tests/ExamplesTest/tests/test_arping.py
+++ b/Tests/ExamplesTest/tests/test_arping.py
@@ -38,7 +38,7 @@ class TestArping(ExampleTest):
 	def test_missing_interface(self):
 		args = {}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: You must provide at least interface name or interface IP (-i switch)' in completed_process.stdout
+		assert 'ERROR: You must provide at least interface name or interface IP (-i switch)' in completed_process.stdout
 
 	@pytest.mark.interface_needed
 	def test_missing_gateway(self, interface_ip_name):
@@ -46,4 +46,4 @@ class TestArping(ExampleTest):
 			'-i': interface_ip_name
 		}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: You must provide target IP (-T switch)' in completed_process.stdout
+		assert 'ERROR: You must provide target IP (-T switch)' in completed_process.stdout

--- a/Tests/ExamplesTest/tests/test_dnsresolver.py
+++ b/Tests/ExamplesTest/tests/test_dnsresolver.py
@@ -18,7 +18,7 @@ class TestDNSResolver(ExampleTest):
 	def test_hostname_not_provided(self):
 		args = {}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Hostname not provided' in completed_process.stdout
+		assert 'ERROR: Hostname not provided' in completed_process.stdout
 
 	def test_hostname_not_exist(self, use_sudo):
 		args = {

--- a/Tests/ExamplesTest/tests/test_httpanalyzer.py
+++ b/Tests/ExamplesTest/tests/test_httpanalyzer.py
@@ -26,4 +26,4 @@ class TestHttpAnalyzer(ExampleTest):
 	def test_no_arg_provided(self):
 		args = {}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Neither interface nor input pcap file were provided' in completed_process.stdout
+		assert 'ERROR: Neither interface nor input pcap file were provided' in completed_process.stdout

--- a/Tests/ExamplesTest/tests/test_ipdefragutil.py
+++ b/Tests/ExamplesTest/tests/test_ipdefragutil.py
@@ -61,4 +61,4 @@ class TestIPDefragUtil(ExampleTest):
 	def test_input_file_missing(self):
 		args = {}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Input file name was not given' in completed_process.stdout
+		assert 'ERROR: Input file name was not given' in completed_process.stdout

--- a/Tests/ExamplesTest/tests/test_ipfragutil.py
+++ b/Tests/ExamplesTest/tests/test_ipfragutil.py
@@ -20,14 +20,14 @@ class TestIPFragUtil(ExampleTest):
 	def test_missing_input_file(self):
 		args = {}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Input file name was not given' in completed_process.stdout
+		assert 'ERROR: Input file name was not given' in completed_process.stdout
 
 	def test_missing_output_file(self):
 		args = {
 			'': path.join('pcap_examples', 'http_req.pcap'),
 		}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Output file name was not given' in completed_process.stdout
+		assert 'ERROR: Output file name was not given' in completed_process.stdout
 
 	def test_missing_frag_size(self, tmpdir):
 		args = {
@@ -35,7 +35,7 @@ class TestIPFragUtil(ExampleTest):
 			'-o': path.join(tmpdir, 'output.pcap'),
 		}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert "Error: Need to choose fragment size using the '-s' flag" in completed_process.stdout
+		assert "ERROR: Need to choose fragment size using the '-s' flag" in completed_process.stdout
 
 	def test_wrong_frag_size(self, tmpdir):
 		args = {
@@ -44,7 +44,7 @@ class TestIPFragUtil(ExampleTest):
 			'-s': '52'
 		}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Fragment size must divide by 8' in completed_process.stdout
+		assert 'ERROR: Fragment size must divide by 8' in completed_process.stdout
 
 	def test_ip_ids(self, tmpdir):
 		args = {

--- a/Tests/ExamplesTest/tests/test_pcapprinter.py
+++ b/Tests/ExamplesTest/tests/test_pcapprinter.py
@@ -16,7 +16,7 @@ class TestPcapPrinter(ExampleTest):
 	def test_input_file_missing(self):
 		args = {}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Input file name was not given' in completed_process.stdout
+		assert 'ERROR: Input file name was not given' in completed_process.stdout
 
 	def test_print_count_packets(self, tmpdir):
 		args = {

--- a/Tests/ExamplesTest/tests/test_pcapsearch.py
+++ b/Tests/ExamplesTest/tests/test_pcapsearch.py
@@ -57,7 +57,7 @@ class TestPcapSearch(ExampleTest):
 	def test_no_args(self):
 		args = {}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Input directory was not given' in completed_process.stdout
+		assert 'ERROR: Input directory was not given' in completed_process.stdout
 
 	def test_invalid_dir(self):
 		args = {
@@ -65,7 +65,7 @@ class TestPcapSearch(ExampleTest):
 			'-s': 'udp'
 		}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Cannot find or open input directory' in completed_process.stdout
+		assert 'ERROR: Cannot find or open input directory' in completed_process.stdout
 
 	def test_invalid_filter(self):
 		args = {
@@ -73,5 +73,5 @@ class TestPcapSearch(ExampleTest):
 			'-s': 'invalid_filter'
 		}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Search criteria isn\'t valid' in completed_process.stdout
+		assert 'ERROR: Search criteria isn\'t valid' in completed_process.stdout
 

--- a/Tests/ExamplesTest/tests/test_pcapsplitter.py
+++ b/Tests/ExamplesTest/tests/test_pcapsplitter.py
@@ -235,14 +235,14 @@ class TestPcapSplitter(ExampleTest):
 	def test_input_file_not_given(self):
 		args = {}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Input file name was not given' in completed_process.stdout
+		assert 'ERROR: Input file name was not given' in completed_process.stdout
 
 	def test_output_dir_not_given(self):
 		args = {
 			'-f': os.path.join('pcap_examples', 'many-protocols.pcap')
 		}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Output directory name was not given' in completed_process.stdout
+		assert 'ERROR: Output directory name was not given' in completed_process.stdout
 
 	def test_split_method_not_given(self, tmpdir):
 		args = {
@@ -250,7 +250,7 @@ class TestPcapSplitter(ExampleTest):
 			'-o': tmpdir
 		}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Split method was not given' in completed_process.stdout
+		assert 'ERROR: Split method was not given' in completed_process.stdout
 
 	def test_output_dir_not_exist(self):
 		args = {
@@ -258,7 +258,7 @@ class TestPcapSplitter(ExampleTest):
 			'-o': 'blablablalba12345'
 		}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Output directory doesn\'t exist' in completed_process.stdout
+		assert 'ERROR: Output directory doesn\'t exist' in completed_process.stdout
 
 	def test_input_file_not_exist(self, tmpdir):
 		args = {
@@ -267,7 +267,7 @@ class TestPcapSplitter(ExampleTest):
 			'-m': 'ip-src-dst'
 		}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Error opening input pcap file' in completed_process.stdout
+		assert 'ERROR: Error opening input pcap file' in completed_process.stdout
 
 	def test_split_method_not_exist(self, tmpdir):
 		args = {
@@ -276,4 +276,4 @@ class TestPcapSplitter(ExampleTest):
 			'-m': 'blabla'
 		}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Unknown method \'blabla\'' in completed_process.stdout
+		assert 'ERROR: Unknown method \'blabla\'' in completed_process.stdout

--- a/Tests/ExamplesTest/tests/test_sslanalyzer.py
+++ b/Tests/ExamplesTest/tests/test_sslanalyzer.py
@@ -26,4 +26,4 @@ class TestSSLAnalyzer(ExampleTest):
 	def test_no_arg_provided(self):
 		args = {}
 		completed_process = self.run_example(args=args, expected_return_code=1)
-		assert 'Error: Neither interface nor input pcap file were provided' in completed_process.stdout
+		assert 'ERROR: Neither interface nor input pcap file were provided' in completed_process.stdout


### PR DESCRIPTION
- Replace all `printf` with `std::cout`
- Remove `using namespace ...`
- Make all examples use the same coding standard