### PR TITLE
add a method to get ipv6 similar to ipv4 for pcapLiveDevice

### DIFF
--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -287,6 +287,12 @@ namespace pcpp
 		IPv4Address getIPv4Address() const;
 
 		/**
+		 * @return The IPv6 address for this interface. If multiple IPv6 addresses are defined for this interface, the first will be picked.
+		 * If no IPv6 addresses are defined, a zeroed IPv6 address (IPv6Address#Zero) will be returned
+		 */
+		IPv6Address getIPv6Address() const;
+
+		/**
 		 * @return The default gateway defined for this interface. If no default gateway is defined, if it's not IPv4 or if couldn't extract
 		 * default gateway IPv4Address#Zero will be returned. If multiple gateways were defined the first one will be returned
 		 */

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -939,6 +939,27 @@ IPv4Address PcapLiveDevice::getIPv4Address() const
 	return IPv4Address::Zero;
 }
 
+IPv6Address PcapLiveDevice::getIPv6Address() const
+{
+	for (std::vector<pcap_addr_t>::const_iterator addrIter = m_Addresses.begin(); addrIter != m_Addresses.end();
+		 addrIter++)
+	{
+		char addrAsString[INET6_ADDRSTRLEN];
+		internal::sockaddr2string(addrIter->addr, addrAsString);
+		if (Logger::getInstance().isDebugEnabled(PcapLogModuleLiveDevice) && addrIter->addr != NULL)
+		{
+			PCPP_LOG_DEBUG("Searching address " << addrAsString);
+		}
+		in6_addr *currAddr = internal::sockaddr2in6_addr(addrIter->addr);
+		if (currAddr == NULL)
+		{
+			PCPP_LOG_DEBUG("Address is NULL");
+			continue;
+		}
+		return IPv6Address(addrAsString);
+	}
+	return IPv6Address::Zero;
+}
 
 IPv4Address PcapLiveDevice::getDefaultGateway() const
 {

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -944,10 +944,10 @@ IPv6Address PcapLiveDevice::getIPv6Address() const
 	for (std::vector<pcap_addr_t>::const_iterator addrIter = m_Addresses.begin(); addrIter != m_Addresses.end();
 		 addrIter++)
 	{
-		char addrAsString[INET6_ADDRSTRLEN];
-		internal::sockaddr2string(addrIter->addr, addrAsString);
 		if (Logger::getInstance().isDebugEnabled(PcapLogModuleLiveDevice) && addrIter->addr != NULL)
 		{
+			char addrAsString[INET6_ADDRSTRLEN];
+			internal::sockaddr2string(addrIter->addr, addrAsString);
 			PCPP_LOG_DEBUG("Searching address " << addrAsString);
 		}
 		in6_addr *currAddr = internal::sockaddr2in6_addr(addrIter->addr);
@@ -956,7 +956,7 @@ IPv6Address PcapLiveDevice::getIPv6Address() const
 			PCPP_LOG_DEBUG("Address is NULL");
 			continue;
 		}
-		return IPv6Address(addrAsString);
+		return IPv6Address(currAddr->s6_addr);
 	}
 	return IPv6Address::Zero;
 }


### PR DESCRIPTION
	modified:   Pcap++/header/PcapLiveDevice.h
	modified:   Pcap++/src/PcapLiveDevice.cpp
	modified:   Tests/Pcap++Test/TestDefinition.h
	modified:   Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
	modified:   Tests/Pcap++Test/main.cpp