### PR TITLE
Drop WinPcap support

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -323,12 +323,10 @@ jobs:
             os: windows-2019
             platform: x86
             config: Release
-            pcap_lib: npcap
           - vs-version: vs2017
             os: windows-2016
             platform: x86
             config: Release
-            pcap_lib: npcap
           - vs-version: vs2017
             os: windows-2016
             platform: x64
@@ -345,12 +343,6 @@ jobs:
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v1
 
-      - name: Install WinPcap
-        run: |
-          ci\install_winpcap.bat
-          echo "PCAP_SDK_DIR=C:\WpdPack" >> $env:GITHUB_ENV
-        if: matrix.pcap_lib != 'npcap'
-
       - name: Install NPcap
         env:
           NPCAP_USERNAME: ${{ secrets.NPCAP_USERNAME }}
@@ -358,7 +350,6 @@ jobs:
         run: |
           ci\install_npcap.bat
           echo "PCAP_SDK_DIR=C:\Npcap-sdk" >> $env:GITHUB_ENV
-        if: matrix.pcap_lib == 'npcap'
 
       - name: Download pthreads
         run: |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [PcapPlusPlus](https://pcapplusplus.github.io/) is a multiplatform C++ library for capturing, parsing and crafting of network packets. It is designed to be efficient, powerful and easy to use.
 
-PcapPlusPlus enables decoding and forging capabilities for a large variety of network protocols. It also provides easy to use C++ wrappers for the most popular packet processing engines such as [libpcap](https://www.tcpdump.org/), [WinPcap](https://www.winpcap.org/), [Npcap](https://nmap.org/npcap/), [DPDK](https://www.dpdk.org/) and [PF_RING](https://www.ntop.org/products/packet-capture/pf_ring/).
+PcapPlusPlus enables decoding and forging capabilities for a large variety of network protocols. It also provides easy to use C++ wrappers for the most popular packet processing engines such as [libpcap](https://www.tcpdump.org/), [Npcap](https://nmap.org/npcap/), [DPDK](https://www.dpdk.org/) and [PF_RING](https://www.ntop.org/products/packet-capture/pf_ring/).
 
 ## Table Of Contents
 
@@ -79,7 +79,7 @@ Follow the build instructions according to your platform in the [Build From Sour
 
 ## Feature Overview
 
-- __Packet capture__ through an easy to use C++ wrapper for popular packet capture engines such as [libpcap](https://www.tcpdump.org/), [WinPcap](https://www.winpcap.org/), [Npcap](https://nmap.org/npcap/), [Intel DPDK](https://www.dpdk.org/), [ntop’s PF_RING](https://www.ntop.org/products/packet-capture/pf_ring/) and [raw sockets](https://en.wikipedia.org/wiki/Network_socket#Raw_socket) [[Learn more](https://pcapplusplus.github.io/docs/features#packet-capture)]
+- __Packet capture__ through an easy to use C++ wrapper for popular packet capture engines such as [libpcap](https://www.tcpdump.org/), [Npcap](https://nmap.org/npcap/), [Intel DPDK](https://www.dpdk.org/), [ntop’s PF_RING](https://www.ntop.org/products/packet-capture/pf_ring/) and [raw sockets](https://en.wikipedia.org/wiki/Network_socket#Raw_socket) [[Learn more](https://pcapplusplus.github.io/docs/features#packet-capture)]
 - __Packet parsing and crafting__ including detailed analysis of protocols and layers, packet generation and packet edit for a large variety of [network protocols](https://pcapplusplus.github.io/docs/features#supported-network-protocols) [[Learn more](https://pcapplusplus.github.io/docs/features#packet-parsing-and-crafting)]
 - __Read and write packets from/to files__ in both __PCAP__ and __PCAPNG__ formats [[Learn more](https://pcapplusplus.github.io/docs/features#read-and-write-packets-fromto-files)]
 - __Packet processing in line rate__ through an efficient and easy to use C++ wrapper for [DPDK](https://www.dpdk.org/) and [PF_RING](https://www.ntop.org/products/packet-capture/pf_ring/) [[Learn more](https://pcapplusplus.github.io/docs/features#dpdk-support)]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ init:
 - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
 
 install:
-- if "%pcap_lib%"=="npcap" (ci\install_npcap.bat) else (ci\install_winpcap.bat)
+- ci\install_npcap.bat
 - git clone https://github.com/seladb/PcapPlusPlus-Deploy
 - cd PcapPlusPlus-Deploy\Packages
 - if "%compiler%"=="mingw32" set PATH=%PATH%;C:\MinGW\bin&& 7z e pthreads-GC-w32-2.10-mingw32-pre-20160821-1-dev.tar.xz -oC:\pthreads && 7z x C:\pthreads\pthreads-GC-w32-2.10-mingw32-pre-20160821-1-dev.tar -oC:\pthreads && xcopy /Y C:\pthreads\include\* C:\MinGW\include && xcopy /Y C:\pthreads\lib\* C:\MinGW\lib
@@ -35,7 +35,7 @@ install:
 - if "%compiler%"=="mingw32" python ci\patch_mingw.py
 
 before_build:
-- if "%pcap_lib%"=="npcap" (set PCAP_SDK_DIR=C:\Npcap-sdk) else (set PCAP_SDK_DIR=C:\WpdPack)
+- set PCAP_SDK_DIR=C:\Npcap-sdk
 - cd C:\projects\PcapPlusPlus
 - if "%compiler%"=="mingw32" configure-windows-mingw.bat mingw32 -m C:\MinGW -w %PCAP_SDK_DIR%
 - if "%compiler:~0,4%"=="vs20" configure-windows-visual-studio.bat -v %compiler% -w %PCAP_SDK_DIR% -p C:\pthreads %ZSTD_HOME_PARAM%

--- a/ci/install_winpcap.bat
+++ b/ci/install_winpcap.bat
@@ -1,7 +1,0 @@
-git submodule update --init --recursive
-git clone https://github.com/mfontanini/winpcap-installer.git
-cd winpcap-installer
-winpcap-boundary-meter-4.1.3.exe /S
-cd ..
-curl https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip --output WpdPack_4_1_2.zip
-7z x .\WpdPack_4_1_2.zip -oc:\

--- a/configure-windows-mingw.bat
+++ b/configure-windows-mingw.bat
@@ -3,7 +3,7 @@ setlocal
 
 echo.
 echo ******************************************
-echo PcapPlusPlus Windows configuration script 
+echo PcapPlusPlus Windows configuration script
 echo ******************************************
 echo.
 
@@ -16,10 +16,10 @@ set MINGW_HOME=
 set PCAP_SDK_HOME=
 
 :: check the number of arguments: If got at least one argument continue to command-line mode, else continue to wizard mode
-if "%1" NEQ "" ( 
-	call :GETOPT %1 %2 %3 %4 %5 %6 %7 %8 %9 
-) else ( 
-	call :READ_PARAMS_FROM_USER 
+if "%1" NEQ "" (
+	call :GETOPT %1 %2 %3 %4 %5 %6 %7 %8 %9
+) else (
+	call :READ_PARAMS_FROM_USER
 )
 :: if one of the modes returned with an error, exit script
 if "%ERRORLEVEL%" NEQ "0" exit /B 1
@@ -127,7 +127,7 @@ goto GETOPT_START
 	set MINGW_TYPE=%1
 	:: exit ok
 	exit /B 0
-	
+
 :CASEmingw-w64
 	set MINGW_TYPE=%1
 	:: exit ok
@@ -136,7 +136,7 @@ goto GETOPT_START
 :: handling help switches (-h or --help)
 :CASE--help
 :CASE-h
-	:: call the HELP "function" 
+	:: call the HELP "function"
 	call :HELP
 	:: exit with error code 3, meaning ask the caller to exit the script
 	exit /B 3
@@ -210,7 +210,7 @@ goto GETOPT_START
 :: a "function" that implements the wizard mode which reads MinGW home and WinPcap/Npcap SDK by displaying a wizard for the user
 :READ_PARAMS_FROM_USER
 
-echo MinGW32 or MinGW-w64 are required for compiling PcapPlusPlus. Please specify 
+echo MinGW32 or MinGW-w64 are required for compiling PcapPlusPlus. Please specify
 echo the type you want to use (can be either "mingw32" or "mingw-w64")
 echo.
 :while0
@@ -238,7 +238,7 @@ echo.
 if "%MINGW_TYPE%"=="mingw32" goto msys-not-required
 
 :: get MSYS2 location from user and verify it exists
-echo MSYS2 is required for compiling PcapPlusPlus. 
+echo MSYS2 is required for compiling PcapPlusPlus.
 echo If MSYS2 are not installed, please download and install it from: https://www.msys2.org/
 echo.
 :while3
@@ -252,9 +252,8 @@ echo.
 
 :msys-not-required
 
-:: get WinPcap/Npcap SDK location from user and verify it exists
-echo WinPcap or Npcap SDK is required for compiling PcapPlusPlus.
-echo For downloading WinPcap SDK (developer's pack) please go to https://www.winpcap.org/devel.htm
+:: get Npcap SDK location from user and verify it exists
+echo Npcap SDK is required for compiling PcapPlusPlus.
 echo For downloading Npcap SDK please go to https://nmap.org/npcap/#download
 echo.
 :while2


### PR DESCRIPTION
The WinPcap website is down and the project is quite old and has been superseeded by NPcap on Windows.

Comparaison between both: 
https://npcap.com/vs-winpcap.html

Let's remove it no ?