### PR TITLE
Improve the test framework

### DIFF
--- a/Tests/Packet++Test/Tests/IcmpV6Tests.cpp
+++ b/Tests/Packet++Test/Tests/IcmpV6Tests.cpp
@@ -36,7 +36,7 @@ PTF_TEST_CASE(IcmpV6ParsingTest)
 	pcpp::ICMPv6EchoLayer *echoRequestLayer = echoRequestPacket.getLayerOfType<pcpp::ICMPv6EchoLayer>();
 	PTF_ASSERT_NOT_NULL(echoRequestLayer);
 	PTF_ASSERT_TRUE(echoRequestLayer->isMessageOfType(pcpp::ICMPv6MessageType::ICMPv6_ECHO_REQUEST));
-	PTF_ASSERT_EQUAL((int)echoRequestLayer->getMessageType(), (int)pcpp::ICMPv6MessageType::ICMPv6_ECHO_REQUEST);
+	PTF_ASSERT_EQUAL(echoRequestLayer->getMessageType(), pcpp::ICMPv6MessageType::ICMPv6_ECHO_REQUEST, enumclass);
 	PTF_ASSERT_EQUAL(echoRequestLayer->getCode(), 0);
 	PTF_ASSERT_EQUAL(echoRequestLayer->getChecksum(), 0x7a4c);
 	PTF_ASSERT_EQUAL(echoRequestLayer->getIdentifier(), 0x0018);
@@ -51,7 +51,7 @@ PTF_TEST_CASE(IcmpV6ParsingTest)
 	pcpp::ICMPv6EchoLayer *echoReplyLayer = echoReplyPacket.getLayerOfType<pcpp::ICMPv6EchoLayer>();
 	PTF_ASSERT_NOT_NULL(echoReplyLayer);
 	PTF_ASSERT_TRUE(echoReplyLayer->isMessageOfType(pcpp::ICMPv6MessageType::ICMPv6_ECHO_REPLY));
-	PTF_ASSERT_EQUAL((int)echoReplyLayer->getMessageType(), (int)pcpp::ICMPv6MessageType::ICMPv6_ECHO_REPLY);
+	PTF_ASSERT_EQUAL(echoReplyLayer->getMessageType(), pcpp::ICMPv6MessageType::ICMPv6_ECHO_REPLY, enumclass);
 	PTF_ASSERT_EQUAL(echoReplyLayer->getCode(), 0);
 	PTF_ASSERT_EQUAL(echoReplyLayer->getChecksum(), 0x794c);
 	PTF_ASSERT_EQUAL(echoReplyLayer->getIdentifier(), 0x0018);
@@ -65,7 +65,7 @@ PTF_TEST_CASE(IcmpV6ParsingTest)
 	pcpp::NDPNeighborSolicitationLayer *neighSoliLayer = neighSoliPacket.getLayerOfType<pcpp::NDPNeighborSolicitationLayer>();
 	PTF_ASSERT_NOT_NULL(neighSoliLayer);
 	PTF_ASSERT_EQUAL(neighSoliLayer->getHeaderLen(), 32);
-	PTF_ASSERT_EQUAL((int)neighSoliLayer->getMessageType(), (int)pcpp::ICMPv6MessageType::ICMPv6_NEIGHBOR_SOLICITATION);
+	PTF_ASSERT_EQUAL(neighSoliLayer->getMessageType(), pcpp::ICMPv6MessageType::ICMPv6_NEIGHBOR_SOLICITATION, enumclass);
 	PTF_ASSERT_EQUAL(neighSoliLayer->getCode(), 0);
 	PTF_ASSERT_EQUAL(neighSoliLayer->getChecksum(), 0xfe98);
 	PTF_ASSERT_EQUAL(neighSoliLayer->getTargetIP(), pcpp::IPv6Address("fd53:7cb8:383:2::1:117"));
@@ -84,7 +84,7 @@ PTF_TEST_CASE(IcmpV6ParsingTest)
 
 	pcpp::IcmpV6Layer *icmpNeighSoliLayer = neighSoliPacket.getLayerOfType<pcpp::IcmpV6Layer>();
 	PTF_ASSERT_EQUAL(icmpNeighSoliLayer->getHeaderLen(), 32);
-	PTF_ASSERT_EQUAL((int)icmpNeighSoliLayer->getMessageType(), (int)pcpp::ICMPv6MessageType::ICMPv6_NEIGHBOR_SOLICITATION);
+	PTF_ASSERT_EQUAL(icmpNeighSoliLayer->getMessageType(), pcpp::ICMPv6MessageType::ICMPv6_NEIGHBOR_SOLICITATION, enumclass);
 	PTF_ASSERT_EQUAL(icmpNeighSoliLayer->getCode(), 0);
 	PTF_ASSERT_EQUAL(icmpNeighSoliLayer->getChecksum(), 0xfe98);
 
@@ -92,7 +92,7 @@ PTF_TEST_CASE(IcmpV6ParsingTest)
 	PTF_ASSERT_TRUE(neighAdvPacket.isPacketOfType(pcpp::ICMPv6));
 	pcpp::NDPNeighborAdvertisementLayer *neighAdvLayer = neighAdvPacket.getLayerOfType<pcpp::NDPNeighborAdvertisementLayer>();
 	PTF_ASSERT_EQUAL(neighAdvLayer->getHeaderLen(), 32);
-	PTF_ASSERT_EQUAL((int)neighAdvLayer->getMessageType(), (int)pcpp::ICMPv6MessageType::ICMPv6_NEIGHBOR_ADVERTISEMENT);
+	PTF_ASSERT_EQUAL(neighAdvLayer->getMessageType(), pcpp::ICMPv6MessageType::ICMPv6_NEIGHBOR_ADVERTISEMENT, enumclass);
 	PTF_ASSERT_EQUAL(neighAdvLayer->getCode(), 0);
 	PTF_ASSERT_EQUAL(neighAdvLayer->getChecksum(), 0x9abb);
 	PTF_ASSERT_TRUE(neighAdvLayer->getRouterFlag());
@@ -112,7 +112,7 @@ PTF_TEST_CASE(IcmpV6ParsingTest)
 
 	pcpp::IcmpV6Layer *icmpNeighAdv = neighAdvPacket.getLayerOfType<pcpp::IcmpV6Layer>();
 	PTF_ASSERT_EQUAL(icmpNeighAdv->getHeaderLen(), 32);
-	PTF_ASSERT_EQUAL((int)icmpNeighAdv->getMessageType(), (int)pcpp::ICMPv6MessageType::ICMPv6_NEIGHBOR_ADVERTISEMENT);
+	PTF_ASSERT_EQUAL(icmpNeighAdv->getMessageType(), pcpp::ICMPv6MessageType::ICMPv6_NEIGHBOR_ADVERTISEMENT, enumclass);
 	PTF_ASSERT_EQUAL(icmpNeighAdv->getCode(), 0);
 	PTF_ASSERT_EQUAL(icmpNeighAdv->getChecksum(), 0x9abb);
 
@@ -136,7 +136,7 @@ PTF_TEST_CASE(IcmpV6ParsingTest)
 	PTF_ASSERT_NOT_NULL(icmpV6Layer);
 	PTF_ASSERT_EQUAL(icmpV6Layer->getHeaderLen(), 48);
 	PTF_ASSERT_TRUE(icmpV6Layer->isMessageOfType(pcpp::ICMPv6MessageType::ICMPv6_MULTICAST_LISTENER_DISCOVERY_REPORTS));
-	PTF_ASSERT_EQUAL((int)icmpV6Layer->getMessageType(), (int)pcpp::ICMPv6MessageType::ICMPv6_MULTICAST_LISTENER_DISCOVERY_REPORTS);
+	PTF_ASSERT_EQUAL(icmpV6Layer->getMessageType(), pcpp::ICMPv6MessageType::ICMPv6_MULTICAST_LISTENER_DISCOVERY_REPORTS, enumclass);
 	PTF_ASSERT_EQUAL(icmpV6Layer->getCode(), 0);
 	PTF_ASSERT_EQUAL(icmpV6Layer->getChecksum(), 0x2b5a);
 	PTF_ASSERT_EQUAL(icmpV6Layer->toString(), "ICMPv6 Layer, Message type: 143");

--- a/Tests/Packet++Test/Tests/PPPoETests.cpp
+++ b/Tests/Packet++Test/Tests/PPPoETests.cpp
@@ -114,14 +114,14 @@ PTF_TEST_CASE(PPPoEDiscoveryLayerParsingTest)
 
 	pcpp::PPPoEDiscoveryLayer::PPPoETag thirdTag = pppoeDiscoveryLayer->getTag(pcpp::PPPoEDiscoveryLayer::PPPOE_TAG_AC_NAME);
 	PTF_ASSERT_FALSE(thirdTag.isNull());
-	PTF_ASSERT_EQUAL(thirdTag, pppoeDiscoveryLayer->getNextTag(secondTag), object_no_str);
+	PTF_ASSERT_TRUE(thirdTag == pppoeDiscoveryLayer->getNextTag(secondTag));
 	PTF_ASSERT_EQUAL(thirdTag.getType(), pcpp::PPPoEDiscoveryLayer::PPPOE_TAG_AC_NAME, enum);
 	PTF_ASSERT_EQUAL(thirdTag.getDataSize(), 4);
 	PTF_ASSERT_EQUAL(thirdTag.getValueAsString(), "BRAS");
 
 	pcpp::PPPoEDiscoveryLayer::PPPoETag fourthTag = pppoeDiscoveryLayer->getTag(pcpp::PPPoEDiscoveryLayer::PPPOE_TAG_AC_COOKIE);
 	PTF_ASSERT_FALSE(fourthTag.isNull());
-	PTF_ASSERT_EQUAL(fourthTag, pppoeDiscoveryLayer->getNextTag(thirdTag), object_no_str);
+	PTF_ASSERT_TRUE(fourthTag == pppoeDiscoveryLayer->getNextTag(thirdTag));
 	PTF_ASSERT_EQUAL(fourthTag.getType(), pcpp::PPPoEDiscoveryLayer::PPPOE_TAG_AC_COOKIE, enum);
 	PTF_ASSERT_EQUAL(fourthTag.getDataSize(), 16);
 	PTF_ASSERT_EQUAL(fourthTag.getValueAs<uint64_t>(), 0xf284240687050f3dULL);

--- a/Tests/Packet++Test/Tests/SomeIpTests.cpp
+++ b/Tests/Packet++Test/Tests/SomeIpTests.cpp
@@ -65,7 +65,7 @@ PTF_TEST_CASE(SomeIpParsingTest)
 	PTF_ASSERT_EQUAL(someIpLayer->getSessionID(), 0xa);
 	PTF_ASSERT_EQUAL(someIpLayer->getProtocolVersion(), 1);
 	PTF_ASSERT_EQUAL(someIpLayer->getInterfaceVersion(), 0x5);
-	PTF_ASSERT_EQUAL((int)someIpLayer->getMessageType(), (int)pcpp::SomeIpLayer::MsgType::REQUEST);
+	PTF_ASSERT_EQUAL(someIpLayer->getMessageType(), pcpp::SomeIpLayer::MsgType::REQUEST, enumclass);
 	PTF_ASSERT_EQUAL(someIpLayer->getMessageTypeAsInt(), (uint8_t)pcpp::SomeIpLayer::MsgType::REQUEST);
 	PTF_ASSERT_EQUAL(someIpLayer->getReturnCode(), 0);
 	PTF_ASSERT_EQUAL(someIpLayer->getPduPayloadSize(), 22);
@@ -87,7 +87,7 @@ PTF_TEST_CASE(SomeIpParsingTest)
 	PTF_ASSERT_EQUAL(someIpLayer2_1->getSessionID(), 0xa);
 	PTF_ASSERT_EQUAL(someIpLayer2_1->getProtocolVersion(), 1);
 	PTF_ASSERT_EQUAL(someIpLayer2_1->getInterfaceVersion(), 0x5);
-	PTF_ASSERT_EQUAL((int)someIpLayer2_1->getMessageType(), (int)pcpp::SomeIpLayer::MsgType::REQUEST);
+	PTF_ASSERT_EQUAL(someIpLayer2_1->getMessageType(), pcpp::SomeIpLayer::MsgType::REQUEST, enumclass);
 	PTF_ASSERT_EQUAL(someIpLayer2_1->getMessageTypeAsInt(), (uint8_t)pcpp::SomeIpLayer::MsgType::REQUEST);
 	PTF_ASSERT_EQUAL(someIpLayer2_1->getReturnCode(), 0);
 	PTF_ASSERT_EQUAL(someIpLayer2_1->getPduPayloadSize(), 22);
@@ -108,7 +108,7 @@ PTF_TEST_CASE(SomeIpParsingTest)
 	PTF_ASSERT_EQUAL(someIpLayer2_2->getSessionID(), 0xb);
 	PTF_ASSERT_EQUAL(someIpLayer2_2->getProtocolVersion(), 1);
 	PTF_ASSERT_EQUAL(someIpLayer2_2->getInterfaceVersion(), 0x6);
-	PTF_ASSERT_EQUAL((int)someIpLayer2_2->getMessageType(), (int)pcpp::SomeIpLayer::MsgType::REQUEST);
+	PTF_ASSERT_EQUAL(someIpLayer2_2->getMessageType(), pcpp::SomeIpLayer::MsgType::REQUEST, enumclass);
 	PTF_ASSERT_EQUAL(someIpLayer2_2->getMessageTypeAsInt(), (uint8_t)pcpp::SomeIpLayer::MsgType::REQUEST);
 	PTF_ASSERT_EQUAL(someIpLayer2_2->getReturnCode(), 0);
 	PTF_ASSERT_EQUAL(someIpLayer2_2->getPduPayloadSize(), 20);
@@ -193,7 +193,7 @@ PTF_TEST_CASE(SomeIpTpParsingTest)
 	PTF_ASSERT_EQUAL(someIpTpLayer1->getSessionID(), 0x0);
 	PTF_ASSERT_EQUAL(someIpTpLayer1->getProtocolVersion(), 1);
 	PTF_ASSERT_EQUAL(someIpTpLayer1->getInterfaceVersion(), 0x1);
-	PTF_ASSERT_EQUAL((int)someIpTpLayer1->getMessageType(), (int)pcpp::SomeIpLayer::MsgType::TP_REQUEST_NO_RETURN);
+	PTF_ASSERT_EQUAL(someIpTpLayer1->getMessageType(), pcpp::SomeIpLayer::MsgType::TP_REQUEST_NO_RETURN, enumclass);
 	PTF_ASSERT_EQUAL(someIpTpLayer1->getMessageTypeAsInt(), (uint8_t)pcpp::SomeIpLayer::MsgType::TP_REQUEST_NO_RETURN);
 	PTF_ASSERT_EQUAL(someIpTpLayer1->getReturnCode(), 0);
 	PTF_ASSERT_EQUAL(someIpTpLayer1->getOffset(), 0);
@@ -217,7 +217,7 @@ PTF_TEST_CASE(SomeIpTpParsingTest)
 	PTF_ASSERT_EQUAL(someIpTpLayer2->getSessionID(), 0x0);
 	PTF_ASSERT_EQUAL(someIpTpLayer2->getProtocolVersion(), 1);
 	PTF_ASSERT_EQUAL(someIpTpLayer2->getInterfaceVersion(), 0x1);
-	PTF_ASSERT_EQUAL((int)someIpTpLayer2->getMessageType(), (int)pcpp::SomeIpLayer::MsgType::TP_REQUEST_NO_RETURN);
+	PTF_ASSERT_EQUAL(someIpTpLayer2->getMessageType(), pcpp::SomeIpLayer::MsgType::TP_REQUEST_NO_RETURN, enumclass);
 	PTF_ASSERT_EQUAL(someIpTpLayer2->getMessageTypeAsInt(), (uint8_t)pcpp::SomeIpLayer::MsgType::TP_REQUEST_NO_RETURN);
 	PTF_ASSERT_EQUAL(someIpTpLayer2->getReturnCode(), 0);
 	PTF_ASSERT_EQUAL(someIpTpLayer2->getOffset() * 16, 91872);

--- a/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
+++ b/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
@@ -721,9 +721,9 @@ PTF_TEST_CASE(TestTcpReassemblyMultipleConns)
 	pcpp::TcpReassembly::ConnectionInfoList::const_iterator iterConn1 = managedConnections.find(results.flowKeysList[0]);
 	pcpp::TcpReassembly::ConnectionInfoList::const_iterator iterConn2 = managedConnections.find(results.flowKeysList[1]);
 	pcpp::TcpReassembly::ConnectionInfoList::const_iterator iterConn3 = managedConnections.find(results.flowKeysList[2]);
-	PTF_ASSERT_NOT_EQUAL(iterConn1, managedConnections.end(), object_no_str);
-	PTF_ASSERT_NOT_EQUAL(iterConn2, managedConnections.end(), object_no_str);
-	PTF_ASSERT_NOT_EQUAL(iterConn3, managedConnections.end(), object_no_str);
+	PTF_ASSERT_TRUE(iterConn1 != managedConnections.end());
+	PTF_ASSERT_TRUE(iterConn2 != managedConnections.end());
+	PTF_ASSERT_TRUE(iterConn3 != managedConnections.end());
 	PTF_ASSERT_GREATER_THAN(tcpReassembly.isConnectionOpen(iterConn1->second), 0);
 	PTF_ASSERT_EQUAL(tcpReassembly.isConnectionOpen(iterConn2->second), 0);
 	PTF_ASSERT_EQUAL(tcpReassembly.isConnectionOpen(iterConn3->second), 0);
@@ -974,9 +974,9 @@ PTF_TEST_CASE(TestTcpReassemblyCleanup)
 	pcpp::TcpReassembly::ConnectionInfoList::const_iterator iterConn1 = managedConnections.find(results.flowKeysList[0]);
 	pcpp::TcpReassembly::ConnectionInfoList::const_iterator iterConn2 = managedConnections.find(results.flowKeysList[1]);
 	pcpp::TcpReassembly::ConnectionInfoList::const_iterator iterConn3 = managedConnections.find(results.flowKeysList[2]);
-	PTF_ASSERT_NOT_EQUAL(iterConn1, managedConnections.end(), object_no_str);
-	PTF_ASSERT_NOT_EQUAL(iterConn2, managedConnections.end(), object_no_str);
-	PTF_ASSERT_NOT_EQUAL(iterConn3, managedConnections.end(), object_no_str);
+	PTF_ASSERT_TRUE(iterConn1 != managedConnections.end());
+	PTF_ASSERT_TRUE(iterConn2 != managedConnections.end());
+	PTF_ASSERT_TRUE(iterConn3 != managedConnections.end());
 	PTF_ASSERT_EQUAL(tcpReassembly.isConnectionOpen(iterConn1->second), 0);
 	PTF_ASSERT_EQUAL(tcpReassembly.isConnectionOpen(iterConn2->second), 0);
 	PTF_ASSERT_EQUAL(tcpReassembly.isConnectionOpen(iterConn3->second), 0);
@@ -996,9 +996,9 @@ PTF_TEST_CASE(TestTcpReassemblyCleanup)
 	iterConn1 = managedConnections.find(flowKeys[0]);
 	iterConn2 = managedConnections.find(flowKeys[1]);
 	iterConn3 = managedConnections.find(flowKeys[2]);
-	PTF_ASSERT_NOT_EQUAL(iterConn1, managedConnections.end(), object_no_str);
-	PTF_ASSERT_NOT_EQUAL(iterConn2, managedConnections.end(), object_no_str);
-	PTF_ASSERT_NOT_EQUAL(iterConn3, managedConnections.end(), object_no_str);
+	PTF_ASSERT_TRUE(iterConn1 != managedConnections.end());
+	PTF_ASSERT_TRUE(iterConn2 != managedConnections.end());
+	PTF_ASSERT_TRUE(iterConn3 != managedConnections.end());
 	PTF_ASSERT_EQUAL(tcpReassembly.isConnectionOpen(iterConn1->second), -1);
 	PTF_ASSERT_EQUAL(tcpReassembly.isConnectionOpen(iterConn2->second), -1);
 	PTF_ASSERT_EQUAL(tcpReassembly.isConnectionOpen(iterConn3->second), -1);
@@ -1036,8 +1036,8 @@ PTF_TEST_CASE(TestTcpReassemblyMaxOOOFrags)
 
 	pcpp::TcpReassembly::ConnectionInfoList::const_iterator iterConn1 = managedConnections1.find(results1.flowKeysList[0]);
 	pcpp::TcpReassembly::ConnectionInfoList::const_iterator iterConn2 = managedConnections2.find(results2.flowKeysList[0]);
-	PTF_ASSERT_NOT_EQUAL(iterConn1, managedConnections1.end(), object_no_str);
-	PTF_ASSERT_NOT_EQUAL(iterConn2, managedConnections2.end(), object_no_str);
+	PTF_ASSERT_TRUE(iterConn1 != managedConnections1.end());
+	PTF_ASSERT_TRUE(iterConn2 != managedConnections2.end());
 	PTF_ASSERT_EQUAL(tcpReassembly1.isConnectionOpen(iterConn1->second), 1);
 	PTF_ASSERT_EQUAL(tcpReassembly2.isConnectionOpen(iterConn2->second), 1);
 	PTF_ASSERT_EQUAL(results1.stats.begin()->second.numOfDataPackets, 1); // The second data packet is incomplete so we stopped at one

--- a/Tests/PcppTestFramework/PcppTestFramework.h
+++ b/Tests/PcppTestFramework/PcppTestFramework.h
@@ -6,20 +6,44 @@
 #include "memplumber.h"
 #include "PcppTestFrameworkCommon.h"
 
-#define _PTF_PRINT_TYPE(val) "[" << val << "]"
-#define object_no_str_PTF_PRINT_TYPE(val) "'" << #val << "'"
-#define hex_PTF_PRINT_TYPE(val) "0x" << std::hex << val
-#define enum_PTF_PRINT_TYPE(val) #val << "[" << val << "]"
-#define ptr_PTF_PRINT_TYPE(val) #val << "[" << val << "]"
+#define _PTF_PRINT_TYPE_ACTUAL(exp, val) val
+#define _PTF_PRINT_TYPE_EXPECTED(exp, val) val
+#define hex_PTF_PRINT_TYPE_ACTUAL(exp, val) "0x" << std::hex << +val << std::dec
+#define hex_PTF_PRINT_TYPE_EXPECTED(exp, val) "0x" << std::hex << +val << std::dec
+#define enum_PTF_PRINT_TYPE_ACTUAL(exp, val) "enum[" << val << "]"
+#define enum_PTF_PRINT_TYPE_EXPECTED(exp, val) exp << "[" << val << "]"
+#define ptr_PTF_PRINT_TYPE_ACTUAL(exp, val) exp << "[ptr: " << val << "]"
+#define ptr_PTF_PRINT_TYPE_EXPECTED(exp, val) exp << "[ptr: " << val << "]"
+#define enumclass_PTF_PRINT_TYPE_ACTUAL(exp, val) "enum[" << +static_cast<std::underlying_type<decltype(val)>::type>(val) << "]"
+#define enumclass_PTF_PRINT_TYPE_EXPECTED(exp, val) exp << "[" << +static_cast<std::underlying_type<decltype(val)>::type>(val) << "]"
+
+#define PTF_PRINT_ASSERTION(severity, op) \
+	std::cout << std::left << std::setw(35) << __FUNCTION__ << ": " \
+    << severity \
+	<< " (" << __FILE__ << ":" << __LINE__ << "). " \
+	<< "Assert " << op << " failed:" \
+	<< std::endl
+
+#define PTF_PRINT_COMPARE_ASSERTION(severity, op, actualExp, actualVal, expectedExp, expectedVal, objType) \
+	PTF_PRINT_ASSERTION(severity, op) \
+	<< "   Actual:   " << objType##_PTF_PRINT_TYPE_ACTUAL(actualExp, actualVal) \
+	<< std::endl \
+	<< "   Expected: " << objType##_PTF_PRINT_TYPE_EXPECTED(expectedExp, expectedVal) \
+	<< std::endl
+
+#define PTF_PRINT_COMPARE_ASSERTION_FAILED(op, actualExp, actualVal, expectedExp, expectedVal, objType) \
+	PTF_PRINT_COMPARE_ASSERTION("FAILED", op, actualExp, actualVal, expectedExp, expectedVal, objType)
+
+#define PTF_PRINT_COMPARE_ASSERTION_NON_CRITICAL(op, actualExp, actualVal, expectedExp, expectedVal, objType) \
+	PTF_PRINT_COMPARE_ASSERTION("NON-CRITICAL", op, actualExp, actualVal, expectedExp, expectedVal, objType)
 
 #define PTF_TEST_CASE(TestName) void TestName(int& ptfResult, bool printVerbose, bool showSkipped)
 
 #define PTF_INTERNAL_RUN(TestName) \
 	TestName(ptfResult, printVerbose, showSkipped); \
 	if (ptfResult == PTF_RESULT_FAILED) { \
-		std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-		<< "FAILED (" << __FILE__ << ":" << __LINE__ << "). " \
-		<< "Internal test '" << #TestName << "' failed" \
+		PTF_PRINT_ASSERTION("FAILED", "INTERNAL TEST") \
+		<< "   Internal test '" << #TestName << "' failed" \
 		<< std::endl; \
 		return; \
 	} \
@@ -33,32 +57,24 @@
 	ptfResult = PTF_RESULT_PASSED; \
 	return
 
+
 #define PTF_ASSERT_EQUAL(actual, expected, ...) \
 	{ \
-		if (actual != expected) { \
-			std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-			<< "FAILED (" << __FILE__ << ":" << __LINE__ << "). " \
-			<< "Assert EQUAL failed: " \
-			<< "actual: " << __VA_ARGS__##_PTF_PRINT_TYPE(actual) \
-			<< " != " \
-			<< "expected: " << __VA_ARGS__##_PTF_PRINT_TYPE(expected) \
-			<< std::endl; \
+		auto ptfActual = actual; \
+		auto ptfExpected = static_cast<decltype(ptfActual)>(expected); \
+		if (ptfActual != ptfExpected) { \
+			PTF_PRINT_COMPARE_ASSERTION_FAILED("EQUAL", #actual, ptfActual, #expected, ptfExpected, __VA_ARGS__); \
 			ptfResult = PTF_RESULT_FAILED; \
 			return; \
 		} \
 	}
 
-
 #define PTF_ASSERT_NOT_EQUAL(actual, expected, ...) \
 	{ \
-		if (actual == expected) { \
-			std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-			<< "FAILED (" << __FILE__ << ":" << __LINE__ << "). " \
-			<< "Assert NOT EQUAL failed: " \
-			<< "actual: " << __VA_ARGS__##_PTF_PRINT_TYPE(actual) \
-			<< " == " \
-			<< "expected: " << __VA_ARGS__##_PTF_PRINT_TYPE(expected) \
-			<< std::endl; \
+		auto ptfActual = actual; \
+		auto ptfExpected = static_cast<decltype(ptfActual)>(expected); \
+		if (ptfActual == ptfExpected) { \
+			PTF_PRINT_COMPARE_ASSERTION_FAILED("NOT EQUAL", #actual, ptfActual, #expected, ptfExpected, __VA_ARGS__); \
 			ptfResult = PTF_RESULT_FAILED; \
 			return; \
 		} \
@@ -66,14 +82,10 @@
 
 #define PTF_ASSERT_GREATER_THAN(actual, expected, ...) \
 	{ \
-		if (actual <= expected) { \
-			std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-			<< "FAILED (" << __FILE__ << ":" << __LINE__ << "). " \
-			<< "Assert GREATER THAN failed: " \
-			<< "actual: " << __VA_ARGS__##_PTF_PRINT_TYPE(actual) \
-			<< " <= " \
-			<< "expected: " << __VA_ARGS__##_PTF_PRINT_TYPE(expected) \
-			<< std::endl; \
+		auto ptfActual = actual; \
+		auto ptfExpected = static_cast<decltype(ptfActual)>(expected); \
+		if (ptfActual <= ptfExpected) { \
+			PTF_PRINT_COMPARE_ASSERTION_FAILED("GREATER THAN", #actual, ptfActual, #expected, ptfExpected, __VA_ARGS__); \
 			ptfResult = PTF_RESULT_FAILED; \
 			return; \
 		} \
@@ -81,14 +93,10 @@
 
 #define PTF_ASSERT_GREATER_OR_EQUAL_THAN(actual, expected, ...) \
 	{ \
-		if (actual < expected) { \
-			std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-			<< "FAILED (" << __FILE__ << ":" << __LINE__ << "). " \
-			<< "Assert GREATER OR EQUAL THAN failed: " \
-			<< "actual: " << __VA_ARGS__##_PTF_PRINT_TYPE(actual) \
-			<< " < " \
-			<< "expected: " << __VA_ARGS__##_PTF_PRINT_TYPE(expected) \
-			<< std::endl; \
+		auto ptfActual = actual; \
+		auto ptfExpected = static_cast<decltype(ptfActual)>(expected); \
+		if (ptfActual < ptfExpected) { \
+			PTF_PRINT_COMPARE_ASSERTION_FAILED("GREATER OR EQUAL THAN", #actual, ptfActual, #expected, ptfExpected, __VA_ARGS__); \
 			ptfResult = PTF_RESULT_FAILED; \
 			return; \
 		} \
@@ -96,14 +104,10 @@
 
 #define PTF_ASSERT_LOWER_THAN(actual, expected, ...) \
 	{ \
-		if (actual >= expected) { \
-			std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-			<< "FAILED (" << __FILE__ << ":" << __LINE__ << "). " \
-			<< "Assert LOWER THAN failed: " \
-			<< "actual: " << __VA_ARGS__##_PTF_PRINT_TYPE(actual) \
-			<< " >= " \
-			<< "expected: " << __VA_ARGS__##_PTF_PRINT_TYPE(expected) \
-			<< std::endl; \
+		auto ptfActual = actual; \
+		auto ptfExpected = static_cast<decltype(ptfActual)>(expected); \
+		if (ptfActual >= ptfExpected) { \
+			PTF_PRINT_COMPARE_ASSERTION_FAILED("LOWER THAN", #actual, ptfActual, #expected, ptfExpected, __VA_ARGS__); \
 			ptfResult = PTF_RESULT_FAILED; \
 			return; \
 		} \
@@ -111,14 +115,10 @@
 
 #define PTF_ASSERT_LOWER_OR_EQUAL_THAN(actual, expected, ...) \
 	{ \
-		if (actual > expected) { \
-			std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-			<< "FAILED (" << __FILE__ << ":" << __LINE__ << "). " \
-			<< "Assert LOWER OR EQUAL THAN failed: " \
-			<< "actual: " << __VA_ARGS__##_PTF_PRINT_TYPE(actual) \
-			<< " > " \
-			<< "expected: " << __VA_ARGS__##_PTF_PRINT_TYPE(expected) \
-			<< std::endl; \
+		auto ptfActual = actual; \
+		auto ptfExpected = static_cast<decltype(ptfActual)>(expected); \
+		if (ptfActual > ptfExpected) { \
+			PTF_PRINT_COMPARE_ASSERTION_FAILED("LOWER OR EQUAL THAN", #actual, ptfActual, #expected, ptfExpected, __VA_ARGS__); \
 			ptfResult = PTF_RESULT_FAILED; \
 			return; \
 		} \
@@ -126,10 +126,10 @@
 
 #define PTF_ASSERT_BUF_COMPARE(buf1, buf2, size) \
 	if (memcmp(buf1, buf2, size) != 0) { \
-		std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-		<< "FAILED (" << __FILE__ << ":" << __LINE__ << "). " \
-		<< "Assert BUFFER COMPARE failed: " \
-		<< #buf1 << " != " << #buf2 \
+		PTF_PRINT_ASSERTION("FAILED", "BUFFER COMPARE") \
+		<< "   [ " << #buf1 << " ]" << std::endl \
+		<< "   <>" << std::endl \
+	  	<< "   [ " << #buf2 << " ]" \
 		<< std::endl; \
 		ptfResult = PTF_RESULT_FAILED; \
 		return; \
@@ -137,9 +137,8 @@
 
 #define PTF_ASSERT_TRUE(exp) \
 	if (!(exp)) { \
-		std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-		<< "FAILED (" << __FILE__ << ":" << __LINE__ << "). " \
-		<< "Assert TRUE failed: " << #exp \
+		PTF_PRINT_ASSERTION("FAILED", "TRUE") \
+		<< "   [" << #exp  << "]" \
 		<< std::endl; \
 		ptfResult = PTF_RESULT_FAILED; \
 		return; \
@@ -147,9 +146,8 @@
 
 #define PTF_ASSERT_FALSE(exp) \
 	if (exp) { \
-		std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-		<< "FAILED (" << __FILE__ << ":" << __LINE__ << "). " \
-		<< "Assert FALSE failed: " << #exp \
+		PTF_PRINT_ASSERTION("FAILED", "FALSE") \
+		<< "   [" << #exp  << "]" \
 		<< std::endl; \
 		ptfResult = PTF_RESULT_FAILED; \
 		return; \
@@ -157,10 +155,8 @@
 
 #define PTF_ASSERT_NOT_NULL(exp) \
 	if ((exp) == NULL) { \
-		std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-		<< "FAILED (" << __FILE__ << ":" << __LINE__ << "). " \
-		<< "Assert NOT NULL failed: " \
-		<< #exp << " is NULL" \
+		PTF_PRINT_ASSERTION("FAILED", "NOT NULL") \
+		<< "   [" << #exp << "] is NULL" \
 		<< std::endl; \
 		ptfResult = PTF_RESULT_FAILED; \
 		return; \
@@ -168,38 +164,32 @@
 
 #define PTF_ASSERT_NULL(exp) \
 	if ((exp) != NULL) { \
-		std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-		<< "FAILED (" << __FILE__ << ":" << __LINE__ << "). " \
-		<< "Assert NULL failed: " \
-		<< #exp << " is not NULL" \
+		PTF_PRINT_ASSERTION("FAILED", "NULL") \
+		<< "   [" << #exp << "] is not NULL" \
 		<< std::endl; \
 		ptfResult = PTF_RESULT_FAILED; \
 		return; \
 	}
 
 #define PTF_NON_CRITICAL_EQUAL(actual, expected, ...) \
-	if (actual != expected) { \
-		std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-		<< "NON-CRITICAL (" << __FILE__ << ":" << __LINE__ << "). " \
-		<< "Assert EQUAL failed: " \
-		<< "actual: " << __VA_ARGS__##_PTF_PRINT_TYPE(actual) \
-		<< " != " \
-		<< "expected: " << __VA_ARGS__##_PTF_PRINT_TYPE(expected) \
-		<< std::endl; \
+	{ \
+		auto ptfActual = actual; \
+		auto ptfExpected = static_cast<decltype(ptfActual)>(expected); \
+		if (ptfActual != ptfExpected) { \
+			PTF_PRINT_COMPARE_ASSERTION_NON_CRITICAL("EQUAL", #actual, ptfActual, #expected, ptfExpected, __VA_ARGS__); \
+		} \
 	}
-
 
 #define PTF_NON_CRITICAL_TRUE(exp) \
 	if (!exp) { \
-		std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
-		<< "NON-CRITICAL (" << __FILE__ << ":" << __LINE__ << "). " \
-		<< "Expression is not TRUE: " << #exp \
+		PTF_PRINT_ASSERTION("NON-CRITICAL", "TRUE") \
+		<< "   [" << #exp  << "]" \
 		<< std::endl; \
 	}
 
 #define PTF_PRINT_VERBOSE(data) \
 	if(printVerbose) { \
-		std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
+		std::cout << std::left << std::setw(35) << __FUNCTION__ << ": " \
 		<< "[VERBOSE] " \
 		<< data \
 		<< std::endl; \
@@ -208,7 +198,7 @@
 #define PTF_SKIP_TEST(why) \
 	{ \
 		if (showSkipped) { \
-			std::cout << std::left << std::setw(30) << __FUNCTION__ << ": " \
+			std::cout << std::left << std::setw(35) << __FUNCTION__ << ": " \
 			<< "SKIPPED (" << why << ")" \
 			<< std::endl; \
 		} \

--- a/Tests/PcppTestFramework/PcppTestFramework.h
+++ b/Tests/PcppTestFramework/PcppTestFramework.h
@@ -19,7 +19,7 @@
 
 #define PTF_PRINT_ASSERTION(severity, op) \
 	std::cout << std::left << std::setw(35) << __FUNCTION__ << ": " \
-    << severity \
+	<< severity \
 	<< " (" << __FILE__ << ":" << __LINE__ << "). " \
 	<< "Assert " << op << " failed:" \
 	<< std::endl

--- a/Tests/PcppTestFramework/PcppTestFrameworkRun.h
+++ b/Tests/PcppTestFramework/PcppTestFrameworkRun.h
@@ -63,7 +63,7 @@ static bool __ptfCheckTags(const std::string &tagSet, const std::string &tagSetT
 	{ \
 		if (showSkippedTests) \
 		{ \
-			std::cout << std::left << std::setw(30) << #TestName << ": SKIPPED (tags don't match)" << std::endl; \
+			std::cout << std::left << std::setw(35) << #TestName << ": SKIPPED (tags don't match)" << std::endl; \
 		} \
 		TestName##_result = PTF_RESULT_SKIPPED; \
 	} \
@@ -91,7 +91,7 @@ static bool __ptfCheckTags(const std::string &tagSet, const std::string &tagSetT
 				if (memLeakCount > 0 || memLeakSize > 0) \
 				{ \
 					TestName##_result = PTF_RESULT_FAILED; \
-					std::cout << std::left << std::setw(30) << #TestName << ": FAILED. Memory leak found! " \
+					std::cout << std::left << std::setw(35) << #TestName << ": FAILED. Memory leak found! " \
 					<< memLeakCount << " objects and " \
 					<< memLeakSize << "[bytes] leaked" << std::endl; \
 				} \
@@ -99,7 +99,7 @@ static bool __ptfCheckTags(const std::string &tagSet, const std::string &tagSetT
 		} \
 		if (TestName##_result == PTF_RESULT_PASSED) \
 		{ \
-			std::cout << std::left << std::setw(30) << #TestName << ": PASSED" << std::endl; \
+			std::cout << std::left << std::setw(35) << #TestName << ": PASSED" << std::endl; \
 		} \
 	} \
 	if (TestName##_result == PTF_RESULT_PASSED) testsPassed++; \


### PR DESCRIPTION
This PR includes the following improvements to the test framework:
- Evaluate `actual` and `expected` only once at the beginning of the assertion macros instead of twice (once inside the `if` statement and then again when printing)
- Better printing of assertion failures
- Support `PTF_ASSERT_EQUAL` with enum classes
- Remove `object_no_str_PTF_PRINT_TYPE` which is not really needed (no point using `PTF_ASSERT_EQUAL` with objects)
- Increase the width from 30 to 35 chars to fix this: 
![image](https://user-images.githubusercontent.com/9059541/209253050-ea5b927a-4fe9-49c1-847f-cf862b2defdb.png)
