### PR TITLE
ci: enable set-direction on libpcap

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Configure PcapPlusPlus
-        run: ./configure-linux.sh --default ${{ matrix.configure }}
+        run: ./configure-linux.sh --default ${{ matrix.configure }} --set-direction-enabled
 
       - name: Build PcapPlusPlus
         run: make all
@@ -156,7 +156,7 @@ jobs:
           python-version: "3.8.x"
 
       - name: Configure PcapPlusPlus
-        run: ./configure-mac_os_x.sh
+        run: ./configure-mac_os_x.sh --set-direction-enabled
 
       - name: Build PcapPlusPlus
         run: make all

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -502,18 +502,22 @@ PTF_TEST_CASE(TestPcapLiveDeviceSpecialCfg)
 	PTF_ASSERT_GREATER_THAN(packetCount, 0);
 
 #ifdef HAS_SET_DIRECTION_ENABLED
-	// create a non-default configuration with only cpturing incoming packets and open the device again
+	packetCount = 0;
+
+	// create a non-default configuration with only capturing incoming packets and open the device again
 	pcpp::PcapLiveDevice::DeviceConfiguration devConfigWithDirection(pcpp::PcapLiveDevice::Promiscuous, 10, 2000000, pcpp::PcapLiveDevice::PCPP_IN);
 
 	liveDev->open(devConfigWithDirection);
-
-	packetCount = 0;
+	PTF_ASSERT_TRUE(liveDev->isOpened());
 
 	// start capturing in non-default configuration witch only captures incoming traffics
 	PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeNoTimeoutPacketCount, &packetCount, 7), -1);
 
-	PTF_ASSERT_GREATER_THAN(packetCount, 0);
 	liveDev->close();
+	PTF_ASSERT_FALSE(liveDev->isOpened());
+
+	PTF_ASSERT_GREATER_THAN(packetCount, 0);
+
 #endif
 
 	// create a non-default configuration with a snapshot length of 10 bytes

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -490,8 +490,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceSpecialCfg)
 
 	// create a non-default configuration with timeout of 10ms and open the device again
 	pcpp::PcapLiveDevice::DeviceConfiguration devConfig(pcpp::PcapLiveDevice::Promiscuous, 10, 2000000);
-	liveDev->open(devConfig);
-	PTF_ASSERT_TRUE(liveDev->isOpened());
+	PTF_ASSERT_TRUE(liveDev->open(devConfig));
 
 	// start capturing in non-default configuration
 	PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeNoTimeoutPacketCount, &packetCount, 7), -1);
@@ -506,9 +505,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceSpecialCfg)
 
 	// create a non-default configuration with only capturing incoming packets and open the device again
 	pcpp::PcapLiveDevice::DeviceConfiguration devConfigWithDirection(pcpp::PcapLiveDevice::Promiscuous, 10, 2000000, pcpp::PcapLiveDevice::PCPP_OUT);
-
-	liveDev->open(devConfigWithDirection);
-	PTF_ASSERT_TRUE(liveDev->isOpened());
+	PTF_ASSERT_TRUE(liveDev->open(devConfigWithDirection));
 
 	// start capturing in non-default configuration witch only captures incoming traffics
 	PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeNoTimeoutPacketCount, &packetCount, 7), -1);

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -505,7 +505,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceSpecialCfg)
 	packetCount = 0;
 
 	// create a non-default configuration with only capturing incoming packets and open the device again
-	pcpp::PcapLiveDevice::DeviceConfiguration devConfigWithDirection(pcpp::PcapLiveDevice::Promiscuous, 10, 2000000, pcpp::PcapLiveDevice::PCPP_IN);
+	pcpp::PcapLiveDevice::DeviceConfiguration devConfigWithDirection(pcpp::PcapLiveDevice::Promiscuous, 10, 2000000, pcpp::PcapLiveDevice::PCPP_OUT);
 
 	liveDev->open(devConfigWithDirection);
 	PTF_ASSERT_TRUE(liveDev->isOpened());


### PR DESCRIPTION
@seladb 

Enabling the set-direction features will return errors in CI.

I'm not sure to understand why it's create such issue could you have a look ?