### PR TITLE
Use CXXFLAGS when compiling hash library

### DIFF
--- a/3rdParty/hash-library/Makefile
+++ b/3rdParty/hash-library/Makefile
@@ -13,7 +13,7 @@ DEFS := -DUNIVERSAL -fPIC
 
 Obj/%.o: %.cpp
 	@echo Building file: $<
-	@$(CXX) $(INCLUDES) -Wall -O2 $(GLOBAL_FLAGS) $(DEFS) -g -c -o "$@" "$<"
+	@$(CXX) $(INCLUDES) -Wall -O2 $(GLOBAL_FLAGS) $(DEFS) $(CXXFLAGS) -g -c -o "$@" "$<"
 
 CUR_TARGET := $(notdir $(shell pwd))
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Vcpkg port: <https://github.com/microsoft/vcpkg/tree/master/ports/pcapplusplus>
 ### Conan
 
 ```text
-conan install pcapplusplus/21.05@
+conan install pcapplusplus/21.11@
 ```
 
 The package in ConanCenter: <https://conan.io/center/pcapplusplus>


### PR DESCRIPTION
So as to fix oss-fuzz build

Without using these flags, std library for c++11 gets used when
compiling md5.cpp which is incompatible with the stdlib
used in the rest of libPacket++.a

Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=28915
