### PR TITLE
Make the app name provided to DPDK configurable

### DIFF
--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -127,7 +127,7 @@ namespace pcpp
 		 * returned false it's impossible to use DPDK with PcapPlusPlus. You can get some more details about mbufs and pools in
 		 * DpdkDevice.h file description or in DPDK web site
 		 */
-		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, uint32_t initDpdkArgc = 0, char **initDpdkArgv = NULL);
+		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, uint32_t initDpdkArgc = 0, char **initDpdkArgv = NULL, const char *prgname = "pcapplusplusapp");
 
 		/**
 		 * Get a DpdkDevice by port ID

--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -122,13 +122,13 @@ namespace pcpp
 		 * @param[in] masterCore The core DPDK will use as master to control all worker thread. The default, unless set otherwise, is 0
 		 * @param[in] initDpdkArgc Number of optional arguments
 		 * @param[in] initDpdkArgv Optional arguments
-		 * @param[in] prgName program name to be provided for the DPDK
+		 * @param[in] appName program name to be provided for the DPDK
 		 * @return True if initialization succeeded or false if huge-pages or DPDK kernel driver are not loaded, if mBufPoolSizePerDevice
 		 * isn't power of 2 minus 1, if DPDK infra initialization failed or if DpdkDevice initialization failed. Anyway, if this method
 		 * returned false it's impossible to use DPDK with PcapPlusPlus. You can get some more details about mbufs and pools in
 		 * DpdkDevice.h file description or in DPDK web site
 		 */
-		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, uint32_t initDpdkArgc = 0, char **initDpdkArgv = NULL, const char *prgName = "pcapplusplusapp");
+		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, uint32_t initDpdkArgc = 0, char **initDpdkArgv = NULL, const std::string& appName = "pcapplusplusapp");
 
 		/**
 		 * Get a DpdkDevice by port ID

--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -122,12 +122,13 @@ namespace pcpp
 		 * @param[in] masterCore The core DPDK will use as master to control all worker thread. The default, unless set otherwise, is 0
 		 * @param[in] initDpdkArgc Number of optional arguments
 		 * @param[in] initDpdkArgv Optional arguments
+		 * @param[in] prgName program name to be provided for the DPDK
 		 * @return True if initialization succeeded or false if huge-pages or DPDK kernel driver are not loaded, if mBufPoolSizePerDevice
 		 * isn't power of 2 minus 1, if DPDK infra initialization failed or if DpdkDevice initialization failed. Anyway, if this method
 		 * returned false it's impossible to use DPDK with PcapPlusPlus. You can get some more details about mbufs and pools in
 		 * DpdkDevice.h file description or in DPDK web site
 		 */
-		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, uint32_t initDpdkArgc = 0, char **initDpdkArgv = NULL, const char *prgname = "pcapplusplusapp");
+		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, uint32_t initDpdkArgc = 0, char **initDpdkArgv = NULL, const char *prgName = "pcapplusplusapp");
 
 		/**
 		 * Get a DpdkDevice by port ID

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -70,7 +70,7 @@ DpdkDeviceList::~DpdkDeviceList()
 	m_DpdkDeviceList.clear();
 }
 
-bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore, uint32_t initDpdkArgc, char **initDpdkArgv, const char *prgname)
+bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore, uint32_t initDpdkArgc, char **initDpdkArgv, const char *prgName)
 {
 	char **initDpdkArgvBuffer;
 
@@ -100,7 +100,7 @@ bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice,
 
 
 	std::stringstream dpdkParamsStream;
-	dpdkParamsStream << prgname << " ";
+	dpdkParamsStream << prgName << " ";
 	dpdkParamsStream << "-n ";
 	dpdkParamsStream << "2 ";
 	dpdkParamsStream << "-c ";

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -70,7 +70,7 @@ DpdkDeviceList::~DpdkDeviceList()
 	m_DpdkDeviceList.clear();
 }
 
-bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore, uint32_t initDpdkArgc, char **initDpdkArgv)
+bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore, uint32_t initDpdkArgc, char **initDpdkArgv, const char *prgname)
 {
 	char **initDpdkArgvBuffer;
 
@@ -100,7 +100,7 @@ bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice,
 
 
 	std::stringstream dpdkParamsStream;
-	dpdkParamsStream << "pcapplusplusapp ";
+	dpdkParamsStream << prgname << " ";
 	dpdkParamsStream << "-n ";
 	dpdkParamsStream << "2 ";
 	dpdkParamsStream << "-c ";

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -70,7 +70,7 @@ DpdkDeviceList::~DpdkDeviceList()
 	m_DpdkDeviceList.clear();
 }
 
-bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore, uint32_t initDpdkArgc, char **initDpdkArgv, const char *prgName)
+bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore, uint32_t initDpdkArgc, char **initDpdkArgv, const std::string& appName)
 {
 	char **initDpdkArgvBuffer;
 
@@ -100,7 +100,7 @@ bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice,
 
 
 	std::stringstream dpdkParamsStream;
-	dpdkParamsStream << prgName << " ";
+	dpdkParamsStream << appName << " ";
 	dpdkParamsStream << "-n ";
 	dpdkParamsStream << "2 ";
 	dpdkParamsStream << "-c ";


### PR DESCRIPTION
… overwrite the application's syslog ident