### PR TITLE
Update clangformat

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,7 @@
 ---
 BasedOnStyle: Microsoft
 UseTab: Always
+AllowShortFunctionsOnASingleLine: All
+NamespaceIndentation: All
 
 ...


### PR DESCRIPTION
Not important for now but It seems that these options are better match to existing code (Especially for *Layer headers) . What do you think?