### PR TITLE
ci: fix Npcap URL moved

### DIFF
--- a/ci/install_npcap.bat
+++ b/ci/install_npcap.bat
@@ -10,10 +10,10 @@ if "%NPCAP_OEM_CREDENTIALS_DEFINED%"=="2" (
 
 if "%NPCAP_OEM_CREDENTIALS_DEFINED%"=="2" (
 	echo Using Npcap OEM version %NPCAP_FILE%
-	curl --digest --user %NPCAP_USERNAME%:%NPCAP_PASSWORD% https://nmap.org/npcap/oem/dist/%NPCAP_FILE% --output %NPCAP_FILE%
+	curl -L --digest --user %NPCAP_USERNAME%:%NPCAP_PASSWORD% https://npcap.com/oem/dist/%NPCAP_FILE% --output %NPCAP_FILE%
 ) else (
 	echo Using Npcap free version %NPCAP_FILE%
-	curl https://nmap.org/npcap/dist/%NPCAP_FILE% --output %NPCAP_FILE%
+	curl -L https://npcap.com/dist/%NPCAP_FILE% --output %NPCAP_FILE%
 )
 
 %NPCAP_FILE% /S /winpcap_mode
@@ -23,6 +23,6 @@ if not "%NPCAP_OEM_CREDENTIALS_DEFINED%"=="2" (
 	xcopy C:\Windows\SysWOW64\Npcap\*.dll C:\Windows\SysWOW64
 )
 
-curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 120 https://nmap.org/npcap/dist/npcap-sdk-1.04.zip --output npcap-sdk-1.04.zip
+curl -L --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 120 https://npcap.com/dist/npcap-sdk-1.04.zip --output npcap-sdk-1.04.zip
 mkdir C:\Npcap-sdk
 7z x .\npcap-sdk-1.04.zip -oC:\Npcap-sdk


### PR DESCRIPTION
Curl return a 301.

We can also add a -L param to follow redict

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://npcap.com/dist/npcap-sdk-1.04.zip">here</a>.</p>
<hr>
<address>Apache/2.4.6 (CentOS) Server at nmap.org Port 443</address>
</body></html>
```