### PR TITLE
External driver path for dpdk

### DIFF
--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -127,7 +127,7 @@ namespace pcpp
 		 * returned false it's impossible to use DPDK with PcapPlusPlus. You can get some more details about mbufs and pools in 
 		 * DpdkDevice.h file description or in DPDK web site
 		 */
-		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, int initDpdkArgc = 0, char **initDpdkArgv = NULL);
+		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, uint32_t initDpdkArgc = 0, char **initDpdkArgv = NULL);
 
 		/**
 		 * Get a DpdkDevice by port ID

--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -120,13 +120,14 @@ namespace pcpp
 		 * The size of the mbuf pool size dictates how many packets can be handled by the application at the same time. For example: if
 		 * pool size is 1023 it means that no more than 1023 packets can be handled or stored in application memory at every point in time
 		 * @param[in] masterCore The core DPDK will use as master to control all worker thread. The default, unless set otherwise, is 0
-		 * @param[in] pmdDriverPath Path to the Poll Mode Driver (PMD) shared objects.
+		 * @param[in] initDpdkArgc Number of optional arguments
+		 * @param[in] initDpdkArgv Optional arguments
 		 * @return True if initialization succeeded or false if huge-pages or DPDK kernel driver are not loaded, if mBufPoolSizePerDevice
 		 * isn't power of 2 minus 1, if DPDK infra initialization failed or if DpdkDevice initialization failed. Anyway, if this method
 		 * returned false it's impossible to use DPDK with PcapPlusPlus. You can get some more details about mbufs and pools in 
 		 * DpdkDevice.h file description or in DPDK web site
 		 */
-		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, std::string pmdDriverPath = "");
+		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, int initDpdkArgc = 0, char **initDpdkArgv = nullptr);
 
 		/**
 		 * Get a DpdkDevice by port ID

--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -120,12 +120,13 @@ namespace pcpp
 		 * The size of the mbuf pool size dictates how many packets can be handled by the application at the same time. For example: if
 		 * pool size is 1023 it means that no more than 1023 packets can be handled or stored in application memory at every point in time
 		 * @param[in] masterCore The core DPDK will use as master to control all worker thread. The default, unless set otherwise, is 0
+		 * @param[in] pmdDriverPath Path to the Poll Mode Driver (PMD) shared objects.
 		 * @return True if initialization succeeded or false if huge-pages or DPDK kernel driver are not loaded, if mBufPoolSizePerDevice
 		 * isn't power of 2 minus 1, if DPDK infra initialization failed or if DpdkDevice initialization failed. Anyway, if this method
 		 * returned false it's impossible to use DPDK with PcapPlusPlus. You can get some more details about mbufs and pools in 
 		 * DpdkDevice.h file description or in DPDK web site
 		 */
-		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0);
+		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, std::string pmdDriverPath = "");
 
 		/**
 		 * Get a DpdkDevice by port ID

--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -127,7 +127,7 @@ namespace pcpp
 		 * returned false it's impossible to use DPDK with PcapPlusPlus. You can get some more details about mbufs and pools in 
 		 * DpdkDevice.h file description or in DPDK web site
 		 */
-		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, int initDpdkArgc = 0, char **initDpdkArgv = nullptr);
+		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, int initDpdkArgc = 0, char **initDpdkArgv = NULL);
 
 		/**
 		 * Get a DpdkDevice by port ID

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -104,11 +104,11 @@ bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice,
 	uint32_t i = 0;
 	while (i < initDpdkArgc && initDpdkArgv[i] != nullptr)
 	{
-		dpdkParamsStream << initDpdkArgv[i] << " ";;
+		dpdkParamsStream << initDpdkArgv[i] << " ";
 		i++;
 	}
 
-	initDpdkArgc += 7;
+	initDpdkArgc += i;
 	std::string dpdkParamsArray[initDpdkArgc];
 	initDpdkArgvBuffer = new char*[initDpdkArgc];
 	i = 0;

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -62,7 +62,7 @@ DpdkDeviceList::~DpdkDeviceList()
 	m_DpdkDeviceList.clear();
 }
 
-bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore, int initDpdkArgc, char **initDpdkArgv)
+bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore, uint32_t initDpdkArgc, char **initDpdkArgv)
 {
 	uint32_t maxArgLen = 0;
 	char **initDpdkArgvBuffer;
@@ -102,7 +102,7 @@ bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice,
 	dpdkParamsStream << (int)masterCore << " ";
 
 	uint32_t i = 0;
-	while (i < initDpdkArgc && initDpdkArgv[i] != nullptr)
+	while (i < initDpdkArgc && initDpdkArgv[i] != NULL)
 	{
 		dpdkParamsStream << initDpdkArgv[i] << " ";
 		i++;

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -107,7 +107,8 @@ bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice,
 		i++;
 	}
 
-	initDpdkArgc += i;
+	// Should be equal to the number of static params
+	initDpdkArgc += 7;
 	std::string dpdkParamsArray[initDpdkArgc];
 	initDpdkArgvBuffer = new char*[initDpdkArgc];
 	i = 0;

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -64,7 +64,6 @@ DpdkDeviceList::~DpdkDeviceList()
 
 bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore, uint32_t initDpdkArgc, char **initDpdkArgv)
 {
-	uint32_t maxArgLen = 0;
 	char **initDpdkArgvBuffer;
 
 	if (m_IsDpdkInitialized)

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -107,7 +107,7 @@ bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice,
 	dpdkParamsStream << "0x" << std::hex << std::setw(2) << std::setfill('0') << coreMask << " ";
 	dpdkParamsStream << "--master-lcore ";
 	dpdkParamsStream << (int)masterCore;
-	if(pmdDriverPath.length() <= 1)
+	if(pmdDriverPath.length() >= 1)
 	{
 		dpdkParamsStream << " -d ";
 		dpdkParamsStream << pmdDriverPath;

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -107,7 +107,7 @@ bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice,
 	dpdkParamsStream << "0x" << std::hex << std::setw(2) << std::setfill('0') << coreMask << " ";
 	dpdkParamsStream << "--master-lcore ";
 	dpdkParamsStream << (int)masterCore;
-	if(pmdDriverPath <= 1)
+	if(pmdDriverPath.length() <= 1)
 	{
 		dpdkParamsStream << " -d ";
 		dpdkParamsStream << pmdDriverPath;


### PR DESCRIPTION
Small contribution for dpdk. If the shared objects of external drivers can't found during the initialization DPDK returns 0 available devices. By using -d eal flag we can provide the target shared object or its path. I added the path as a last argument so it can be more backward compatible