### PR TITLE
Add getNextPacket

### DIFF
--- a/Tests/Fuzzers/FuzzTarget.cpp
+++ b/Tests/Fuzzers/FuzzTarget.cpp
@@ -54,18 +54,21 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 		return 1;
 	}
 
-	// parse the raw packet into a parsed packet
-	pcpp::Packet parsedPacket(&rawPacket);
-
-	// verify the packet is IPv4
-	if (parsedPacket.isPacketOfType(pcpp::IPv4))
+	while (reader.getNextPacket(rawPacket))
 	{
-		// extract source and dest IPs
-		pcpp::IPv4Address srcIP = parsedPacket.getLayerOfType<pcpp::IPv4Layer>()->getSrcIPv4Address();
-		pcpp::IPv4Address destIP = parsedPacket.getLayerOfType<pcpp::IPv4Layer>()->getDstIPv4Address();
+		// parse the raw packet into a parsed packet
+		pcpp::Packet parsedPacket(&rawPacket);
 
-		// print source and dest IPs
-		std::cout << "Source IP is '" << srcIP.toString() << "'; Dest IP is '" << destIP.toString() << "'" << std::endl;
+		// verify the packet is IPv4
+		if (parsedPacket.isPacketOfType(pcpp::IPv4))
+		{
+			// extract source and dest IPs
+			pcpp::IPv4Address srcIP = parsedPacket.getLayerOfType<pcpp::IPv4Layer>()->getSrcIPv4Address();
+			pcpp::IPv4Address destIP = parsedPacket.getLayerOfType<pcpp::IPv4Layer>()->getDstIPv4Address();
+
+			// print source and dest IPs
+			std::cout << "Source IP is '" << srcIP.toString() << "'; Dest IP is '" << destIP.toString() << "'" << std::endl;
+		}
 	}
 
 	// close the file

--- a/Tests/Fuzzers/FuzzTarget.cpp
+++ b/Tests/Fuzzers/FuzzTarget.cpp
@@ -54,7 +54,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 		return 1;
 	}
 
-	while (reader.getNextPacket(rawPacket))
+	do
 	{
 		// parse the raw packet into a parsed packet
 		pcpp::Packet parsedPacket(&rawPacket);
@@ -70,6 +70,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size)
 			std::cout << "Source IP is '" << srcIP.toString() << "'; Dest IP is '" << destIP.toString() << "'" << std::endl;
 		}
 	}
+	while (reader.getNextPacket(rawPacket));
 
 	// close the file
 	reader.close();


### PR DESCRIPTION
Use the idea from https://github.com/seladb/PcapPlusPlus/issues/856#issuecomment-1086590528 of parsing packets in a loop. It improves the fuzzer's speed (from 65575 exec/s to 521916 exec/s on my machine) and coverage.