### PR TITLE
Fix memory leak in LightPcapNg when closing files

### DIFF
--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_platform.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_platform.c
@@ -178,7 +178,11 @@ size_t light_size(light_file fd)
 int light_close(light_file fd)
 {
 	light_close_compressed(fd);
-	return fclose(fd->file);
+	int rc = fclose(fd->file);
+
+	free(fd);
+
+	return rc;
 }
 
 int light_flush(light_file fd)


### PR DESCRIPTION
Ensure that light_close frees the memory that was allocated in light_open. Fixes issue #885.