### PR TITLE
Issue #732 - change the variable type that holds `getopt_long` result from `char` to `int`

### DIFF
--- a/Examples/ArpSpoofing/main.cpp
+++ b/Examples/ArpSpoofing/main.cpp
@@ -183,8 +183,8 @@ int main(int argc, char* argv[])
 
 	std::string iface = "", victim = "", gateway = "";
 	int optionIndex = 0;
-	char opt = 0;
-	while((opt = getopt_long (argc, argv, "i:c:g:hv", L3FwdOptions, &optionIndex)) != -1)
+	int opt = 0;
+	while((opt = getopt_long(argc, argv, "i:c:g:hv", L3FwdOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/Arping/main.cpp
+++ b/Examples/Arping/main.cpp
@@ -113,9 +113,9 @@ int main(int argc, char* argv[])
 	bool ifaceNameOrIpProvided = false;
 	int timeoutSec = pcpp::NetworkUtils::DefaultTimeout;
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
-	while((opt = getopt_long (argc, argv, "i:s:S:T:c:hvlw:", ArpingOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "i:s:S:T:c:hvlw:", ArpingOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/DNSResolver/main.cpp
+++ b/Examples/DNSResolver/main.cpp
@@ -99,9 +99,9 @@ int main(int argc, char* argv[])
 	int timeoutSec = -1;
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
-	while((opt = getopt_long (argc, argv, "i:d:g:s:t:hvl", DNSResolverOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "i:d:g:s:t:hvl", DNSResolverOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/DnsSpoofing/main.cpp
+++ b/Examples/DnsSpoofing/main.cpp
@@ -361,7 +361,7 @@ int main(int argc, char* argv[])
 	pcpp::AppName::init(argc, argv);
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
 	std::string interfaceNameOrIP;
 
@@ -372,7 +372,7 @@ int main(int argc, char* argv[])
 
 	std::vector<std::string> hostList;
 
-	while((opt = getopt_long (argc, argv, "i:d:c:o:hvl", DnsSpoofingOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "i:d:c:o:hvl", DnsSpoofingOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/DpdkBridge/main.cpp
+++ b/Examples/DpdkBridge/main.cpp
@@ -203,12 +203,12 @@ int main(int argc, char* argv[])
 	pcpp::CoreMask coreMaskToUse = (pcpp::getCoreMaskForAllMachineCores() & 7);
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
 	uint32_t mBufPoolSize = DEFAULT_MBUF_POOL_SIZE;
 	uint16_t queueQuantity = DEFAULT_QUEUE_QUANTITY;
 
-	while((opt = getopt_long (argc, argv, "d:c:m:q:hvl", DpdkBridgeOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "d:c:m:q:hvl", DpdkBridgeOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/DpdkExample-FilterTraffic/main.cpp
+++ b/Examples/DpdkExample-FilterTraffic/main.cpp
@@ -278,7 +278,7 @@ int main(int argc, char* argv[])
 	int sendPacketsToPort = -1;
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
 	uint32_t mBufPoolSize = DEFAULT_MBUF_POOL_SIZE;
 
@@ -288,7 +288,7 @@ int main(int argc, char* argv[])
 	uint16_t 			dstPortToMatch = 0;
 	pcpp::ProtocolType	protocolToMatch = pcpp::UnknownProtocol;
 
-	while((opt = getopt_long (argc, argv, "d:c:s:f:m:i:I:p:P:r:hvl", FilterTrafficOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "d:c:s:f:m:i:I:p:P:r:hvl", FilterTrafficOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/HttpAnalyzer/main.cpp
+++ b/Examples/HttpAnalyzer/main.cpp
@@ -528,9 +528,9 @@ int main(int argc, char* argv[])
 
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
-	while((opt = getopt_long (argc, argv, "i:p:f:o:r:hvld", HttpAnalyzerOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "i:p:f:o:r:hvld", HttpAnalyzerOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/IPDefragUtil/main.cpp
+++ b/Examples/IPDefragUtil/main.cpp
@@ -276,7 +276,7 @@ int main(int argc, char* argv[])
 	pcpp::AppName::init(argc, argv);
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
 	std::string outputFile = "";
 	bool filterByBpfFilter = false;
@@ -286,7 +286,7 @@ int main(int argc, char* argv[])
 	bool copyAllPacketsToOutputFile = false;
 
 
-	while((opt = getopt_long (argc, argv, "o:d:f:ahv", DefragUtilOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "o:d:f:ahv", DefragUtilOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/IPFragUtil/main.cpp
+++ b/Examples/IPFragUtil/main.cpp
@@ -373,7 +373,7 @@ int main(int argc, char* argv[])
 	pcpp::AppName::init(argc, argv);
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
 	std::string outputFile = "";
 	int fragSize = -1;
@@ -383,7 +383,7 @@ int main(int argc, char* argv[])
 	std::map<uint16_t, bool> ipIDMap;
 	bool copyAllPacketsToOutputFile = false;
 
-	while((opt = getopt_long (argc, argv, "o:s:d:f:ahv", FragUtilOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "o:s:d:f:ahv", FragUtilOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/IcmpFileTransfer/Common.cpp
+++ b/Examples/IcmpFileTransfer/Common.cpp
@@ -117,7 +117,7 @@ void readCommandLineArguments(int argc, char* argv[],
 	bool blockSizeSet = false;
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
 	while((opt = getopt_long(argc, argv, "i:d:s:rp:b:hvl", IcmpFTOptions, &optionIndex)) != -1)
 	{

--- a/Examples/KniPong/main.cpp
+++ b/Examples/KniPong/main.cpp
@@ -128,7 +128,7 @@ inline void parseArgs(int argc, char* argv[], KniPongArgs& args)
 	// Default port:
 	args.kniPort = DEFAULT_PORT;
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 	while ((opt = getopt_long(argc, argv, "s:d:n:p:hv", KniPongOptions, &optionIndex)) != -1)
 	{
 		switch (opt)

--- a/Examples/PcapPrinter/main.cpp
+++ b/Examples/PcapPrinter/main.cpp
@@ -209,9 +209,9 @@ int main(int argc, char* argv[])
 	int packetCount = -1;
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
-	while((opt = getopt_long (argc, argv, "o:c:i:svh", PcapPrinterOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "o:c:i:svh", PcapPrinterOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/PcapSearch/main.cpp
+++ b/Examples/PcapSearch/main.cpp
@@ -308,9 +308,9 @@ int main(int argc, char* argv[])
 	extensionsToSearch["pcapng"] = true;
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
-	while((opt = getopt_long (argc, argv, "d:s:r:e:hvn", PcapSearchOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "d:s:r:e:hvn", PcapSearchOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/PcapSplitter/main.cpp
+++ b/Examples/PcapSplitter/main.cpp
@@ -231,9 +231,9 @@ int main(int argc, char* argv[])
 	bool paramWasSet = false;
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
-	while((opt = getopt_long (argc, argv, "f:o:m:p:i:vh", PcapSplitterOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "f:o:m:p:i:vh", PcapSplitterOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/PfRingExample-FilterTraffic/main.cpp
+++ b/Examples/PfRingExample-FilterTraffic/main.cpp
@@ -261,9 +261,9 @@ int main(int argc, char* argv[])
 	pcpp::ProtocolType	protocolToMatch = pcpp::UnknownProtocol;
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
-	while((opt = getopt_long (argc, argv, "n:s:t:f:i:I:p:P:r:hvl", PfFilterTrafficOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "n:s:t:f:i:I:p:P:r:hvl", PfFilterTrafficOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/SSLAnalyzer/main.cpp
+++ b/Examples/SSLAnalyzer/main.cpp
@@ -507,9 +507,9 @@ int main(int argc, char* argv[])
 
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
-	while((opt = getopt_long (argc, argv, "i:f:o:r:hvld", SSLAnalyzerOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "i:f:o:r:hvld", SSLAnalyzerOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/TLSFingerprinting/main.cpp
+++ b/Examples/TLSFingerprinting/main.cpp
@@ -539,9 +539,9 @@ int main(int argc, char* argv[])
 	std::string tlsFingerprintType = TLS_FP_CH_ONLY;
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
-	while((opt = getopt_long (argc, argv, "i:r:o:t:f:s:vhl", TLSFingerprintingOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "i:r:o:t:f:s:vhl", TLSFingerprintingOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Examples/TcpReassembly/main.cpp
+++ b/Examples/TcpReassembly/main.cpp
@@ -598,9 +598,9 @@ int main(int argc, char* argv[])
 	size_t maxOpenFiles = DEFAULT_MAX_NUMBER_OF_CONCURRENT_OPEN_FILES;
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 
-	while((opt = getopt_long (argc, argv, "i:r:o:e:f:mcsvhl", TcpAssemblyOptions, &optionIndex)) != -1)
+	while((opt = getopt_long(argc, argv, "i:r:o:e:f:mcsvhl", TcpAssemblyOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -34,7 +34,7 @@ void printUsage()
 int main(int argc, char* argv[])
 {
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 	std::string userTags = "", configTags = "";
 	bool memVerbose = false;
 	bool skipMemLeakCheck = false;

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[])
 	bool skipMemLeakCheck = false;
 
 	int optionIndex = 0;
-	char opt = 0;
+	int opt = 0;
 	while((opt = getopt_long(argc, argv, "k:i:br:p:d:nvt:smw", PcapTestOptions, &optionIndex)) != -1)
 	{
 		switch (opt)


### PR DESCRIPTION
This causes errors on `aarch64` platforms