### PR TITLE
Fix internet checksum calculation

### DIFF
--- a/Packet++/src/PacketUtils.cpp
+++ b/Packet++/src/PacketUtils.cpp
@@ -29,7 +29,8 @@ uint16_t computeChecksum(ScalarBuffer<uint16_t> vec[], size_t vecSize)
 
 		if (buffLen == 1)
 		{
-			uint8_t lastByte = *(vec[i].buffer);
+			uint16_t lastByte = 0;
+			*((uint8_t*)(&lastByte)) = *((uint8_t*)(vec[i].buffer));
 			PCPP_LOG_DEBUG("1 byte left, adding value: 0x" << std::uppercase << std::hex << lastByte);
 			localSum += lastByte;
 			PCPP_LOG_DEBUG("Local sum = " << localSum << ", 0x" << std::uppercase << std::hex << localSum);

--- a/Tests/Packet++Test/TestDefinition.h
+++ b/Tests/Packet++Test/TestDefinition.h
@@ -36,6 +36,7 @@ PTF_TEST_CASE(TcpPacketWithOptionsParsing2);
 PTF_TEST_CASE(TcpMalformedPacketParsing);
 PTF_TEST_CASE(TcpPacketCreation);
 PTF_TEST_CASE(TcpPacketCreation2);
+PTF_TEST_CASE(TcpChecksumInvalidRead);
 
 // Implemented in PacketUtilsTests.cpp
 PTF_TEST_CASE(PacketUtilsHash5TupleUdp);

--- a/Tests/Packet++Test/Tests/TcpTests.cpp
+++ b/Tests/Packet++Test/Tests/TcpTests.cpp
@@ -287,3 +287,20 @@ PTF_TEST_CASE(TcpPacketCreation2)
 	PTF_ASSERT_TRUE(tcpSnackOption.isNotNull());
 	PTF_ASSERT_TRUE(tcpSnackOption.setValue(htobe32(1000)));
 } // TcpPacketCreation2
+
+PTF_TEST_CASE(TcpChecksumInvalidRead)
+{
+	uint8_t *m = new uint8_t[3];
+	m[0] = 0x01;
+	m[1] = 0x12;
+	m[2] = 0xF3;
+
+	pcpp::ScalarBuffer<uint16_t> vec[1];
+	vec[0].buffer = (uint16_t*)m;
+	vec[0].len = 3;
+
+	uint16_t c = pcpp::computeChecksum(vec, 1);
+	PTF_ASSERT_EQUAL(c, 0xbedU);
+
+	delete [] m;
+} // TcpChecksumInvalidRead

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -131,6 +131,7 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(TcpPacketCreation, "tcp");
 	PTF_RUN_TEST(TcpPacketCreation2, "tcp");
 	PTF_RUN_TEST(TcpMalformedPacketParsing, "tcp");
+	PTF_RUN_TEST(TcpChecksumInvalidRead, "tcp");
 
 	PTF_RUN_TEST(PacketUtilsHash5TupleUdp, "udp");
 	PTF_RUN_TEST(PacketUtilsHash5TupleTcp, "tcp");


### PR DESCRIPTION
Bugfix of internet checksum for odd length packets.
Odd length packets are possible when sending/receiving Tcp payload.

This fixes:
- invalid read of one byte past the end of the buffer. Verified with
  valgrind.
- wrong checksum on big endian systems. Verified with qemu-ppc.

Initially this fix was done for an older version of libpcapplusplus we are using.
The fix was used in a production system for quite some time now.
Without the fix we had some spurious segfaults on windows debug builds.
The backtrace and valgrind helped us narrowing down the problem to this function.

