### PR TITLE
Fix BGP parse

### DIFF
--- a/Packet++/src/TcpLayer.cpp
+++ b/Packet++/src/TcpLayer.cpp
@@ -370,7 +370,11 @@ void TcpLayer::parseNextLayer()
 			m_NextLayer = new PayloadLayer(payload, payloadLen, this, m_Packet);
 	}
 	else if (BgpLayer::isBgpPort(portSrc, portDst))
+	{
 		m_NextLayer = BgpLayer::parseBgpLayer(payload, payloadLen, this, m_Packet);
+		if (!m_NextLayer)
+			m_NextLayer = new PayloadLayer(payload, payloadLen, this, m_Packet);
+	}
 	else if (SSHLayer::isSSHPort(portSrc, portDst))
 		m_NextLayer = SSHLayer::createSSHMessage(payload, payloadLen, this, m_Packet);
 	else if (DnsLayer::isDataValid(payload, payloadLen, true) && (DnsLayer::isDnsPort(portDst) || DnsLayer::isDnsPort(portSrc)))


### PR DESCRIPTION
`parseBgpLayer` can return `NULL`. If the return is `NULL` the remainder payload should be marked as `PayloadLayer`