### PR TITLE
Pytest rootpath option

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -51,7 +51,7 @@ jobs:
           cd Tests/ExamplesTest
           ${{ matrix.python }} -m pip install -U pip
           ${{ matrix.python }} -m pip install -r requirements.txt
-          ${{ matrix.python }} -m pytest --interface eth0
+          ${{ matrix.python }} -m pytest --interface eth0 --root-path=../../Dist/examples
 
       - name: Check installation
         run: |
@@ -175,7 +175,7 @@ jobs:
           cd Tests/ExamplesTest
           python -m pip install -U pip
           python -m pip install -r requirements.txt
-          python -m pytest --interface en0 --use-sudo
+          python -m pytest --interface en0 --use-sudo --root-path=../../Dist/examples
 
       - name: Check installation
         run: |
@@ -268,7 +268,7 @@ jobs:
         run: |
           cd Tests\ExamplesTest
           python -m pip install -r requirements.txt
-          python -m pytest
+          python -m pytest --root-path=../../Dist/examples
 
   visual-studio:
     runs-on: windows-2019
@@ -346,7 +346,7 @@ jobs:
         run: |
           cd Tests\ExamplesTest
           python -m pip install -r requirements.txt
-          python -m pytest
+          python -m pytest --root-path=../../Dist/examples
 
   android:
     strategy:

--- a/Tests/ExamplesTest/conftest.py
+++ b/Tests/ExamplesTest/conftest.py
@@ -1,4 +1,7 @@
 import pytest
+import os
+
+DEFAULT_EXAMPLE_DIR = os.path.abspath("../../Dist/examples/")
 
 
 def pytest_addoption(parser):
@@ -6,6 +9,12 @@ def pytest_addoption(parser):
         "--interface", action="store", help="interface IP address or name."
     )
     parser.addoption("--gateway", action="store", help="default gateway IP address.")
+    parser.addoption(
+        "--root-path",
+        action="store",
+        default=DEFAULT_EXAMPLE_DIR,
+        help="root path to use.",
+    )
     parser.addoption(
         "--use-sudo",
         action="store_true",

--- a/Tests/ExamplesTest/tests/test_dnsresolver.py
+++ b/Tests/ExamplesTest/tests/test_dnsresolver.py
@@ -1,4 +1,3 @@
-import subprocess
 import pytest
 from .test_utils import ExampleTest
 

--- a/Tests/ExamplesTest/tests/test_utils.py
+++ b/Tests/ExamplesTest/tests/test_utils.py
@@ -1,21 +1,24 @@
-import platform
-import os
 from itertools import filterfalse
+import os
+import platform
+import pytest
 import subprocess
-import tempfile
-
-DEFAULT_EXAMPLE_DIR = os.path.abspath("../../Dist/examples/")
 
 
 def run_example(
-    example_name, args, timeout=10, expected_return_code=0, requires_root=False
+    example_name,
+    args,
+    root_path,
+    timeout=10,
+    expected_return_code=0,
+    requires_root=False,
 ):
     command_to_run = (
         ["sudo"]
         if requires_root
         and (platform.system() == "Linux" or platform.system() == "Darwin")
         else []
-    ) + [os.path.join(DEFAULT_EXAMPLE_DIR, example_name)]
+    ) + [os.path.join(root_path, example_name)]
     for flag, val in args.items():
         if flag:
             command_to_run.append(flag)
@@ -63,12 +66,17 @@ def compare_stdout_with_file(stdout, file_path, skip_line_predicate):
 
 
 class ExampleTest(object):
+    @pytest.fixture(autouse=True)
+    def _root_path(self, request):
+        self.root_path = request.config.getoption("--root-path")
+
     def run_example(
         self, args, timeout=10, expected_return_code=0, requires_root=False
     ):
         return run_example(
             example_name=self.__class__.__name__[4:],
             args=args,
+            root_path=self.root_path,
             timeout=timeout,
             expected_return_code=expected_return_code,
             requires_root=requires_root,


### PR DESCRIPTION
The examples binaries outpath is actually hardcoded in the Makefile.

it's not the case with the cmake build system.

Introduce an option to pytest to give the example binaries path