### PR TITLE
Added extra matchSubnet definition

### DIFF
--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -112,6 +112,14 @@ namespace pcpp
 
 		/**
 		 * Checks whether the address matches a subnet.
+		 * For example: if subnet is 10.1.1.1/24 and address is 10.1.1.9 then the method will return true
+		 * Another example: if subnet is 10.1.1.1/16 and address is 11.1.1.9 then the method will return false
+		 * @param[in] subnet A string in X.X.X.X/Y format representing the masked subnet to compare with the address
+		 */
+		bool matchSubnet(const std::string& subnet) const;
+
+		/**
+		 * Checks whether the address matches a subnet.
 		 * For example: if subnet is 10.1.1.X, subnet mask is 255.255.255.0 and address is 10.1.1.9 then the method will return true
 		 * Another example: if subnet is 10.1.X.X, subnet mask is 255.0.0.0 and address is 11.1.1.9 then the method will return false
 		 * @param[in] subnet The subnet to be verified. Notice it's an IPv4Address type, so subnets with don't-cares (like 10.0.0.X) must have some number

--- a/Common++/src/IpAddress.cpp
+++ b/Common++/src/IpAddress.cpp
@@ -1,6 +1,9 @@
 #define LOG_MODULE CommonLogModuleIpUtils
 
+#include <cmath>
 #include <errno.h>
+#include <sstream>
+#include <stdint.h>
 #include "Logger.h"
 #include "IpUtils.h"
 #include "IpAddress.h"
@@ -40,6 +43,29 @@ namespace pcpp
 	{
 		if (inet_pton(AF_INET, addrAsString.data(), m_Bytes) <= 0)
 			memset(m_Bytes, 0, sizeof(m_Bytes));
+	}
+
+
+	bool IPv4Address::matchSubnet(const std::string& subnet) const
+	{
+		std::stringstream ss(subnet);
+    	std::string subnetOnly, subnetPrefixStr;
+        std::getline(ss, subnetOnly, '/');
+        std::getline(ss, subnetPrefixStr);
+
+		uint32_t subnetPrefix = std::stoi(subnetPrefixStr);
+		uint32_t subnetMask = ((uint32_t)pow(2, 32 - subnetPrefix) - 1) ^ UINT32_MAX;
+
+		IPv4Address subnetAsIpAddr(subnetOnly);
+		IPv4Address maskAsIpAddr(subnetMask);
+
+		if (!maskAsIpAddr.isValid() || !subnetAsIpAddr.isValid())
+		{
+			PCPP_LOG_ERROR("Subnet '" << subnet << "' is in illegal format");
+			return false;
+		}
+
+		return matchSubnet(subnetAsIpAddr, maskAsIpAddr);
 	}
 
 

--- a/Tests/Pcap++Test/Tests/IpMacTests.cpp
+++ b/Tests/Pcap++Test/Tests/IpMacTests.cpp
@@ -40,12 +40,15 @@ PTF_TEST_CASE(TestIPAddress)
 	PTF_ASSERT_EQUAL(ip4AddrFromIpAddr, secondIPv4Address);
 
 	pcpp::IPv4Address ipv4Addr("10.0.0.4"), subnet1("10.0.0.0"), subnet2("10.10.0.0"), mask("255.255.255.0");
+	std::string maskedSubnet1("10.0.0.0/24"), maskedSubnet2("10.10.0.0/24");
 	PTF_ASSERT_TRUE(ipv4Addr.isValid());
 	PTF_ASSERT_TRUE(subnet1.isValid());
 	PTF_ASSERT_TRUE(subnet2.isValid());
 	PTF_ASSERT_TRUE(mask.isValid());
 	PTF_ASSERT_TRUE(ipv4Addr.matchSubnet(subnet1, mask));
 	PTF_ASSERT_FALSE(ipv4Addr.matchSubnet(subnet2, mask));
+	PTF_ASSERT_TRUE(ipv4Addr.matchSubnet(maskedSubnet1));
+	PTF_ASSERT_FALSE(ipv4Addr.matchSubnet(maskedSubnet2));
 
 	pcpp::IPv4Address badAddress(std::string("sdgdfgd"));
 	PTF_ASSERT_FALSE(badAddress.isValid());


### PR DESCRIPTION
Added another defintion for IPv4Address::matchSubnet where the parameter is a string representing a subnet with a mask prefix in the well known format 'X.X.X.X/Y'

Signed-off-by: Yishai Jaffe <yishai1999@gmail.com>