### PR TITLE
Fix broken teardown in `TestPcapLiveDeviceClone`

### DIFF
--- a/Tests/Pcap++Test/Common/TestUtils.h
+++ b/Tests/Pcap++Test/Common/TestUtils.h
@@ -12,16 +12,21 @@ private:
 
 	pcpp::IDevice* m_Device;
 	bool m_CancelTeardown;
+	bool m_DeleteDevice;
 
 public:
 
-	DeviceTeardown(pcpp::IDevice* device) : m_Device(device), m_CancelTeardown(false) {}
+	DeviceTeardown(pcpp::IDevice* device, bool deleteDevice = false) : m_Device(device), m_CancelTeardown(false), m_DeleteDevice(deleteDevice) {}
 
 	~DeviceTeardown()
 	{
 		if (!m_CancelTeardown && m_Device != NULL && m_Device->isOpened())
 		{
 			m_Device->close();
+		}
+		if (m_DeleteDevice)
+		{
+			delete m_Device;
 		}
 	}
 

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -266,7 +266,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceClone)
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_GREATER_THAN(liveDev->getMtu(), 0);
 	PTF_ASSERT_TRUE(liveDev->open());
-	DeviceTeardown devTeardown(liveDev);
+	DeviceTeardown devTeardown(liveDev, true);
 	int packetCount = 0;
 	int numOfTimeStatsWereInvoked = 0;
 	PTF_ASSERT_TRUE(liveDev->startCapture(&packetArrives, (void*)&packetCount, 1, &statsUpdate, (void*)&numOfTimeStatsWereInvoked));
@@ -296,8 +296,8 @@ PTF_TEST_CASE(TestPcapLiveDeviceClone)
 	PTF_ASSERT_FALSE(liveDev->startCapture(&packetArrives, (void*)&packetCount, 1, &statsUpdate, (void*)&numOfTimeStatsWereInvoked));
 	pcpp::Logger::getInstance().enableLogs();
 
-	delete liveDev;
 } // TestPcapLiveDeviceClone
+
 
 
 PTF_TEST_CASE(TestPcapLiveDeviceNoNetworking)


### PR DESCRIPTION
Since `DeviceTeardown` runs after `delete liveDev` it runs on invalid memory. This causes a failure which I observed with VS 2019.
The fix is to add a flag to `DeviceTeardown` to allow deleting the device.