### PR TITLE
packet++/VlanLayer: use the proper endianness correction to retrieve …

### DIFF
--- a/Packet++/src/VlanLayer.cpp
+++ b/Packet++/src/VlanLayer.cpp
@@ -31,17 +31,17 @@ VlanLayer::VlanLayer(const uint16_t vlanID, bool cfi, uint8_t priority, uint16_t
 
 uint16_t VlanLayer::getVlanID() const
 {
-	return htobe16(getVlanHeader()->vlan) & 0xFFF;
+	return be16toh(getVlanHeader()->vlan) & 0xFFF;
 }
 
 uint8_t VlanLayer::getCFI() const
 {
-	return ((htobe16(getVlanHeader()->vlan) >> 12) & 1);
+	return ((be16toh(getVlanHeader()->vlan) >> 12) & 1);
 }
 
 uint8_t VlanLayer::getPriority() const
 {
-	return (htobe16(getVlanHeader()->vlan) >> 13) & 7;
+	return (be16toh(getVlanHeader()->vlan) >> 13) & 7;
 }
 
 void VlanLayer::setVlanID(uint16_t id)


### PR DESCRIPTION
…VLAN TCI

Issue: #762

It does not make any difference in the result,
but reading the code is confusing:
it wrongly suggests that the value is encoded in host endianness instead of in big endian.