### PR TITLE
Pcap++: fix segfault in case pcap_activate() fail

### DIFF
--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -275,7 +275,7 @@ pcap_t* PcapLiveDevice::doOpen(const DeviceConfiguration& config)
 	{
 		PCPP_LOG_ERROR(pcap_geterr(pcap));
 		pcap_close(pcap);
-		pcap = NULL;
+		return NULL;
 	}
 
 #ifdef HAS_SET_DIRECTION_ENABLED


### PR DESCRIPTION
pcap is set to NULL and then used in pcap_setdirection() / pcap_datalink()
this generate a segfault.

Return NULL instead of continuing