### PR TITLE
ipUtils: fix MinGW macro name

### DIFF
--- a/Common++/header/IpUtils.h
+++ b/Common++/header/IpUtils.h
@@ -23,9 +23,9 @@
 
 // Both Visual C++ Compiler and MinGW-w64 define inet_ntop() and inet_pton()
 // Add compatibility functions for old MinGW (aka MinGW32)
-// We use "__MINGW64_MAJOR_VERSION" and not __MINGW64__ to detect MinGW-w64 compiler
+// We use "__MINGW64_VERSION_MAJOR" and not __MINGW64__ to detect MinGW-w64 compiler
 // because the second one is not defined for MinGW-w64 in 32bits mode
-#if defined(_WIN32) && !defined(_MSC_VER) && !defined(__MINGW64_MAJOR_VERSION)
+#if defined(_WIN32) && !defined(_MSC_VER) && !defined(__MINGW64_VERSION_MAJOR)
 /**
  * Convert a network format address to presentation format.
  * @param[in] af Address family, can be either AF_INET (IPv4) or AF_INET6 (IPv6)

--- a/Common++/src/IpUtils.cpp
+++ b/Common++/src/IpUtils.cpp
@@ -63,7 +63,7 @@ namespace pcpp
 } // namespace pcpp
 
 // Only MinGW32 doesn't have these functions (not MinGW-w64 nor Visual C++)
-#if defined(_WIN32) && !defined(_MSC_VER) && !defined(__MINGW64_MAJOR_VERSION)
+#if defined(_WIN32) && !defined(_MSC_VER) && !defined(__MINGW64_VERSION_MAJOR)
 /* const char *
  * inet_ntop4(src, dst, size)
  *	format an IPv4 address


### PR DESCRIPTION
Just found that inet_ntop() warning were still present whereas it shouldn't.

This should now fix it definitely!

MinGW use __MINGW_MAJOR_VERSION
But MinGW-w64 use __MINGW64_VERSION_MAJOR 