### PR TITLE
make PcapLiveDevice constructor public

### DIFF
--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -109,8 +109,6 @@ namespace pcpp
 		bool m_CaptureCallbackMode;
 		LinkLayerType m_LinkType;
 
-		// c'tor is not public, there should be only one for every interface (created by PcapLiveDeviceList)
-		PcapLiveDevice(pcap_if_t* pInterface, bool calculateMTU, bool calculateMacAddress, bool calculateDefaultGateway);
 		// copy c'tor is not public
 		PcapLiveDevice( const PcapLiveDevice& other );
 		PcapLiveDevice& operator=(const PcapLiveDevice& other);
@@ -234,6 +232,11 @@ namespace pcpp
 			}
 		};
 
+		/**
+		 * Create new PcapLiveDevice. Typically handled by PcapLiveDeviceList but may be manually created for special use cases such
+		 * as capturing from the same interface more than once on platforms that support it
+		 */
+		PcapLiveDevice(pcap_if_t* pInterface, bool calculateMTU, bool calculateMacAddress, bool calculateDefaultGateway);
 
 		/**
 		 * A destructor for this class


### PR DESCRIPTION
This PR makes `PcapLiveDevice` public for special use cases such as capturing from the same interface more than once (with different bpf filters). It does not change any default functionality: PcapLiveDeviceList still creates one PcapLiveDevice as before so is completely backwards compatible, however it _allows_ users to instantiate their own PcapLiveDevice if they wish.

This came out of a discussion on the mailing list: https://groups.google.com/g/pcapplusplus-support/c/cqyiiZaMCyk

[pktvisor](https://github.com/ns1labs/pktvisor) is using this change successfully in a fork, and I would like it to be merged upstream so that we can sync to the latest version.
