### PR TITLE
Fix timeval-to-timespec conversions

### DIFF
--- a/Pcap++/src/NetworkUtils.cpp
+++ b/Pcap++/src/NetworkUtils.cpp
@@ -169,7 +169,7 @@ MacAddress NetworkUtils::getMacAddress(IPv4Address ipAddr, PcapLiveDevice* devic
 	// create the timeout
 	timespec timeout = {
 			now.tv_sec + arpTimeout,
-			now.tv_usec
+			static_cast<long>(now.tv_usec * 1000)
 	};
 
 	// start capturing. The capture is done on another thread, hence "arpPacketRecieved" is running on that thread
@@ -436,7 +436,7 @@ IPv4Address NetworkUtils::getIPv4Address(std::string hostname, PcapLiveDevice* d
 	// create the timeout
 	timespec timeout = {
 			now.tv_sec + dnsTimeout,
-			now.tv_usec
+			static_cast<long>(now.tv_usec * 1000)
 	};
 
 	// start capturing. The capture is done on another thread, hence "dnsResponseRecieved" is running on that thread

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -188,7 +188,7 @@ bool PcapFileReaderDevice::getNextPacket(RawPacket& rawPacket)
 	uint8_t* pMyPacketData = new uint8_t[pkthdr.caplen];
 	memcpy(pMyPacketData, pPacketData, pkthdr.caplen);
 #if defined(PCAP_TSTAMP_PRECISION_NANO)
-	timespec ts = { pkthdr.ts.tv_sec, pkthdr.ts.tv_usec }; //because we opened with nano second precision 'tv_usec' is actually nanos
+	timespec ts = { pkthdr.ts.tv_sec, static_cast<long>(pkthdr.ts.tv_usec) }; //because we opened with nano second precision 'tv_usec' is actually nanos
 #else
 	struct timeval ts = pkthdr.ts;
 #endif


### PR DESCRIPTION
Time values returned by `gettimeofday()` have **micro**seconds in
`timeval::tv_usec` while `timespec::ts_nsec` is **nano**seconds.

`timeval::tv_usec` is 64 bit (at least on some platforms), while
`timespec::tv_nsec` is always 'long'. An explicit cast is required to
avoid -Wnarrowing warnings/errors.

Signed-off-by: Christian Eggers <ceggers@arri.de>