### PR TITLE
added support for aarch64

### DIFF
--- a/configure-linux.sh
+++ b/configure-linux.sh
@@ -251,17 +251,17 @@ fi
 PLATFORM_MK="mk/platform.mk"
 PCAPPLUSPLUS_MK="mk/PcapPlusPlus.mk"
 
-# copy the basic Linux platform.mk
-cp -f mk/platform.mk.linux $PLATFORM_MK
-
 # copy the common (all platforms) PcapPlusPlus.mk
 cp -f mk/PcapPlusPlus.mk.common $PCAPPLUSPLUS_MK
 
 # add the Linux definitions to PcapPlusPlus.mk
-cat mk/PcapPlusPlus.mk.linux >> $PCAPPLUSPLUS_MK
 if [ -n "$BUILD_FOR_ARM64" ]; then
+   cp -f mk/platform.mk.linux.aarch64 $PLATFORM_MK
    cat mk/PcapPlusPlus.mk.linux.aarch64 >> $PCAPPLUSPLUS_MK
-   cat mk/platform.mk.linux.aarch64 >> $PLATFORM_MK
+else
+   # copy the basic Linux platform.mk
+   cp -f mk/platform.mk.linux $PLATFORM_MK
+   cat mk/PcapPlusPlus.mk.linux >> $PCAPPLUSPLUS_MK
 fi
 
 # set current directory as PCAPPLUSPLUS_HOME in platform.mk

--- a/configure-linux.sh
+++ b/configure-linux.sh
@@ -16,7 +16,7 @@ function HELP {
    echo "  1) Without any switches. In this case the script will guide you through using wizards"
    echo "  2) With switches, as described below"
    echo ""
-   echo -e "Basic usage: $SCRIPT [-h] [--pf-ring] [--pf-ring-home] [--dpdk] [--dpdk-home] [--use-immediate-mode] [--set-direction-enabled] [--install-dir] [--libpcap-include-dir] [--libpcap-lib-dir] [--use-zstd]"\\n
+   echo -e "Basic usage: $SCRIPT [-h] [--pf-ring] [--pf-ring-home] [--dpdk] [--dpdk-home] [--use-immediate-mode] [--set-direction-enabled] [--install-dir] [--libpcap-include-dir] [--libpcap-lib-dir] [--use-zstd] [--aarch64]"\\n
    echo "The following switches are recognized:"
    echo "--default                --Setup PcapPlusPlus for Linux without PF_RING or DPDK. In this case you must not set --pf-ring or --dpdk"
    echo ""
@@ -39,6 +39,8 @@ function HELP {
    echo "--use-zstd               --Use Zstd for pcapng files compression/decompression. This parameter is optional"
    echo ""
    echo "--musl                   --Musl base destination platform: i.e. Alpine. This parameter is optional"
+   echo ""
+   echo "--aarch64                --build for linux arm64 architecture"
    echo ""
    echo -e "-h|--help                --Displays this help message and exits. No further actions are performed"\\n
    echo -e "Examples:"
@@ -125,7 +127,7 @@ if [ $NUMARGS -eq 0 ]; then
 else
 
    # these are all the possible switches
-   OPTS=`getopt -o h --long default,pf-ring,pf-ring-home:,dpdk,dpdk-home:,help,use-immediate-mode,set-direction-enabled,install-dir:,libpcap-include-dir:,libpcap-lib-dir:,use-zstd,musl -- "$@"`
+   OPTS=`getopt -o h --long default,pf-ring,pf-ring-home:,dpdk,dpdk-home:,help,use-immediate-mode,set-direction-enabled,install-dir:,libpcap-include-dir:,libpcap-lib-dir:,use-zstd,musl,aarch64 -- "$@"`
 
    # if user put an illegal switch - print HELP and exit
    if [ $? -ne 0 ]; then
@@ -208,6 +210,11 @@ else
          MUSL=1
          shift ;;
 
+      # build for Linux aarch64
+      --aarch64)
+         BUILD_FOR_ARM64=1
+         shift ;;
+
        # help switch - display help and exit
        -h|--help)
          HELP
@@ -252,6 +259,10 @@ cp -f mk/PcapPlusPlus.mk.common $PCAPPLUSPLUS_MK
 
 # add the Linux definitions to PcapPlusPlus.mk
 cat mk/PcapPlusPlus.mk.linux >> $PCAPPLUSPLUS_MK
+if [ -n "$BUILD_FOR_ARM64" ]; then
+   cat mk/PcapPlusPlus.mk.linux.aarch64 >> $PCAPPLUSPLUS_MK
+   cat mk/platform.mk.linux.aarch64 >> $PLATFORM_MK
+fi
 
 # set current directory as PCAPPLUSPLUS_HOME in platform.mk
 echo -e "\n\nPCAPPLUSPLUS_HOME := "$PWD >> $PLATFORM_MK

--- a/mk/PcapPlusPlus.mk.linux.aarch64
+++ b/mk/PcapPlusPlus.mk.linux.aarch64
@@ -1,0 +1,8 @@
+### LINUX ###
+
+# libs
+PCAPPP_LIBS += -lpcap -lpthread
+
+# allow user to add custom LDFLAGS
+PCAPPP_BUILD_FLAGS += $(LDFLAGS)
+

--- a/mk/platform.mk.linux.aarch64
+++ b/mk/platform.mk.linux.aarch64
@@ -1,0 +1,31 @@
+BIN_EXT :=
+
+LIB_PREFIX := lib
+
+LIB_EXT := .a
+
+ifeq ($(origin CXX),default)
+CXX := /usr/bin/aarch64-linux-gnu-g++
+endif
+
+ifeq ($(origin CC),default)
+CC := /usr/bin/aarch64-linux-gnu-gcc
+endif
+
+ifeq ($(origin AR),default)
+AR := /usr/bin/aarch64-linux-gnu-ar
+endif
+
+RM := rm
+
+CP := cp
+
+MV := mv
+
+TOUCH := touch
+
+MKDIR := mkdir
+
+INSTALL_SCRIPT := install.sh
+
+UNINSTALL_SCRIPT := uninstall.sh


### PR DESCRIPTION
The aim of this PR is to add support for aarch64 cross compilation.

pre-requisites:
sudo apt-get update && sudo apt-get install -y \
    wget \
    gcc \
    make \
    flex \
    bison \
    gcc-aarch64-linux-gnu \
    g++-aarch64-linux-gnu \
    binutils-aarch64-linux-gnu \
    libpcap-dev

usage:
./configure-linux.sh --default --aarch64
make libs