### PR TITLE
PacketUtils: cleaner computeChecksum code

### DIFF
--- a/Packet++/src/PacketUtils.cpp
+++ b/Packet++/src/PacketUtils.cpp
@@ -17,25 +17,27 @@ uint16_t computeChecksum(ScalarBuffer<uint16_t> vec[], size_t vecSize)
 	for (size_t i = 0; i<vecSize; i++)
 	{
 		uint32_t localSum = 0;
-		size_t buffLen = vec[i].len;
-		while (buffLen > 1)
+
+		// vec len is in bytes
+		for (size_t j = 0; j < vec[i].len / 2; j++)
 		{
-			PCPP_LOG_DEBUG("Value to add = 0x" << std::uppercase << std::hex << *(vec[i].buffer));
-			localSum += *(vec[i].buffer);
-			++(vec[i].buffer);
-			buffLen -= 2;
+			PCPP_LOG_DEBUG("Value to add = 0x" << std::uppercase << std::hex << vec[i].buffer[j]);
+			localSum += vec[i].buffer[j];
 		}
 		PCPP_LOG_DEBUG("Local sum = " << localSum << ", 0x" << std::uppercase << std::hex << localSum);
 
-		if (buffLen == 1)
-		{
-			uint16_t lastByte = 0;
-			*((uint8_t*)(&lastByte)) = *((uint8_t*)(vec[i].buffer));
+		// check if there is one byte left
+		if (vec[i].len % 2) {
+			// access to the last byte using an uint8_t pointer
+			uint8_t *vecBytes = (uint8_t *)vec[i].buffer;
+			uint8_t lastByte = vecBytes[vec[i].len - 1];
 			PCPP_LOG_DEBUG("1 byte left, adding value: 0x" << std::uppercase << std::hex << lastByte);
-			localSum += lastByte;
+			// swap this in case we are on bigEndian arch
+			localSum += le16toh(lastByte);
 			PCPP_LOG_DEBUG("Local sum = " << localSum << ", 0x" << std::uppercase << std::hex << localSum);
 		}
 
+		// carry count is added to the sum
 		while (localSum>>16)
 		{
 			localSum = (localSum & 0xffff) + (localSum >> 16);

--- a/Packet++/src/PacketUtils.cpp
+++ b/Packet++/src/PacketUtils.cpp
@@ -61,8 +61,8 @@ uint16_t computeChecksum(ScalarBuffer<uint16_t> vec[], size_t vecSize)
 
 	PCPP_LOG_DEBUG("Calculated checksum = " << sum << ", 0x" << std::uppercase << std::hex << result);
 
-	// We return the result in Network byte order
-	return htons(result);
+	// We return the result in BigEndian byte order
+	return htobe16(result);
 }
 
 static const uint32_t FNV_PRIME = 16777619u;

--- a/Packet++/src/PacketUtils.cpp
+++ b/Packet++/src/PacketUtils.cpp
@@ -33,9 +33,10 @@ uint16_t computeChecksum(ScalarBuffer<uint16_t> vec[], size_t vecSize)
 			uint8_t *vecBytes = (uint8_t *)vec[i].buffer;
 			uint8_t lastByte = vecBytes[vec[i].len - 1];
 			PCPP_LOG_DEBUG("1 byte left, adding value: 0x" << std::uppercase << std::hex << lastByte);
-			// We have read the latest byte manually but this byte should be interpreted
+			// We have read the latest byte manually but this byte should be properly interpreted
 			// as a 0xFF on LE and a 0xFF00 on BE to have a proper checksum computation
-			localSum += le16toh(lastByte);
+			localSum += be16toh(lastByte << 8);
+
 			PCPP_LOG_DEBUG("Local sum = " << localSum << ", 0x" << std::uppercase << std::hex << localSum);
 		}
 

--- a/Tests/Packet++Test/TestDefinition.h
+++ b/Tests/Packet++Test/TestDefinition.h
@@ -37,6 +37,7 @@ PTF_TEST_CASE(TcpMalformedPacketParsing);
 PTF_TEST_CASE(TcpPacketCreation);
 PTF_TEST_CASE(TcpPacketCreation2);
 PTF_TEST_CASE(TcpChecksumInvalidRead);
+PTF_TEST_CASE(TcpChecksumMultiBuffer);
 
 // Implemented in PacketUtilsTests.cpp
 PTF_TEST_CASE(PacketUtilsHash5TupleUdp);

--- a/Tests/Packet++Test/Tests/TcpTests.cpp
+++ b/Tests/Packet++Test/Tests/TcpTests.cpp
@@ -304,3 +304,30 @@ PTF_TEST_CASE(TcpChecksumInvalidRead)
 
 	delete [] m;
 } // TcpChecksumInvalidRead
+
+PTF_TEST_CASE(TcpChecksumMultiBuffer)
+{
+	// Taken from https://en.wikipedia.org/wiki/IPv4_header_checksum#Calculating_the_IPv4_header_checksum
+	uint16_t m[4] = {0x4500, 0x0073, 0x0000, 0x4000};
+	uint16_t n[3] = {0x4011, 0xc0a8, 0x0001};
+	uint16_t o[2] = {0xc0a8, 0x00c7};
+	uint16_t checksum_expected = 0xb861;
+
+	pcpp::ScalarBuffer<uint16_t> vec[4];
+	vec[0].buffer = m;
+	vec[0].len = 8;
+	vec[1].buffer = n;
+	vec[1].len = 6;
+	vec[2].buffer = o;
+	vec[2].len = 4;
+	vec[3].buffer = &checksum_expected;
+	vec[3].len = 2;
+
+	uint16_t c = pcpp::computeChecksum(vec, 3);
+	// computeChecksum return in network byte order
+	PTF_ASSERT_EQUAL(c, htons(checksum_expected));
+
+	// Adding the checksum should be equal to 0x0
+	c = pcpp::computeChecksum(vec, 4);
+	PTF_ASSERT_EQUAL(c, 0);
+} // TcpChecksumInvalidRead

--- a/Tests/Packet++Test/Tests/TcpTests.cpp
+++ b/Tests/Packet++Test/Tests/TcpTests.cpp
@@ -325,7 +325,7 @@ PTF_TEST_CASE(TcpChecksumMultiBuffer)
 
 	uint16_t c = pcpp::computeChecksum(vec, 3);
 	// computeChecksum return in network byte order
-	PTF_ASSERT_EQUAL(c, htons(checksum_expected));
+	PTF_ASSERT_EQUAL(c, htobe16(checksum_expected));
 
 	// Adding the checksum should be equal to 0x0
 	c = pcpp::computeChecksum(vec, 4);

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -137,6 +137,7 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(TcpPacketCreation2, "tcp");
 	PTF_RUN_TEST(TcpMalformedPacketParsing, "tcp");
 	PTF_RUN_TEST(TcpChecksumInvalidRead, "tcp");
+	PTF_RUN_TEST(TcpChecksumMultiBuffer, "tcp");
 
 	PTF_RUN_TEST(PacketUtilsHash5TupleUdp, "udp");
 	PTF_RUN_TEST(PacketUtilsHash5TupleTcp, "tcp");


### PR DESCRIPTION
Hi @guebe,

You recently submit a patch to fix compute checksum on bigendian and avoid an out of bound reading.

This caught my attention as this part is a bit hard to read. 

Here is a clean rework, could you review this and confirm if it works on BigEndian arch?

Thanks