### PR TITLE
Clang tidy: modernize use nullptr instead of NULL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,14 @@ if(PCAPPP_ENABLE_PCAP_SET_DIRECTION)
   add_definitions(-DHAS_SET_DIRECTION_ENABLED)
 endif()
 
+option(PCAPPP_ENABLE_CLANG-TIDY "Run Clang-Tidy static analysis during build" OFF)
+
+if (PCAPPP_ENABLE_CLANG-TIDY)
+  find_program(CLANG_TIDY_EXE NAMES "clang-tidy" REQUIRED)
+  set(CLANG_TIDY_COMMAND "${CLANG_TIDY_EXE}" "--fix" "--checks=modernize-use-nullptr")
+  set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND})
+endif()
+
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 if(MSVC)

--- a/Common++/src/GeneralUtils.cpp
+++ b/Common++/src/GeneralUtils.cpp
@@ -74,12 +74,12 @@ char* cross_platform_memmem(const char* haystack, size_t haystackLen, const char
 	char* ptr = (char*)haystack;
 	while (needleLen <= (haystackLen - (ptr - haystack)))
 	{
-		if (NULL != (ptr = (char*)memchr(ptr, (int)(*needle), haystackLen - (ptr - haystack))))
+		if (nullptr != (ptr = (char*)memchr(ptr, (int)(*needle), haystackLen - (ptr - haystack))))
 		{
 			// check if there is room to do a memcmp
 			if(needleLen > (haystackLen - (ptr - haystack)))
 			{
-				return NULL;
+				return nullptr;
 			}
 
 			if (0 == memcmp(ptr, needle, needleLen))
@@ -91,7 +91,7 @@ char* cross_platform_memmem(const char* haystack, size_t haystackLen, const char
 			break;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 }

--- a/Common++/src/IpAddress.cpp
+++ b/Common++/src/IpAddress.cpp
@@ -30,7 +30,7 @@ namespace pcpp
 	{
 		char addrBuffer[INET_ADDRSTRLEN];
 
-		if (inet_ntop(AF_INET, toBytes(), addrBuffer, sizeof(addrBuffer)) != NULL)
+		if (inet_ntop(AF_INET, toBytes(), addrBuffer, sizeof(addrBuffer)) != nullptr)
 			return std::string(addrBuffer);
 
 		return std::string();
@@ -117,7 +117,7 @@ namespace pcpp
 	{
 		char addrBuffer[INET6_ADDRSTRLEN];
 
-		if (inet_ntop(AF_INET6, toBytes(), addrBuffer, sizeof(addrBuffer)) != NULL)
+		if (inet_ntop(AF_INET6, toBytes(), addrBuffer, sizeof(addrBuffer)) != nullptr)
 			return std::string(addrBuffer);
 
 		return std::string();

--- a/Common++/src/IpUtils.cpp
+++ b/Common++/src/IpUtils.cpp
@@ -20,12 +20,12 @@ namespace pcpp
 	{
 		in_addr* sockaddr2in_addr(struct sockaddr* sa)
 		{
-			if (sa == NULL)
-				return NULL;
+			if (sa == nullptr)
+				return nullptr;
 			if (sa->sa_family == AF_INET)
 				return &(((struct sockaddr_in*)sa)->sin_addr);
 			PCPP_LOG_DEBUG("sockaddr family is not AF_INET. Returning NULL");
-			return NULL;
+			return nullptr;
 		}
 
 		in6_addr* sockaddr2in6_addr(struct sockaddr* sa)
@@ -33,13 +33,13 @@ namespace pcpp
 			if (sa->sa_family == AF_INET6)
 				return &(((struct sockaddr_in6*)sa)->sin6_addr);
 			PCPP_LOG_DEBUG("sockaddr family is not AF_INET6. Returning NULL");
-			return NULL;
+			return nullptr;
 		}
 
 		void sockaddr2string(struct sockaddr* sa, char* resultString)
 		{
 			in_addr* ipv4Addr = sockaddr2in_addr(sa);
-			if (ipv4Addr != NULL)
+			if (ipv4Addr != nullptr)
 			{
 				PCPP_LOG_DEBUG("IPv4 packet address");
 				inet_ntop(AF_INET, &(((sockaddr_in*)sa)->sin_addr), resultString, INET_ADDRSTRLEN);

--- a/Common++/src/MacAddress.cpp
+++ b/Common++/src/MacAddress.cpp
@@ -29,7 +29,7 @@ void MacAddress::init(const char* addr)
 		byte[1] = *addr++;
 		if(*addr != '\0') // holds the ":" char or end of string
 			++addr; // ignore the ":" char
-		m_Address[i] = static_cast<uint8_t>(strtol(byte, NULL, 16));
+		m_Address[i] = static_cast<uint8_t>(strtol(byte, nullptr, 16));
 
 		// The strtol function returns zero value in two cases: when an error occurs or the string '00' is converted.
 		// This code verifies that it's the second case.

--- a/Common++/src/SystemUtils.cpp
+++ b/Common++/src/SystemUtils.cpp
@@ -189,7 +189,7 @@ std::string executeShellCommand(const std::string &command)
 	std::string result = "";
 	while(!feof(pipe))
 	{
-		if(fgets(buffer, 128, pipe) != NULL)
+		if(fgets(buffer, 128, pipe) != nullptr)
 			result += buffer;
 	}
 	PCLOSE(pipe);
@@ -346,10 +346,10 @@ void ApplicationEventHandler::handlerRoutine(int signum)
 		// The way to make sure the signal is called only once is using this lock and putting NULL in m_ApplicationInterruptedHandler
 		const std::lock_guard<std::mutex> lock(UnixLinuxHandlerRoutineMutex);
 
-		if (ApplicationEventHandler::getInstance().m_ApplicationInterruptedHandler != NULL)
+		if (ApplicationEventHandler::getInstance().m_ApplicationInterruptedHandler != nullptr)
 			ApplicationEventHandler::getInstance().m_ApplicationInterruptedHandler(ApplicationEventHandler::getInstance().m_ApplicationInterruptedCookie);
 
-		ApplicationEventHandler::getInstance().m_ApplicationInterruptedHandler = NULL;
+		ApplicationEventHandler::getInstance().m_ApplicationInterruptedHandler = nullptr;
 
 		return;
 	}
@@ -363,7 +363,7 @@ void ApplicationEventHandler::handlerRoutine(int signum)
 
 
 ApplicationEventHandler::ApplicationEventHandler() :
-		 m_ApplicationInterruptedHandler(NULL), m_ApplicationInterruptedCookie(NULL)
+		 m_ApplicationInterruptedHandler(nullptr), m_ApplicationInterruptedCookie(nullptr)
 {
 }
 
@@ -379,7 +379,7 @@ void ApplicationEventHandler::onApplicationInterrupted(EventHandlerCallback hand
 	memset(&action, 0, sizeof(struct sigaction));
 	action.sa_handler = handlerRoutine;
 	sigemptyset(&action.sa_mask);
-	sigaction(SIGINT, &action, NULL);
+	sigaction(SIGINT, &action, nullptr);
 #endif
 }
 

--- a/Examples/ArpSpoofing/main.cpp
+++ b/Examples/ArpSpoofing/main.cpp
@@ -24,12 +24,12 @@
 
 static struct option L3FwdOptions[] =
 {
-	{"interface",  required_argument, 0, 'i'},
-	{"victim", required_argument, 0, 'c'},
-	{"gateway", required_argument, 0, 'g'},
-	{"help", no_argument, 0, 'h'},
-	{"version", no_argument, 0, 'v'},
-	{0, 0, 0, 0}
+	{"interface",  required_argument, nullptr, 'i'},
+	{"victim", required_argument, nullptr, 'c'},
+	{"gateway", required_argument, nullptr, 'g'},
+	{"help", no_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'v'},
+	{nullptr, 0, nullptr, 0}
 };
 
 
@@ -226,7 +226,7 @@ int main(int argc, char* argv[])
 	pcpp::PcapLiveDevice* pIfaceDevice = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ifaceAddr);
 
 	//Verifying interface is valid
-	if (pIfaceDevice == NULL)
+	if (pIfaceDevice == nullptr)
 	{
 		EXIT_WITH_ERROR("Cannot find interface");
 	}

--- a/Examples/Arping/main.cpp
+++ b/Examples/Arping/main.cpp
@@ -30,16 +30,16 @@
 
 static struct option ArpingOptions[] =
 {
-	{"interface",  optional_argument, 0, 'i'},
-	{"source-mac",  optional_argument, 0, 's'},
-	{"source-ip", optional_argument, 0, 'S'},
-	{"target-ip", required_argument, 0, 'T'},
-	{"count", optional_argument, 0, 'c'},
-	{"help", optional_argument, 0, 'h'},
-	{"version", no_argument, 0, 'v'},
-	{"list", optional_argument, 0, 'l'},
-	{"timeout", optional_argument, 0, 'w'},
-	{0, 0, 0, 0}
+	{"interface",  optional_argument, nullptr, 'i'},
+	{"source-mac",  optional_argument, nullptr, 's'},
+	{"source-ip", optional_argument, nullptr, 'S'},
+	{"target-ip", required_argument, nullptr, 'T'},
+	{"count", optional_argument, nullptr, 'c'},
+	{"help", optional_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'v'},
+	{"list", optional_argument, nullptr, 'l'},
+	{"timeout", optional_argument, nullptr, 'w'},
+	{nullptr, 0, nullptr, 0}
 };
 
 
@@ -179,13 +179,13 @@ int main(int argc, char* argv[])
 		EXIT_WITH_ERROR("Target IP is not valid");
 
 
-	pcpp::PcapLiveDevice* dev = NULL;
+	pcpp::PcapLiveDevice* dev = nullptr;
 
 	// Search interface by name or IP
 	if (!ifaceNameOrIP.empty())
 	{
 		dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(ifaceNameOrIP);
-		if (dev == NULL)
+		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 	}
 	else

--- a/Examples/DNSResolver/main.cpp
+++ b/Examples/DNSResolver/main.cpp
@@ -18,15 +18,15 @@
 
 static struct option DNSResolverOptions[] =
 {
-	{"interface",  required_argument, 0, 'i'},
-	{"hostname", required_argument, 0, 's'},
-	{"dns-server", required_argument, 0, 'd'},
-	{"gateway", required_argument, 0, 'g'},
-	{"timeout", optional_argument, 0, 't'},
-	{"help", no_argument, 0, 'h'},
-	{"version", no_argument, 0, 'v'},
-	{"list", no_argument, 0, 'l'},
-	{0, 0, 0, 0}
+	{"interface",  required_argument, nullptr, 'i'},
+	{"hostname", required_argument, nullptr, 's'},
+	{"dns-server", required_argument, nullptr, 'd'},
+	{"gateway", required_argument, nullptr, 'g'},
+	{"timeout", optional_argument, nullptr, 't'},
+	{"help", no_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'v'},
+	{"list", no_argument, nullptr, 'l'},
+	{nullptr, 0, nullptr, 0}
 };
 
 
@@ -175,13 +175,13 @@ int main(int argc, char* argv[])
 		EXIT_WITH_ERROR("Hostname not provided");
 
 	// find the interface to send the DNS request from
-	pcpp::PcapLiveDevice* dev = NULL;
+	pcpp::PcapLiveDevice* dev = nullptr;
 
 	// if interface name or IP was provided - find the device accordingly
 	if (interfaceNameOrIPProvided)
 	{
 		dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
-		if (dev == NULL)
+		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 	}
 	// if interface name or IP was not provided - find a device that has a default gateway
@@ -198,7 +198,7 @@ int main(int argc, char* argv[])
 			}
 		}
 
-		if (dev == NULL)
+		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find an interface with a default gateway");
 	}
 

--- a/Examples/DnsSpoofing/main.cpp
+++ b/Examples/DnsSpoofing/main.cpp
@@ -42,14 +42,14 @@
 
 static struct option DnsSpoofingOptions[] =
 {
-	{"interface",  required_argument, 0, 'i'},
-	{"spoof-dns-server", required_argument, 0, 'd'},
-	{"client-ip", required_argument, 0, 'c'},
-	{"host-list", required_argument, 0, 'o'},
-	{"help", no_argument, 0, 'h'},
-	{"version", no_argument, 0, 'v'},
-	{"list", no_argument, 0, 'l'},
-	{0, 0, 0, 0}
+	{"interface",  required_argument, nullptr, 'i'},
+	{"spoof-dns-server", required_argument, nullptr, 'd'},
+	{"client-ip", required_argument, nullptr, 'c'},
+	{"host-list", required_argument, nullptr, 'o'},
+	{"help", no_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'v'},
+	{"list", no_argument, nullptr, 'l'},
+	{nullptr, 0, nullptr, 0}
 };
 
 
@@ -157,7 +157,7 @@ void handleDnsRequest(pcpp::RawPacket* packet, pcpp::PcapLiveDevice* dev, void* 
 	pcpp::DnsLayer* dnsLayer = dnsRequest.getLayerOfType<pcpp::DnsLayer>();
 
 	// skip DNS requests with more than 1 request or with 0 requests
-	if (dnsLayer->getDnsHeader()->numberOfQuestions != pcpp::hostToNet16(1) || dnsLayer->getFirstQuery() == NULL)
+	if (dnsLayer->getDnsHeader()->numberOfQuestions != pcpp::hostToNet16(1) || dnsLayer->getFirstQuery() == nullptr)
 		return;
 
 	// skip DNS requests which are not of class IN and type A (IPv4) or AAAA (IPv6)
@@ -174,7 +174,7 @@ void handleDnsRequest(pcpp::RawPacket* packet, pcpp::PcapLiveDevice* dev, void* 
 		// go over all hosts in dnsHostsToSpoof list and see if current query matches one of them
 		for (std::vector<std::string>::iterator iter = args->dnsHostsToSpoof.begin(); iter != args->dnsHostsToSpoof.end(); iter++)
 		{
-			if (dnsLayer->getQuery(*iter, false) != NULL)
+			if (dnsLayer->getQuery(*iter, false) != nullptr)
 			{
 				hostMatch = true;
 				break;
@@ -197,7 +197,7 @@ void handleDnsRequest(pcpp::RawPacket* packet, pcpp::PcapLiveDevice* dev, void* 
 	pcpp::IPAddress srcIP = ipLayer->getSrcIPAddress();
 	pcpp::IPv4Layer* ip4Layer = dynamic_cast<pcpp::IPv4Layer*>(ipLayer);
 	pcpp::IPv6Layer* ip6Layer = dynamic_cast<pcpp::IPv6Layer*>(ipLayer);
-	if (ip4Layer != NULL)
+	if (ip4Layer != nullptr)
 	{
 		ip4Layer->setSrcIPv4Address(ip4Layer->getDstIPv4Address());
 		ip4Layer->setDstIPv4Address(srcIP.getIPv4());
@@ -428,7 +428,7 @@ int main(int argc, char* argv[])
 		}
 	}
 
-	pcpp::PcapLiveDevice* dev = NULL;
+	pcpp::PcapLiveDevice* dev = nullptr;
 
 	// check if interface argument is IP or name and extract the device
 	if (interfaceNameOrIP.empty())
@@ -437,7 +437,7 @@ int main(int argc, char* argv[])
 	}
 
 	dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
-	if (dev == NULL)
+	if (dev == nullptr)
 		EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 
 	// verify DNS server IP is a valid IPv4 address

--- a/Examples/HttpAnalyzer/main.cpp
+++ b/Examples/HttpAnalyzer/main.cpp
@@ -51,16 +51,16 @@
 
 static struct option HttpAnalyzerOptions[] =
 {
-	{"interface",  required_argument, 0, 'i'},
-	{"dst-port",  required_argument, 0, 'p'},
-	{"input-file",  required_argument, 0, 'f'},
-	{"output-file", required_argument, 0, 'o'},
-	{"rate-calc-period", required_argument, 0, 'r'},
-	{"disable-rates-print", no_argument, 0, 'd'},
-	{"list-interfaces", no_argument, 0, 'l'},
-	{"help", no_argument, 0, 'h'},
-	{"version", no_argument, 0, 'v'},
-	{0, 0, 0, 0}
+	{"interface",  required_argument, nullptr, 'i'},
+	{"dst-port",  required_argument, nullptr, 'p'},
+	{"input-file",  required_argument, nullptr, 'f'},
+	{"output-file", required_argument, nullptr, 'o'},
+	{"rate-calc-period", required_argument, nullptr, 'r'},
+	{"disable-rates-print", no_argument, nullptr, 'd'},
+	{"list-interfaces", no_argument, nullptr, 'l'},
+	{"help", no_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'v'},
+	{nullptr, 0, nullptr, 0}
 };
 
 
@@ -160,7 +160,7 @@ void httpPacketArrive(pcpp::RawPacket* packet, pcpp::PcapLiveDevice* dev, void* 
 	data->statsCollector->collectStats(&parsedPacket);
 
 	// if needed - write the packet to the output pcap file
-	if (data->pcapWriter != NULL)
+	if (data->pcapWriter != nullptr)
 	{
 		data->pcapWriter->writePacket(*packet);
 	}
@@ -456,7 +456,7 @@ void analyzeHttpFromLiveTraffic(pcpp::PcapLiveDevice* dev, bool printRatesPeriod
 		EXIT_WITH_ERROR("Could not set up filter on device");
 
 	// if needed to save the captured packets to file - open a writer device
-	pcpp::PcapFileWriterDevice* pcapWriter = NULL;
+	pcpp::PcapFileWriterDevice* pcapWriter = nullptr;
 	if (savePacketsToFileName != "")
 	{
 		pcapWriter = new pcpp::PcapFileWriterDevice(savePacketsToFileName);
@@ -504,7 +504,7 @@ void analyzeHttpFromLiveTraffic(pcpp::PcapLiveDevice* dev, bool printRatesPeriod
 	printStatsSummary(collector);
 
 	// close and free the writer device
-	if (pcapWriter != NULL)
+	if (pcapWriter != nullptr)
 	{
 		pcapWriter->close();
 		delete pcapWriter;
@@ -587,7 +587,7 @@ int main(int argc, char* argv[])
 	else // analyze in live traffic mode
 	{
 		pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
-		if (dev == NULL)
+		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 
 		// start capturing and analyzing traffic

--- a/Examples/IPDefragUtil/main.cpp
+++ b/Examples/IPDefragUtil/main.cpp
@@ -21,13 +21,13 @@
 
 static struct option DefragUtilOptions[] =
 {
-	{"output-file", required_argument, 0, 'o'},
-	{"filter-by-ipid", required_argument, 0, 'd'},
-	{"bpf-filter", required_argument, 0, 'f'},
-	{"copy-all-packets", no_argument, 0, 'a'},
-	{"help", no_argument, 0, 'h'},
-	{"version", no_argument, 0, 'v'},
-	{0, 0, 0, 0}
+	{"output-file", required_argument, nullptr, 'o'},
+	{"filter-by-ipid", required_argument, nullptr, 'd'},
+	{"bpf-filter", required_argument, nullptr, 'f'},
+	{"copy-all-packets", no_argument, nullptr, 'a'},
+	{"help", no_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'v'},
+	{nullptr, 0, nullptr, 0}
 };
 
 /**
@@ -154,7 +154,7 @@ void processPackets(pcpp::IFileReaderDevice* reader, pcpp::IFileWriterDevice* wr
 		{
 			// get the IPv4 layer
 			pcpp::IPv4Layer* ipv4Layer = parsedPacket.getLayerOfType<pcpp::IPv4Layer>();
-			if (ipv4Layer != NULL)
+			if (ipv4Layer != nullptr)
 			{
 				// check if packet ID matches one of the IP IDs requested by the user
 				if (fragIDs.find((uint32_t)pcpp::netToHost16(ipv4Layer->getIPv4Header()->ipId)) != fragIDs.end())
@@ -169,7 +169,7 @@ void processPackets(pcpp::IFileReaderDevice* reader, pcpp::IFileWriterDevice* wr
 
 			// get the IPv6 layer
 			pcpp::IPv6Layer* ipv6Layer = parsedPacket.getLayerOfType<pcpp::IPv6Layer>();
-			if (ipv6Layer != NULL && ipv6Layer->isFragment())
+			if (ipv6Layer != nullptr && ipv6Layer->isFragment())
 			{
 				// if this packet is a fragment, get the fragmentation header
 				pcpp::IPv6FragmentationHeader* fragHdr = ipv6Layer->getExtensionOfType<pcpp::IPv6FragmentationHeader>();
@@ -394,13 +394,13 @@ int main(int argc, char* argv[])
 
 
 	// create a writer device for output file in the same file type as input file
-	pcpp::IFileWriterDevice* writer = NULL;
+	pcpp::IFileWriterDevice* writer = nullptr;
 
-	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != NULL)
+	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != nullptr)
 	{
 		writer = new pcpp::PcapFileWriterDevice(outputFile, ((pcpp::PcapFileReaderDevice*)reader)->getLinkLayerType());
 	}
-	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != NULL)
+	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != nullptr)
 	{
 		writer = new pcpp::PcapNgFileWriterDevice(outputFile);
 	}

--- a/Examples/IPFragUtil/main.cpp
+++ b/Examples/IPFragUtil/main.cpp
@@ -23,14 +23,14 @@
 
 static struct option FragUtilOptions[] =
 {
-	{"output-file", required_argument, 0, 'o'},
-	{"frag-size", required_argument, 0, 's'},
-	{"filter-by-ipid", required_argument, 0, 'd'},
-	{"bpf-filter", required_argument, 0, 'f'},
-	{"copy-all-packets", no_argument, 0, 'a'},
-	{"help", no_argument, 0, 'h'},
-	{"version", no_argument, 0, 'v'},
-	{0, 0, 0, 0}
+	{"output-file", required_argument, nullptr, 'o'},
+	{"frag-size", required_argument, nullptr, 's'},
+	{"filter-by-ipid", required_argument, nullptr, 'd'},
+	{"bpf-filter", required_argument, nullptr, 'f'},
+	{"copy-all-packets", no_argument, nullptr, 'a'},
+	{"help", no_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'v'},
+	{nullptr, 0, nullptr, 0}
 };
 
 /**
@@ -158,7 +158,7 @@ void splitIPPacketToFragmentsBySize(pcpp::RawPacket* rawPacket, size_t fragmentS
 	else
 		return;
 
-	pcpp::Layer* ipLayer = NULL;
+	pcpp::Layer* ipLayer = nullptr;
 	if (ipProto == pcpp::IPv4)
 		ipLayer = packet.getLayerOfType<pcpp::IPv4Layer>();
 	else // ipProto == IPv6
@@ -195,7 +195,7 @@ void splitIPPacketToFragmentsBySize(pcpp::RawPacket* rawPacket, size_t fragmentS
 		pcpp::Packet newFrag(newFragRawPacket);
 
 		// find the IPv4/6 layer of the new fragment
-		pcpp::Layer* fragIpLayer = NULL;
+		pcpp::Layer* fragIpLayer = nullptr;
 		if (ipProto == pcpp::IPv4)
 			fragIpLayer = newFrag.getLayerOfType<pcpp::IPv4Layer>();
 		else // ipProto == IPv6
@@ -289,7 +289,7 @@ void processPackets(pcpp::IFileReaderDevice* reader, pcpp::IFileWriterDevice* wr
 		{
 			// get the IPv4 layer
 			pcpp::IPv4Layer* ipLayer = parsedPacket.getLayerOfType<pcpp::IPv4Layer>();
-			if (ipLayer != NULL)
+			if (ipLayer != nullptr)
 			{
 				// check if packet ID matches one of the IP IDs requested by the user
 				if (ipIDs.find(pcpp::netToHost16(ipLayer->getIPv4Header()->ipId)) != ipIDs.end())
@@ -507,13 +507,13 @@ int main(int argc, char* argv[])
 
 
 	// create a writer device for output file in the same file type as input file
-	pcpp::IFileWriterDevice* writer = NULL;
+	pcpp::IFileWriterDevice* writer = nullptr;
 
-	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != NULL)
+	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != nullptr)
 	{
 		writer = new pcpp::PcapFileWriterDevice(outputFile, ((pcpp::PcapFileReaderDevice*)reader)->getLinkLayerType());
 	}
-	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != NULL)
+	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != nullptr)
 	{
 		writer = new pcpp::PcapNgFileWriterDevice(outputFile);
 	}

--- a/Examples/IcmpFileTransfer/Common.cpp
+++ b/Examples/IcmpFileTransfer/Common.cpp
@@ -21,16 +21,16 @@
 
 static struct option IcmpFTOptions[] =
 {
-	{"interface",  required_argument, 0, 'i'},
-	{"dest-ip",  required_argument, 0, 'd'},
-	{"send-file",  required_argument, 0, 's'},
-	{"receive-file", no_argument, 0, 'r'},
-	{"speed", required_argument, 0, 'p'},
-	{"block-size", required_argument, 0, 'b'},
-	{"list-interfaces", no_argument, 0, 'l'},
-	{"help", no_argument, 0, 'h'},
-	{"version", no_argument, 0, 'v'},
-	{0, 0, 0, 0}
+	{"interface",  required_argument, nullptr, 'i'},
+	{"dest-ip",  required_argument, nullptr, 'd'},
+	{"send-file",  required_argument, nullptr, 's'},
+	{"receive-file", no_argument, nullptr, 'r'},
+	{"speed", required_argument, nullptr, 'p'},
+	{"block-size", required_argument, nullptr, 'b'},
+	{"list-interfaces", no_argument, nullptr, 'l'},
+	{"help", no_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'v'},
+	{nullptr, no_argument, nullptr, no_argument}
 };
 
 
@@ -172,7 +172,7 @@ void readCommandLineArguments(int argc, char* argv[],
 	if (!interfaceIP.isValid())
 	{
 		pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByName(interfaceNameOrIP);
-		if (dev == NULL)
+		if (dev == nullptr)
 			EXIT_WITH_ERROR_PRINT_USAGE("Cannot find interface by provided name");
 
 		myIP = dev->getIPv4Address();
@@ -237,9 +237,9 @@ bool sendIcmpMessage(pcpp::PcapLiveDevice* dev,
 
 	// then ICMP
 	pcpp::IcmpLayer icmpLayer;
-	if (sendRequest && icmpLayer.setEchoRequestData(icmpMsgId, 0, msgType, data, dataLen) == NULL)
+	if (sendRequest && icmpLayer.setEchoRequestData(icmpMsgId, 0, msgType, data, dataLen) == nullptr)
 		EXIT_WITH_ERROR("Cannot set ICMP echo request data");
-	else if (!sendRequest && icmpLayer.setEchoReplyData(icmpMsgId, 0, msgType, data, dataLen) == NULL)
+	else if (!sendRequest && icmpLayer.setEchoReplyData(icmpMsgId, 0, msgType, data, dataLen) == nullptr)
 		EXIT_WITH_ERROR("Cannot set ICMP echo response data");
 
 	// create an new packet and add all layers to it

--- a/Examples/IcmpFileTransfer/IcmpFileTransfer-catcher.cpp
+++ b/Examples/IcmpFileTransfer/IcmpFileTransfer-catcher.cpp
@@ -72,14 +72,14 @@ static bool waitForFileTransferStart(pcpp::RawPacket* rawPacket, pcpp::PcapLiveD
 	if (!parsedPacket.isPacketOfType(pcpp::ICMP) || !parsedPacket.isPacketOfType(pcpp::IPv4))
 		return false;
 
-	if (icmpVoidData == NULL)
+	if (icmpVoidData == nullptr)
 		return false;
 
 	IcmpFileTransferStart* icmpFTStart = (IcmpFileTransferStart*)icmpVoidData;
 
 	// extract the ICMP layer, verify it's an ICMP request
 	pcpp::IcmpLayer* icmpLayer = parsedPacket.getLayerOfType<pcpp::IcmpLayer>();
-	if (icmpLayer->getEchoRequestData() == NULL)
+	if (icmpLayer->getEchoRequestData() == nullptr)
 		return false;
 
 	// verify the source IP is the pitcher's IP and the dest IP is the catcher's IP
@@ -107,7 +107,7 @@ static bool waitForFileTransferStart(pcpp::RawPacket* rawPacket, pcpp::PcapLiveD
 			dev->getMacAddress(), ethLayer->getSourceMac(),
 			icmpFTStart->catcherIPAddr, icmpFTStart->pitcherIPAddr,
 			icmpId, ICMP_FT_ACK,
-			NULL, 0))
+			nullptr, 0))
 		EXIT_WITH_ERROR("Cannot send ACK message to pitcher");
 
 	// set the current ICMP ID. It's important for the catcher to keep track of the ICMP ID to make sure it doesn't miss any message
@@ -131,14 +131,14 @@ static bool getFileContent(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev
 	if (!parsedPacket.isPacketOfType(pcpp::ICMP) || !parsedPacket.isPacketOfType(pcpp::IPv4))
 		return false;
 
-	if (icmpVoidData == NULL)
+	if (icmpVoidData == nullptr)
 		return false;
 
 	IcmpFileContentDataRecv* icmpData = (IcmpFileContentDataRecv*)icmpVoidData;
 
 	// extract the ICMP layer, verify it's an ICMP request
 	pcpp::IcmpLayer* icmpLayer = parsedPacket.getLayerOfType<pcpp::IcmpLayer>();
-	if (icmpLayer->getEchoRequestData() == NULL)
+	if (icmpLayer->getEchoRequestData() == nullptr)
 		return false;
 
 	// verify the source IP is the pitcher's IP and the dest IP is the catcher's IP
@@ -204,7 +204,7 @@ void receiveFile(pcpp::IPv4Address pitcherIP, pcpp::IPv4Address catcherIP)
 {
 	// identify the interface to listen and send packets to
 	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(catcherIP);
-	if (dev == NULL)
+	if (dev == nullptr)
 		EXIT_WITH_ERROR("Cannot find network interface with IP '" << catcherIP << "'");
 
 	// try to open the interface (device)
@@ -282,14 +282,14 @@ static bool startFileTransfer(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* 
 	if (!parsedPacket.isPacketOfType(pcpp::ICMP) || !parsedPacket.isPacketOfType(pcpp::IPv4))
 		return false;
 
-	if (icmpVoidData == NULL)
+	if (icmpVoidData == nullptr)
 		return false;
 
 	IcmpFileTransferStart* icmpFTStart = (IcmpFileTransferStart*)icmpVoidData;
 
 	// extract the ICMP layer, verify it's an ICMP request
 	pcpp::IcmpLayer* icmpLayer = parsedPacket.getLayerOfType<pcpp::IcmpLayer>();
-	if (icmpLayer->getEchoRequestData() == NULL)
+	if (icmpLayer->getEchoRequestData() == nullptr)
 		return false;
 
 	// verify the source IP is the pitcher's IP and the dest IP is the catcher's IP
@@ -332,14 +332,14 @@ static bool sendContent(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev, v
 	if (!parsedPacket.isPacketOfType(pcpp::ICMP) || !parsedPacket.isPacketOfType(pcpp::IPv4))
 		return false;
 
-	if (icmpVoidData == NULL)
+	if (icmpVoidData == nullptr)
 		return false;
 
 	IcmpFileContentDataSend* icmpFileContentData = (IcmpFileContentDataSend*)icmpVoidData;
 
 	// extract the ICMP layer, verify it's an ICMP request
 	pcpp::IcmpLayer* icmpLayer = parsedPacket.getLayerOfType<pcpp::IcmpLayer>();
-	if (icmpLayer->getEchoRequestData() == NULL)
+	if (icmpLayer->getEchoRequestData() == nullptr)
 		return false;
 
 	// verify the source IP is the pitcher's IP and the dest IP is the catcher's IP
@@ -370,7 +370,7 @@ static bool sendContent(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev, v
 				dev->getMacAddress(), ethLayer->getSourceMac(),
 				icmpFileContentData->catcherIPAddr, icmpFileContentData->pitcherIPAddr,
 				icmpId, ICMP_FT_END,
-				NULL, 0))
+				nullptr, 0))
 			EXIT_WITH_ERROR("Cannot send file transfer end message to pitcher");
 
 		// then return true so the sendFile() will stop blocking
@@ -432,7 +432,7 @@ void sendFile(const std::string &filePath, pcpp::IPv4Address pitcherIP, pcpp::IP
 {
 	// identify the interface to listen and send packets to
 	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(catcherIP);
-	if (dev == NULL)
+	if (dev == nullptr)
 		EXIT_WITH_ERROR("Cannot find network interface with IP '" << catcherIP << "'");
 
 	// try to open the interface (device)
@@ -485,7 +485,7 @@ void sendFile(const std::string &filePath, pcpp::IPv4Address pitcherIP, pcpp::IP
 				true,
 				0,
 				blockSize,
-				NULL
+				nullptr
 		};
 
 		// create the memory block that will contain the file data chunks that will be transferred to the pitcher
@@ -530,7 +530,7 @@ int main(int argc, char* argv[])
 	size_t blockSize = 0;
 
 	// disable stdout buffering so all std::cout command will be printed immediately
-	setbuf(stdout, NULL);
+	setbuf(stdout, nullptr);
 
 	// read and parse command line arguments. This method also takes care of arguments correctness. If they're not correct, it'll exit the program
 	readCommandLineArguments(argc, argv, "catcher", "pitcher", sender, receiver, catcherIP, pitcherIP, fileNameToSend, packetsPerSec, blockSize);

--- a/Examples/IcmpFileTransfer/IcmpFileTransfer-pitcher.cpp
+++ b/Examples/IcmpFileTransfer/IcmpFileTransfer-pitcher.cpp
@@ -94,14 +94,14 @@ static void waitForFileTransferStart(pcpp::RawPacket* rawPacket, pcpp::PcapLiveD
 	if (!parsedPacket.isPacketOfType(pcpp::ICMP) || !parsedPacket.isPacketOfType(pcpp::IPv4))
 		return;
 
-	if (icmpVoidData == NULL)
+	if (icmpVoidData == nullptr)
 		return;
 
 	IcmpFileTransferStartRecv* icmpFTStart = (IcmpFileTransferStartRecv*)icmpVoidData;
 
 	// extract the ICMP layer, verify it's an ICMP reply
 	pcpp::IcmpLayer* icmpLayer = parsedPacket.getLayerOfType<pcpp::IcmpLayer>();
-	if (icmpLayer->getEchoReplyData() == NULL)
+	if (icmpLayer->getEchoReplyData() == nullptr)
 		return;
 
 	// verify the source IP is the catcher's IP and the dest IP is the pitcher's IP
@@ -115,7 +115,7 @@ static void waitForFileTransferStart(pcpp::RawPacket* rawPacket, pcpp::PcapLiveD
 		return;
 
 	// verify there is data in the ICMP reply
-	if (icmpLayer->getEchoReplyData()->data == NULL)
+	if (icmpLayer->getEchoReplyData()->data == nullptr)
 		return;
 
 	// extract the file name from the ICMP reply data
@@ -139,14 +139,14 @@ static void getFileContent(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev
 	if (!parsedPacket.isPacketOfType(pcpp::ICMP) || !parsedPacket.isPacketOfType(pcpp::IPv4))
 		return;
 
-	if (icmpVoidData == NULL)
+	if (icmpVoidData == nullptr)
 		return;
 
 	IcmpFileContentData* icmpFileContentData = (IcmpFileContentData*)icmpVoidData;
 
 	// extract the ICMP layer, verify it's an ICMP reply
 	pcpp::IcmpLayer* icmpLayer = parsedPacket.getLayerOfType<pcpp::IcmpLayer>();
-	if (icmpLayer->getEchoReplyData() == NULL)
+	if (icmpLayer->getEchoReplyData() == nullptr)
 		return;
 
 	// verify the source IP is the catcher's IP and the dest IP is the pitcher's IP
@@ -185,7 +185,7 @@ static void getFileContent(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev
 	}
 
 	// verify the ICMP reply has data
-	if (icmpLayer->getEchoReplyData()->data == NULL)
+	if (icmpLayer->getEchoReplyData()->data == nullptr)
 		return;
 
 	// increment the expected ICMP ID
@@ -214,7 +214,7 @@ void receiveFile(pcpp::IPv4Address pitcherIP, pcpp::IPv4Address catcherIP, int p
 {
 	// identify the interface to listen and send packets to
 	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(pitcherIP);
-	if (dev == NULL)
+	if (dev == nullptr)
 		EXIT_WITH_ERROR("Cannot find network interface with IP '" << pitcherIP << "'");
 
 	// try to open the interface (device)
@@ -261,7 +261,7 @@ void receiveFile(pcpp::IPv4Address pitcherIP, pcpp::IPv4Address catcherIP, int p
 	// while didn't receive response from the catcher, keep sending the ICMP_FT_WAITING_FT_START message
 	while (!icmpFTStart.gotFileTransferStartMsg)
 	{
-		sendIcmpRequest(dev, pitcherMacAddr, catcherMacAddr, pitcherIP, catcherIP, icmpId, ICMP_FT_WAITING_FT_START, NULL, 0);
+		sendIcmpRequest(dev, pitcherMacAddr, catcherMacAddr, pitcherIP, catcherIP, icmpId, ICMP_FT_WAITING_FT_START, nullptr, 0);
 		icmpId++;
 		// sleep for a few seconds between sending the message
 		pcpp::multiPlatformSleep(SEND_TIMEOUT_BEFORE_FT_START);
@@ -314,7 +314,7 @@ void receiveFile(pcpp::IPv4Address pitcherIP, pcpp::IPv4Address catcherIP, int p
 		// keep sending ICMP requests with ICMP_FT_WAITING_DATA message in the timestamp field until all file was received or until an error occurred
 		while (!icmpFileContentData.fileTransferCompleted && !icmpFileContentData.fileTransferError)
 		{
-			sendIcmpRequest(dev, pitcherMacAddr, catcherMacAddr, pitcherIP, catcherIP, icmpId, ICMP_FT_WAITING_DATA, NULL, 0);
+			sendIcmpRequest(dev, pitcherMacAddr, catcherMacAddr, pitcherIP, catcherIP, icmpId, ICMP_FT_WAITING_DATA, nullptr, 0);
 
 			// if rate limit was set by the user, sleep between sending packets
 			if (packetPerSec > 1)
@@ -334,7 +334,7 @@ void receiveFile(pcpp::IPv4Address pitcherIP, pcpp::IPv4Address catcherIP, int p
 		{
 			for (int i = 0; i < NUM_OF_ABORT_MESSAGES_TO_SEND; i++)
 			{
-				sendIcmpRequest(dev, pitcherMacAddr, catcherMacAddr, pitcherIP, catcherIP, icmpId, ICMP_FT_ABORT, NULL, 0);
+				sendIcmpRequest(dev, pitcherMacAddr, catcherMacAddr, pitcherIP, catcherIP, icmpId, ICMP_FT_ABORT, nullptr, 0);
 				usleep(SLEEP_BETWEEN_ABORT_MESSAGES);
 			}
 
@@ -369,14 +369,14 @@ static bool waitForFileTransferStartAck(pcpp::RawPacket* rawPacket, pcpp::PcapLi
 	if (!parsedPacket.isPacketOfType(pcpp::ICMP) || !parsedPacket.isPacketOfType(pcpp::IPv4))
 		return false;
 
-	if (icmpVoidData == NULL)
+	if (icmpVoidData == nullptr)
 		return false;
 
 	IcmpFileTransferStartSend* icmpData = (IcmpFileTransferStartSend*)icmpVoidData;
 
 	// extract the ICMP layer, verify it's an ICMP reply
 	pcpp::IcmpLayer* icmpLayer = parsedPacket.getLayerOfType<pcpp::IcmpLayer>();
-	if (icmpLayer->getEchoReplyData() == NULL)
+	if (icmpLayer->getEchoReplyData() == nullptr)
 		return false;
 
 	// verify the ICMP ID of the reply matched the ICMP ID the pitcher sent in the request
@@ -405,7 +405,7 @@ void sendFile(const std::string &filePath, pcpp::IPv4Address pitcherIP, pcpp::IP
 {
 	// identify the interface to listen and send packets to
 	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(pitcherIP);
-	if (dev == NULL)
+	if (dev == nullptr)
 		EXIT_WITH_ERROR("Cannot find network interface with IP '" << pitcherIP << "'");
 
 	// try to open the interface (device)
@@ -534,7 +534,7 @@ void sendFile(const std::string &filePath, pcpp::IPv4Address pitcherIP, pcpp::IP
 
 		// done sending the file to the catcher, send an ICMP request with message type ICMP_FT_END (in the timestamp field) to the catcher
 		// to indicate all file was sent
-		if (!sendIcmpRequest(dev, pitcherMacAddr, catcherMacAddr, pitcherIP, catcherIP, icmpId, ICMP_FT_END, NULL, 0))
+		if (!sendIcmpRequest(dev, pitcherMacAddr, catcherMacAddr, pitcherIP, catcherIP, icmpId, ICMP_FT_END, nullptr, 0))
 			EXIT_WITH_ERROR("Cannot send file transfer end message");
 
 		std::cout << std::endl << std::endl
@@ -566,7 +566,7 @@ int main(int argc, char* argv[])
 	size_t blockSize = 0;
 
 	// disable stdout buffering so all std::cout command will be printed immediately
-	setbuf(stdout, NULL);
+	setbuf(stdout, nullptr);
 
 	// read and parse command line arguments. This method also takes care of arguments correctness. If they're not correct, it'll exit the program
 	readCommandLineArguments(argc, argv, "pitcher", "catcher", sender, receiver, pitcherIP, catcherIP, fileNameToSend, packetsPerSec, blockSize);

--- a/Examples/PcapPlusPlus-benchmark/benchmark.cpp
+++ b/Examples/PcapPlusPlus-benchmark/benchmark.cpp
@@ -34,14 +34,14 @@ bool handle_dns(Packet& packet)
 	DnsLayer* dnsLayer = packet.getLayerOfType<DnsLayer>();
 
 	DnsQuery* query = dnsLayer->getFirstQuery();
-	while (query != NULL)
+	while (query != nullptr)
 	{
 		count++;
 		query = dnsLayer->getNextQuery(query);
 	}
 
 	DnsResource* answer = dnsLayer->getFirstAnswer();
-	while (answer != NULL)
+	while (answer != nullptr)
 	{
 		count++;
 		answer = dnsLayer->getNextAnswer(answer);

--- a/Examples/PcapPrinter/main.cpp
+++ b/Examples/PcapPrinter/main.cpp
@@ -24,13 +24,13 @@
 
 static struct option PcapPrinterOptions[] =
 {
-	{"output-file", required_argument, 0, 'o'},
-	{"packet-count", required_argument, 0, 'c'},
-	{"filter", required_argument, 0, 'i'},
-	{"summary", no_argument, 0, 's'},
-	{"help", no_argument, 0, 'h'},
-	{"version", no_argument, 0, 'v'},
-	{0, 0, 0, 0}
+	{"output-file", required_argument, nullptr, 'o'},
+	{"packet-count", required_argument, nullptr, 'c'},
+	{"filter", required_argument, nullptr, 'i'},
+	{"summary", no_argument, nullptr, 's'},
+	{"help", no_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'v'},
+	{nullptr, 0, nullptr, 0}
 };
 
 
@@ -112,19 +112,19 @@ std::string printFileSummary(pcpp::IFileReaderDevice* reader)
 	stream << "   File name: " << reader->getFileName() << std::endl;
 	stream << "   File size: " << reader->getFileSize() << " bytes" << std::endl;
 
-	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != NULL)
+	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != nullptr)
 	{
 		pcpp::PcapFileReaderDevice* pcapReader = dynamic_cast<pcpp::PcapFileReaderDevice*>(reader);
 		pcpp::LinkLayerType linkLayer = pcapReader->getLinkLayerType();
 		stream << "   Link layer type: " << linkLayerToString(linkLayer) << std::endl;
 	}
-	else if (dynamic_cast<pcpp::SnoopFileReaderDevice*>(reader) != NULL)
+	else if (dynamic_cast<pcpp::SnoopFileReaderDevice*>(reader) != nullptr)
 	{
 		pcpp::SnoopFileReaderDevice* snoopReader = dynamic_cast<pcpp::SnoopFileReaderDevice*>(reader);
 		pcpp::LinkLayerType linkLayer = snoopReader->getLinkLayerType();
 		stream << "   Link layer type: " << linkLayerToString(linkLayer) << std::endl;
 	}
-	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != NULL)
+	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != nullptr)
 	{
 		pcpp::PcapNgFileReaderDevice* pcapNgReader = dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader);
 		if (pcapNgReader->getOS() != "")
@@ -304,20 +304,20 @@ int main(int argc, char* argv[])
 	int printedPacketCount = 0;
 
 	// if the file is a pcap file
-	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != NULL)
+	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != nullptr)
 	{
 		// print all requested packets in the pcap file
 		pcpp::PcapFileReaderDevice* pcapReader = dynamic_cast<pcpp::PcapFileReaderDevice*>(reader);
 		printedPacketCount = printPcapPackets(pcapReader, out, packetCount);
 	}
-	else if (dynamic_cast<pcpp::SnoopFileReaderDevice*>(reader) != NULL)
+	else if (dynamic_cast<pcpp::SnoopFileReaderDevice*>(reader) != nullptr)
 	{
 		// print all requested packets in the pcap file
 		pcpp::SnoopFileReaderDevice* snoopReader = dynamic_cast<pcpp::SnoopFileReaderDevice*>(reader);
 		printedPacketCount = printPcapPackets(snoopReader, out, packetCount);
 	}
 	// if the file is a pcap-ng file
-	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != NULL)
+	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != nullptr)
 	{
 		// print all requested packets in the pcap-ng file
 		pcpp::PcapNgFileReaderDevice* pcapNgReader = dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader);

--- a/Examples/PcapSearch/main.cpp
+++ b/Examples/PcapSearch/main.cpp
@@ -41,14 +41,14 @@
 
 static struct option PcapSearchOptions[] =
 {
-	{"input-dir",  required_argument, 0, 'd'},
-	{"not-include-sub-dir", no_argument, 0, 'n'},
-	{"search", required_argument, 0, 's'},
-	{"detailed-report", required_argument, 0, 'r'},
-	{"set-extensions", required_argument, 0, 'e'},
-	{"version", no_argument, 0, 'v'},
-	{"help", no_argument, 0, 'h'},
-	{0, 0, 0, 0}
+	{"input-dir",  required_argument, nullptr, 'd'},
+	{"not-include-sub-dir", no_argument, nullptr, 'n'},
+	{"search", required_argument, nullptr, 's'},
+	{"detailed-report", required_argument, nullptr, 'r'},
+	{"set-extensions", required_argument, nullptr, 'e'},
+	{"version", no_argument, nullptr, 'v'},
+	{"help", no_argument, nullptr, 'h'},
+	{nullptr, 0, nullptr, 0}
 };
 
 
@@ -124,7 +124,7 @@ int searchPcap(std::string pcapFilePath, std::string searchCriteria, std::ofstre
 	// if the reader fails to open
 	if (!reader->open())
 	{
-		if (detailedReportFile != NULL)
+		if (detailedReportFile != nullptr)
 		{
 			// PcapPlusPlus logger saves the last internal error. Write this error to the report file
 			(*detailedReportFile) << "File '" << pcapFilePath << "':" << std::endl;
@@ -145,7 +145,7 @@ int searchPcap(std::string pcapFilePath, std::string searchCriteria, std::ofstre
 		return 0;
 	}
 
-	if (detailedReportFile != NULL)
+	if (detailedReportFile != nullptr)
 	{
 		(*detailedReportFile) << "File '" << pcapFilePath << "':" << std::endl;
 	}
@@ -157,7 +157,7 @@ int searchPcap(std::string pcapFilePath, std::string searchCriteria, std::ofstre
 	while (reader->getNextPacket(rawPacket))
 	{
 		// if a detailed report is required, parse the packet and print it to the report file
-		if (detailedReportFile != NULL)
+		if (detailedReportFile != nullptr)
 		{
 			// parse the packet
 			pcpp::Packet parsedPacket(&rawPacket);
@@ -178,7 +178,7 @@ int searchPcap(std::string pcapFilePath, std::string searchCriteria, std::ofstre
 	reader->close();
 
 	// finalize the report
-	if (detailedReportFile != NULL)
+	if (detailedReportFile != nullptr)
 	{
 		if (packetCount > 0)
 			(*detailedReportFile) << "\n";
@@ -207,7 +207,7 @@ void searchDirectories(const std::string &directory, bool includeSubDirectories,
 	DIR *dir = opendir(directory.c_str());
 
 	// dir is null usually when user has no access permissions
-	if (dir == NULL)
+	if (dir == nullptr)
 		return;
 
 	struct dirent *entry = readdir(dir);
@@ -215,7 +215,7 @@ void searchDirectories(const std::string &directory, bool includeSubDirectories,
 	std::vector<std::string> pcapList;
 
 	// go over all files in this directory
-	while (entry != NULL)
+	while (entry != nullptr)
 	{
 		std::string name(entry->d_name);
 
@@ -373,7 +373,7 @@ int main(int argc, char* argv[])
 	}
 
 	DIR *dir = opendir(inputDirectory.c_str());
-	if (dir == NULL)
+	if (dir == nullptr)
 	{
 		EXIT_WITH_ERROR("Cannot find or open input directory");
 	}
@@ -386,7 +386,7 @@ int main(int argc, char* argv[])
 	}
 
 	// open the detailed report file if requested by the user
-	std::ofstream* detailedReportFile = NULL;
+	std::ofstream* detailedReportFile = nullptr;
 	if (detailedReportFileName != "")
 	{
 		detailedReportFile = new std::ofstream();
@@ -414,7 +414,7 @@ int main(int argc, char* argv[])
 		<< totalPacketsFound << " packets were matched to search criteria"
 		<< std::endl;
 
-	if (detailedReportFile != NULL)
+	if (detailedReportFile != nullptr)
 	{
 		if (detailedReportFile->is_open())
 			detailedReportFile->close();

--- a/Examples/PcapSplitter/main.cpp
+++ b/Examples/PcapSplitter/main.cpp
@@ -63,14 +63,14 @@
 
 static struct option PcapSplitterOptions[] =
 {
-	{"input-file",  required_argument, 0, 'f'},
-	{"output-file", required_argument, 0, 'o'},
-	{"method", required_argument, 0, 'm'},
-	{"param", required_argument, 0, 'p'},
-	{"filter", required_argument, 0, 'i'},
-	{"help", no_argument, 0, 'h'},
-	{"version", no_argument, 0, 'v'},
-	{0, 0, 0, 0}
+	{"input-file",  required_argument, nullptr, 'f'},
+	{"output-file", required_argument, nullptr, 'o'},
+	{"method", required_argument, nullptr, 'm'},
+	{"param", required_argument, nullptr, 'p'},
+	{"filter", required_argument, nullptr, 'i'},
+	{"help", no_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'v'},
+	{nullptr, 0, nullptr, 0}
 };
 
 
@@ -287,12 +287,12 @@ int main(int argc, char* argv[])
 		EXIT_WITH_ERROR("Split method was not given");
 	}
 
-	Splitter* splitter = NULL;
+	Splitter* splitter = nullptr;
 
 	// decide of the splitter to use, according to the user's choice
 	if (method == SPLIT_BY_FILE_SIZE)
 	{
-		uint64_t paramAsUint64 = (paramWasSet ? strtoull(param, NULL, 10) : 0);
+		uint64_t paramAsUint64 = (paramWasSet ? strtoull(param, nullptr, 10) : 0);
 		splitter = new FileSizeSplitter(paramAsUint64);
 	}
 	else if (method == SPLIT_BY_PACKET_COUNT)
@@ -356,9 +356,9 @@ int main(int argc, char* argv[])
 
 	// open a pcap file for reading
 	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader(inputPcapFileName);
-	bool isReaderPcapng = (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != NULL);
+	bool isReaderPcapng = (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != nullptr);
 
-	if (reader == NULL || !reader->open())
+	if (reader == nullptr || !reader->open())
 	{
 		EXIT_WITH_ERROR("Error opening input pcap file");
 	}
@@ -420,7 +420,7 @@ int main(int argc, char* argv[])
 
 		// if file number exists in the map but PcapFileWriterDevice is null it means this file was open once and
 		// then closed. In this case we need to re-open the PcapFileWriterDevice in append mode
-		else if (outputFiles[fileNum] == NULL)
+		else if (outputFiles[fileNum] == nullptr)
 		{
 			// get file name from the splitter and add the .pcap extension
 			std::string fileName = splitter->getFileName(parsedPacket, outputPcapFileName, fileNum) + outputFileExtenison;
@@ -456,7 +456,7 @@ int main(int argc, char* argv[])
 
 				// free the writer memory and put null in the map record
 				delete outputFiles[*it];
-				outputFiles[*it] = NULL;
+				outputFiles[*it] = nullptr;
 			}
 		}
 

--- a/Examples/SSLAnalyzer/main.cpp
+++ b/Examples/SSLAnalyzer/main.cpp
@@ -51,15 +51,15 @@
 
 static struct option SSLAnalyzerOptions[] =
 {
-	{"interface",  required_argument, 0, 'i'},
-	{"input-file",  required_argument, 0, 'f'},
-	{"output-file", required_argument, 0, 'o'},
-	{"rate-calc-period", required_argument, 0, 'r'},
-	{"disable-rates-print", no_argument, 0, 'd'},
-	{"list-interfaces", no_argument, 0, 'l'},
-	{"help", no_argument, 0, 'h'},
-	{"version", no_argument, 0, 'v'},
-	{0, 0, 0, 0}
+	{"interface",  required_argument, nullptr, 'i'},
+	{"input-file",  required_argument, nullptr, 'f'},
+	{"output-file", required_argument, nullptr, 'o'},
+	{"rate-calc-period", required_argument, nullptr, 'r'},
+	{"disable-rates-print", no_argument, nullptr, 'd'},
+	{"list-interfaces", no_argument, nullptr, 'l'},
+	{"help", no_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'v'},
+	{nullptr, 0, nullptr, 0}
 };
 
 
@@ -158,7 +158,7 @@ void sslPacketArrive(pcpp::RawPacket* packet, pcpp::PcapLiveDevice* dev, void* c
 	data->statsCollector->collectStats(&parsedPacket);
 
 	// if needed - write the packet to the output pcap file
-	if (data->pcapWriter != NULL)
+	if (data->pcapWriter != nullptr)
 	{
 		data->pcapWriter->writePacket(*packet);
 	}
@@ -436,7 +436,7 @@ void analyzeSSLFromLiveTraffic(pcpp::PcapLiveDevice* dev, bool printRatesPeriodi
 
 
 	// if needed to save the captured packets to file - open a writer device
-	pcpp::PcapFileWriterDevice* pcapWriter = NULL;
+	pcpp::PcapFileWriterDevice* pcapWriter = nullptr;
 	if (savePacketsToFileName != "")
 	{
 		pcapWriter = new pcpp::PcapFileWriterDevice(savePacketsToFileName);
@@ -484,7 +484,7 @@ void analyzeSSLFromLiveTraffic(pcpp::PcapLiveDevice* dev, bool printRatesPeriodi
 	printStatsSummary(collector);
 
 	// close and free the writer device
-	if (pcapWriter != NULL)
+	if (pcapWriter != nullptr)
 	{
 		pcapWriter->close();
 		delete pcapWriter;
@@ -559,7 +559,7 @@ int main(int argc, char* argv[])
 	{
 		// extract pcap live device by interface name or IP address
 		pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
-		if (dev == NULL)
+		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 
 		// start capturing and analyzing traffic

--- a/Examples/TLSFingerprinting/main.cpp
+++ b/Examples/TLSFingerprinting/main.cpp
@@ -28,16 +28,16 @@
 
 static struct option TLSFingerprintingOptions[] =
 {
-	{"interface",  required_argument, 0, 'i'},
-	{"input-file",  required_argument, 0, 'r'},
-	{"output-file", required_argument, 0, 'o'},
-	{"separator", required_argument, 0, 's'},
-	{"tls-fp-type", required_argument, 0, 't'},
-	{"filter", required_argument, 0, 'f'},
-	{"list-interfaces", no_argument, 0, 'l'},
-	{"help", no_argument, 0, 'h'},
-	{"version", no_argument, 0, 'v'},
-	{0, 0, 0, 0}
+	{"interface",  required_argument, nullptr, 'i'},
+	{"input-file",  required_argument, nullptr, 'r'},
+	{"output-file", required_argument, nullptr, 'o'},
+	{"separator", required_argument, nullptr, 's'},
+	{"tls-fp-type", required_argument, nullptr, 't'},
+	{"filter", required_argument, nullptr, 'f'},
+	{"list-interfaces", no_argument, nullptr, 'l'},
+	{"help", no_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'v'},
+	{nullptr, 0, nullptr, 0}
 };
 
 #define EXIT_WITH_ERROR(reason) do { \
@@ -332,14 +332,14 @@ void handlePacket(pcpp::RawPacket* rawPacket, const HandlePacketData* data)
 	{
 		// extract the SSL/TLS handhsake layer
 		pcpp::SSLHandshakeLayer* sslHandshakeLayer = parsedPacket.getLayerOfType<pcpp::SSLHandshakeLayer>();
-		if (sslHandshakeLayer != NULL)
+		if (sslHandshakeLayer != nullptr)
 		{
 			// if user requested to extract ClientHello TLS fingerprint
 			if (data->chFP)
 			{
 				// check if the SSL/TLS handhsake layer contains a ClientHello message
 				pcpp::SSLClientHelloMessage* clientHelloMessage = sslHandshakeLayer->getHandshakeMessageOfType<pcpp::SSLClientHelloMessage>();
-				if (clientHelloMessage != NULL)
+				if (clientHelloMessage != nullptr)
 				{
 					data->stats->numOfCHPackets++;
 
@@ -357,7 +357,7 @@ void handlePacket(pcpp::RawPacket* rawPacket, const HandlePacketData* data)
 			{
 				// check if the SSL/TLS handhsake layer contains a ServerHello message
 				pcpp::SSLServerHelloMessage* servertHelloMessage = sslHandshakeLayer->getHandshakeMessageOfType<pcpp::SSLServerHelloMessage>();
-				if (servertHelloMessage != NULL)
+				if (servertHelloMessage != nullptr)
 				{
 					data->stats->numOfSHPackets++;
 
@@ -458,7 +458,7 @@ void doTlsFingerprintingOnLiveTraffic(const std::string& interfaceNameOrIP, std:
 {
 	// extract pcap live device by interface name or IP address
 	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
-	if (dev == NULL)
+	if (dev == nullptr)
 		EXIT_WITH_ERROR("Couldn't find interface by given IP address or name");
 
 	if (!dev->open())

--- a/Examples/TcpReassembly/main.cpp
+++ b/Examples/TcpReassembly/main.cpp
@@ -58,18 +58,18 @@
 
 static struct option TcpAssemblyOptions[] =
 {
-	{"interface",  required_argument, 0, 'i'},
-	{"input-file",  required_argument, 0, 'r'},
-	{"output-dir", required_argument, 0, 'o'},
-	{"list-interfaces", no_argument, 0, 'l'},
-	{"filter", required_argument, 0, 'e'},
-	{"write-metadata", no_argument, 0, 'm'},
-	{"write-to-console", no_argument, 0, 'c'},
-	{"separate-sides", no_argument, 0, 's'},
-	{"max-file-desc", required_argument, 0, 'f'},
-	{"help", no_argument, 0, 'h'},
-	{"version", no_argument, 0, 'v'},
-	{0, 0, 0, 0}
+	{"interface",  required_argument, nullptr, 'i'},
+	{"input-file",  required_argument, nullptr, 'r'},
+	{"output-dir", required_argument, nullptr, 'o'},
+	{"list-interfaces", no_argument, nullptr, 'l'},
+	{"filter", required_argument, nullptr, 'e'},
+	{"write-metadata", no_argument, nullptr, 'm'},
+	{"write-to-console", no_argument, nullptr, 'c'},
+	{"separate-sides", no_argument, nullptr, 's'},
+	{"max-file-desc", required_argument, nullptr, 'f'},
+	{"help", no_argument, nullptr, 'h'},
+	{"version", no_argument, nullptr, 'v'},
+	{nullptr, 0, nullptr, 0}
 };
 
 
@@ -83,7 +83,7 @@ private:
 	/**
 	 * A private c'tor (as this is a singleton)
 	 */
-	GlobalConfig() { writeMetadata = false; writeToConsole = false; separateSides = false; maxOpenFiles = DEFAULT_MAX_NUMBER_OF_CONCURRENT_OPEN_FILES; m_RecentConnsWithActivity = NULL; }
+	GlobalConfig() { writeMetadata = false; writeToConsole = false; separateSides = false; maxOpenFiles = DEFAULT_MAX_NUMBER_OF_CONCURRENT_OPEN_FILES; m_RecentConnsWithActivity = nullptr; }
 
 	// A least-recently-used (LRU) list of all connections seen so far. Each connection is represented by its flow key. This LRU list is used to decide which connection was seen least
 	// recently in case we reached max number of open file descriptors and we need to decide which files to close
@@ -181,7 +181,7 @@ public:
 		// This is a lazy implementation - the instance isn't created until the user requests it for the first time.
 		// the side of the LRU list is determined by the max number of allowed open files at any point in time. Default is DEFAULT_MAX_NUMBER_OF_CONCURRENT_OPEN_FILES
 		// but the user can choose another number
-		if (m_RecentConnsWithActivity == NULL)
+		if (m_RecentConnsWithActivity == nullptr)
 			m_RecentConnsWithActivity = new pcpp::LRUList<uint32_t>(maxOpenFiles);
 
 		// return the pointer
@@ -230,7 +230,7 @@ struct TcpReassemblyData
 	/**
 	 * the default c'tor
 	 */
-	TcpReassemblyData() { fileStreams[0] = NULL; fileStreams[1] = NULL; clear(); }
+	TcpReassemblyData() { fileStreams[0] = nullptr; fileStreams[1] = nullptr; clear(); }
 
 	/**
 	 * The default d'tor
@@ -238,10 +238,10 @@ struct TcpReassemblyData
 	~TcpReassemblyData()
 	{
 		// close files on both sides if open
-		if (fileStreams[0] != NULL)
+		if (fileStreams[0] != nullptr)
 			GlobalConfig::getInstance().closeFileSteam(fileStreams[0]);
 
-		if (fileStreams[1] != NULL)
+		if (fileStreams[1] != nullptr)
 			GlobalConfig::getInstance().closeFileSteam(fileStreams[1]);
 	}
 
@@ -251,16 +251,16 @@ struct TcpReassemblyData
 	void clear()
 	{
 		// for the file stream - close them if they're not null
-		if (fileStreams[0] != NULL)
+		if (fileStreams[0] != nullptr)
 		{
 			GlobalConfig::getInstance().closeFileSteam(fileStreams[0]);
-			fileStreams[0] = NULL;
+			fileStreams[0] = nullptr;
 		}
 
-		if (fileStreams[1] != NULL)
+		if (fileStreams[1] != nullptr)
 		{
 			GlobalConfig::getInstance().closeFileSteam(fileStreams[1]);
-			fileStreams[1] = NULL;
+			fileStreams[1] = nullptr;
 		}
 
 		reopenFileStreams[0] = false;
@@ -362,7 +362,7 @@ static void tcpReassemblyMsgReadyCallback(int8_t sideIndex, const pcpp::TcpStrea
 		side = 0;
 
 	// if the file stream on the relevant side isn't open yet (meaning it's the first data on this connection)
-	if (iter->second.fileStreams[side] == NULL)
+	if (iter->second.fileStreams[side] == nullptr)
 	{
 		// add the flow key of this connection to the list of open connections. If the return value isn't NULL it means that there are too many open files
 		// and we need to close the connection with least recently used file(s) in order to open a new one.
@@ -380,11 +380,11 @@ static void tcpReassemblyMsgReadyCallback(int8_t sideIndex, const pcpp::TcpStrea
 				// close files on both sides (if they're open)
 				for (int index = 0; index < 2; index++)
 				{
-					if (iter2->second.fileStreams[index] != NULL)
+					if (iter2->second.fileStreams[index] != nullptr)
 					{
 						// close the file
 						GlobalConfig::getInstance().closeFileSteam(iter2->second.fileStreams[index]);
-						iter2->second.fileStreams[index] = NULL;
+						iter2->second.fileStreams[index] = nullptr;
 
 						// set the reopen flag to true to indicate that next time this file will be opened it will be opened in append mode (and not overwrite mode)
 						iter2->second.reopenFileStreams[index] = true;
@@ -676,7 +676,7 @@ int main(int argc, char* argv[])
 	{
 		// extract pcap live device by interface name or IP address
 		pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
-		if (dev == NULL)
+		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 
 		// start capturing packets and do TCP reassembly

--- a/Examples/Tutorials/Tutorial-LiveTraffic/main.cpp
+++ b/Examples/Tutorials/Tutorial-LiveTraffic/main.cpp
@@ -113,7 +113,7 @@ int main(int argc, char* argv[])
 
 	// find the interface by IP address
 	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(interfaceIPAddr);
-	if (dev == NULL)
+	if (dev == nullptr)
 	{
 		std::cerr << "Cannot find interface with IPv4 address of '" << interfaceIPAddr << "'" << std::endl;
 		return 1;

--- a/Examples/Tutorials/Tutorial-PacketCraftAndEdit/main.cpp
+++ b/Examples/Tutorials/Tutorial-PacketCraftAndEdit/main.cpp
@@ -21,7 +21,7 @@ int main(int argc, char* argv[])
 	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader("1_http_packet.pcap");
 
 	// verify that a reader interface was indeed created
-	if (reader == NULL)
+	if (reader == nullptr)
 	{
 		std::cerr << "Cannot determine reader for file type" << std::endl;
 		return 1;

--- a/Examples/Tutorials/Tutorial-PacketParsing/main.cpp
+++ b/Examples/Tutorials/Tutorial-PacketParsing/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* argv[])
 	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader("1_http_packet.pcap");
 
 	// verify that a reader interface was indeed created
-	if (reader == NULL)
+	if (reader == nullptr)
 	{
 		std::cerr << "Cannot determine reader for file type" << std::endl;
 		return 1;
@@ -110,7 +110,7 @@ int main(int argc, char* argv[])
 	pcpp::Packet parsedPacket(&rawPacket);
 
 	// first let's go over the layers one by one and find out its type, its total length, its header length and its payload length
-	for (pcpp::Layer* curLayer = parsedPacket.getFirstLayer(); curLayer != NULL; curLayer = curLayer->getNextLayer())
+	for (pcpp::Layer* curLayer = parsedPacket.getFirstLayer(); curLayer != nullptr; curLayer = curLayer->getNextLayer())
 	{
 		std::cout
 			<< "Layer type: " << getProtocolTypeAsString(curLayer->getProtocol()) << "; " // get layer type
@@ -122,7 +122,7 @@ int main(int argc, char* argv[])
 
 	// now let's get the Ethernet layer
 	pcpp::EthLayer* ethernetLayer = parsedPacket.getLayerOfType<pcpp::EthLayer>();
-	if (ethernetLayer == NULL)
+	if (ethernetLayer == nullptr)
 	{
 		std::cerr << "Something went wrong, couldn't find Ethernet layer" << std::endl;
 		return 1;
@@ -136,7 +136,7 @@ int main(int argc, char* argv[])
 
 	// let's get the IPv4 layer
 	pcpp::IPv4Layer* ipLayer = parsedPacket.getLayerOfType<pcpp::IPv4Layer>();
-	if (ipLayer == NULL)
+	if (ipLayer == nullptr)
 	{
 		std::cerr << "Something went wrong, couldn't find IPv4 layer" << std::endl;
 		return 1;
@@ -151,7 +151,7 @@ int main(int argc, char* argv[])
 
 	// let's get the TCP layer
 	pcpp::TcpLayer* tcpLayer = parsedPacket.getLayerOfType<pcpp::TcpLayer>();
-	if (tcpLayer == NULL)
+	if (tcpLayer == nullptr)
 	{
 		std::cerr << "Something went wrong, couldn't find TCP layer" << std::endl;
 		return 1;
@@ -173,7 +173,7 @@ int main(int argc, char* argv[])
 
 	// let's get the HTTP request layer
 	pcpp::HttpRequestLayer* httpRequestLayer = parsedPacket.getLayerOfType<pcpp::HttpRequestLayer>();
-	if (httpRequestLayer == NULL)
+	if (httpRequestLayer == nullptr)
 	{
 		std::cerr << "Something went wrong, couldn't find HTTP request layer" << std::endl;
 		return 1;

--- a/Examples/Tutorials/Tutorial-PcapFiles/main.cpp
+++ b/Examples/Tutorials/Tutorial-PcapFiles/main.cpp
@@ -12,7 +12,7 @@ int main(int argc, char* argv[])
 	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader("input.pcap");
 
 	// verify that a reader interface was indeed created
-	if (reader == NULL)
+	if (reader == nullptr)
 	{
 		std::cerr << "Cannot determine reader for file type" << std::endl;
 		return 1;

--- a/Packet++/src/BgpLayer.cpp
+++ b/Packet++/src/BgpLayer.cpp
@@ -31,13 +31,13 @@ size_t BgpLayer::getHeaderLen() const
 BgpLayer* BgpLayer::parseBgpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
 {
 	if (dataLen < sizeof(bgp_common_header))
-		return NULL;
+		return nullptr;
 
 	bgp_common_header* bgpHeader = (bgp_common_header*)data;
 
 	// illegal header data - length is too small
 	if (be16toh(bgpHeader->length) < static_cast<uint16_t>(sizeof(bgp_common_header)))
-		return NULL;
+		return nullptr;
 
 	switch (bgpHeader->messageType)
 	{
@@ -52,7 +52,7 @@ BgpLayer* BgpLayer::parseBgpLayer(uint8_t* data, size_t dataLen, Layer* prevLaye
 	case 5: // ROUTE-REFRESH
 		return new BgpRouteRefreshMessageLayer(data, dataLen, prevLayer, packet);
 	default:
-		return NULL;
+		return nullptr;
 	}
 }
 
@@ -155,7 +155,7 @@ BgpOpenMessageLayer::BgpOpenMessageLayer(uint16_t myAutonomousSystem, uint16_t h
 
 size_t BgpOpenMessageLayer::optionalParamsToByteArray(const std::vector<optional_parameter>& optionalParams, uint8_t* resultByteArr, size_t maxByteArrSize)
 {
-	if (resultByteArr == NULL || maxByteArrSize == 0)
+	if (resultByteArr == nullptr || maxByteArrSize == 0)
 	{
 		return 0;
 	}
@@ -199,7 +199,7 @@ void BgpOpenMessageLayer::setBgpId(const IPv4Address& newBgpId)
 	}
 
 	bgp_open_message* msgHdr = getOpenMsgHeader();
-	if (msgHdr == NULL)
+	if (msgHdr == nullptr)
 	{
 		return;
 	}
@@ -210,7 +210,7 @@ void BgpOpenMessageLayer::setBgpId(const IPv4Address& newBgpId)
 void BgpOpenMessageLayer::getOptionalParameters(std::vector<optional_parameter>& optionalParameters)
 {
 	bgp_open_message* msgHdr = getOpenMsgHeader();
-	if (msgHdr == NULL || msgHdr->optionalParameterLength == 0)
+	if (msgHdr == nullptr || msgHdr->optionalParameterLength == 0)
 	{
 		return;
 	}
@@ -251,7 +251,7 @@ void BgpOpenMessageLayer::getOptionalParameters(std::vector<optional_parameter>&
 size_t BgpOpenMessageLayer::getOptionalParametersLength()
 {
 	bgp_open_message* msgHdr = getOpenMsgHeader();
-	if (msgHdr != NULL)
+	if (msgHdr != nullptr)
 	{
 		return (size_t)(msgHdr->optionalParameterLength);
 	}
@@ -408,7 +408,7 @@ void BgpUpdateMessageLayer::parsePrefixAndIPData(uint8_t* dataPtr, size_t dataLe
 
 size_t BgpUpdateMessageLayer::prefixAndIPDataToByteArray(const std::vector<prefix_and_ip>& prefixAndIpData, uint8_t* resultByteArr, size_t maxByteArrSize)
 {
-	if (resultByteArr == NULL || maxByteArrSize == 0)
+	if (resultByteArr == nullptr || maxByteArrSize == 0)
 	{
 		return 0;
 	}
@@ -469,7 +469,7 @@ size_t BgpUpdateMessageLayer::prefixAndIPDataToByteArray(const std::vector<prefi
 
 size_t BgpUpdateMessageLayer::pathAttributesToByteArray(const std::vector<path_attribute>& pathAttributes, uint8_t* resultByteArr, size_t maxByteArrSize)
 {
-	if (resultByteArr == NULL || maxByteArrSize == 0)
+	if (resultByteArr == nullptr || maxByteArrSize == 0)
 	{
 		return 0;
 	}
@@ -754,7 +754,7 @@ bool BgpUpdateMessageLayer::clearNetworkLayerReachabilityInfo()
 
 BgpNotificationMessageLayer::BgpNotificationMessageLayer(uint8_t errorCode, uint8_t errorSubCode)
 {
-	initMessageData(errorCode, errorSubCode, NULL, 0);
+	initMessageData(errorCode, errorSubCode, nullptr, 0);
 }
 
 BgpNotificationMessageLayer::BgpNotificationMessageLayer(uint8_t errorCode, uint8_t errorSubCode, const uint8_t* notificationData, size_t notificationDataLen)
@@ -772,7 +772,7 @@ BgpNotificationMessageLayer::BgpNotificationMessageLayer(uint8_t errorCode, uint
 void BgpNotificationMessageLayer::initMessageData(uint8_t errorCode, uint8_t errorSubCode, const uint8_t* notificationData, size_t notificationDataLen)
 {
 	size_t headerLen = sizeof(bgp_notification_message);
-	if (notificationData != NULL && notificationDataLen > 0)
+	if (notificationData != nullptr && notificationDataLen > 0)
 	{
 		headerLen += notificationDataLen;
 	}
@@ -805,13 +805,13 @@ uint8_t* BgpNotificationMessageLayer::getNotificationData() const
 		return m_Data + sizeof(bgp_notification_message);
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 std::string BgpNotificationMessageLayer::getNotificationDataAsHexString() const
 {
 	uint8_t* notificationData = getNotificationData();
-	if (notificationData == NULL)
+	if (notificationData == nullptr)
 	{
 		return "";
 	}
@@ -821,7 +821,7 @@ std::string BgpNotificationMessageLayer::getNotificationDataAsHexString() const
 
 bool BgpNotificationMessageLayer::setNotificationData(const uint8_t* newNotificationData, size_t newNotificationDataLen)
 {
-	if (newNotificationData == NULL)
+	if (newNotificationData == nullptr)
 	{
 		newNotificationDataLen = 0;
 	}
@@ -861,7 +861,7 @@ bool BgpNotificationMessageLayer::setNotificationData(const std::string& newNoti
 {
 	if (newNotificationDataAsHexString.empty())
 	{
-		return setNotificationData(NULL, 0);
+		return setNotificationData(nullptr, 0);
 	}
 
 	uint8_t newNotificationData[1500];

--- a/Packet++/src/DhcpLayer.cpp
+++ b/Packet++/src/DhcpLayer.cpp
@@ -19,7 +19,7 @@ DhcpOption DhcpOptionBuilder::build() const
 		if (m_RecValueLen != 0)
 		{
 			PCPP_LOG_ERROR("Can't set DHCP END option or DHCP PAD option with size different than 0, tried to set size " << (int)m_RecValueLen);
-			return DhcpOption(NULL);
+			return DhcpOption(nullptr);
 		}
 
 		recSize = sizeof(uint8_t);
@@ -31,7 +31,7 @@ DhcpOption DhcpOptionBuilder::build() const
 	if (recSize > 1)
 	{
 		recordBuffer[1] = static_cast<uint8_t>(m_RecValueLen);
-		if (m_RecValue != NULL)
+		if (m_RecValue != nullptr)
 			memcpy(recordBuffer+2, m_RecValue, m_RecValueLen);
 		else
 			memset(recordBuffer+2, 0, m_RecValueLen);
@@ -75,7 +75,7 @@ DhcpLayer::DhcpLayer(DhcpMessageType msgType, const MacAddress& clientMacAddr) :
 MacAddress DhcpLayer::getClientHardwareAddress() const
 {
 	dhcp_header* hdr = getDhcpHeader();
-	if (hdr != NULL && hdr->hardwareType == 1 && hdr->hardwareAddressLength == 6)
+	if (hdr != nullptr && hdr->hardwareType == 1 && hdr->hardwareAddressLength == 6)
 		return MacAddress(hdr->clientHardwareAddress);
 
 	PCPP_LOG_DEBUG("Hardware type isn't Ethernet or hardware addr len != 6, returning MacAddress:Zero");
@@ -227,7 +227,7 @@ DhcpOption DhcpLayer::addOptionAt(const DhcpOptionBuilder& optionBuilder, int of
 	if (newOpt.isNull())
 	{
 		PCPP_LOG_ERROR("Cannot build new option of type " << (int)newOpt.getType());
-		return DhcpOption(NULL);
+		return DhcpOption(nullptr);
 	}
 
 	size_t sizeToExtend = newOpt.getTotalSize();
@@ -235,7 +235,7 @@ DhcpOption DhcpLayer::addOptionAt(const DhcpOptionBuilder& optionBuilder, int of
 	if (!extendLayer(offset, sizeToExtend))
 	{
 		PCPP_LOG_ERROR("Could not extend DhcpLayer in [" << newOpt.getTotalSize() << "] bytes");
-		return DhcpOption(NULL);
+		return DhcpOption(nullptr);
 	}
 
 	memcpy(m_Data + offset, newOpt.getRecordBasePtr(), newOpt.getTotalSize());

--- a/Packet++/src/DhcpV6Layer.cpp
+++ b/Packet++/src/DhcpV6Layer.cpp
@@ -42,14 +42,14 @@ size_t DhcpV6Option::getDataSize() const
 DhcpV6Option DhcpV6OptionBuilder::build() const
 {
 	if (m_RecType == 0)
-		return DhcpV6Option(NULL);
+		return DhcpV6Option(nullptr);
 	size_t optionSize = 2 * sizeof(uint16_t) + m_RecValueLen;
 	uint8_t* recordBuffer = new uint8_t[optionSize];
 	uint16_t optionTypeVal = htobe16(static_cast<uint16_t>(m_RecType));
 	uint16_t optionLength = htobe16(static_cast<uint16_t>(m_RecValueLen));
 	memcpy(recordBuffer, &optionTypeVal, sizeof(uint16_t));
 	memcpy(recordBuffer + sizeof(uint16_t), &optionLength, sizeof(uint16_t));
-	if (optionSize > 0 && m_RecValue != NULL)
+	if (optionSize > 0 && m_RecValue != nullptr)
 		memcpy(recordBuffer + 2*sizeof(uint16_t), m_RecValue, m_RecValueLen);
 
 	return DhcpV6Option(recordBuffer);
@@ -164,7 +164,7 @@ DhcpV6Option DhcpV6Layer::addOptionAt(const DhcpV6OptionBuilder& optionBuilder, 
 	if (newOpt.isNull())
 	{
 		PCPP_LOG_ERROR("Cannot build new option");
-		return DhcpV6Option(NULL);
+		return DhcpV6Option(nullptr);
 	}
 
 	size_t sizeToExtend = newOpt.getTotalSize();
@@ -172,7 +172,7 @@ DhcpV6Option DhcpV6Layer::addOptionAt(const DhcpV6OptionBuilder& optionBuilder, 
 	if (!extendLayer(offset, sizeToExtend))
 	{
 		PCPP_LOG_ERROR("Could not extend DhcpLayer in [" << newOpt.getTotalSize() << "] bytes");
-		return DhcpV6Option(NULL);
+		return DhcpV6Option(nullptr);
 	}
 
 	memcpy(m_Data + offset, newOpt.getRecordBasePtr(), newOpt.getTotalSize());
@@ -200,7 +200,7 @@ DhcpV6Option DhcpV6Layer::addOptionAfter(const DhcpV6OptionBuilder& optionBuilde
 	if (prevOpt.isNull())
 	{
 		PCPP_LOG_ERROR("Option type " << optionType << " doesn't exist in layer");
-		return DhcpV6Option(NULL);
+		return DhcpV6Option(nullptr);
 	}
 	offset = prevOpt.getRecordBasePtr() + prevOpt.getTotalSize() - m_Data;
 	return addOptionAt(optionBuilder, offset);
@@ -215,7 +215,7 @@ DhcpV6Option DhcpV6Layer::addOptionBefore(const DhcpV6OptionBuilder& optionBuild
 	if (nextOpt.isNull())
 	{
 		PCPP_LOG_ERROR("Option type " << optionType << " doesn't exist in layer");
-		return DhcpV6Option(NULL);
+		return DhcpV6Option(nullptr);
 	}
 
 	offset = nextOpt.getRecordBasePtr() - m_Data;

--- a/Packet++/src/DnsLayer.cpp
+++ b/Packet++/src/DnsLayer.cpp
@@ -48,7 +48,7 @@ DnsLayer& DnsLayer::operator=(const DnsLayer& other)
 	Layer::operator=(other);
 
 	IDnsResource* curResource = m_ResourceList;
-	while (curResource != NULL)
+	while (curResource != nullptr)
 	{
 		IDnsResource* temp = curResource->getNextResource();
 		delete curResource;
@@ -63,7 +63,7 @@ DnsLayer& DnsLayer::operator=(const DnsLayer& other)
 DnsLayer::~DnsLayer()
 {
 	IDnsResource* curResource = m_ResourceList;
-	while (curResource != NULL)
+	while (curResource != nullptr)
 	{
 		IDnsResource* nextResource = curResource->getNextResource();
 		delete curResource;
@@ -75,12 +75,12 @@ void DnsLayer::init(size_t offsetAdjustment, bool callParseResource)
 {
 	m_OffsetAdjustment = offsetAdjustment;
 	m_Protocol = DNS;
-	m_ResourceList = NULL;
+	m_ResourceList = nullptr;
 
-	m_FirstQuery = NULL;
-	m_FirstAnswer = NULL;
-	m_FirstAuthority = NULL;
-	m_FirstAdditional = NULL;
+	m_FirstQuery = nullptr;
+	m_FirstAnswer = nullptr;
+	m_FirstAuthority = nullptr;
+	m_FirstAdditional = nullptr;
 
 	if (callParseResource)
 		parseResources();
@@ -115,7 +115,7 @@ bool DnsLayer::extendLayer(int offsetInLayer, size_t numOfBytesToExtend, IDnsRes
 		return false;
 
 	IDnsResource* curResource = resource->getNextResource();
-	while (curResource != NULL)
+	while (curResource != nullptr)
 	{
 		curResource->m_OffsetInLayer += numOfBytesToExtend;
 		curResource = curResource->getNextResource();
@@ -130,7 +130,7 @@ bool DnsLayer::shortenLayer(int offsetInLayer, size_t numOfBytesToShorten, IDnsR
 		return false;
 
 	IDnsResource* curResource = resource->getNextResource();
-	while (curResource != NULL)
+	while (curResource != nullptr)
 	{
 		curResource->m_OffsetInLayer -= numOfBytesToShorten;
 		curResource = curResource->getNextResource();
@@ -182,9 +182,9 @@ void DnsLayer::parseResources()
 			numOfAdditional--;
 		}
 
-		DnsResource* newResource = NULL;
-		DnsQuery* newQuery = NULL;
-		IDnsResource* newGenResource = NULL;
+		DnsResource* newResource = nullptr;
+		DnsQuery* newQuery = nullptr;
+		IDnsResource* newGenResource = nullptr;
 		if (resType == DnsQueryType)
 		{
 			newQuery = new DnsQuery(this, offsetInPacket);
@@ -206,7 +206,7 @@ void DnsLayer::parseResources()
 		}
 
 		// this resource is the first resource
-		if (m_ResourceList == NULL)
+		if (m_ResourceList == nullptr)
 		{
 			m_ResourceList = newGenResource;
 			curResource = m_ResourceList;
@@ -217,13 +217,13 @@ void DnsLayer::parseResources()
 			curResource = curResource->getNextResource();
 		}
 
-		if (resType == DnsQueryType && m_FirstQuery == NULL)
+		if (resType == DnsQueryType && m_FirstQuery == nullptr)
 			m_FirstQuery = newQuery;
-		else if (resType == DnsAnswerType && m_FirstAnswer == NULL)
+		else if (resType == DnsAnswerType && m_FirstAnswer == nullptr)
 			m_FirstAnswer = newResource;
-		else if (resType == DnsAuthorityType && m_FirstAuthority == NULL)
+		else if (resType == DnsAuthorityType && m_FirstAuthority == nullptr)
 			m_FirstAuthority = newResource;
-		else if (resType == DnsAdditionalType && m_FirstAdditional == NULL)
+		else if (resType == DnsAdditionalType && m_FirstAdditional == nullptr)
 			m_FirstAdditional = newResource;
 	}
 
@@ -234,8 +234,8 @@ IDnsResource* DnsLayer::getResourceByName(IDnsResource* startFrom, size_t resour
 	size_t index = 0;
 	while (index < resourceCount)
 	{
-		if (startFrom == NULL)
-			return NULL;
+		if (startFrom == nullptr)
+			return nullptr;
 
 		std::string resourceName = startFrom->getName();
 		if (exactMatch && resourceName == name)
@@ -248,16 +248,16 @@ IDnsResource* DnsLayer::getResourceByName(IDnsResource* startFrom, size_t resour
 		index++;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 DnsQuery* DnsLayer::getQuery(const std::string& name, bool exactMatch) const
 {
 	uint16_t numOfQueries = be16toh(getDnsHeader()->numberOfQuestions);
 	IDnsResource* res = getResourceByName(m_FirstQuery, numOfQueries, name, exactMatch);
-	if (res != NULL)
+	if (res != nullptr)
 		return dynamic_cast<DnsQuery*>(res);
-	return NULL;
+	return nullptr;
 }
 
 
@@ -269,11 +269,11 @@ DnsQuery* DnsLayer::getFirstQuery() const
 
 DnsQuery* DnsLayer::getNextQuery(DnsQuery* query) const
 {
-	if (query == NULL
-		|| query->getNextResource() == NULL
+	if (query == nullptr
+		|| query->getNextResource() == nullptr
 		|| query->getType() != DnsQueryType
 		|| query->getNextResource()->getType() != DnsQueryType)
-		return NULL;
+		return nullptr;
 
 	return (DnsQuery*)(query->getNextResource());
 }
@@ -287,9 +287,9 @@ DnsResource* DnsLayer::getAnswer(const std::string& name, bool exactMatch) const
 {
 	uint16_t numOfAnswers = be16toh(getDnsHeader()->numberOfAnswers);
 	IDnsResource* res = getResourceByName(m_FirstAnswer, numOfAnswers, name, exactMatch);
-	if (res != NULL)
+	if (res != nullptr)
 		return dynamic_cast<DnsResource*>(res);
-	return NULL;
+	return nullptr;
 }
 
 DnsResource* DnsLayer::getFirstAnswer() const
@@ -299,11 +299,11 @@ DnsResource* DnsLayer::getFirstAnswer() const
 
 DnsResource* DnsLayer::getNextAnswer(DnsResource* answer) const
 {
-	if (answer == NULL
-		|| answer->getNextResource() == NULL
+	if (answer == nullptr
+		|| answer->getNextResource() == nullptr
 		|| answer->getType() != DnsAnswerType
 		|| answer->getNextResource()->getType() != DnsAnswerType)
-		return NULL;
+		return nullptr;
 
 	return (DnsResource*)(answer->getNextResource());
 }
@@ -317,9 +317,9 @@ DnsResource* DnsLayer::getAuthority(const std::string& name, bool exactMatch) co
 {
 	uint16_t numOfAuthorities = be16toh(getDnsHeader()->numberOfAuthority);
 	IDnsResource* res = getResourceByName(m_FirstAuthority, numOfAuthorities, name, exactMatch);
-	if (res != NULL)
+	if (res != nullptr)
 		return dynamic_cast<DnsResource*>(res);
-	return NULL;
+	return nullptr;
 }
 
 DnsResource* DnsLayer::getFirstAuthority() const
@@ -329,11 +329,11 @@ DnsResource* DnsLayer::getFirstAuthority() const
 
 DnsResource* DnsLayer::getNextAuthority(DnsResource* authority) const
 {
-	if (authority == NULL
-		|| authority->getNextResource() == NULL
+	if (authority == nullptr
+		|| authority->getNextResource() == nullptr
 		|| authority->getType() != DnsAuthorityType
 		|| authority->getNextResource()->getType() != DnsAuthorityType)
-		return NULL;
+		return nullptr;
 
 	return (DnsResource*)(authority->getNextResource());
 }
@@ -347,9 +347,9 @@ DnsResource* DnsLayer::getAdditionalRecord(const std::string& name, bool exactMa
 {
 	uint16_t numOfAdditionalRecords = be16toh(getDnsHeader()->numberOfAdditional);
 	IDnsResource* res = getResourceByName(m_FirstAdditional, numOfAdditionalRecords, name, exactMatch);
-	if (res != NULL)
+	if (res != nullptr)
 		return dynamic_cast<DnsResource*>(res);
-	return NULL;
+	return nullptr;
 }
 
 DnsResource* DnsLayer::getFirstAdditionalRecord() const
@@ -359,11 +359,11 @@ DnsResource* DnsLayer::getFirstAdditionalRecord() const
 
 DnsResource* DnsLayer::getNextAdditionalRecord(DnsResource* additionalRecord) const
 {
-	if (additionalRecord == NULL
-		|| additionalRecord->getNextResource() == NULL
+	if (additionalRecord == nullptr
+		|| additionalRecord->getNextResource() == nullptr
 		|| additionalRecord->getType() != DnsAdditionalType
 		|| additionalRecord->getNextResource()->getType() != DnsAdditionalType)
-		return NULL;
+		return nullptr;
 
 	return (DnsResource*)(additionalRecord->getNextResource());
 }
@@ -438,7 +438,7 @@ IDnsResource* DnsLayer::getFirstResource(DnsResourceType resType) const
 		return m_FirstAdditional;
 	}
 	default:
-		return NULL;
+		return nullptr;
 	}
 }
 
@@ -493,23 +493,23 @@ DnsResource* DnsLayer::addResource(DnsResourceType resType, const std::string& n
 	{
 		delete newResource;
 		PCPP_LOG_ERROR("Couldn't set new resource data");
-		return NULL;
+		return nullptr;
 	}
 
 	size_t newResourceOffsetInLayer = getBasicHeaderSize();
 	IDnsResource* curResource = m_ResourceList;
-	while (curResource != NULL && curResource->getType() <= resType)
+	while (curResource != nullptr && curResource->getType() <= resType)
 	{
 		newResourceOffsetInLayer += curResource->getSize();
 		IDnsResource* nextResource = curResource->getNextResource();
-		if (nextResource == NULL || nextResource->getType() > resType)
+		if (nextResource == nullptr || nextResource->getType() > resType)
 			break;
 		curResource = nextResource;
 	}
 
 
 	// set next resource for new resource. This must happen here for extendLayer to succeed
-	if (curResource != NULL)
+	if (curResource != nullptr)
 	{
 		if (curResource->getType() > newResource->getType())
 			newResource->setNexResource(m_ResourceList);
@@ -524,14 +524,14 @@ DnsResource* DnsLayer::addResource(DnsResourceType resType, const std::string& n
 	{
 		PCPP_LOG_ERROR("Couldn't extend DNS layer, addResource failed");
 		delete newResource;
-		return NULL;
+		return nullptr;
 	}
 
 	// connect the new resource to layer
 	newResource->setDnsLayer(this, newResourceOffsetInLayer);
 
 	// connect the new resource to the layer's resource list
-	if (curResource != NULL)
+	if (curResource != nullptr)
 	{
 		curResource->setNexResource(newResource);
 		// this means the new resource is the first of it's type
@@ -574,18 +574,18 @@ DnsQuery* DnsLayer::addQuery(const std::string& name, DnsType dnsType, DnsClass 
 	// find the offset in the layer to insert the new query
 	size_t newQueryOffsetInLayer = getBasicHeaderSize();
 	DnsQuery* curQuery = getFirstQuery();
-	while (curQuery != NULL)
+	while (curQuery != nullptr)
 	{
 		newQueryOffsetInLayer += curQuery->getSize();
 		DnsQuery* nextQuery = getNextQuery(curQuery);
-		if (nextQuery == NULL)
+		if (nextQuery == nullptr)
 			break;
 		curQuery = nextQuery;
 
 	}
 
 	// set next resource for new query. This must happen here for extendLayer to succeed
-	if (curQuery != NULL)
+	if (curQuery != nullptr)
 		newQuery->setNexResource(curQuery->getNextResource());
 	else
 		newQuery->setNexResource(m_ResourceList);
@@ -595,14 +595,14 @@ DnsQuery* DnsLayer::addQuery(const std::string& name, DnsType dnsType, DnsClass 
 	{
 		PCPP_LOG_ERROR("Couldn't extend DNS layer, addQuery failed");
 		delete newQuery;
-		return NULL;
+		return nullptr;
 	}
 
 	// connect the new query to layer
 	newQuery->setDnsLayer(this, newQueryOffsetInLayer);
 
 	// connect the new query to the layer's resource list
-	if (curQuery != NULL)
+	if (curQuery != nullptr)
 		curQuery->setNexResource(newQuery);
 	else // curQuery == NULL, meaning this is the first query
 	{
@@ -618,8 +618,8 @@ DnsQuery* DnsLayer::addQuery(const std::string& name, DnsType dnsType, DnsClass 
 
 DnsQuery* DnsLayer::addQuery(DnsQuery* const copyQuery)
 {
-	if (copyQuery == NULL)
-		return NULL;
+	if (copyQuery == nullptr)
+		return nullptr;
 
 	return addQuery(copyQuery->getName(), copyQuery->getDnsType(), copyQuery->getDnsClass());
 }
@@ -627,7 +627,7 @@ DnsQuery* DnsLayer::addQuery(DnsQuery* const copyQuery)
 bool DnsLayer::removeQuery(const std::string& queryNameToRemove, bool exactMatch)
 {
 	DnsQuery* queryToRemove = getQuery(queryNameToRemove, exactMatch);
-	if (queryToRemove == NULL)
+	if (queryToRemove == nullptr)
 	{
 		PCPP_LOG_DEBUG("Query not found");
 		return false;
@@ -651,7 +651,7 @@ bool DnsLayer::removeQuery(DnsQuery* queryToRemove)
 DnsResource* DnsLayer::addAnswer(const std::string& name, DnsType dnsType, DnsClass dnsClass, uint32_t ttl, IDnsResourceData* data)
 {
 	DnsResource* res = addResource(DnsAnswerType, name, dnsType, dnsClass, ttl, data);
-	if (res != NULL)
+	if (res != nullptr)
 	{
 		// increase number of answer records
 		getDnsHeader()->numberOfAnswers = htobe16(getAnswerCount() + 1);
@@ -662,8 +662,8 @@ DnsResource* DnsLayer::addAnswer(const std::string& name, DnsType dnsType, DnsCl
 
 DnsResource* DnsLayer::addAnswer(DnsResource* const copyAnswer)
 {
-	if (copyAnswer == NULL)
-		return NULL;
+	if (copyAnswer == nullptr)
+		return nullptr;
 
 	return addAnswer(copyAnswer->getName(), copyAnswer->getDnsType(), copyAnswer->getDnsClass(), copyAnswer->getTTL(), copyAnswer->getData().get());
 }
@@ -671,7 +671,7 @@ DnsResource* DnsLayer::addAnswer(DnsResource* const copyAnswer)
 bool DnsLayer::removeAnswer(const std::string& answerNameToRemove, bool exactMatch)
 {
 	DnsResource* answerToRemove = getAnswer(answerNameToRemove, exactMatch);
-	if (answerToRemove == NULL)
+	if (answerToRemove == nullptr)
 	{
 		PCPP_LOG_DEBUG("Answer record not found");
 		return false;
@@ -696,7 +696,7 @@ bool DnsLayer::removeAnswer(DnsResource* answerToRemove)
 DnsResource* DnsLayer::addAuthority(const std::string& name, DnsType dnsType, DnsClass dnsClass, uint32_t ttl, IDnsResourceData* data)
 {
 	DnsResource* res = addResource(DnsAuthorityType, name, dnsType, dnsClass, ttl, data);
-	if (res != NULL)
+	if (res != nullptr)
 	{
 		// increase number of authority records
 		getDnsHeader()->numberOfAuthority = htobe16(getAuthorityCount() + 1);
@@ -707,8 +707,8 @@ DnsResource* DnsLayer::addAuthority(const std::string& name, DnsType dnsType, Dn
 
 DnsResource* DnsLayer::addAuthority(DnsResource* const copyAuthority)
 {
-	if (copyAuthority == NULL)
-		return NULL;
+	if (copyAuthority == nullptr)
+		return nullptr;
 
 	return addAuthority(copyAuthority->getName(), copyAuthority->getDnsType(), copyAuthority->getDnsClass(), copyAuthority->getTTL(), copyAuthority->getData().get());
 }
@@ -716,7 +716,7 @@ DnsResource* DnsLayer::addAuthority(DnsResource* const copyAuthority)
 bool DnsLayer::removeAuthority(const std::string& authorityNameToRemove, bool exactMatch)
 {
 	DnsResource* authorityToRemove = getAuthority(authorityNameToRemove, exactMatch);
-	if (authorityToRemove == NULL)
+	if (authorityToRemove == nullptr)
 	{
 		PCPP_LOG_DEBUG("Authority not found");
 		return false;
@@ -741,7 +741,7 @@ bool DnsLayer::removeAuthority(DnsResource* authorityToRemove)
 DnsResource* DnsLayer::addAdditionalRecord(const std::string& name, DnsType dnsType, DnsClass dnsClass, uint32_t ttl, IDnsResourceData* data)
 {
 	DnsResource* res = addResource(DnsAdditionalType, name, dnsType, dnsClass, ttl, data);
-	if (res != NULL)
+	if (res != nullptr)
 	{
 		// increase number of authority records
 		getDnsHeader()->numberOfAdditional = htobe16(getAdditionalRecordCount() + 1);
@@ -753,7 +753,7 @@ DnsResource* DnsLayer::addAdditionalRecord(const std::string& name, DnsType dnsT
 DnsResource* DnsLayer::addAdditionalRecord(const std::string& name, DnsType dnsType, uint16_t customData1, uint32_t customData2, IDnsResourceData* data)
 {
 	DnsResource* res = addAdditionalRecord(name, dnsType, DNS_CLASS_ANY, customData2, data);
-	if (res != NULL)
+	if (res != nullptr)
 	{
 		res->setCustomDnsClass(customData1);
 	}
@@ -763,8 +763,8 @@ DnsResource* DnsLayer::addAdditionalRecord(const std::string& name, DnsType dnsT
 
 DnsResource* DnsLayer::addAdditionalRecord(DnsResource* const copyAdditionalRecord)
 {
-	if (copyAdditionalRecord == NULL)
-		return NULL;
+	if (copyAdditionalRecord == nullptr)
+		return nullptr;
 
 	return addAdditionalRecord(copyAdditionalRecord->getName(), copyAdditionalRecord->getDnsType(), copyAdditionalRecord->getCustomDnsClass(), copyAdditionalRecord->getTTL(), copyAdditionalRecord->getData().get());
 }
@@ -772,7 +772,7 @@ DnsResource* DnsLayer::addAdditionalRecord(DnsResource* const copyAdditionalReco
 bool DnsLayer::removeAdditionalRecord(const std::string& additionalRecordNameToRemove, bool exactMatch)
 {
 	DnsResource* additionalRecordToRemove = getAdditionalRecord(additionalRecordNameToRemove, exactMatch);
-	if (additionalRecordToRemove == NULL)
+	if (additionalRecordToRemove == nullptr)
 	{
 		PCPP_LOG_DEBUG("Additional record not found");
 		return false;
@@ -795,7 +795,7 @@ bool DnsLayer::removeAdditionalRecord(DnsResource* additionalRecordToRemove)
 
 bool DnsLayer::removeResource(IDnsResource* resourceToRemove)
 {
-	if (resourceToRemove == NULL)
+	if (resourceToRemove == nullptr)
 	{
 		PCPP_LOG_DEBUG("resourceToRemove cannot be NULL");
 		return false;
@@ -806,7 +806,7 @@ bool DnsLayer::removeResource(IDnsResource* resourceToRemove)
 
 	if (m_ResourceList != resourceToRemove)
 	{
-		while (prevResource != NULL)
+		while (prevResource != nullptr)
 		{
 			IDnsResource* temp = prevResource->getNextResource();
 			if (temp == resourceToRemove)
@@ -816,7 +816,7 @@ bool DnsLayer::removeResource(IDnsResource* resourceToRemove)
 		}
 	}
 
-	if (prevResource == NULL)
+	if (prevResource == nullptr)
 	{
 		PCPP_LOG_DEBUG("Resource not found");
 		return false;
@@ -843,10 +843,10 @@ bool DnsLayer::removeResource(IDnsResource* resourceToRemove)
 	if (getFirstResource(resourceToRemove->getType()) == resourceToRemove)
 	{
 		IDnsResource* nextResource = resourceToRemove->getNextResource();
-		if (nextResource != NULL && nextResource->getType() == resourceToRemove->getType())
+		if (nextResource != nullptr && nextResource->getType() == resourceToRemove->getType())
 			setFirstResource(resourceToRemove->getType(), nextResource);
 		else
-			setFirstResource(resourceToRemove->getType(), NULL);
+			setFirstResource(resourceToRemove->getType(), nullptr);
 	}
 
 	// free resourceToRemove memory

--- a/Packet++/src/DnsResource.cpp
+++ b/Packet++/src/DnsResource.cpp
@@ -10,7 +10,7 @@ namespace pcpp
 {
 
 IDnsResource::IDnsResource(DnsLayer* dnsLayer, size_t offsetInLayer)
-	: m_DnsLayer(dnsLayer), m_OffsetInLayer(offsetInLayer), m_NextResource(NULL)
+	: m_DnsLayer(dnsLayer), m_OffsetInLayer(offsetInLayer), m_NextResource(nullptr)
 {
 	char decodedName[256];
 	m_NameLength = decodeName((const char*)getRawData(), decodedName);
@@ -19,13 +19,13 @@ IDnsResource::IDnsResource(DnsLayer* dnsLayer, size_t offsetInLayer)
 }
 
 IDnsResource::IDnsResource(uint8_t* emptyRawData)
-	: m_DnsLayer(NULL), m_OffsetInLayer(0), m_NextResource(NULL), m_DecodedName(""), m_NameLength(0), m_ExternalRawData(emptyRawData)
+	: m_DnsLayer(nullptr), m_OffsetInLayer(0), m_NextResource(nullptr), m_DecodedName(""), m_NameLength(0), m_ExternalRawData(emptyRawData)
 {
 }
 
 uint8_t* IDnsResource::getRawData() const
 {
-	if (m_DnsLayer == NULL)
+	if (m_DnsLayer == nullptr)
 		return m_ExternalRawData;
 
 	return m_DnsLayer->m_Data + m_OffsetInLayer;
@@ -227,7 +227,7 @@ bool IDnsResource::setName(const std::string& newName)
 	char encodedName[256];
 	size_t encodedNameLen = 0;
 	encodeName(newName, encodedName, encodedNameLen);
-	if (m_DnsLayer != NULL)
+	if (m_DnsLayer != nullptr)
 	{
 		if (encodedNameLen > m_NameLength)
 		{
@@ -267,7 +267,7 @@ void IDnsResource::setDnsLayer(DnsLayer* dnsLayer, size_t offsetInLayer)
 	memcpy(dnsLayer->m_Data + offsetInLayer, m_ExternalRawData, getSize());
 	m_DnsLayer = dnsLayer;
 	m_OffsetInLayer = offsetInLayer;
-	m_ExternalRawData = NULL;
+	m_ExternalRawData = nullptr;
 }
 
 uint32_t DnsResource::getTTL() const
@@ -347,7 +347,7 @@ bool DnsResource::setData(IDnsResourceData* data)
 	size_t dataLength = 0;
 	uint8_t dataAsByteArr[256];
 
-	if (data == NULL)
+	if (data == nullptr)
 	{
 		PCPP_LOG_ERROR("Given data is NULL");
 		return false;
@@ -415,7 +415,7 @@ bool DnsResource::setData(IDnsResourceData* data)
 	size_t dataLengthOffset = m_NameLength + (2*sizeof(uint16_t)) + sizeof(uint32_t);
 	size_t dataOffset = dataLengthOffset + sizeof(uint16_t);
 
-	if (m_DnsLayer != NULL)
+	if (m_DnsLayer != nullptr)
 	{
 		size_t curLength = getDataLength();
 		if (dataLength > curLength)

--- a/Packet++/src/DnsResourceData.cpp
+++ b/Packet++/src/DnsResourceData.cpp
@@ -12,7 +12,7 @@ namespace pcpp
 
 size_t IDnsResourceData::decodeName(const char* encodedName, char* result, IDnsResource* dnsResource) const
 {
-	if (dnsResource == NULL)
+	if (dnsResource == nullptr)
 	{
 		PCPP_LOG_ERROR("Cannot decode name, DNS resource object is NULL");
 		return 0;
@@ -23,7 +23,7 @@ size_t IDnsResourceData::decodeName(const char* encodedName, char* result, IDnsR
 
 void IDnsResourceData::encodeName(const std::string& decodedName, char* result, size_t& resultLen, IDnsResource* dnsResource) const
 {
-	if (dnsResource == NULL)
+	if (dnsResource == nullptr)
 	{
 		PCPP_LOG_ERROR("Cannot encode name, DNS resource object is NULL");
 		return;
@@ -141,9 +141,9 @@ bool MxDnsResourceData::toByteArr(uint8_t* arr, size_t& arrLength, IDnsResource*
 
 GenericDnsResourceData::GenericDnsResourceData(uint8_t* dataPtr, size_t dataLen)
 {
-	m_Data = NULL;
+	m_Data = nullptr;
 	m_DataLen = 0;
-	if (dataLen > 0 && dataPtr != NULL)
+	if (dataLen > 0 && dataPtr != nullptr)
 	{
 		m_DataLen = dataLen;
 		m_Data = new uint8_t[dataLen];
@@ -153,7 +153,7 @@ GenericDnsResourceData::GenericDnsResourceData(uint8_t* dataPtr, size_t dataLen)
 
 GenericDnsResourceData::GenericDnsResourceData(const std::string& dataAsHexString)
 {
-	m_Data = NULL;
+	m_Data = nullptr;
 	uint8_t tempDataArr[2048];
 	m_DataLen = hexStringToByteArray(dataAsHexString, tempDataArr, 2048);
 	if (m_DataLen != 0)
@@ -167,7 +167,7 @@ GenericDnsResourceData::GenericDnsResourceData(const GenericDnsResourceData& oth
 {
 	m_DataLen = other.m_DataLen;
 
-	if (m_DataLen > 0 && other.m_Data != NULL)
+	if (m_DataLen > 0 && other.m_Data != nullptr)
 	{
 		m_Data = new uint8_t[m_DataLen];
 		memcpy(m_Data, other.m_Data, m_DataLen);
@@ -176,12 +176,12 @@ GenericDnsResourceData::GenericDnsResourceData(const GenericDnsResourceData& oth
 
 GenericDnsResourceData& GenericDnsResourceData::operator=(const GenericDnsResourceData& other)
 {
-	if (m_Data != NULL)
+	if (m_Data != nullptr)
 		delete [] m_Data;
 
-	m_Data = NULL;
+	m_Data = nullptr;
 	m_DataLen = other.m_DataLen;
-	if (m_DataLen > 0 && other.m_Data != NULL)
+	if (m_DataLen > 0 && other.m_Data != nullptr)
 	{
 		m_Data = new uint8_t[m_DataLen];
 		memcpy(m_Data, other.m_Data, m_DataLen);
@@ -205,7 +205,7 @@ std::string GenericDnsResourceData::toString() const
 
 bool GenericDnsResourceData::toByteArr(uint8_t* arr, size_t& arrLength, IDnsResource* dnsResource) const
 {
-	if (m_DataLen == 0 || m_Data == NULL)
+	if (m_DataLen == 0 || m_Data == nullptr)
 	{
 		PCPP_LOG_ERROR("Input data is null or illegal");
 		return false;

--- a/Packet++/src/EthLayer.cpp
+++ b/Packet++/src/EthLayer.cpp
@@ -83,7 +83,7 @@ void EthLayer::parseNextLayer()
 
 void EthLayer::computeCalculateFields()
 {
-	if (m_NextLayer == NULL)
+	if (m_NextLayer == nullptr)
 		return;
 
 	switch (m_NextLayer->getProtocol())

--- a/Packet++/src/GreLayer.cpp
+++ b/Packet++/src/GreLayer.cpp
@@ -79,7 +79,7 @@ uint8_t* GreLayer::getFieldValue(GreField field, bool returnOffsetEvenIfFieldMis
 			}
 			break;
 		default: // shouldn't get there
-			return NULL;
+			return nullptr;
 		}
 
 		if (field == curField)
@@ -87,17 +87,17 @@ uint8_t* GreLayer::getFieldValue(GreField field, bool returnOffsetEvenIfFieldMis
 			if (curFieldExists || returnOffsetEvenIfFieldMissing)
 				return origPtr;
 
-			return NULL;
+			return nullptr;
 		}
 	} // for
 
-	return NULL;
+	return nullptr;
 }
 
 void GreLayer::computeCalculateFieldsInner()
 {
 	gre_basic_header* header = (gre_basic_header*)m_Data;
-	if (m_NextLayer != NULL)
+	if (m_NextLayer != nullptr)
 	{
 		switch (m_NextLayer->getProtocol())
 		{
@@ -133,7 +133,7 @@ bool GreLayer::getSequenceNumber(uint32_t& seqNumber) const
 		return false;
 
 	uint32_t* val = (uint32_t*)getFieldValue(GreSeq, false);
-	if (val == NULL)
+	if (val == nullptr)
 		return false;
 
 	seqNumber = be32toh(*val);
@@ -281,7 +281,7 @@ bool GREv0Layer::getChecksum(uint16_t& checksum)
 		return false;
 
 	uint16_t* val = (uint16_t*)getFieldValue(GreChecksumOrRouting, false);
-	if (val == NULL)
+	if (val == nullptr)
 		return false;
 
 	checksum = be16toh(*val);
@@ -361,7 +361,7 @@ bool GREv0Layer::getOffset(uint16_t& offset) const
 		return false;
 
 	uint8_t* val = (uint8_t*)getFieldValue(GreChecksumOrRouting, false);
-	if (val == NULL)
+	if (val == nullptr)
 		return false;
 
 	offset = be16toh(*(val+2));
@@ -374,7 +374,7 @@ bool GREv0Layer::getKey(uint32_t& key) const
 		return false;
 
 	uint32_t* val = (uint32_t*)getFieldValue(GreKey, false);
-	if (val == NULL)
+	if (val == nullptr)
 		return false;
 
 	key = be32toh(*val);
@@ -480,7 +480,7 @@ bool GREv1Layer::getAcknowledgmentNum(uint32_t& ackNum) const
 		return false;
 
 	uint32_t* val = (uint32_t*)getFieldValue(GreAck, false);
-	if (val == NULL)
+	if (val == nullptr)
 		return false;
 
 	ackNum = be32toh(*val);
@@ -597,7 +597,7 @@ void PPP_PPTPLayer::parseNextLayer()
 void PPP_PPTPLayer::computeCalculateFields()
 {
 	ppp_pptp_header* header = getPPP_PPTPHeader();
-	if (m_NextLayer != NULL)
+	if (m_NextLayer != nullptr)
 	{
 		switch (m_NextLayer->getProtocol())
 		{

--- a/Packet++/src/GtpLayer.cpp
+++ b/Packet++/src/GtpLayer.cpp
@@ -21,7 +21,7 @@ namespace pcpp
 
 GtpV1Layer::GtpExtension::GtpExtension()
 {
-	m_Data = NULL;
+	m_Data = nullptr;
 	m_DataLen = 0;
 	m_ExtType = 0;
 }
@@ -50,7 +50,7 @@ GtpV1Layer::GtpExtension& GtpV1Layer::GtpExtension::operator=(const GtpV1Layer::
 
 bool GtpV1Layer::GtpExtension::isNull() const
 {
-	return m_Data == NULL;
+	return m_Data == nullptr;
 }
 
 uint8_t GtpV1Layer::GtpExtension::getExtensionType() const
@@ -60,7 +60,7 @@ uint8_t GtpV1Layer::GtpExtension::getExtensionType() const
 
 size_t GtpV1Layer::GtpExtension::getTotalLength() const
 {
-	if (m_Data == NULL)
+	if (m_Data == nullptr)
 	{
 		return 0;
 	}
@@ -88,9 +88,9 @@ size_t GtpV1Layer::GtpExtension::getContentLength() const
 
 uint8_t* GtpV1Layer::GtpExtension::getContent() const
 {
-	if (m_Data == NULL || getContentLength() == 0)
+	if (m_Data == nullptr || getContentLength() == 0)
 	{
-		return NULL;
+		return nullptr;
 	}
 
 	return m_Data + sizeof(uint8_t);
@@ -98,7 +98,7 @@ uint8_t* GtpV1Layer::GtpExtension::getContent() const
 
 uint8_t GtpV1Layer::GtpExtension::getNextExtensionHeaderType() const
 {
-	if (m_Data == NULL || getTotalLength() < 4)
+	if (m_Data == nullptr || getTotalLength() < 4)
 	{
 		return 0;
 	}
@@ -124,7 +124,7 @@ GtpV1Layer::GtpExtension GtpV1Layer::GtpExtension::getNextExtension() const
 
 void GtpV1Layer::GtpExtension::setNextHeaderType(uint8_t nextHeaderType)
 {
-	if (m_Data != NULL && m_DataLen > 1)
+	if (m_Data != nullptr && m_DataLen > 1)
 	{
 		m_Data[getTotalLength() - 1] = nextHeaderType;
 	}
@@ -203,7 +203,7 @@ void GtpV1Layer::init(GtpV1MessageType messageType, uint32_t teid, bool setSeqNu
 
 bool GtpV1Layer::isGTPv1(const uint8_t* data, size_t dataSize)
 {
-	if(data != NULL && dataSize >= sizeof(gtpv1_header) && (data[0] & 0xE0) == 0x20)
+	if(data != nullptr && dataSize >= sizeof(gtpv1_header) && (data[0] & 0xE0) == 0x20)
 	{
 		return true;
 	}
@@ -213,19 +213,19 @@ bool GtpV1Layer::isGTPv1(const uint8_t* data, size_t dataSize)
 
 GtpV1Layer::gtpv1_header_extra* GtpV1Layer::getHeaderExtra() const
 {
-	if (m_Data != NULL && m_DataLen >= sizeof(gtpv1_header) + sizeof(gtpv1_header_extra))
+	if (m_Data != nullptr && m_DataLen >= sizeof(gtpv1_header) + sizeof(gtpv1_header_extra))
 	{
 		return (gtpv1_header_extra*)(m_Data + sizeof(gtpv1_header));
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 bool GtpV1Layer::getSequenceNumber(uint16_t& seqNumber) const
 {
 	gtpv1_header* header = getHeader();
 	gtpv1_header_extra* headerExtra = getHeaderExtra();
-	if (header != NULL && headerExtra != NULL && header->sequenceNumberFlag == 1)
+	if (header != nullptr && headerExtra != nullptr && header->sequenceNumberFlag == 1)
 	{
 		seqNumber = be16toh(headerExtra->sequenceNumber);
 		return true;
@@ -238,7 +238,7 @@ bool GtpV1Layer::setSequenceNumber(const uint16_t seqNumber)
 {
 	// get GTP header
 	gtpv1_header* header = getHeader();
-	if (header == NULL)
+	if (header == nullptr)
 	{
 		PCPP_LOG_ERROR("Set sequence failed: GTP header is NULL");
 		return false;
@@ -257,7 +257,7 @@ bool GtpV1Layer::setSequenceNumber(const uint16_t seqNumber)
 
 	// get the extra header
 	gtpv1_header_extra* headerExtra = getHeaderExtra();
-	if (headerExtra == NULL)
+	if (headerExtra == nullptr)
 	{
 		PCPP_LOG_ERROR("Set sequence failed: extra header is NULL");
 		return false;
@@ -277,7 +277,7 @@ bool GtpV1Layer::getNpduNumber(uint8_t& npduNum) const
 {
 	gtpv1_header* header = getHeader();
 	gtpv1_header_extra* headerExtra = getHeaderExtra();
-	if (header != NULL && headerExtra != NULL && header->npduNumberFlag == 1)
+	if (header != nullptr && headerExtra != nullptr && header->npduNumberFlag == 1)
 	{
 		npduNum = headerExtra->npduNumber;
 		return true;
@@ -290,7 +290,7 @@ bool GtpV1Layer::setNpduNumber(const uint8_t npduNum)
 {
 	// get GTP header
 	gtpv1_header* header = getHeader();
-	if (header == NULL)
+	if (header == nullptr)
 	{
 		PCPP_LOG_ERROR("Set N-PDU failed: GTP header is NULL");
 		return false;
@@ -309,7 +309,7 @@ bool GtpV1Layer::setNpduNumber(const uint8_t npduNum)
 
 	// get the extra header
 	gtpv1_header_extra* headerExtra = getHeaderExtra();
-	if (headerExtra == NULL)
+	if (headerExtra == nullptr)
 	{
 		PCPP_LOG_ERROR("Set N-PDU failed: extra header is NULL");
 		return false;
@@ -329,7 +329,7 @@ bool GtpV1Layer::getNextExtensionHeaderType(uint8_t& nextExtType) const
 {
 	gtpv1_header* header = getHeader();
 	gtpv1_header_extra* headerExtra = getHeaderExtra();
-	if (header != NULL && headerExtra != NULL && header->extensionHeaderFlag == 1)
+	if (header != nullptr && headerExtra != nullptr && header->extensionHeaderFlag == 1)
 	{
 		nextExtType = headerExtra->nextExtensionHeader;
 		return true;
@@ -354,7 +354,7 @@ GtpV1Layer::GtpExtension GtpV1Layer::addExtension(uint8_t extensionType, uint16_
 {
 	// get GTP header
 	gtpv1_header* header = getHeader();
-	if (header == NULL)
+	if (header == nullptr)
 	{
 		PCPP_LOG_ERROR("Add extension failed: GTP header is NULL");
 		return GtpExtension();
@@ -375,7 +375,7 @@ GtpV1Layer::GtpExtension GtpV1Layer::addExtension(uint8_t extensionType, uint16_
 
 	// get the extra header
 	gtpv1_header_extra* headerExtra = getHeaderExtra();
-	if (headerExtra == NULL)
+	if (headerExtra == nullptr)
 	{
 		PCPP_LOG_ERROR("Add extension failed: extra header is NULL");
 		return GtpExtension();
@@ -433,7 +433,7 @@ GtpV1MessageType GtpV1Layer::getMessageType() const
 {
 	gtpv1_header* header = getHeader();
 
-	if (header == NULL)
+	if (header == nullptr)
 	{
 		return GtpV1_MessageTypeUnknown;
 	}
@@ -524,7 +524,7 @@ std::string GtpV1Layer::getMessageTypeAsString() const
 {
 	gtpv1_header* header = getHeader();
 
-	if (header == NULL)
+	if (header == nullptr)
 	{
 		return GTPv1MsgTypeToStringMap.find(0)->second;
 	}
@@ -543,7 +543,7 @@ std::string GtpV1Layer::getMessageTypeAsString() const
 bool GtpV1Layer::isGTPUMessage() const
 {
 	gtpv1_header* header = getHeader();
-	if (header == NULL)
+	if (header == nullptr)
 	{
 		return false;
 	}
@@ -554,7 +554,7 @@ bool GtpV1Layer::isGTPUMessage() const
 bool GtpV1Layer::isGTPCMessage() const
 {
 	gtpv1_header* header = getHeader();
-	if (header == NULL)
+	if (header == nullptr)
 	{
 		return false;
 	}
@@ -612,7 +612,7 @@ void GtpV1Layer::parseNextLayer()
 size_t GtpV1Layer::getHeaderLen() const
 {
 	gtpv1_header* header = getHeader();
-	if (header == NULL)
+	if (header == nullptr)
 	{
 		return 0;
 	}
@@ -627,7 +627,7 @@ size_t GtpV1Layer::getHeaderLen() const
 	else
 	{
 		gtpv1_header_extra* headerExtra = getHeaderExtra();
-		if (headerExtra != NULL && (header->extensionHeaderFlag == 1 || header->sequenceNumberFlag == 1 || header->npduNumberFlag == 1))
+		if (headerExtra != nullptr && (header->extensionHeaderFlag == 1 || header->sequenceNumberFlag == 1 || header->npduNumberFlag == 1))
 		{
 			res += sizeof(gtpv1_header_extra);
 			GtpExtension nextExt = getNextExtension();
@@ -647,7 +647,7 @@ std::string GtpV1Layer::toString() const
 	std::string res = "GTP v1 Layer";
 
 	gtpv1_header* header = getHeader();
-	if (header != NULL)
+	if (header != nullptr)
 	{
 		std::stringstream teidStream;
 		teidStream << be32toh(header->teid);
@@ -671,7 +671,7 @@ std::string GtpV1Layer::toString() const
 void GtpV1Layer::computeCalculateFields()
 {
 	gtpv1_header* hdr = getHeader();
-	if (hdr == NULL)
+	if (hdr == nullptr)
 	{
 		return;
 	}

--- a/Packet++/src/HttpLayer.cpp
+++ b/Packet++/src/HttpLayer.cpp
@@ -17,10 +17,10 @@ namespace pcpp
 
 HeaderField* HttpMessage::addField(const std::string& fieldName, const std::string& fieldValue)
 {
-	if (getFieldByName(fieldName) != NULL)
+	if (getFieldByName(fieldName) != nullptr)
 	{
 		PCPP_LOG_ERROR("Field '" << fieldName << "' already exists!");
-		return NULL;
+		return nullptr;
 	}
 
 	return TextBasedProtocolMessage::addField(fieldName, fieldValue);
@@ -28,10 +28,10 @@ HeaderField* HttpMessage::addField(const std::string& fieldName, const std::stri
 
 HeaderField* HttpMessage::addField(const HeaderField& newField)
 {
-	if (getFieldByName(newField.getFieldName()) != NULL)
+	if (getFieldByName(newField.getFieldName()) != nullptr)
 	{
 		PCPP_LOG_ERROR("Field '" << newField.getFieldName() << "' already exists!");
-		return NULL;
+		return nullptr;
 	}
 
 	return TextBasedProtocolMessage::addField(newField);
@@ -39,10 +39,10 @@ HeaderField* HttpMessage::addField(const HeaderField& newField)
 
 HeaderField* HttpMessage::insertField(HeaderField* prevField, const std::string& fieldName, const std::string& fieldValue)
 {
-	if (getFieldByName(fieldName) != NULL)
+	if (getFieldByName(fieldName) != nullptr)
 	{
 		PCPP_LOG_ERROR("Field '" << fieldName << "' already exists!");
-		return NULL;
+		return nullptr;
 	}
 
 	return TextBasedProtocolMessage::insertField(prevField, fieldName, fieldValue);
@@ -50,10 +50,10 @@ HeaderField* HttpMessage::insertField(HeaderField* prevField, const std::string&
 
 HeaderField* HttpMessage::insertField(HeaderField* prevField, const HeaderField& newField)
 {
-	if (getFieldByName(newField.getFieldName()) != NULL)
+	if (getFieldByName(newField.getFieldName()) != nullptr)
 	{
 		PCPP_LOG_ERROR("Field '" << newField.getFieldName() << "' already exists!");
-		return NULL;
+		return nullptr;
 	}
 
 	return TextBasedProtocolMessage::insertField(prevField, newField);
@@ -87,7 +87,7 @@ HttpRequestLayer& HttpRequestLayer::operator=(const HttpRequestLayer& other)
 {
 	HttpMessage::operator=(other);
 
-	if (m_FirstLine != NULL)
+	if (m_FirstLine != nullptr)
 		delete m_FirstLine;
 
 	m_FirstLine = new HttpRequestFirstLine(this);
@@ -99,7 +99,7 @@ HttpRequestLayer& HttpRequestLayer::operator=(const HttpRequestLayer& other)
 std::string HttpRequestLayer::getUrl() const
 {
 	HeaderField* hostField = getFieldByName(PCPP_HTTP_HOST_FIELD);
-	if (hostField == NULL)
+	if (hostField == nullptr)
 		return m_FirstLine->getUri();
 
 	return hostField->getFieldValue() + m_FirstLine->getUri();
@@ -194,7 +194,7 @@ HttpRequestFirstLine::HttpRequestFirstLine(HttpRequestLayer* httpRequest) : m_Ht
 	}
 
 	char* endOfFirstLine;
-	if ((endOfFirstLine = (char*)memchr((char*)(m_HttpRequest->m_Data + m_VersionOffset), '\n', m_HttpRequest->m_DataLen-(size_t)m_VersionOffset)) != NULL)
+	if ((endOfFirstLine = (char*)memchr((char*)(m_HttpRequest->m_Data + m_VersionOffset), '\n', m_HttpRequest->m_DataLen-(size_t)m_VersionOffset)) != nullptr)
 	{
 		m_FirstLineEndOffset = endOfFirstLine - (char*)m_HttpRequest->m_Data + 1;
 		m_IsComplete = true;
@@ -360,7 +360,7 @@ void HttpRequestFirstLine::parseVersion()
 {
 	char* data = (char*)(m_HttpRequest->m_Data + m_UriOffset);
 	char* verPos = cross_platform_memmem(data, m_HttpRequest->getDataLen() - m_UriOffset, " HTTP/", 6);
-	if (verPos == NULL)
+	if (verPos == nullptr)
 	{
 		m_Version = HttpVersionUnknown;
 		m_VersionOffset = -1;
@@ -711,7 +711,7 @@ HttpResponseLayer& HttpResponseLayer::operator=(const HttpResponseLayer& other)
 {
 	HttpMessage::operator=(other);
 
-	if (m_FirstLine != NULL)
+	if (m_FirstLine != nullptr)
 		delete m_FirstLine;
 
 	m_FirstLine = new HttpResponseFirstLine(this);
@@ -726,7 +726,7 @@ HeaderField* HttpResponseLayer::setContentLength(int contentLength, const std::s
 	contentLengthAsString << contentLength;
 	std::string contentLengthFieldName(PCPP_HTTP_CONTENT_LENGTH_FIELD);
 	HeaderField* contentLengthField = getFieldByName(contentLengthFieldName);
-	if (contentLengthField == NULL)
+	if (contentLengthField == nullptr)
 	{
 		HeaderField* prevField = getFieldByName(prevFieldName);
 		contentLengthField = insertField(prevField, PCPP_HTTP_CONTENT_LENGTH_FIELD, contentLengthAsString.str());
@@ -742,7 +742,7 @@ int HttpResponseLayer::getContentLength() const
 	std::string contentLengthFieldName(PCPP_HTTP_CONTENT_LENGTH_FIELD);
 	std::transform(contentLengthFieldName.begin(), contentLengthFieldName.end(), contentLengthFieldName.begin(), ::tolower);
 	HeaderField* contentLengthField = getFieldByName(contentLengthFieldName);
-	if (contentLengthField != NULL)
+	if (contentLengthField != nullptr)
 		return atoi(contentLengthField->getFieldValue().c_str());
 	return 0;
 }
@@ -1249,7 +1249,7 @@ HttpResponseFirstLine::HttpResponseFirstLine(HttpResponseLayer* httpResponse) : 
 
 
 	char* endOfFirstLine;
-	if ((endOfFirstLine = (char*)memchr((char*)(m_HttpResponse->m_Data), '\n', m_HttpResponse->m_DataLen)) != NULL)
+	if ((endOfFirstLine = (char*)memchr((char*)(m_HttpResponse->m_Data), '\n', m_HttpResponse->m_DataLen)) != nullptr)
 	{
 		m_FirstLineEndOffset = endOfFirstLine - (char*)m_HttpResponse->m_Data + 1;
 		m_IsComplete = true;

--- a/Packet++/src/IPReassembly.cpp
+++ b/Packet++/src/IPReassembly.cpp
@@ -70,7 +70,7 @@ class IPv4FragmentWrapper : public IPFragmentWrapper
 public:
 	explicit IPv4FragmentWrapper(Packet* fragment)
 	{
-		m_IPLayer = fragment->isPacketOfType(IPv4) ? fragment->getLayerOfType<IPv4Layer>() : NULL;
+		m_IPLayer = fragment->isPacketOfType(IPv4) ? fragment->getLayerOfType<IPv4Layer>() : nullptr;
 	}
 
 	// implement abstract methods
@@ -139,18 +139,18 @@ class IPv6FragmentWrapper : public IPFragmentWrapper
 public:
 	explicit IPv6FragmentWrapper(Packet* fragment)
 	{
-		m_IPLayer = fragment->isPacketOfType(IPv6) ? fragment->getLayerOfType<IPv6Layer>() : NULL;
-		if (m_IPLayer != NULL)
+		m_IPLayer = fragment->isPacketOfType(IPv6) ? fragment->getLayerOfType<IPv6Layer>() : nullptr;
+		if (m_IPLayer != nullptr)
 			m_FragHeader = m_IPLayer->getExtensionOfType<IPv6FragmentationHeader>();
 		else
-			m_FragHeader = NULL;
+			m_FragHeader = nullptr;
 	}
 
 	// implement abstract methods
 
 	bool isFragment()
 	{
-		return (m_FragHeader != NULL);
+		return (m_FragHeader != nullptr);
 	}
 
 	bool isFirstFragment()
@@ -185,7 +185,7 @@ public:
 
 	uint32_t hashPacket()
 	{
-		if (m_FragHeader == NULL)
+		if (m_FragHeader == nullptr)
 			return 0;
 
 		ScalarBuffer<uint8_t> vec[3];
@@ -290,7 +290,7 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, 
 	// create fragment wrapper
 	IPv4FragmentWrapper ipv4Wrapper(fragment);
 	IPv6FragmentWrapper ipv6Wrapper(fragment);
-	IPFragmentWrapper* fragWrapper = NULL;
+	IPFragmentWrapper* fragWrapper = nullptr;
 	if (fragment->isPacketOfType(IPv4))
 		fragWrapper = &ipv4Wrapper;
 	else // fragment->isPacketOfType(IPv6)
@@ -307,7 +307,7 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, 
 	// create a hash from source IP, destination IP and IP/fragment ID
 	uint32_t hash = fragWrapper->hashPacket();
 
-	IPFragmentData* fragData = NULL;
+	IPFragmentData* fragData = nullptr;
 
 	// check whether this packet already exists in the map
 	std::map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(hash);
@@ -329,7 +329,7 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, 
 		fragData = iter->second;
 
 		// mark this packet as used
-		m_PacketLRU.put(hash, NULL);
+		m_PacketLRU.put(hash, nullptr);
 	}
 
 	bool gotLastFragment = false;
@@ -337,7 +337,7 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, 
 	// if current fragment is the first fragment of this packet
 	if (fragWrapper->isFirstFragment())
 	{
-		if (fragData->data == NULL) // first fragment
+		if (fragData->data == nullptr) // first fragment
 		{
 			PCPP_LOG_DEBUG("[FragID=0x" << std::hex << fragWrapper->getFragmentId() << "] Got first fragment, allocating RawPacket");
 
@@ -353,7 +353,7 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, 
 		{
 			PCPP_LOG_DEBUG("[FragID=0x" << std::hex << fragWrapper->getFragmentId() << "] Got duplicated first fragment");
 			status = FRAGMENT;
-			return NULL;
+			return nullptr;
 		}
 	}
 
@@ -367,11 +367,11 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, 
 		if (fragData->currentOffset == fragOffset)
 		{
 			// malformed fragment which is not the first fragment but its offset is 0
-			if (fragData->data == NULL)
+			if (fragData->data == nullptr)
 			{
 				PCPP_LOG_DEBUG("[FragID=0x" << std::hex << fragWrapper->getFragmentId() << "] Fragment is malformed");
 				status = MALFORMED_FRAGMENT;
-				return NULL;
+				return nullptr;
 			}
 
 			PCPP_LOG_DEBUG("[FragID=0x" << std::hex << fragWrapper->getFragmentId() << "] Found next matching fragment with offset " << fragOffset << ", adding fragment data to reassembled packet");
@@ -409,7 +409,7 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, 
 			fragData->outOfOrderFragments.pushBack(newFrag);
 
 			status = OUT_OF_ORDER_FRAGMENT;
-			return NULL;
+			return nullptr;
 		}
 		else
 		{
@@ -472,7 +472,7 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, 
 	if (status != FIRST_FRAGMENT)
 		status = FRAGMENT;
 
-	return NULL;
+	return nullptr;
 }
 
 Packet* IPReassembly::processPacket(RawPacket* fragment, ReassemblyStatus& status, ProtocolType parseUntil, OsiModelLayer parseUntilLayer)
@@ -499,7 +499,7 @@ Packet* IPReassembly::getCurrentPacket(const PacketKey& key)
 		IPFragmentData* fragData = iter->second;
 
 		// some data already exists
-		if (fragData != NULL && fragData->data != NULL)
+		if (fragData != nullptr && fragData->data != nullptr)
 		{
 			// create a copy of the RawPacket object
 			RawPacket* partialRawPacket = new RawPacket(*(fragData->data));
@@ -539,7 +539,7 @@ Packet* IPReassembly::getCurrentPacket(const PacketKey& key)
 		}
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 void IPReassembly::removePacket(const PacketKey& key)
@@ -573,8 +573,8 @@ void IPReassembly::addNewFragment(uint32_t hash, IPFragmentData* fragData)
 		std::map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(packetRemoved);
 		IPFragmentData* dataRemoved = iter->second;
 
-		PacketKey* key = NULL;
-		if (m_OnFragmentsCleanCallback != NULL)
+		PacketKey* key = nullptr;
+		if (m_OnFragmentsCleanCallback != nullptr)
 			key = dataRemoved->packetKey->clone();
 
 		PCPP_LOG_DEBUG("Reached maximum packet capacity, removing data for FragID=0x" << std::hex << dataRemoved->fragmentID);
@@ -582,7 +582,7 @@ void IPReassembly::addNewFragment(uint32_t hash, IPFragmentData* fragData)
 		m_FragmentMap.erase(iter);
 
 		// fire callback if not null
-		if (m_OnFragmentsCleanCallback != NULL)
+		if (m_OnFragmentsCleanCallback != nullptr)
 		{
 			m_OnFragmentsCleanCallback(key, m_CallbackUserCookie);
 			delete key;

--- a/Packet++/src/IPSecLayer.cpp
+++ b/Packet++/src/IPSecLayer.cpp
@@ -39,13 +39,13 @@ uint8_t* AuthenticationHeaderLayer::getICVBytes() const
 	size_t icvLength = getICVLength();
 	if (icvLength > 0)
 		return m_Data + sizeof(ipsec_authentication_header);
-	return NULL;
+	return nullptr;
 }
 
 std::string AuthenticationHeaderLayer::getICVHexStream() const
 {
 	uint8_t* bytes = getICVBytes();
-	if (bytes == NULL)
+	if (bytes == nullptr)
 		return "";
 
 	return byteArrayToHexString(bytes, getICVLength());

--- a/Packet++/src/IPv4Layer.cpp
+++ b/Packet++/src/IPv4Layer.cpp
@@ -57,7 +57,7 @@ IPv4OptionBuilder::IPv4OptionBuilder(const IPv4TimestampOptionValue& timestampVa
 {
 	m_RecType = (uint8_t)IPV4OPT_Timestamp;
 	m_RecValueLen = 0;
-	m_RecValue = NULL;
+	m_RecValue = nullptr;
 
 	if (timestampValue.type == IPv4TimestampOptionValue::Unknown)
 	{
@@ -129,7 +129,7 @@ IPv4OptionBuilder::IPv4OptionBuilder(const IPv4TimestampOptionValue& timestampVa
 IPv4Option IPv4OptionBuilder::build() const
 {
 	if (!m_BuilderParamsValid)
-		return IPv4Option(NULL);
+		return IPv4Option(nullptr);
 
 	size_t optionSize = m_RecValueLen + 2 * sizeof(uint8_t);
 
@@ -139,7 +139,7 @@ IPv4Option IPv4OptionBuilder::build() const
 		if (m_RecValueLen != 0)
 		{
 			PCPP_LOG_ERROR("Can't set IPv4 NOP option or IPv4 End-of-options option with size different than 0, tried to set size " << (int)m_RecValueLen);
-			return IPv4Option(NULL);
+			return IPv4Option(nullptr);
 		}
 
 		optionSize = sizeof(uint8_t);
@@ -151,7 +151,7 @@ IPv4Option IPv4OptionBuilder::build() const
 	if (optionSize > 1)
 	{
 		recordBuffer[1] = static_cast<uint8_t>(optionSize);
-		if (optionSize > 2 && m_RecValue != NULL)
+		if (optionSize > 2 && m_RecValue != nullptr)
 			memcpy(recordBuffer + 2, m_RecValue, m_RecValueLen);
 	}
 
@@ -339,7 +339,7 @@ void IPv4Layer::computeCalculateFields()
 	ipHdr->totalLength = htobe16(m_DataLen);
 	ipHdr->headerChecksum = 0;
 
-	if (m_NextLayer != NULL)
+	if (m_NextLayer != nullptr)
 	{
 		switch (m_NextLayer->getProtocol())
 		{
@@ -471,14 +471,14 @@ IPv4Option IPv4Layer::addOptionAt(const IPv4OptionBuilder& optionBuilder, int of
 	{
 		PCPP_LOG_ERROR("Cannot add option - adding this option will exceed IPv4 total option size which is " << IPV4_MAX_OPT_SIZE);
 		newOption.purgeRecordData();
-		return IPv4Option(NULL);
+		return IPv4Option(nullptr);
 	}
 
 	if (!extendLayer(offset, sizeToExtend))
 	{
 		PCPP_LOG_ERROR("Could not extend IPv4Layer in [" << sizeToExtend << "] bytes");
 		newOption.purgeRecordData();
-		return IPv4Option(NULL);
+		return IPv4Option(nullptr);
 	}
 
 	memcpy(m_Data + offset, newOption.getRecordBasePtr(), newOption.getTotalSize());

--- a/Packet++/src/IPv6Extensions.cpp
+++ b/Packet++/src/IPv6Extensions.cpp
@@ -23,7 +23,7 @@ IPv6Extension& IPv6Extension::operator=(const IPv6Extension& other)
 	// notice this is not necessarily safe - it assumes the current extension has enough memory allocated to consume
 	// the other extension. That's why the assignment operator isn't public (it's currently used only inside IPv6Layer)
 	memcpy(getDataPtr(), other.getDataPtr(), other.getExtensionLen());
-	m_NextHeader = NULL;
+	m_NextHeader = nullptr;
 	m_ExtType = other.m_ExtType;
 
 	return *this;
@@ -31,7 +31,7 @@ IPv6Extension& IPv6Extension::operator=(const IPv6Extension& other)
 
 uint8_t* IPv6Extension::getDataPtr() const
 {
-	if (m_DataContainer != NULL)
+	if (m_DataContainer != nullptr)
 		return m_DataContainer->getDataPtr(m_Offset);
 
 	return m_ShadowData;
@@ -44,7 +44,7 @@ void IPv6Extension::initShadowPtr(size_t size)
 
 IPv6Extension::~IPv6Extension()
 {
-	if (m_ShadowData != NULL)
+	if (m_ShadowData != nullptr)
 		delete [] m_ShadowData;
 }
 
@@ -200,7 +200,7 @@ IPv6RoutingHeader::IPv6RoutingHeader(uint8_t routingType, uint8_t segmentsLeft, 
 	routingHeader->routingType = routingType;
 	routingHeader->segmentsLeft = segmentsLeft;
 
-	if (additionalRoutingDataLen > 0 && additionalRoutingData != NULL)
+	if (additionalRoutingDataLen > 0 && additionalRoutingData != nullptr)
 	{
 		uint8_t* additionalDataPtr = getDataPtr() + sizeof(ipv6_routing_header);
 		memcpy(additionalDataPtr, additionalRoutingData, additionalRoutingDataLen);
@@ -212,7 +212,7 @@ uint8_t* IPv6RoutingHeader::getRoutingAdditionalData() const
 	if (getExtensionLen() > sizeof(ipv6_routing_header))
 		return getDataPtr() + sizeof(ipv6_routing_header);
 
-	return NULL;
+	return nullptr;
 }
 
 size_t IPv6RoutingHeader::getRoutingAdditionalDataLength() const
@@ -256,7 +256,7 @@ IPv6AuthenticationHeader::IPv6AuthenticationHeader(uint32_t securityParametersIn
 	authHeader->securityParametersIndex = htobe32(securityParametersIndex);
 	authHeader->sequenceNumber = htobe32(sequenceNumber);
 
-	if (integrityCheckValueLen > 0 && integrityCheckValue != NULL)
+	if (integrityCheckValueLen > 0 && integrityCheckValue != nullptr)
 	{
 		uint8_t* icvPtr = getDataPtr() + sizeof(ipv6_authentication_header);
 		memcpy(icvPtr, integrityCheckValue, integrityCheckValueLen);
@@ -268,7 +268,7 @@ uint8_t* IPv6AuthenticationHeader::getIntegrityCheckValue() const
 	if (getExtensionLen() > sizeof(ipv6_authentication_header))
 		return getDataPtr() + sizeof(ipv6_authentication_header);
 
-	return NULL;
+	return nullptr;
 }
 
 size_t IPv6AuthenticationHeader::getIntegrityCheckValueLength() const

--- a/Packet++/src/IPv6Layer.cpp
+++ b/Packet++/src/IPv6Layer.cpp
@@ -22,8 +22,8 @@ void IPv6Layer::initLayer()
 	m_DataLen = sizeof(ip6_hdr);
 	m_Data = new uint8_t[m_DataLen];
 	m_Protocol = IPv6;
-	m_FirstExtension = NULL;
-	m_LastExtension = NULL;
+	m_FirstExtension = nullptr;
+	m_LastExtension = nullptr;
 	m_ExtensionsLen = 0;
 	memset(m_Data, 0, sizeof(ip6_hdr));
 }
@@ -31,8 +31,8 @@ void IPv6Layer::initLayer()
 IPv6Layer::IPv6Layer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet) : Layer(data, dataLen, prevLayer, packet)
 {
 	m_Protocol = IPv6;
-	m_FirstExtension = NULL;
-	m_LastExtension = NULL;
+	m_FirstExtension = nullptr;
+	m_LastExtension = nullptr;
 	m_ExtensionsLen = 0;
 
 	parseExtensions();
@@ -57,8 +57,8 @@ IPv6Layer::IPv6Layer(const IPv6Address& srcIP, const IPv6Address& dstIP)
 
 IPv6Layer::IPv6Layer(const IPv6Layer& other) : Layer(other)
 {
-	m_FirstExtension = NULL;
-	m_LastExtension = NULL;
+	m_FirstExtension = nullptr;
+	m_LastExtension = nullptr;
 	m_ExtensionsLen = 0;
 	parseExtensions();
 }
@@ -82,13 +82,13 @@ IPv6Layer& IPv6Layer::operator=(const IPv6Layer& other)
 void IPv6Layer::parseExtensions()
 {
 	uint8_t nextHdr = getIPv6Header()->nextHeader;
-	IPv6Extension* curExt = NULL;
+	IPv6Extension* curExt = nullptr;
 
 	size_t offset = sizeof(ip6_hdr);
 
 	while (offset <= m_DataLen - 2*sizeof(uint8_t)) // 2*sizeof(uint8_t) is the min len for IPv6 extensions
 	{
-		IPv6Extension* newExt = NULL;
+		IPv6Extension* newExt = nullptr;
 
 		switch (nextHdr)
 		{
@@ -123,10 +123,10 @@ void IPv6Layer::parseExtensions()
 		}
 		}
 
-		if (newExt == NULL)
+		if (newExt == nullptr)
 			break;
 
-		if (m_FirstExtension == NULL)
+		if (m_FirstExtension == nullptr)
 		{
 			m_FirstExtension = newExt;
 			curExt = m_FirstExtension;
@@ -148,15 +148,15 @@ void IPv6Layer::parseExtensions()
 void IPv6Layer::deleteExtensions()
 {
 	IPv6Extension* curExt = m_FirstExtension;
-	while (curExt != NULL)
+	while (curExt != nullptr)
 	{
 		IPv6Extension* tmpExt = curExt->getNextHeader();
 		delete curExt;
 		curExt = tmpExt;
 	}
 
-	m_FirstExtension = NULL;
-	m_LastExtension = NULL;
+	m_FirstExtension = nullptr;
+	m_LastExtension = nullptr;
 	m_ExtensionsLen = 0;
 
 }
@@ -167,7 +167,7 @@ size_t IPv6Layer::getExtensionCount() const
 
 	IPv6Extension* curExt = m_FirstExtension;
 
-	while (curExt != NULL)
+	while (curExt != nullptr)
 	{
 		extensionCount++;
 		curExt = curExt->getNextHeader();
@@ -178,7 +178,7 @@ size_t IPv6Layer::getExtensionCount() const
 
 void IPv6Layer::removeAllExtensions()
 {
-	if (m_LastExtension != NULL)
+	if (m_LastExtension != nullptr)
 		getIPv6Header()->nextHeader = m_LastExtension->getBaseHeader()->nextHeader;
 
 	shortenLayer((int)sizeof(ip6_hdr), m_ExtensionsLen);
@@ -189,7 +189,7 @@ void IPv6Layer::removeAllExtensions()
 bool IPv6Layer::isFragment() const
 {
 	IPv6FragmentationHeader* fragHdr = getExtensionOfType<IPv6FragmentationHeader>();
-	return (fragHdr != NULL);
+	return (fragHdr != nullptr);
 }
 
 void IPv6Layer::parseNextLayer()
@@ -203,7 +203,7 @@ void IPv6Layer::parseNextLayer()
 	size_t payloadLen = m_DataLen - headerLen;
 
 	uint8_t nextHdr;
-	if (m_LastExtension != NULL)
+	if (m_LastExtension != nullptr)
 	{
 		if (m_LastExtension->getExtensionType() == IPv6Extension::IPv6Fragmentation)
 		{
@@ -277,7 +277,7 @@ void IPv6Layer::computeCalculateFields()
 	ipHdr->payloadLength = htobe16(m_DataLen - sizeof(ip6_hdr));
 	ipHdr->ipVersion = (6 & 0x0f);
 
-	if (m_NextLayer != NULL)
+	if (m_NextLayer != nullptr)
 	{
 		uint8_t nextHeader = 0;
 		switch (m_NextLayer->getProtocol())
@@ -301,7 +301,7 @@ void IPv6Layer::computeCalculateFields()
 
 		if (nextHeader != 0)
 		{
-			if (m_LastExtension != NULL)
+			if (m_LastExtension != nullptr)
 				m_LastExtension->getBaseHeader()->nextHeader = nextHeader;
 			else
 				ipHdr->nextHeader = nextHeader;
@@ -316,7 +316,7 @@ std::string IPv6Layer::toString() const
 	{
 		result += ", Options=[";
 		IPv6Extension* curExt = m_FirstExtension;
-		while (curExt != NULL)
+		while (curExt != nullptr)
 		{
 			switch (curExt->getExtensionType())
 			{

--- a/Packet++/src/IcmpLayer.cpp
+++ b/Packet++/src/IcmpLayer.cpp
@@ -15,7 +15,7 @@ namespace pcpp
 icmp_router_address_structure* icmp_router_advertisement::getRouterAddress(int index) const
 {
 	if (index < 0 || index >= header->advertisementCount)
-		return NULL;
+		return nullptr;
 
 	uint8_t* headerAsByteArr = (uint8_t*)header;
 	return (icmp_router_address_structure*)(headerAsByteArr + sizeof(icmp_router_advertisement_hdr) + index * sizeof(icmp_router_address_structure));
@@ -48,7 +48,7 @@ bool IcmpLayer::cleanIcmpLayer()
 {
 	// remove all layers after
 
-	if (m_Packet != NULL)
+	if (m_Packet != nullptr)
 	{
 		bool res = m_Packet->removeAllLayersAfter(this);
 		if (!res)
@@ -77,7 +77,7 @@ bool IcmpLayer::setEchoData(IcmpMessageType echoType, uint16_t id, uint16_t sequ
 
 	getIcmpHeader()->type = (uint8_t)echoType;
 
-	icmp_echo_request* header = NULL;
+	icmp_echo_request* header = nullptr;
 	if (echoType == ICMP_ECHO_REQUEST)
 		header = getEchoRequestData();
 	else if (echoType == ICMP_ECHO_REPLY)
@@ -90,7 +90,7 @@ bool IcmpLayer::setEchoData(IcmpMessageType echoType, uint16_t id, uint16_t sequ
 	header->header->id = htobe16(id);
 	header->header->sequence = htobe16(sequence);
 	header->header->timestamp = timestamp;
-	if (data != NULL && dataLen > 0)
+	if (data != nullptr && dataLen > 0)
 		memcpy(header->data, data, dataLen);
 
 	return true;
@@ -98,20 +98,20 @@ bool IcmpLayer::setEchoData(IcmpMessageType echoType, uint16_t id, uint16_t sequ
 
 bool IcmpLayer::setIpAndL4Layers(IPv4Layer* ipLayer, Layer* l4Layer)
 {
-	if (m_Packet == NULL)
+	if (m_Packet == nullptr)
 	{
 		PCPP_LOG_ERROR("Cannot set ICMP data that involves IP and L4 layers on a layer not attached to a packet. "
 				"Please add the ICMP layer to a packet and try again");
 		return false;
 	}
 
-	if (ipLayer != NULL && !m_Packet->addLayer(ipLayer))
+	if (ipLayer != nullptr && !m_Packet->addLayer(ipLayer))
 	{
 		PCPP_LOG_ERROR("Couldn't add IP layer to ICMP packet");
 		return false;
 	}
 
-	if (l4Layer != NULL && !m_Packet->addLayer(l4Layer))
+	if (l4Layer != nullptr && !m_Packet->addLayer(l4Layer))
 	{
 		PCPP_LOG_ERROR("Couldn't add L4 layer to ICMP packet");
 		return false;
@@ -123,7 +123,7 @@ bool IcmpLayer::setIpAndL4Layers(IPv4Layer* ipLayer, Layer* l4Layer)
 icmp_echo_request* IcmpLayer::getEchoRequestData()
 {
 	if (!isMessageOfType(ICMP_ECHO_REQUEST))
-		return NULL;
+		return nullptr;
 
 	m_EchoData.header = (icmp_echo_hdr*)m_Data;
 	m_EchoData.data = (uint8_t*)(m_Data + sizeof(icmp_echo_hdr));
@@ -137,13 +137,13 @@ icmp_echo_request* IcmpLayer::setEchoRequestData(uint16_t id, uint16_t sequence,
 	if (setEchoData(ICMP_ECHO_REQUEST, id, sequence, timestamp, data, dataLen))
 		return getEchoRequestData();
 	else
-		return NULL;
+		return nullptr;
 }
 
 icmp_echo_reply* IcmpLayer::getEchoReplyData()
 {
 	if (!isMessageOfType(ICMP_ECHO_REPLY))
-		return NULL;
+		return nullptr;
 
 	m_EchoData.header = (icmp_echo_hdr*)m_Data;
 	m_EchoData.data = (uint8_t*)(m_Data + sizeof(icmp_echo_hdr));
@@ -157,14 +157,14 @@ icmp_echo_reply* IcmpLayer::setEchoReplyData(uint16_t id, uint16_t sequence, uin
 	if (setEchoData(ICMP_ECHO_REPLY, id, sequence, timestamp, data, dataLen))
 		return getEchoReplyData();
 	else
-		return NULL;
+		return nullptr;
 }
 
 
 icmp_timestamp_request* IcmpLayer::getTimestampRequestData()
 {
 	if (!isMessageOfType(ICMP_TIMESTAMP_REQUEST))
-		return NULL;
+		return nullptr;
 
 	return (icmp_timestamp_request*)m_Data;
 }
@@ -172,10 +172,10 @@ icmp_timestamp_request* IcmpLayer::getTimestampRequestData()
 icmp_timestamp_request* IcmpLayer::setTimestampRequestData(uint16_t id, uint16_t sequence, timeval originateTimestamp)
 {
 	if (!cleanIcmpLayer())
-		return NULL;
+		return nullptr;
 
 	if (!this->extendLayer(m_DataLen, sizeof(icmp_timestamp_request) - sizeof(icmphdr)))
-		return NULL;
+		return nullptr;
 
 	getIcmpHeader()->type = (uint8_t)ICMP_TIMESTAMP_REQUEST;
 
@@ -193,7 +193,7 @@ icmp_timestamp_request* IcmpLayer::setTimestampRequestData(uint16_t id, uint16_t
 icmp_timestamp_reply* IcmpLayer::getTimestampReplyData()
 {
 	if (!isMessageOfType(ICMP_TIMESTAMP_REPLY))
-		return NULL;
+		return nullptr;
 
 	return (icmp_timestamp_reply*)m_Data;
 }
@@ -202,10 +202,10 @@ icmp_timestamp_reply* IcmpLayer::setTimestampReplyData(uint16_t id, uint16_t seq
 		timeval originateTimestamp, timeval receiveTimestamp, timeval transmitTimestamp)
 {
 	if (!cleanIcmpLayer())
-		return NULL;
+		return nullptr;
 
 	if (!this->extendLayer(m_DataLen, sizeof(icmp_timestamp_reply) - sizeof(icmphdr)))
-		return NULL;
+		return nullptr;
 
 	getIcmpHeader()->type = (uint8_t)ICMP_TIMESTAMP_REPLY;
 
@@ -223,7 +223,7 @@ icmp_timestamp_reply* IcmpLayer::setTimestampReplyData(uint16_t id, uint16_t seq
 icmp_destination_unreachable* IcmpLayer::getDestUnreachableData()
 {
 	if (!isMessageOfType(ICMP_DEST_UNREACHABLE))
-		return NULL;
+		return nullptr;
 
 	return (icmp_destination_unreachable*)m_Data;
 }
@@ -231,10 +231,10 @@ icmp_destination_unreachable* IcmpLayer::getDestUnreachableData()
 icmp_destination_unreachable* IcmpLayer::setDestUnreachableData(IcmpDestUnreachableCodes code, uint16_t nextHopMTU, IPv4Layer* ipHeader, Layer* l4Header)
 {
 	if (!cleanIcmpLayer())
-		return NULL;
+		return nullptr;
 
 	if (!this->extendLayer(m_DataLen, sizeof(icmp_destination_unreachable) - sizeof(icmphdr)))
-		return NULL;
+		return nullptr;
 
 	getIcmpHeader()->type = (uint8_t)ICMP_DEST_UNREACHABLE;
 
@@ -244,7 +244,7 @@ icmp_destination_unreachable* IcmpLayer::setDestUnreachableData(IcmpDestUnreacha
 	header->unused = 0;
 
 	if (!setIpAndL4Layers(ipHeader, l4Header))
-		return NULL;
+		return nullptr;
 
 	return header;
 }
@@ -252,7 +252,7 @@ icmp_destination_unreachable* IcmpLayer::setDestUnreachableData(IcmpDestUnreacha
 icmp_source_quench* IcmpLayer::getSourceQuenchdata()
 {
 	if (!isMessageOfType(ICMP_SOURCE_QUENCH))
-		return NULL;
+		return nullptr;
 
 	return (icmp_source_quench*)m_Data;
 
@@ -261,10 +261,10 @@ icmp_source_quench* IcmpLayer::getSourceQuenchdata()
 icmp_source_quench* IcmpLayer::setSourceQuenchdata(IPv4Layer* ipHeader, Layer* l4Header)
 {
 	if (!cleanIcmpLayer())
-		return NULL;
+		return nullptr;
 
 	if (!this->extendLayer(m_DataLen, sizeof(icmp_source_quench) - sizeof(icmphdr)))
-		return NULL;
+		return nullptr;
 
 	getIcmpHeader()->type = (uint8_t)ICMP_SOURCE_QUENCH;
 
@@ -272,7 +272,7 @@ icmp_source_quench* IcmpLayer::setSourceQuenchdata(IPv4Layer* ipHeader, Layer* l
 	header->unused = 0;
 
 	if (!setIpAndL4Layers(ipHeader, l4Header))
-		return NULL;
+		return nullptr;
 
 	return header;
 }
@@ -280,7 +280,7 @@ icmp_source_quench* IcmpLayer::setSourceQuenchdata(IPv4Layer* ipHeader, Layer* l
 icmp_redirect* IcmpLayer::getRedirectData()
 {
 	if (!isMessageOfType(ICMP_REDIRECT))
-		return NULL;
+		return nullptr;
 
 	return (icmp_redirect*)m_Data;
 }
@@ -290,14 +290,14 @@ icmp_redirect* IcmpLayer::setRedirectData(uint8_t code, IPv4Address gatewayAddre
 	if (code > 3)
 	{
 		PCPP_LOG_ERROR("Unknown code " << (int)code << " for ICMP redirect data");
-		return NULL;
+		return nullptr;
 	}
 
 	if (!cleanIcmpLayer())
-		return NULL;
+		return nullptr;
 
 	if (!this->extendLayer(m_DataLen, sizeof(icmp_redirect) - sizeof(icmphdr)))
-		return NULL;
+		return nullptr;
 
 	getIcmpHeader()->type = (uint8_t)ICMP_REDIRECT;
 
@@ -306,7 +306,7 @@ icmp_redirect* IcmpLayer::setRedirectData(uint8_t code, IPv4Address gatewayAddre
 	header->gatewayAddress = gatewayAddress.toInt();
 
 	if (!setIpAndL4Layers(ipHeader, l4Header))
-		return NULL;
+		return nullptr;
 
 	return header;
 }
@@ -314,7 +314,7 @@ icmp_redirect* IcmpLayer::setRedirectData(uint8_t code, IPv4Address gatewayAddre
 icmp_router_advertisement* IcmpLayer::getRouterAdvertisementData() const
 {
 	if (!isMessageOfType(ICMP_ROUTER_ADV))
-		return NULL;
+		return nullptr;
 
 	m_RouterAdvData.header = (icmp_router_advertisement_hdr*)m_Data;
 
@@ -326,14 +326,14 @@ icmp_router_advertisement* IcmpLayer::setRouterAdvertisementData(uint8_t code, u
 	if (code != 0 && code != 16)
 	{
 		PCPP_LOG_ERROR("Unknown code " << (int)code << " for ICMP router advertisement data (only codes 0 and 16 are legal)");
-		return NULL;
+		return nullptr;
 	}
 
 	if (!cleanIcmpLayer())
-		return NULL;
+		return nullptr;
 
 	if (!this->extendLayer(m_DataLen, sizeof(icmp_router_advertisement_hdr) + (routerAddresses.size()*sizeof(icmp_router_address_structure)) - sizeof(icmphdr)))
-		return NULL;
+		return nullptr;
 
 	getIcmpHeader()->type = (uint8_t)ICMP_ROUTER_ADV;
 
@@ -357,7 +357,7 @@ icmp_router_advertisement* IcmpLayer::setRouterAdvertisementData(uint8_t code, u
 icmp_router_solicitation* IcmpLayer::getRouterSolicitationData()
 {
 	if (!isMessageOfType(ICMP_ROUTER_SOL))
-		return NULL;
+		return nullptr;
 
 	return (icmp_router_solicitation*)m_Data;
 }
@@ -365,7 +365,7 @@ icmp_router_solicitation* IcmpLayer::getRouterSolicitationData()
 icmp_router_solicitation* IcmpLayer::setRouterSolicitationData()
 {
 	if (!cleanIcmpLayer())
-		return NULL;
+		return nullptr;
 
 	getIcmpHeader()->type = (uint8_t)ICMP_ROUTER_SOL;
 
@@ -378,7 +378,7 @@ icmp_router_solicitation* IcmpLayer::setRouterSolicitationData()
 icmp_time_exceeded* IcmpLayer::getTimeExceededData()
 {
 	if (!isMessageOfType(ICMP_TIME_EXCEEDED))
-		return NULL;
+		return nullptr;
 
 	return (icmp_time_exceeded*)m_Data;
 }
@@ -388,14 +388,14 @@ icmp_time_exceeded* IcmpLayer::setTimeExceededData(uint8_t code, IPv4Layer* ipHe
 	if (code > 1)
 	{
 		PCPP_LOG_ERROR("Unknown code " << (int)code << " for ICMP time exceeded data");
-		return NULL;
+		return nullptr;
 	}
 
 	if (!cleanIcmpLayer())
-		return NULL;
+		return nullptr;
 
 	if (!this->extendLayer(m_DataLen, sizeof(icmp_time_exceeded) - sizeof(icmphdr)))
-		return NULL;
+		return nullptr;
 
 	getIcmpHeader()->type = (uint8_t)ICMP_TIME_EXCEEDED;
 
@@ -404,7 +404,7 @@ icmp_time_exceeded* IcmpLayer::setTimeExceededData(uint8_t code, IPv4Layer* ipHe
 	header->unused = 0;
 
 	if (!setIpAndL4Layers(ipHeader, l4Header))
-		return NULL;
+		return nullptr;
 
 	return header;
 }
@@ -412,7 +412,7 @@ icmp_time_exceeded* IcmpLayer::setTimeExceededData(uint8_t code, IPv4Layer* ipHe
 icmp_param_problem* IcmpLayer::getParamProblemData()
 {
 	if (!isMessageOfType(ICMP_PARAM_PROBLEM))
-		return NULL;
+		return nullptr;
 
 	return (icmp_param_problem*)m_Data;
 }
@@ -422,14 +422,14 @@ icmp_param_problem* IcmpLayer::setParamProblemData(uint8_t code, uint8_t errorOc
 	if (code > 2)
 	{
 		PCPP_LOG_ERROR("Unknown code " << (int)code << " for ICMP parameter problem data");
-		return NULL;
+		return nullptr;
 	}
 
 	if (!cleanIcmpLayer())
-		return NULL;
+		return nullptr;
 
 	if (!this->extendLayer(m_DataLen, sizeof(icmp_param_problem) - sizeof(icmphdr)))
-		return NULL;
+		return nullptr;
 
 	getIcmpHeader()->type = (uint8_t)ICMP_PARAM_PROBLEM;
 
@@ -440,7 +440,7 @@ icmp_param_problem* IcmpLayer::setParamProblemData(uint8_t code, uint8_t errorOc
 	header->pointer = errorOctetPointer;
 
 	if (!setIpAndL4Layers(ipHeader, l4Header))
-		return NULL;
+		return nullptr;
 
 	return header;
 }
@@ -448,7 +448,7 @@ icmp_param_problem* IcmpLayer::setParamProblemData(uint8_t code, uint8_t errorOc
 icmp_address_mask_request* IcmpLayer::getAddressMaskRequestData()
 {
 	if (!isMessageOfType(ICMP_ADDRESS_MASK_REQUEST))
-		return NULL;
+		return nullptr;
 
 	return (icmp_address_mask_request*)m_Data;
 }
@@ -456,10 +456,10 @@ icmp_address_mask_request* IcmpLayer::getAddressMaskRequestData()
 icmp_address_mask_request* IcmpLayer::setAddressMaskRequestData(uint16_t id, uint16_t sequence, IPv4Address mask)
 {
 	if (!cleanIcmpLayer())
-		return NULL;
+		return nullptr;
 
 	if (!this->extendLayer(m_DataLen, sizeof(icmp_address_mask_request) - sizeof(icmphdr)))
-		return NULL;
+		return nullptr;
 
 	getIcmpHeader()->type = (uint8_t)ICMP_ADDRESS_MASK_REQUEST;
 
@@ -475,7 +475,7 @@ icmp_address_mask_request* IcmpLayer::setAddressMaskRequestData(uint16_t id, uin
 icmp_address_mask_reply* IcmpLayer::getAddressMaskReplyData()
 {
 	if (!isMessageOfType(ICMP_ADDRESS_MASK_REPLY))
-		return NULL;
+		return nullptr;
 
 	return (icmp_address_mask_reply*)m_Data;
 }
@@ -483,10 +483,10 @@ icmp_address_mask_reply* IcmpLayer::getAddressMaskReplyData()
 icmp_address_mask_reply* IcmpLayer::setAddressMaskReplyData(uint16_t id, uint16_t sequence, IPv4Address mask)
 {
 	if (!cleanIcmpLayer())
-		return NULL;
+		return nullptr;
 
 	if (!this->extendLayer(m_DataLen, sizeof(icmp_address_mask_reply) - sizeof(icmphdr)))
-		return NULL;
+		return nullptr;
 
 	getIcmpHeader()->type = (uint8_t)ICMP_ADDRESS_MASK_REPLY;
 
@@ -502,7 +502,7 @@ icmp_address_mask_reply* IcmpLayer::setAddressMaskReplyData(uint16_t id, uint16_
 icmp_info_request* IcmpLayer::getInfoRequestData()
 {
 	if (!isMessageOfType(ICMP_INFO_REQUEST))
-		return NULL;
+		return nullptr;
 
 	return (icmp_info_request*)m_Data;
 }
@@ -510,10 +510,10 @@ icmp_info_request* IcmpLayer::getInfoRequestData()
 icmp_info_request* IcmpLayer::setInfoRequestData(uint16_t id, uint16_t sequence)
 {
 	if (!cleanIcmpLayer())
-		return NULL;
+		return nullptr;
 
 	if (!this->extendLayer(m_DataLen, sizeof(icmp_info_request) - sizeof(icmphdr)))
-		return NULL;
+		return nullptr;
 
 	getIcmpHeader()->type = (uint8_t)ICMP_INFO_REQUEST;
 
@@ -528,7 +528,7 @@ icmp_info_request* IcmpLayer::setInfoRequestData(uint16_t id, uint16_t sequence)
 icmp_info_reply* IcmpLayer::getInfoReplyData()
 {
 	if (!isMessageOfType(ICMP_INFO_REPLY))
-		return NULL;
+		return nullptr;
 
 	return (icmp_info_reply*)m_Data;
 }
@@ -536,10 +536,10 @@ icmp_info_reply* IcmpLayer::getInfoReplyData()
 icmp_info_reply* IcmpLayer::setInfoReplyData(uint16_t id, uint16_t sequence)
 {
 	if (!cleanIcmpLayer())
-		return NULL;
+		return nullptr;
 
 	if (!this->extendLayer(m_DataLen, sizeof(icmp_info_reply) - sizeof(icmphdr)))
-		return NULL;
+		return nullptr;
 
 	getIcmpHeader()->type = (uint8_t)ICMP_INFO_REPLY;
 
@@ -620,7 +620,7 @@ void IcmpLayer::computeCalculateFields()
 
 	size_t icmpLen = 0;
 	Layer* curLayer = this;
-	while (curLayer != NULL)
+	while (curLayer != nullptr)
 	{
 		icmpLen += curLayer->getHeaderLen();
 		curLayer = curLayer->getNextLayer();

--- a/Packet++/src/IcmpV6Layer.cpp
+++ b/Packet++/src/IcmpV6Layer.cpp
@@ -50,7 +50,7 @@ IcmpV6Layer::IcmpV6Layer(ICMPv6MessageType msgType, uint8_t code, const uint8_t 
 	hdr->type = static_cast<uint8_t>(msgType);
 	hdr->code = code;
 
-	if (data != NULL && dataLen > 0)
+	if (data != nullptr && dataLen > 0)
 		memcpy(m_Data + sizeof(icmpv6hdr), data, dataLen);
 }
 
@@ -85,7 +85,7 @@ void IcmpV6Layer::calculateChecksum()
 
 	getIcmpv6Header()->checksum = 0;
 
-	if (m_PrevLayer != NULL)
+	if (m_PrevLayer != nullptr)
 	{
 		ScalarBuffer<uint16_t> vec[2];
 
@@ -145,7 +145,7 @@ ICMPv6EchoLayer::ICMPv6EchoLayer(ICMPv6EchoType echoType, uint16_t id, uint16_t 
 	header->id = htobe16(id);
 	header->sequence = htobe16(sequence);
 
-	if (data != NULL && dataLen > 0)
+	if (data != nullptr && dataLen > 0)
 		memcpy(getEchoDataPtr(), data, dataLen);
 }
 

--- a/Packet++/src/IgmpLayer.cpp
+++ b/Packet++/src/IgmpLayer.cpp
@@ -59,7 +59,7 @@ ProtocolType IgmpLayer::getIGMPVerFromData(uint8_t* data, size_t dataLen, bool& 
 {
 	isQuery = false;
 
-	if (dataLen < 8 || data == NULL)
+	if (dataLen < 8 || data == nullptr)
 		return UnknownProtocol;
 
 	switch ((int)data[0])
@@ -368,7 +368,7 @@ igmpv3_group_record* IgmpV3ReportLayer::getFirstGroupRecord() const
 {
 	// check if there are group records at all
 	if (getHeaderLen() <= sizeof(igmpv3_report_header))
-		return NULL;
+		return nullptr;
 
 	uint8_t* curGroupPtr = m_Data + sizeof(igmpv3_report_header);
 	return (igmpv3_group_record*)curGroupPtr;
@@ -376,12 +376,12 @@ igmpv3_group_record* IgmpV3ReportLayer::getFirstGroupRecord() const
 
 igmpv3_group_record* IgmpV3ReportLayer::getNextGroupRecord(igmpv3_group_record* groupRecord) const
 {
-	if (groupRecord == NULL)
-		return NULL;
+	if (groupRecord == nullptr)
+		return nullptr;
 
 	// prev group was the last group
 	if ((uint8_t*)groupRecord + groupRecord->getRecordLen() - m_Data >= (int)getHeaderLen())
-		return NULL;
+		return nullptr;
 
 	igmpv3_group_record* nextGroup = (igmpv3_group_record*)((uint8_t*)groupRecord + groupRecord->getRecordLen());
 
@@ -400,7 +400,7 @@ igmpv3_group_record* IgmpV3ReportLayer::addGroupRecordAt(uint8_t recordType, con
 	if (offset > (int)getHeaderLen())
 	{
 		PCPP_LOG_ERROR("Cannot add group record, offset is out of layer bounds");
-		return NULL;
+		return nullptr;
 	}
 
 	size_t groupRecordSize = sizeof(igmpv3_group_record) + sizeof(uint32_t)*sourceAddresses.size();
@@ -408,7 +408,7 @@ igmpv3_group_record* IgmpV3ReportLayer::addGroupRecordAt(uint8_t recordType, con
 	if (!extendLayer(offset, groupRecordSize))
 	{
 		PCPP_LOG_ERROR("Cannot add group record, cannot extend layer");
-		return NULL;
+		return nullptr;
 	}
 
 	uint8_t* groupRecordBuffer = new uint8_t[groupRecordSize];
@@ -447,7 +447,7 @@ igmpv3_group_record* IgmpV3ReportLayer::addGroupRecordAtIndex(uint8_t recordType
 	if (index < 0 || index > groupCnt)
 	{
 		PCPP_LOG_ERROR("Cannot add group record, index " << index << " out of bounds");
-		return NULL;
+		return nullptr;
 	}
 
 	size_t offset = sizeof(igmpv3_report_header);
@@ -455,10 +455,10 @@ igmpv3_group_record* IgmpV3ReportLayer::addGroupRecordAtIndex(uint8_t recordType
 	igmpv3_group_record* curRecord = getFirstGroupRecord();
 	for (int i = 0; i < index; i++)
 	{
-		if (curRecord == NULL)
+		if (curRecord == nullptr)
 		{
 			PCPP_LOG_ERROR("Cannot add group record, cannot find group record at index " << i);
-			return NULL;
+			return nullptr;
 		}
 
 		offset += curRecord->getRecordLen();
@@ -483,7 +483,7 @@ bool IgmpV3ReportLayer::removeGroupRecordAtIndex(int index)
 	igmpv3_group_record* curRecord = getFirstGroupRecord();
 	for (int i = 0; i < index; i++)
 	{
-		if (curRecord == NULL)
+		if (curRecord == nullptr)
 		{
 			PCPP_LOG_ERROR("Cannot remove group record at index " << index << ", cannot find group record at index " << i);
 			return false;

--- a/Packet++/src/Layer.cpp
+++ b/Packet++/src/Layer.cpp
@@ -14,7 +14,7 @@ Layer::~Layer()
 		delete [] m_Data;
 }
 
-Layer::Layer(const Layer& other) : m_Packet(NULL), m_Protocol(other.m_Protocol), m_NextLayer(NULL), m_PrevLayer(NULL), m_IsAllocatedInPacket(false)
+Layer::Layer(const Layer& other) : m_Packet(nullptr), m_Protocol(other.m_Protocol), m_NextLayer(nullptr), m_PrevLayer(nullptr), m_IsAllocatedInPacket(false)
 {
 	m_DataLen = other.getHeaderLen();
 	m_Data = new uint8_t[other.m_DataLen];
@@ -26,14 +26,14 @@ Layer& Layer::operator=(const Layer& other)
 	if (this == &other)
 		return *this;
 
-	if (m_Data != NULL)
+	if (m_Data != nullptr)
 		delete [] m_Data;
 
 	m_DataLen = other.getHeaderLen();
-	m_Packet = NULL;
+	m_Packet = nullptr;
 	m_Protocol = other.m_Protocol;
-	m_NextLayer = NULL;
-	m_PrevLayer = NULL;
+	m_NextLayer = nullptr;
+	m_PrevLayer = nullptr;
 	m_Data = new uint8_t[other.m_DataLen];
 	m_IsAllocatedInPacket = false;
 	memcpy(m_Data, other.m_Data, other.m_DataLen);
@@ -48,13 +48,13 @@ void Layer::copyData(uint8_t* toArr) const
 
 bool Layer::extendLayer(int offsetInLayer, size_t numOfBytesToExtend)
 {
-	if (m_Data == NULL)
+	if (m_Data == nullptr)
 	{
 		PCPP_LOG_ERROR("Layer's data is NULL");
 		return false;
 	}
 
-	if (m_Packet == NULL)
+	if (m_Packet == nullptr)
 	{
 		if ((size_t)offsetInLayer > m_DataLen)
 		{
@@ -76,13 +76,13 @@ bool Layer::extendLayer(int offsetInLayer, size_t numOfBytesToExtend)
 
 bool Layer::shortenLayer(int offsetInLayer, size_t numOfBytesToShorten)
 {
-	if (m_Data == NULL)
+	if (m_Data == nullptr)
 	{
 		PCPP_LOG_ERROR("Layer's data is NULL");
 		return false;
 	}
 
-	if (m_Packet == NULL)
+	if (m_Packet == nullptr)
 	{
 		if ((size_t)offsetInLayer >= m_DataLen)
 		{

--- a/Packet++/src/MplsLayer.cpp
+++ b/Packet++/src/MplsLayer.cpp
@@ -136,7 +136,7 @@ void MplsLayer::parseNextLayer()
 void MplsLayer::computeCalculateFields()
 {
 	Layer* nextLayer = getNextLayer();
-	if (nextLayer != NULL)
+	if (nextLayer != nullptr)
 	{
 		setBottomOfStack((nextLayer->getProtocol() != MPLS));
 	}

--- a/Packet++/src/NdpLayer.cpp
+++ b/Packet++/src/NdpLayer.cpp
@@ -70,7 +70,7 @@ NdpOption NDPLayerBase::addNdpOptionAt(const NdpOptionBuilder &optionBuilder, in
 	{
 		PCPP_LOG_ERROR("Could not extend NdpLayer in [" << sizeToExtend << "] bytes");
 		newOption.purgeRecordData();
-		return NdpOption(NULL);
+		return NdpOption(nullptr);
 	}
 
 	memcpy(m_Data + offset, newOption.getRecordBasePtr(), newOption.getTotalSize());

--- a/Packet++/src/NtpLayer.cpp
+++ b/Packet++/src/NtpLayer.cpp
@@ -558,10 +558,10 @@ namespace pcpp
         struct tm timer_r;
         timer = gmtime_r(&timeStruct, &timer_r);
 
-        if (timer != NULL)
+        if (timer != nullptr)
             timer = &timer_r;
 #endif
-        if (timer == NULL)
+        if (timer == nullptr)
         {
             PCPP_LOG_ERROR("Can't convert time");
             return std::string();

--- a/Packet++/src/PPPoELayer.cpp
+++ b/Packet++/src/PPPoELayer.cpp
@@ -280,7 +280,7 @@ PPPoEDiscoveryLayer::PPPoETag PPPoEDiscoveryLayer::PPPoETagBuilder::build() cons
 	uint16_t tagLength = htobe16(static_cast<uint16_t>(m_RecValueLen));
 	memcpy(recordBuffer, &tagTypeVal, sizeof(uint16_t));
 	memcpy(recordBuffer + sizeof(uint16_t), &tagLength, sizeof(uint16_t));
-	if (tagLength > 0 && m_RecValue != NULL)
+	if (tagLength > 0 && m_RecValue != nullptr)
 		memcpy(recordBuffer + 2*sizeof(uint16_t), m_RecValue, m_RecValueLen);
 
 	return PPPoEDiscoveryLayer::PPPoETag(recordBuffer);
@@ -314,7 +314,7 @@ PPPoEDiscoveryLayer::PPPoETag PPPoEDiscoveryLayer::addTagAt(const PPPoETagBuilde
 	if (!extendLayer(offset, sizeToExtend))
 	{
 		PCPP_LOG_ERROR("Could not extend PPPoEDiscoveryLayer in [" << sizeToExtend << "] bytes");
-		return PPPoETag(NULL);
+		return PPPoETag(nullptr);
 	}
 
 	memcpy(m_Data + offset, newTag.getRecordBasePtr(), newTag.getTotalSize());

--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -24,32 +24,32 @@ namespace pcpp
 {
 
 Packet::Packet(size_t maxPacketLen) :
-	m_RawPacket(NULL),
-	m_FirstLayer(NULL),
-	m_LastLayer(NULL),
+	m_RawPacket(nullptr),
+	m_FirstLayer(nullptr),
+	m_LastLayer(nullptr),
 	m_ProtocolTypes(UnknownProtocol),
 	m_MaxPacketLen(maxPacketLen),
 	m_FreeRawPacket(true),
 	m_CanReallocateData(true)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 	uint8_t* data = new uint8_t[maxPacketLen];
 	memset(data, 0, maxPacketLen);
 	m_RawPacket = new RawPacket(data, 0, time, true, LINKTYPE_ETHERNET);
 }
 
 Packet::Packet(uint8_t* buffer, size_t bufferSize) :
-	m_RawPacket(NULL),
-	m_FirstLayer(NULL),
-	m_LastLayer(NULL),
+	m_RawPacket(nullptr),
+	m_FirstLayer(nullptr),
+	m_LastLayer(nullptr),
 	m_ProtocolTypes(UnknownProtocol),
 	m_MaxPacketLen(bufferSize),
 	m_FreeRawPacket(true),
 	m_CanReallocateData(false)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 	memset(buffer, 0, bufferSize);
 	m_RawPacket = new RawPacket(buffer, 0, time, false, LINKTYPE_ETHERNET);
 }
@@ -58,14 +58,14 @@ void Packet::setRawPacket(RawPacket* rawPacket, bool freeRawPacket, ProtocolType
 {
 	destructPacketData();
 
-	m_FirstLayer = NULL;
-	m_LastLayer = NULL;
+	m_FirstLayer = nullptr;
+	m_LastLayer = nullptr;
 	m_ProtocolTypes = UnknownProtocol;
 	m_MaxPacketLen = rawPacket->getRawDataLen();
 	m_FreeRawPacket = freeRawPacket;
 	m_RawPacket = rawPacket;
 	m_CanReallocateData = true;
-	if (m_RawPacket == NULL)
+	if (m_RawPacket == nullptr)
 		return;
 
 	LinkLayerType linkType = m_RawPacket->getLinkLayerType();
@@ -74,30 +74,30 @@ void Packet::setRawPacket(RawPacket* rawPacket, bool freeRawPacket, ProtocolType
 
 	m_LastLayer = m_FirstLayer;
 	Layer* curLayer = m_FirstLayer;
-	while (curLayer != NULL && (curLayer->getProtocol() & parseUntil) == 0 && curLayer->getOsiModelLayer() <= parseUntilLayer)
+	while (curLayer != nullptr && (curLayer->getProtocol() & parseUntil) == 0 && curLayer->getOsiModelLayer() <= parseUntilLayer)
 	{
 		m_ProtocolTypes |= curLayer->getProtocol();
 		curLayer->parseNextLayer();
 		curLayer->m_IsAllocatedInPacket = true;
 		curLayer = curLayer->getNextLayer();
-		if (curLayer != NULL)
+		if (curLayer != nullptr)
 			m_LastLayer = curLayer;
 	}
 
-	if (curLayer != NULL && (curLayer->getProtocol() & parseUntil) != 0)
+	if (curLayer != nullptr && (curLayer->getProtocol() & parseUntil) != 0)
 	{
 		m_ProtocolTypes |= curLayer->getProtocol();
 		curLayer->m_IsAllocatedInPacket = true;
 	}
 
-	if (curLayer != NULL &&  curLayer->getOsiModelLayer() > parseUntilLayer)
+	if (curLayer != nullptr &&  curLayer->getOsiModelLayer() > parseUntilLayer)
 	{
 		m_LastLayer = curLayer->getPrevLayer();
 		delete curLayer;
-		m_LastLayer->m_NextLayer = NULL;
+		m_LastLayer->m_NextLayer = nullptr;
 	}
 
-	if (m_LastLayer != NULL && parseUntil == UnknownProtocol && parseUntilLayer == OsiModelLayerUnknown)
+	if (m_LastLayer != nullptr && parseUntil == UnknownProtocol && parseUntilLayer == OsiModelLayerUnknown)
 	{
 		// find if there is data left in the raw packet that doesn't belong to any layer. In that case it's probably a packet trailer.
 		// create a PacketTrailerLayer layer and add it at the end of the packet
@@ -121,31 +121,31 @@ void Packet::setRawPacket(RawPacket* rawPacket, bool freeRawPacket, ProtocolType
 Packet::Packet(RawPacket* rawPacket, bool freeRawPacket, ProtocolType parseUntil, OsiModelLayer parseUntilLayer)
 {
 	m_FreeRawPacket = false;
-	m_RawPacket = NULL;
-	m_FirstLayer = NULL;
+	m_RawPacket = nullptr;
+	m_FirstLayer = nullptr;
 	setRawPacket(rawPacket, freeRawPacket, parseUntil, parseUntilLayer);
 }
 
 Packet::Packet(RawPacket* rawPacket, ProtocolType parseUntil)
 {
 	m_FreeRawPacket = false;
-	m_RawPacket = NULL;
-	m_FirstLayer = NULL;
+	m_RawPacket = nullptr;
+	m_FirstLayer = nullptr;
 	setRawPacket(rawPacket, false, parseUntil, OsiModelLayerUnknown);
 }
 
 Packet::Packet(RawPacket* rawPacket, OsiModelLayer parseUntilLayer)
 {
 	m_FreeRawPacket = false;
-	m_RawPacket = NULL;
-	m_FirstLayer = NULL;
+	m_RawPacket = nullptr;
+	m_FirstLayer = nullptr;
 	setRawPacket(rawPacket, false, UnknownProtocol, parseUntilLayer);
 }
 
 void Packet::destructPacketData()
 {
 	Layer* curLayer = m_FirstLayer;
-	while (curLayer != NULL)
+	while (curLayer != nullptr)
 	{
 		Layer* nextLayer = curLayer->getNextLayer();
 		if (curLayer->m_IsAllocatedInPacket)
@@ -153,7 +153,7 @@ void Packet::destructPacketData()
 		curLayer = nextLayer;
 	}
 
-	if (m_RawPacket != NULL && m_FreeRawPacket)
+	if (m_RawPacket != nullptr && m_FreeRawPacket)
 	{
 		delete m_RawPacket;
 	}
@@ -177,12 +177,12 @@ void Packet::copyDataFrom(const Packet& other)
 	m_FirstLayer = createFirstLayer(m_RawPacket->getLinkLayerType());
 	m_LastLayer = m_FirstLayer;
 	Layer* curLayer = m_FirstLayer;
-	while (curLayer != NULL)
+	while (curLayer != nullptr)
 	{
 		curLayer->parseNextLayer();
 		curLayer->m_IsAllocatedInPacket = true;
 		curLayer = curLayer->getNextLayer();
-		if (curLayer != NULL)
+		if (curLayer != nullptr)
 			m_LastLayer = curLayer;
 	}
 }
@@ -205,7 +205,7 @@ void Packet::reallocateRawData(size_t newSize)
 	const uint8_t* dataPtr = m_RawPacket->getRawData();
 
 	Layer* curLayer = m_FirstLayer;
-	while (curLayer != NULL)
+	while (curLayer != nullptr)
 	{
 		PCPP_LOG_DEBUG("Setting new data pointer to layer '" << typeid(curLayer).name() << "'");
 		curLayer->m_Data = (uint8_t*)dataPtr;
@@ -216,7 +216,7 @@ void Packet::reallocateRawData(size_t newSize)
 
 bool Packet::insertLayer(Layer* prevLayer, Layer* newLayer, bool ownInPacket)
 {
-	if (newLayer == NULL)
+	if (newLayer == nullptr)
 	{
 		PCPP_LOG_ERROR("Layer to add is NULL");
 		return false;
@@ -228,7 +228,7 @@ bool Packet::insertLayer(Layer* prevLayer, Layer* newLayer, bool ownInPacket)
 		return false;
 	}
 
-	if (prevLayer != NULL && prevLayer->getProtocol() == PacketTrailer)
+	if (prevLayer != nullptr && prevLayer->getProtocol() == PacketTrailer)
 	{
 		PCPP_LOG_ERROR("Cannot insert layer after packet trailer");
 		return false;
@@ -251,7 +251,7 @@ bool Packet::insertLayer(Layer* prevLayer, Layer* newLayer, bool ownInPacket)
 
 	// insert layer data to raw packet
 	int indexToInsertData = 0;
-	if (prevLayer != NULL)
+	if (prevLayer != nullptr)
 		indexToInsertData = prevLayer->m_Data + prevLayer->getHeaderLen() - m_RawPacket->getRawData();
 	m_RawPacket->insertData(indexToInsertData, newLayer->m_Data, newLayerHeaderLen);
 
@@ -259,7 +259,7 @@ bool Packet::insertLayer(Layer* prevLayer, Layer* newLayer, bool ownInPacket)
 	delete[] newLayer->m_Data;
 
 	// add layer to layers linked list
-	if (prevLayer != NULL)
+	if (prevLayer != nullptr)
 	{
 		newLayer->setNextLayer(prevLayer->getNextLayer());
 		newLayer->setPrevLayer(prevLayer);
@@ -268,12 +268,12 @@ bool Packet::insertLayer(Layer* prevLayer, Layer* newLayer, bool ownInPacket)
 	else //prevLayer == NULL
 	{
 		newLayer->setNextLayer(m_FirstLayer);
-		if (m_FirstLayer != NULL)
+		if (m_FirstLayer != nullptr)
 			m_FirstLayer->setPrevLayer(newLayer);
 		m_FirstLayer = newLayer;
 	}
 
-	if (newLayer->getNextLayer() == NULL)
+	if (newLayer->getNextLayer() == nullptr)
 		m_LastLayer = newLayer;
 	else
 		newLayer->getNextLayer()->setPrevLayer(newLayer);
@@ -293,12 +293,12 @@ bool Packet::insertLayer(Layer* prevLayer, Layer* newLayer, bool ownInPacket)
 
 	// if a packet trailer exists, get its length
 	size_t packetTrailerLen = 0;
-	if (m_LastLayer != NULL && m_LastLayer->getProtocol() == PacketTrailer)
+	if (m_LastLayer != nullptr && m_LastLayer->getProtocol() == PacketTrailer)
 		packetTrailerLen = m_LastLayer->getDataLen();
 
 	// go over all layers from the first layer to the last layer and set the data ptr and data length for each one
 	Layer* curLayer = m_FirstLayer;
-	while (curLayer != NULL)
+	while (curLayer != nullptr)
 	{
 		// set data ptr to layer
 		curLayer->m_Data = (uint8_t*)dataPtr;
@@ -328,7 +328,7 @@ bool Packet::removeLayer(ProtocolType layerType, int index)
 {
 	Layer* layerToRemove = getLayerOfType(layerType, index);
 
-	if (layerToRemove != NULL)
+	if (layerToRemove != nullptr)
 	{
 		return removeLayer(layerToRemove, true);
 	}
@@ -342,7 +342,7 @@ bool Packet::removeLayer(ProtocolType layerType, int index)
 bool Packet::removeFirstLayer()
 {
 	Layer* firstLayer = getFirstLayer();
-	if (firstLayer == NULL)
+	if (firstLayer == nullptr)
 	{
 		PCPP_LOG_ERROR("Packet has no layers");
 		return false;
@@ -354,7 +354,7 @@ bool Packet::removeFirstLayer()
 bool Packet::removeLastLayer()
 {
 	Layer* lastLayer = getLastLayer();
-	if (lastLayer == NULL)
+	if (lastLayer == nullptr)
 	{
 		PCPP_LOG_ERROR("Packet has no layers");
 		return false;
@@ -366,7 +366,7 @@ bool Packet::removeLastLayer()
 bool Packet::removeAllLayersAfter(Layer* layer)
 {
 	Layer* curLayer = layer->getNextLayer();
-	while (curLayer != NULL)
+	while (curLayer != nullptr)
 	{
 		Layer* tempLayer = curLayer->getNextLayer();
 		if (!removeLayer(curLayer, true))
@@ -381,23 +381,23 @@ Layer* Packet::detachLayer(ProtocolType layerType, int index)
 {
 	Layer* layerToDetach = getLayerOfType(layerType, index);
 
-	if (layerToDetach != NULL)
+	if (layerToDetach != nullptr)
 	{
 		if (removeLayer(layerToDetach, false))
 			return layerToDetach;
 		else
-			return NULL;
+			return nullptr;
 	}
 	else
 	{
 		PCPP_LOG_ERROR("Layer of the requested type was not found in packet");
-		return NULL;
+		return nullptr;
 	}
 }
 
 bool Packet::removeLayer(Layer* layer, bool tryToDelete)
 {
-	if (layer == NULL)
+	if (layer == nullptr)
 	{
 		PCPP_LOG_ERROR("Layer is NULL");
 		return false;
@@ -412,7 +412,7 @@ bool Packet::removeLayer(Layer* layer, bool tryToDelete)
 
 	// verify layer is allocated to *this* packet
 	Layer* curLayer = layer;
-	while (curLayer->m_PrevLayer != NULL)
+	while (curLayer->m_PrevLayer != nullptr)
 		curLayer = curLayer->m_PrevLayer;
 	if (curLayer != m_FirstLayer)
 	{
@@ -437,9 +437,9 @@ bool Packet::removeLayer(Layer* layer, bool tryToDelete)
 	}
 
 	// remove layer from layers linked list
-	if (layer->m_PrevLayer != NULL)
+	if (layer->m_PrevLayer != nullptr)
 		layer->m_PrevLayer->setNextLayer(layer->m_NextLayer);
-	if (layer->m_NextLayer != NULL)
+	if (layer->m_NextLayer != nullptr)
 		layer->m_NextLayer->setPrevLayer(layer->m_PrevLayer);
 
 	// take care of head and tail ptrs
@@ -447,12 +447,12 @@ bool Packet::removeLayer(Layer* layer, bool tryToDelete)
 		m_FirstLayer = layer->m_NextLayer;
 	if (m_LastLayer == layer)
 		m_LastLayer = layer->m_PrevLayer;
-	layer->setNextLayer(NULL);
-	layer->setPrevLayer(NULL);
+	layer->setNextLayer(nullptr);
+	layer->setPrevLayer(nullptr);
 
 	// get packet trailer len if exists
 	size_t packetTrailerLen = 0;
-	if (m_LastLayer != NULL && m_LastLayer->getProtocol() == PacketTrailer)
+	if (m_LastLayer != nullptr && m_LastLayer->getProtocol() == PacketTrailer)
 		packetTrailerLen = m_LastLayer->getDataLen();
 
 	// re-calculate all layers data ptr and data length
@@ -467,7 +467,7 @@ bool Packet::removeLayer(Layer* layer, bool tryToDelete)
 	bool anotherLayerWithSameProtocolExists = false;
 
 	// go over all layers from the first layer to the last layer and set the data ptr and data length for each one
-	while (curLayer != NULL)
+	while (curLayer != nullptr)
 	{
 		// set data ptr to layer
 		curLayer->m_Data = (uint8_t*)dataPtr;
@@ -505,7 +505,7 @@ bool Packet::removeLayer(Layer* layer, bool tryToDelete)
 	// if layer was not allocated by this packet or the tryToDelete is not set, detach it from the packet so it can be reused
 	else
 	{
-		layer->m_Packet = NULL;
+		layer->m_Packet = nullptr;
 		layer->m_Data = layerOldData;
 		layer->m_DataLen = layerOldDataSize;
 	}
@@ -517,7 +517,7 @@ Layer* Packet::getLayerOfType(ProtocolType layerType, int index) const
 {
 	Layer* curLayer = getFirstLayer();
 	int curIndex = 0;
-	while (curLayer != NULL)
+	while (curLayer != nullptr)
 	{
 		if (curLayer->getProtocol() == layerType)
 		{
@@ -534,7 +534,7 @@ Layer* Packet::getLayerOfType(ProtocolType layerType, int index) const
 
 bool Packet::extendLayer(Layer* layer, int offsetInLayer, size_t numOfBytesToExtend)
 {
-	if (layer == NULL)
+	if (layer == nullptr)
 	{
 		PCPP_LOG_ERROR("Layer is NULL");
 		return false;
@@ -567,7 +567,7 @@ bool Packet::extendLayer(Layer* layer, int offsetInLayer, size_t numOfBytesToExt
 	// no new data has to be created for this insertion which saves at least little time
 	// this move operation occurs on already allocated memory, which is backed by the reallocation if's provided above
 	// if offsetInLayer == layer->getHeaderLen() insertData will not move any data but only increase the packet size by numOfBytesToExtend
-	m_RawPacket->insertData(indexToInsertData, NULL, numOfBytesToExtend);
+	m_RawPacket->insertData(indexToInsertData, nullptr, numOfBytesToExtend);
 
 	// re-calculate all layers data ptr and data length
 	const uint8_t* dataPtr = m_RawPacket->getRawData();
@@ -575,7 +575,7 @@ bool Packet::extendLayer(Layer* layer, int offsetInLayer, size_t numOfBytesToExt
 	// go over all layers from the first layer to the last layer and set the data ptr and data length for each layer
 	Layer* curLayer = m_FirstLayer;
 	bool passedExtendedLayer = false;
-	while (curLayer != NULL)
+	while (curLayer != nullptr)
 	{
 		// set the data ptr
 		curLayer->m_Data = (uint8_t*)dataPtr;
@@ -599,7 +599,7 @@ bool Packet::extendLayer(Layer* layer, int offsetInLayer, size_t numOfBytesToExt
 
 bool Packet::shortenLayer(Layer* layer, int offsetInLayer, size_t numOfBytesToShorten)
 {
-	if (layer == NULL)
+	if (layer == nullptr)
 	{
 		PCPP_LOG_ERROR("Layer is NULL");
 		return false;
@@ -626,7 +626,7 @@ bool Packet::shortenLayer(Layer* layer, int offsetInLayer, size_t numOfBytesToSh
 	// go over all layers from the first layer to the last layer and set the data ptr and data length for each layer
 	Layer* curLayer = m_FirstLayer;
 	bool passedExtendedLayer = false;
-	while (curLayer != NULL)
+	while (curLayer != nullptr)
 	{
 		// set the data ptr
 		curLayer->m_Data = (uint8_t*)dataPtr;
@@ -653,7 +653,7 @@ void Packet::computeCalculateFields()
 	// calculated fields should be calculated from top layer to bottom layer
 
 	Layer* curLayer = m_LastLayer;
-	while (curLayer != NULL)
+	while (curLayer != nullptr)
 	{
 		curLayer->computeCalculateFields();
 		curLayer = curLayer->getPrevLayer();
@@ -668,7 +668,7 @@ std::string Packet::printPacketInfo(bool timeAsLocalTime) const
 	// convert raw packet timestamp to printable format
 	timespec timestamp = m_RawPacket->getPacketTimeStamp();
 	time_t nowtime = timestamp.tv_sec;
-	struct tm *nowtm = NULL;
+	struct tm *nowtm = nullptr;
 #if __cplusplus > 199711L && !defined(_WIN32)
   // localtime_r and gmtime_r are thread-safe versions of localtime and gmtime,
 	// but they're defined only in newer compilers (>= C++0x).
@@ -680,7 +680,7 @@ std::string Packet::printPacketInfo(bool timeAsLocalTime) const
 	else
 		nowtm = gmtime_r(&nowtime, &nowtm_r);
 
-	if (nowtm != NULL)
+	if (nowtm != nullptr)
 		nowtm = &nowtm_r;
 #else
 	// on Window compilers localtime and gmtime are already thread safe.
@@ -692,7 +692,7 @@ std::string Packet::printPacketInfo(bool timeAsLocalTime) const
 #endif
 
 	char buf[128];
-	if (nowtm != NULL)
+	if (nowtm != nullptr)
 	{
 		char tmbuf[64];
 		strftime(tmbuf, sizeof(tmbuf), "%Y-%m-%d %H:%M:%S", nowtm);
@@ -708,7 +708,7 @@ Layer* Packet::createFirstLayer(LinkLayerType linkType)
 {
 	size_t rawDataLen = (size_t)m_RawPacket->getRawDataLen();
 	if (rawDataLen == 0)
-		return NULL;
+		return nullptr;
 
 	const uint8_t* rawData = m_RawPacket->getRawData();
 
@@ -724,7 +724,7 @@ Layer* Packet::createFirstLayer(LinkLayerType linkType)
 		}
 		else
 		{
-			return new PayloadLayer((uint8_t*)rawData, rawDataLen, NULL, this);
+			return new PayloadLayer((uint8_t*)rawData, rawDataLen, nullptr, this);
 		}
 	}
 	else if (linkType == LINKTYPE_LINUX_SLL)
@@ -736,7 +736,7 @@ Layer* Packet::createFirstLayer(LinkLayerType linkType)
 		if (rawDataLen >= sizeof(uint32_t))
 			return new NullLoopbackLayer((uint8_t*)rawData, rawDataLen, this);
 		else // rawDataLen is too small fir Null/Loopback
-			return new PayloadLayer((uint8_t*)rawData, rawDataLen, NULL, this);
+			return new PayloadLayer((uint8_t*)rawData, rawDataLen, nullptr, this);
 	}
 	else if (linkType == LINKTYPE_RAW || linkType == LINKTYPE_DLT_RAW1 || linkType == LINKTYPE_DLT_RAW2)
 	{
@@ -744,35 +744,35 @@ Layer* Packet::createFirstLayer(LinkLayerType linkType)
 		if (ipVer == 0x40)
 		{
 			return IPv4Layer::isDataValid(rawData, rawDataLen)
-				? static_cast<Layer*>(new IPv4Layer((uint8_t*)rawData, rawDataLen, NULL, this))
-				: static_cast<Layer*>(new PayloadLayer((uint8_t*)rawData, rawDataLen, NULL, this));
+				? static_cast<Layer*>(new IPv4Layer((uint8_t*)rawData, rawDataLen, nullptr, this))
+				: static_cast<Layer*>(new PayloadLayer((uint8_t*)rawData, rawDataLen, nullptr, this));
 		}
 		else if (ipVer == 0x60)
 		{
 			return IPv6Layer::isDataValid(rawData, rawDataLen)
-				? static_cast<Layer*>(new IPv6Layer((uint8_t*)rawData, rawDataLen, NULL, this))
-				: static_cast<Layer*>(new PayloadLayer((uint8_t*)rawData, rawDataLen, NULL, this));
+				? static_cast<Layer*>(new IPv6Layer((uint8_t*)rawData, rawDataLen, nullptr, this))
+				: static_cast<Layer*>(new PayloadLayer((uint8_t*)rawData, rawDataLen, nullptr, this));
 		}
 		else
 		{
-			return new PayloadLayer((uint8_t*)rawData, rawDataLen, NULL, this);
+			return new PayloadLayer((uint8_t*)rawData, rawDataLen, nullptr, this);
 		}
 	}
 	else if (linkType == LINKTYPE_IPV4)
 	{
 		return IPv4Layer::isDataValid(rawData, rawDataLen)
-			? static_cast<Layer*>(new IPv4Layer((uint8_t*)rawData, rawDataLen, NULL, this))
-			: static_cast<Layer*>(new PayloadLayer((uint8_t*)rawData, rawDataLen, NULL, this));
+			? static_cast<Layer*>(new IPv4Layer((uint8_t*)rawData, rawDataLen, nullptr, this))
+			: static_cast<Layer*>(new PayloadLayer((uint8_t*)rawData, rawDataLen, nullptr, this));
 	}
 	else if (linkType == LINKTYPE_IPV6)
 	{
 		return IPv6Layer::isDataValid(rawData, rawDataLen)
-			? static_cast<Layer*>(new IPv6Layer((uint8_t*)rawData, rawDataLen, NULL, this))
-			: static_cast<Layer*>(new PayloadLayer((uint8_t*)rawData, rawDataLen, NULL, this));
+			? static_cast<Layer*>(new IPv6Layer((uint8_t*)rawData, rawDataLen, nullptr, this))
+			: static_cast<Layer*>(new PayloadLayer((uint8_t*)rawData, rawDataLen, nullptr, this));
 	}
 
 	// unknown link type
-	return new PayloadLayer((uint8_t*)rawData, rawDataLen, NULL, this);
+	return new PayloadLayer((uint8_t*)rawData, rawDataLen, nullptr, this);
 }
 
 std::string Packet::toString(bool timeAsLocalTime) const
@@ -793,7 +793,7 @@ void Packet::toStringList(std::vector<std::string>& result, bool timeAsLocalTime
 	result.clear();
 	result.push_back(printPacketInfo(timeAsLocalTime));
 	Layer* curLayer = m_FirstLayer;
-	while (curLayer != NULL)
+	while (curLayer != nullptr)
 	{
 		result.push_back(curLayer->toString());
 		curLayer = curLayer->getNextLayer();

--- a/Packet++/src/PacketUtils.cpp
+++ b/Packet++/src/PacketUtils.cpp
@@ -108,7 +108,7 @@ uint32_t hash5Tuple(Packet* packet, bool const& directionUnique)
 	int srcPosition = 0;
 
 	TcpLayer* tcpLayer = packet->getLayerOfType<TcpLayer>(true); // lookup in reverse order
-	if (tcpLayer != NULL)
+	if (tcpLayer != nullptr)
 	{
 		portSrc = tcpLayer->getTcpHeader()->portSrc;
 		portDst = tcpLayer->getTcpHeader()->portDst;
@@ -133,7 +133,7 @@ uint32_t hash5Tuple(Packet* packet, bool const& directionUnique)
 
 
 	IPv4Layer* ipv4Layer = packet->getLayerOfType<IPv4Layer>();
-	if (ipv4Layer != NULL)
+	if (ipv4Layer != nullptr)
 	{
 		if (portSrc == portDst && ipv4Layer->getIPv4Header()->ipDst < ipv4Layer->getIPv4Header()->ipSrc)
 			srcPosition = 1;
@@ -171,7 +171,7 @@ uint32_t hash2Tuple(Packet* packet)
 	ScalarBuffer<uint8_t> vec[2];
 
 	IPv4Layer* ipv4Layer = packet->getLayerOfType<IPv4Layer>();
-	if (ipv4Layer != NULL)
+	if (ipv4Layer != nullptr)
 	{
 		int srcPosition = 0;
 		if (ipv4Layer->getIPv4Header()->ipDst < ipv4Layer->getIPv4Header()->ipSrc)

--- a/Packet++/src/PayloadLayer.cpp
+++ b/Packet++/src/PayloadLayer.cpp
@@ -24,7 +24,7 @@ PayloadLayer::PayloadLayer(const std::string& payloadAsHexStream)
 	if (hexStringToByteArray(payloadAsHexStream, m_Data, m_DataLen) == 0)
 	{
 		delete [] m_Data;
-		m_Data = NULL;
+		m_Data = nullptr;
 		m_DataLen = 0;
 	}
 }

--- a/Packet++/src/RadiusLayer.cpp
+++ b/Packet++/src/RadiusLayer.cpp
@@ -34,7 +34,7 @@ RadiusLayer::RadiusLayer(uint8_t code, uint8_t id, const uint8_t* authenticator,
 	hdr->code = code;
 	hdr->id = id;
 	hdr->length = htobe16(sizeof(radius_header));
-	if (authenticatorArrSize == 0 || authenticator == NULL)
+	if (authenticatorArrSize == 0 || authenticator == nullptr)
 		return;
 	if (authenticatorArrSize > 16)
 		authenticatorArrSize = 16;
@@ -63,7 +63,7 @@ RadiusAttribute RadiusLayer::addAttrAt(const RadiusAttributeBuilder& attrBuilder
 	if (!extendLayer(offset, sizeToExtend))
 	{
 		PCPP_LOG_ERROR("Could not extend RadiusLayer in [" << newAttr.getTotalSize() << "] bytes");
-		return RadiusAttribute(NULL);
+		return RadiusAttribute(nullptr);
 	}
 
 	memcpy(m_Data + offset, newAttr.getRecordBasePtr(), newAttr.getTotalSize());
@@ -240,7 +240,7 @@ bool RadiusLayer::removeAllAttributes()
 
 bool RadiusLayer::isDataValid(const uint8_t* udpData, size_t udpDataLen)
 {
-	if(udpData != NULL && udpDataLen >= sizeof(radius_header))
+	if(udpData != nullptr && udpDataLen >= sizeof(radius_header))
 	{
 		const radius_header* radHdr = reinterpret_cast<const radius_header*>(udpData);
 		size_t radLen = be16toh(radHdr->length);

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -10,7 +10,7 @@ namespace pcpp
 
 void RawPacket::init(bool deleteRawDataAtDestructor)
 {
-	m_RawData = 0;
+	m_RawData = nullptr;
 	m_RawDataLen = 0;
 	m_FrameLength = 0;
 	m_DeleteRawDataAtDestructor = deleteRawDataAtDestructor;
@@ -47,7 +47,7 @@ RawPacket::~RawPacket()
 
 RawPacket::RawPacket(const RawPacket& other)
 {
-	m_RawData = NULL;
+	m_RawData = nullptr;
 	copyDataFrom(other, true);
 }
 
@@ -55,7 +55,7 @@ RawPacket& RawPacket::operator=(const RawPacket& other)
 {
 	if (this != &other)
 	{
-		if (m_RawData != NULL)
+		if (m_RawData != nullptr)
 			delete [] m_RawData;
 
 		m_RawPacketSet = false;
@@ -99,7 +99,7 @@ bool RawPacket::setRawData(const uint8_t* pRawData, int rawDataLen, timespec tim
 	if(frameLength == -1)
 		frameLength = rawDataLen;
 	m_FrameLength = frameLength;
-	if (m_RawData != 0 && m_DeleteRawDataAtDestructor)
+	if (m_RawData != nullptr && m_DeleteRawDataAtDestructor)
 	{
 		delete[] m_RawData;
 	}
@@ -114,10 +114,10 @@ bool RawPacket::setRawData(const uint8_t* pRawData, int rawDataLen, timespec tim
 
 void RawPacket::clear()
 {
-	if (m_RawData != 0)
+	if (m_RawData != nullptr)
 		delete[] m_RawData;
 
-	m_RawData = 0;
+	m_RawData = nullptr;
 	m_RawDataLen = 0;
 	m_FrameLength = 0;
 	m_RawPacketSet = false;
@@ -136,7 +136,7 @@ void RawPacket::insertData(int atIndex, const uint8_t* dataToInsert, size_t data
 	// if insertData is called with atIndex == m_RawDataLen, then no data is being moved. The data of the raw packet is still extended by dataToInsertLen
 	memmove((uint8_t*)m_RawData + atIndex + dataToInsertLen, (uint8_t*)m_RawData + atIndex, m_RawDataLen - atIndex);
 
-	if (dataToInsert != NULL)
+	if (dataToInsert != nullptr)
 	{
 		// insert data
 		memcpy((uint8_t*)m_RawData + atIndex, dataToInsert, dataToInsertLen);

--- a/Packet++/src/SSHLayer.cpp
+++ b/Packet++/src/SSHLayer.cpp
@@ -19,11 +19,11 @@ namespace pcpp
 SSHLayer* SSHLayer::createSSHMessage(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
 {
 	SSHIdentificationMessage* sshIdnetMsg = SSHIdentificationMessage::tryParse(data, dataLen, prevLayer, packet);
-	if (sshIdnetMsg != NULL)
+	if (sshIdnetMsg != nullptr)
 		return sshIdnetMsg;
 
 	SSHHandshakeMessage* sshHandshakeMessage = SSHHandshakeMessage::tryParse(data, dataLen, prevLayer, packet);
-	if (sshHandshakeMessage != NULL)
+	if (sshHandshakeMessage != nullptr)
 		return sshHandshakeMessage;
 
 	return new SSHEncryptedMessage(data, dataLen, prevLayer, packet);
@@ -46,13 +46,13 @@ SSHIdentificationMessage* SSHIdentificationMessage::tryParse(uint8_t* data, size
 {
 	// Payload must be at least as long as the string "SSH-"
 	if (dataLen < 5)
-		return NULL;
+		return nullptr;
 
 	// Payload must begin with "SSH-" and end with "\n"
 	if (data[0] == 0x53 && data[1] == 0x53 && data[2] == 0x48 && data[3] == 0x2d && data[dataLen - 1] == 0x0a)
 		return new SSHIdentificationMessage(data, dataLen, prevLayer, packet);
 
-	return NULL;
+	return nullptr;
 }
 
 std::string SSHIdentificationMessage::getIdentificationMessage()
@@ -135,7 +135,7 @@ SSHHandshakeMessage* SSHHandshakeMessage::tryParse(uint8_t* data, size_t dataLen
 	if (dataLen < sizeof(SSHHandshakeMessage::ssh_message_base))
 	{
 		PCPP_LOG_DEBUG("Data length is smaller than the minimum size of an SSH handshake message. It's probably not an SSH handshake message");
-		return NULL;
+		return nullptr;
 	}
 
 	SSHHandshakeMessage::ssh_message_base* msgBase = (SSHHandshakeMessage::ssh_message_base*)data;
@@ -144,13 +144,13 @@ SSHHandshakeMessage* SSHHandshakeMessage::tryParse(uint8_t* data, size_t dataLen
 	if (msgLength + sizeof(uint32_t) > dataLen)
 	{
 		PCPP_LOG_DEBUG("Message size is larger than layer size. It's probably not an SSH handshake message");
-		return NULL;
+		return nullptr;
 	}
 
 	if (msgBase->paddingLength > msgLength)
 	{
 		PCPP_LOG_DEBUG("Message padding is larger than message size. It's probably not an SSH handshake message");
-		return NULL;
+		return nullptr;
 	}
 
 	if (msgBase->messageCode != 20 &&
@@ -158,7 +158,7 @@ SSHHandshakeMessage* SSHHandshakeMessage::tryParse(uint8_t* data, size_t dataLen
 		(msgBase->messageCode < 30 || msgBase->messageCode > 49))
 		{
 			PCPP_LOG_DEBUG("Unknown message type " << (int)msgBase->messageCode << ". It's probably not an SSH handshake message");
-			return NULL;
+			return nullptr;
 		}
 
 	switch (msgBase->messageCode)
@@ -224,7 +224,7 @@ std::string SSHKeyExchangeInitMessage::getFieldValue(int fieldOffsetIndex)
 uint8_t* SSHKeyExchangeInitMessage::getCookie()
 {
 	if (m_DataLen < sizeof(ssh_message_base) + 16)
-		return NULL;
+		return nullptr;
 
 	return m_Data + sizeof(ssh_message_base);
 }
@@ -232,7 +232,7 @@ uint8_t* SSHKeyExchangeInitMessage::getCookie()
 std::string SSHKeyExchangeInitMessage::getCookieAsHexStream()
 {
 	uint8_t* cookie = getCookie();
-	if (cookie == NULL)
+	if (cookie == nullptr)
 		return "";
 
 	return byteArrayToHexString(cookie, 16);

--- a/Packet++/src/SSLHandshake.cpp
+++ b/Packet++/src/SSLHandshake.cpp
@@ -1051,7 +1051,7 @@ SSLCipherSuite* SSLCipherSuite::getCipherSuiteByID(uint16_t id)
 {
 	std::map<uint16_t, SSLCipherSuite*>::const_iterator pos = CipherSuiteIdToObjectMap.find(id);
 	if (pos == CipherSuiteIdToObjectMap.end())
-		return NULL;
+		return nullptr;
 	else
 		return pos->second;
 }
@@ -1061,7 +1061,7 @@ SSLCipherSuite* SSLCipherSuite::getCipherSuiteByName(std::string name)
 	uint32_t nameHash = hashString(name);
 	std::map<uint32_t, SSLCipherSuite*>::const_iterator pos = CipherSuiteStringToObjectMap.find(nameHash);
 	if (pos == CipherSuiteStringToObjectMap.end())
-		return NULL;
+		return nullptr;
 	else
 		return pos->second;
 }
@@ -1106,7 +1106,7 @@ uint8_t* SSLExtension::getData() const
 		return getExtensionStruct()->extensionData;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 
@@ -1224,7 +1224,7 @@ SSLHandshakeMessage::SSLHandshakeMessage(uint8_t* data, size_t dataLen, SSLHands
 SSLHandshakeMessage* SSLHandshakeMessage::createHandshakeMessage(uint8_t* data, size_t dataLen, SSLHandshakeLayer* container)
 {
 	if (dataLen < sizeof(ssl_tls_handshake_layer))
-		return NULL;
+		return nullptr;
 
 	ssl_tls_handshake_layer* hsMsgHeader = (ssl_tls_handshake_layer*)data;
 	switch (hsMsgHeader->handshakeType)
@@ -1305,7 +1305,7 @@ SSLClientHelloMessage::SSLClientHelloMessage(uint8_t* data, size_t dataLen, SSLH
 		&& (curPos - m_Data) < (int)messageLen
 		&& (int)messageLen - (curPos - m_Data) >= (int)minSSLExtensionLen)
 	{
-		SSLExtension* newExt = NULL;
+		SSLExtension* newExt = nullptr;
 		uint16_t sslExtType = be16toh(*(uint16_t*)curPos);
 		switch (sslExtType)
 		{
@@ -1362,7 +1362,7 @@ uint8_t* SSLClientHelloMessage::getSessionID() const
 	if (getSessionIDLength() > 0)
 		return (m_Data + sizeof(ssl_tls_client_server_hello) + 1);
 	else
-		return NULL;
+		return nullptr;
 }
 
 int SSLClientHelloMessage::getCipherSuiteCount() const
@@ -1379,7 +1379,7 @@ SSLCipherSuite* SSLClientHelloMessage::getCipherSuite(int index) const
 {
 	bool isValid;
 	uint16_t id = getCipherSuiteID(index, isValid);
-	return (isValid ? SSLCipherSuite::getCipherSuiteByID(id) : NULL);
+	return (isValid ? SSLCipherSuite::getCipherSuiteByID(id) : nullptr);
 }
 
 uint16_t SSLClientHelloMessage::getCipherSuiteID(int index, bool& isValid) const
@@ -1442,7 +1442,7 @@ SSLExtension* SSLClientHelloMessage::getExtensionOfType(uint16_t type) const
 			return curElem;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 SSLExtension* SSLClientHelloMessage::getExtensionOfType(SSLExtensionType type) const
@@ -1455,7 +1455,7 @@ SSLExtension* SSLClientHelloMessage::getExtensionOfType(SSLExtensionType type) c
 			return curElem;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 SSLClientHelloMessage::ClientHelloTLSFingerprint SSLClientHelloMessage::generateTLSFingerprint() const
@@ -1488,7 +1488,7 @@ SSLClientHelloMessage::ClientHelloTLSFingerprint SSLClientHelloMessage::generate
 
 	// extract supported groups
 	TLSSupportedGroupsExtension* supportedGroupsExt = getExtensionOfType<TLSSupportedGroupsExtension>();
-	if (supportedGroupsExt != NULL)
+	if (supportedGroupsExt != nullptr)
 	{
 		std::vector<uint16_t> supportedGroups = supportedGroupsExt->getSupportedGroups();
 		for (std::vector<uint16_t>::const_iterator iter = supportedGroups.begin(); iter != supportedGroups.end(); iter++)
@@ -1498,7 +1498,7 @@ SSLClientHelloMessage::ClientHelloTLSFingerprint SSLClientHelloMessage::generate
 
 	// extract EC point formats
 	TLSECPointFormatExtension* ecPointFormatExt = getExtensionOfType<TLSECPointFormatExtension>();
-	if (ecPointFormatExt != NULL)
+	if (ecPointFormatExt != nullptr)
 	{
 		result.ecPointFormats = ecPointFormatExt->getECPointFormatList();
 	}
@@ -1595,7 +1595,7 @@ SSLServerHelloMessage::SSLServerHelloMessage(uint8_t* data, size_t dataLen, SSLH
 		&& (curPos - m_Data) < (int)messageLen
 		&& (int)messageLen - (curPos - m_Data) >= (int)minSSLExtensionLen)
 	{
-		SSLExtension* newExt = NULL;
+		SSLExtension* newExt = nullptr;
 		uint16_t sslExtType = be16toh(*(uint16_t*)curPos);
 		switch (sslExtType)
 		{
@@ -1629,7 +1629,7 @@ SSLServerHelloMessage::SSLServerHelloMessage(uint8_t* data, size_t dataLen, SSLH
 SSLVersion SSLServerHelloMessage::getHandshakeVersion() const
 {
 	SSLSupportedVersionsExtension* supportedVersionsExt = getExtensionOfType<SSLSupportedVersionsExtension>();
-	if (supportedVersionsExt != NULL)
+	if (supportedVersionsExt != nullptr)
 	{
 		std::vector<SSLVersion> supportedVersions = supportedVersionsExt->getSupportedVersions();
 		if (supportedVersions.size() == 1)
@@ -1657,14 +1657,14 @@ uint8_t* SSLServerHelloMessage::getSessionID() const
 	if (getSessionIDLength() > 0)
 		return (m_Data + sizeof(ssl_tls_client_server_hello) + 1);
 	else
-		return NULL;
+		return nullptr;
 }
 
 SSLCipherSuite* SSLServerHelloMessage::getCipherSuite() const
 {
 	bool isValid;
 	uint16_t id = getCipherSuiteID(isValid);
-	return (isValid ? SSLCipherSuite::getCipherSuiteByID(id) : NULL);
+	return (isValid ? SSLCipherSuite::getCipherSuiteByID(id) : nullptr);
 }
 
 uint16_t SSLServerHelloMessage::getCipherSuiteID(bool& isValid) const
@@ -1709,7 +1709,7 @@ uint16_t SSLServerHelloMessage::getExtensionsLength() const
 SSLExtension* SSLServerHelloMessage::getExtension(int index) const
 {
 	if (index < 0 || index >= (int)m_ExtensionList.size())
-		return NULL;
+		return nullptr;
 
 	return const_cast<SSLExtension*>(m_ExtensionList.at(index));
 }
@@ -1724,7 +1724,7 @@ SSLExtension* SSLServerHelloMessage::getExtensionOfType(uint16_t type) const
 			return curElem;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 SSLExtension* SSLServerHelloMessage::getExtensionOfType(SSLExtensionType type) const
@@ -1737,7 +1737,7 @@ SSLExtension* SSLServerHelloMessage::getExtensionOfType(SSLExtensionType type) c
 			return curElem;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 SSLServerHelloMessage::ServerHelloTLSFingerprint SSLServerHelloMessage::generateTLSFingerprint() const
@@ -1872,7 +1872,7 @@ SSLx509Certificate* SSLCertificateMessage::getCertificate(int index) const
 	if (index < 0 || index > (int)m_CertificateList.size())
 	{
 		PCPP_LOG_DEBUG("certificate index out of range: asked for index " << index << ", total size is " << m_CertificateList.size());
-		return NULL;
+		return nullptr;
 	}
 
 	return const_cast<SSLx509Certificate*>(m_CertificateList.at(index));
@@ -1908,7 +1908,7 @@ uint8_t* SSLServerKeyExchangeMessage::getServerKeyExchangeParams() const
 	if (getMessageLength() > sizeof(ssl_tls_handshake_layer))
 		return (m_Data + sizeof(ssl_tls_handshake_layer));
 
-	return NULL;
+	return nullptr;
 }
 
 size_t SSLServerKeyExchangeMessage::getServerKeyExchangeParamsLength() const
@@ -1934,7 +1934,7 @@ uint8_t* SSLClientKeyExchangeMessage::getClientKeyExchangeParams() const
 	if (getMessageLength() > sizeof(ssl_tls_handshake_layer))
 		return (m_Data + sizeof(ssl_tls_handshake_layer));
 
-	return NULL;
+	return nullptr;
 }
 
 size_t SSLClientKeyExchangeMessage::getClientKeyExchangeParamsLength() const
@@ -1996,7 +1996,7 @@ uint8_t* SSLCertificateRequestMessage::getCertificateAuthorityData() const
 	size_t messageLen = getMessageLength();
 	size_t offset = sizeof(ssl_tls_handshake_layer) + sizeof(uint8_t) + m_ClientCertificateTypes.size() + sizeof(uint16_t);
 	if (offset >= messageLen)
-		return NULL;
+		return nullptr;
 
 	return m_Data + offset;
 }
@@ -2033,7 +2033,7 @@ uint8_t* SSLCertificateVerifyMessage::getSignedHash() const
 	if (getMessageLength() > sizeof(ssl_tls_handshake_layer))
 		return (m_Data + sizeof(ssl_tls_handshake_layer));
 
-	return NULL;
+	return nullptr;
 }
 
 size_t SSLCertificateVerifyMessage::getSignedHashLength() const
@@ -2059,7 +2059,7 @@ uint8_t* SSLFinishedMessage::getSignedHash() const
 	if (getMessageLength() > sizeof(ssl_tls_handshake_layer))
 		return (m_Data + sizeof(ssl_tls_handshake_layer));
 
-	return NULL;
+	return nullptr;
 }
 
 size_t SSLFinishedMessage::getSignedHashLength() const
@@ -2086,7 +2086,7 @@ uint8_t* SSLNewSessionTicketMessage::getSessionTicketData() const
 	if (getMessageLength() > sizeof(ssl_tls_handshake_layer))
 		return (m_Data + sizeof(ssl_tls_handshake_layer));
 
-	return NULL;
+	return nullptr;
 }
 
 size_t SSLNewSessionTicketMessage::getSessionTicketDataLength() const

--- a/Packet++/src/SSLLayer.cpp
+++ b/Packet++/src/SSLLayer.cpp
@@ -69,7 +69,7 @@ SSLLayer* SSLLayer::createSSLMessage(uint8_t* data, size_t dataLen, Layer* prevL
 		}
 
 		default:
-			return NULL;
+			return nullptr;
 	}
 }
 
@@ -133,7 +133,7 @@ SSLHandshakeLayer::SSLHandshakeLayer(uint8_t* data, size_t dataLen, Layer* prevL
 	while (true)
 	{
 		SSLHandshakeMessage* message = SSLHandshakeMessage::createHandshakeMessage(curPos, recordDataLen-curPosIndex, this);
-		if (message == NULL)
+		if (message == nullptr)
 			break;
 
 		m_MessageList.pushBack(message);
@@ -145,7 +145,7 @@ SSLHandshakeLayer::SSLHandshakeLayer(uint8_t* data, size_t dataLen, Layer* prevL
 SSLHandshakeMessage* SSLHandshakeLayer::getHandshakeMessageAt(int index) const
 {
 	if (index < 0 || index >= (int)(m_MessageList.size()))
-		return NULL;
+		return nullptr;
 
 	return const_cast<SSLHandshakeMessage*>(m_MessageList.at(index));
 }
@@ -236,7 +236,7 @@ std::string SSLAlertLayer::toString() const
 uint8_t* SSLApplicationDataLayer::getEncryptedData() const
 {
 	if (getHeaderLen() <= sizeof(ssl_tls_record_layer))
-		return NULL;
+		return nullptr;
 
 	return m_Data + sizeof(ssl_tls_record_layer);
 }

--- a/Packet++/src/SdpLayer.cpp
+++ b/Packet++/src/SdpLayer.cpp
@@ -75,7 +75,7 @@ std::string SdpLayer::toString() const
 IPv4Address SdpLayer::getOwnerIPv4Address() const
 {
 	HeaderField* originator = getFieldByName(PCPP_SDP_ORIGINATOR_FIELD);
-	if (originator == NULL)
+	if (originator == nullptr)
 		return IPv4Address::Zero;
 
 	std::vector<std::string> tokens = splitByWhiteSpaces(originator->getFieldValue());
@@ -93,7 +93,7 @@ uint16_t SdpLayer::getMediaPort(std::string mediaType) const
 	int mediaFieldIndex = 0;
 	HeaderField* mediaDesc = getFieldByName(PCPP_SDP_MEDIA_NAME_FIELD, mediaFieldIndex);
 
-	while (mediaDesc != NULL)
+	while (mediaDesc != nullptr)
 	{
 		std::vector<std::string> tokens = splitByWhiteSpaces(mediaDesc->getFieldValue());
 
@@ -113,7 +113,7 @@ bool SdpLayer::addMediaDescription(std::string mediaType, uint16_t mediaPort, st
 	portStream << mediaPort;
 
 	std::string mediaFieldValue = mediaType + " " + portStream.str() + " " + mediaProtocol + " " + mediaFormat;
-	if (addField(PCPP_SDP_MEDIA_NAME_FIELD, mediaFieldValue) == NULL)
+	if (addField(PCPP_SDP_MEDIA_NAME_FIELD, mediaFieldValue) == nullptr)
 	{
 		PCPP_LOG_ERROR("Failed to add media description field");
 		return false;
@@ -122,7 +122,7 @@ bool SdpLayer::addMediaDescription(std::string mediaType, uint16_t mediaPort, st
 
 	for (std::vector<std::string>::iterator iter = mediaAttributes.begin(); iter != mediaAttributes.end(); iter++)
 	{
-		if (addField(PCPP_SDP_MEDIA_ATTRIBUTE_FIELD, *iter) == NULL)
+		if (addField(PCPP_SDP_MEDIA_ATTRIBUTE_FIELD, *iter) == nullptr)
 		{
 			PCPP_LOG_ERROR("Failed to add media attribute '" << *iter << "'");
 			return false;

--- a/Packet++/src/SipLayer.cpp
+++ b/Packet++/src/SipLayer.cpp
@@ -40,7 +40,7 @@ int SipLayer::getContentLength() const
 	std::string contentLengthFieldName(PCPP_SIP_CONTENT_LENGTH_FIELD);
 	std::transform(contentLengthFieldName.begin(), contentLengthFieldName.end(), contentLengthFieldName.begin(), ::tolower);
 	HeaderField* contentLengthField = getFieldByName(contentLengthFieldName);
-	if (contentLengthField != NULL)
+	if (contentLengthField != nullptr)
 		return atoi(contentLengthField->getFieldValue().c_str());
 	return 0;
 }
@@ -51,7 +51,7 @@ HeaderField* SipLayer::setContentLength(int contentLength, const std::string &pr
 	contentLengthAsString << contentLength;
 	std::string contentLengthFieldName(PCPP_SIP_CONTENT_LENGTH_FIELD);
 	HeaderField* contentLengthField = getFieldByName(contentLengthFieldName);
-	if (contentLengthField == NULL)
+	if (contentLengthField == nullptr)
 	{
 		HeaderField* prevField = getFieldByName(prevFieldName);
 		contentLengthField = insertField(prevField, PCPP_SIP_CONTENT_LENGTH_FIELD, contentLengthAsString.str());
@@ -81,7 +81,7 @@ void SipLayer::parseNextLayer()
 void SipLayer::computeCalculateFields()
 {
 	HeaderField* contentLengthField = getFieldByName(PCPP_SIP_CONTENT_LENGTH_FIELD);
-	if (contentLengthField == NULL)
+	if (contentLengthField == nullptr)
 		return;
 
 	size_t headerLen = getHeaderLen();
@@ -116,7 +116,7 @@ SipRequestFirstLine::SipRequestFirstLine(SipRequestLayer* sipRequest) : m_SipReq
 	parseVersion();
 
 	char* endOfFirstLine;
-	if ((endOfFirstLine = (char *)memchr((char*)(m_SipRequest->m_Data + m_VersionOffset), '\n', m_SipRequest->m_DataLen-(size_t)m_VersionOffset)) != NULL)
+	if ((endOfFirstLine = (char *)memchr((char*)(m_SipRequest->m_Data + m_VersionOffset), '\n', m_SipRequest->m_DataLen-(size_t)m_VersionOffset)) != nullptr)
 	{
 		m_FirstLineEndOffset = endOfFirstLine - (char*)m_SipRequest->m_Data + 1;
 		m_IsComplete = true;
@@ -300,7 +300,7 @@ void SipRequestFirstLine::parseVersion()
 
 	char* data = (char*)(m_SipRequest->m_Data + m_UriOffset);
 	char* verPos = (char*)cross_platform_memmem(data, m_SipRequest->getDataLen() - m_UriOffset, " SIP/", 5);
-	if (verPos == NULL)
+	if (verPos == nullptr)
 	{
 		m_Version = "";
 		m_VersionOffset = -1;
@@ -455,7 +455,7 @@ SipRequestLayer& SipRequestLayer::operator=(const SipRequestLayer& other)
 {
 	SipLayer::operator=(other);
 
-	if (m_FirstLine != NULL)
+	if (m_FirstLine != nullptr)
 		delete m_FirstLine;
 
 	m_FirstLine = new SipRequestFirstLine(this);
@@ -696,7 +696,7 @@ SipResponseLayer& SipResponseLayer::operator=(const SipResponseLayer& other)
 {
 	SipLayer::operator=(other);
 
-	if (m_FirstLine != NULL)
+	if (m_FirstLine != nullptr)
 		delete m_FirstLine;
 
 	m_FirstLine = new SipResponseFirstLine(this);
@@ -1213,7 +1213,7 @@ SipResponseFirstLine::SipResponseFirstLine(SipResponseLayer* sipResponse) : m_Si
 
 
 	char* endOfFirstLine;
-	if ((endOfFirstLine = (char *)memchr((char*)(m_SipResponse->m_Data), '\n', m_SipResponse->m_DataLen)) != NULL)
+	if ((endOfFirstLine = (char *)memchr((char*)(m_SipResponse->m_Data), '\n', m_SipResponse->m_DataLen)) != nullptr)
 	{
 		m_FirstLineEndOffset = endOfFirstLine - (char*)m_SipResponse->m_Data + 1;
 		m_IsComplete = true;
@@ -1281,7 +1281,7 @@ std::string SipResponseFirstLine::parseVersion(char* data, size_t dataLen)
 	}
 
 	char* nextSpace = (char*)memchr(data, ' ', dataLen);
-	if (nextSpace == NULL)
+	if (nextSpace == nullptr)
 		return "";
 
 	return std::string(data, nextSpace - data);

--- a/Packet++/src/SllLayer.cpp
+++ b/Packet++/src/SllLayer.cpp
@@ -104,7 +104,7 @@ void SllLayer::parseNextLayer()
 
 void SllLayer::computeCalculateFields()
 {
-	if (m_NextLayer == NULL)
+	if (m_NextLayer == nullptr)
 		return;
 
 	sll_header* hdr = getSllHeader();

--- a/Packet++/src/SomeIpSdLayer.cpp
+++ b/Packet++/src/SomeIpSdLayer.cpp
@@ -14,7 +14,7 @@ namespace pcpp
  */
 SomeIpSdOption::~SomeIpSdOption()
 {
-	if (m_ShadowData != NULL)
+	if (m_ShadowData != nullptr)
 		delete[] m_ShadowData;
 }
 
@@ -24,7 +24,7 @@ SomeIpSdOption::OptionType SomeIpSdOption::getType() const {
 
 uint8_t* SomeIpSdOption::getDataPtr() const
 {
-	if (m_DataContainer != NULL)
+	if (m_DataContainer != nullptr)
 		return m_DataContainer->getDataPtr(m_Offset);
 
 	return m_ShadowData;
@@ -287,13 +287,13 @@ SomeIpSdEntry::SomeIpSdEntry(const SomeIpSdLayer *pSomeIpSdLayer, size_t offset)
 
 SomeIpSdEntry::~SomeIpSdEntry()
 {
-	if (m_ShadowData != NULL)
+	if (m_ShadowData != nullptr)
 		delete[] m_ShadowData;
 }
 
 uint8_t *SomeIpSdEntry::getDataPtr() const
 {
-	if (m_Layer != NULL)
+	if (m_Layer != nullptr)
 		return m_Layer->getDataPtr(m_Offset);
 
 	return m_ShadowData;

--- a/Packet++/src/TLVData.cpp
+++ b/Packet++/src/TLVData.cpp
@@ -9,7 +9,7 @@ TLVRecordBuilder::TLVRecordBuilder()
 {
 	m_RecType = 0;
 	m_RecValueLen = 0;
-	m_RecValue = NULL;
+	m_RecValue = nullptr;
 }
 
 TLVRecordBuilder::TLVRecordBuilder(uint32_t recType, const uint8_t* recValue, uint8_t recValueLen)
@@ -44,7 +44,7 @@ TLVRecordBuilder::TLVRecordBuilder(uint32_t recType, const std::string& recValue
 {
 	m_RecType = 0;
 	m_RecValueLen = 0;
-	m_RecValue = NULL;
+	m_RecValue = nullptr;
 
 	if (valueIsHexString)
 	{
@@ -66,8 +66,8 @@ void TLVRecordBuilder::copyData(const TLVRecordBuilder& other)
 {
 	m_RecType = other.m_RecType;
 	m_RecValueLen = other.m_RecValueLen;
-	m_RecValue = NULL;
-	if (other.m_RecValue != NULL)
+	m_RecValue = nullptr;
+	if (other.m_RecValue != nullptr)
 	{
 		m_RecValue = new uint8_t[m_RecValueLen];
 		memcpy(m_RecValue, other.m_RecValue, m_RecValueLen);
@@ -81,10 +81,10 @@ TLVRecordBuilder::TLVRecordBuilder(const TLVRecordBuilder& other)
 
 TLVRecordBuilder& TLVRecordBuilder::operator=(const TLVRecordBuilder& other)
 {
-	if (m_RecValue != NULL)
+	if (m_RecValue != nullptr)
 	{
 		delete [] m_RecValue;
-		m_RecValue = NULL;
+		m_RecValue = nullptr;
 	}
 
 	copyData(other);
@@ -94,7 +94,7 @@ TLVRecordBuilder& TLVRecordBuilder::operator=(const TLVRecordBuilder& other)
 
 TLVRecordBuilder::~TLVRecordBuilder()
 {
-	if (m_RecValue != NULL) delete [] m_RecValue;
+	if (m_RecValue != nullptr) delete [] m_RecValue;
 }
 
 void TLVRecordBuilder::init(uint32_t recType, const uint8_t* recValue, size_t recValueLen)
@@ -102,7 +102,7 @@ void TLVRecordBuilder::init(uint32_t recType, const uint8_t* recValue, size_t re
 	m_RecType = recType;
 	m_RecValueLen = recValueLen;
 	m_RecValue = new uint8_t[recValueLen];
-	if (recValue != NULL)
+	if (recValue != nullptr)
 		memcpy(m_RecValue, recValue, recValueLen);
 	else
 		memset(m_RecValue, 0, recValueLen);

--- a/Packet++/src/TcpLayer.cpp
+++ b/Packet++/src/TcpLayer.cpp
@@ -33,11 +33,11 @@ TcpOptionBuilder::TcpOptionBuilder(NopEolOptionTypes optionType)
 	switch (optionType)
 	{
 	case EOL:
-		init((uint8_t)PCPP_TCPOPT_EOL, NULL, 0);
+		init((uint8_t)PCPP_TCPOPT_EOL, nullptr, 0);
 		break;
 	case NOP:
 	default:
-		init((uint8_t)PCPP_TCPOPT_NOP, NULL, 0);
+		init((uint8_t)PCPP_TCPOPT_NOP, nullptr, 0);
 		break;
 	}
 }
@@ -52,7 +52,7 @@ TcpOption TcpOptionBuilder::build() const
 		if (m_RecValueLen != 0)
 		{
 			PCPP_LOG_ERROR("TCP NOP and TCP EOL options are 1-byte long and don't have option value. Tried to set option value of size " << m_RecValueLen);
-			return TcpOption(NULL);
+			return TcpOption(nullptr);
 		}
 
 		optionSize = 1;
@@ -64,7 +64,7 @@ TcpOption TcpOptionBuilder::build() const
 	if (optionSize > 1)
 	{
 		recordBuffer[1] = static_cast<uint8_t>(optionSize);
-		if (optionSize > 2 && m_RecValue != NULL)
+		if (optionSize > 2 && m_RecValue != nullptr)
 			memcpy(recordBuffer+2, m_RecValue, m_RecValueLen);
 	}
 
@@ -101,7 +101,7 @@ TcpOption TcpLayer::getNextTcpOption(TcpOption& tcpOption) const
 {
 	TcpOption nextOpt = m_OptionReader.getNextTLVRecord(tcpOption, getOptionsBasePtr(), getHeaderLen() - sizeof(tcphdr));
 	if (nextOpt.isNotNull() && nextOpt.getType() == TCPOPT_DUMMY)
-		return TcpOption(NULL);
+		return TcpOption(nullptr);
 
 	return nextOpt;
 }
@@ -130,7 +130,7 @@ TcpOption TcpLayer::addTcpOptionAfter(const TcpOptionBuilder& optionBuilder, Tcp
 		if (prevOpt.isNull())
 		{
 			PCPP_LOG_ERROR("Previous option of type " << (int)prevOptionType << " not found, cannot add a new TCP option");
-			return TcpOption(NULL);
+			return TcpOption(nullptr);
 		}
 
 		offset = prevOpt.getRecordBasePtr() + prevOpt.getTotalSize() - m_Data;
@@ -207,7 +207,7 @@ TcpOption TcpLayer::addTcpOptionAt(const TcpOptionBuilder& optionBuilder, int of
 	{
 		PCPP_LOG_ERROR("Could not extend TcpLayer in [" << sizeToExtend << "] bytes");
 		newOption.purgeRecordData();
-		return TcpOption(NULL);
+		return TcpOption(nullptr);
 	}
 
 	memcpy(m_Data + offset, newOption.getRecordBasePtr(), newOption.getTotalSize());
@@ -248,7 +248,7 @@ uint16_t TcpLayer::calculateChecksum(bool writeResultToPacket)
 	uint16_t checksumRes = 0;
 	uint16_t currChecksumValue = tcpHdr->headerChecksum;
 
-	if (m_PrevLayer != NULL)
+	if (m_PrevLayer != nullptr)
 	{
 		tcpHdr->headerChecksum = 0;
 		ScalarBuffer<uint16_t> vec[2];

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -41,7 +41,7 @@ TcpReassembly::TcpReassembly(OnTcpMessageReady onMessageReadyCallback, void* use
 	m_RemoveConnInfo = config.removeConnInfo;
 	m_MaxNumToClean = (config.removeConnInfo == true && config.maxNumToClean == 0) ? 30 : config.maxNumToClean;
 	m_MaxOutOfOrderFragments = config.maxOutOfOrderFragments;
-	m_PurgeTimepoint = time(NULL) + PURGE_FREQ_SECS;
+	m_PurgeTimepoint = time(nullptr) + PURGE_FREQ_SECS;
 	m_EnableBaseBufferClearCondition = config.enableBaseBufferClearCondition;
 }
 
@@ -51,10 +51,10 @@ TcpReassembly::ReassemblyStatus TcpReassembly::reassemblePacket(Packet& tcpData)
 	// automatic cleanup
 	if (m_RemoveConnInfo == true)
 	{
-		if (time(NULL) >= m_PurgeTimepoint)
+		if (time(nullptr) >= m_PurgeTimepoint)
 		{
 			purgeClosedConnections();
-			m_PurgeTimepoint = time(NULL) + PURGE_FREQ_SECS;
+			m_PurgeTimepoint = time(nullptr) + PURGE_FREQ_SECS;
 		}
 	}
 
@@ -78,7 +78,7 @@ TcpReassembly::ReassemblyStatus TcpReassembly::reassemblePacket(Packet& tcpData)
 
 	// Ignore non-TCP packets
 	TcpLayer* tcpLayer = tcpData.getLayerOfType<TcpLayer>(true); // lookup in reverse order
-	if (tcpLayer == NULL)
+	if (tcpLayer == nullptr)
 	{
 		return NonTcpPacket;
 	}
@@ -108,7 +108,7 @@ TcpReassembly::ReassemblyStatus TcpReassembly::reassemblePacket(Packet& tcpData)
 		return Ignore_PacketWithNoData;
 	}
 
-	TcpReassemblyData* tcpReassemblyData = NULL;
+	TcpReassemblyData* tcpReassemblyData = nullptr;
 
 	// calculate flow key for this packet
 	uint32_t flowKey = hash5Tuple(&tcpData);
@@ -134,7 +134,7 @@ TcpReassembly::ReassemblyStatus TcpReassembly::reassemblePacket(Packet& tcpData)
 		m_ConnectionInfo[flowKey] = tcpReassemblyData->connData;
 
 		// fire connection start callback
-		if (m_OnConnStart != NULL)
+		if (m_OnConnStart != nullptr)
 			m_OnConnStart(tcpReassemblyData->connData, m_UserCookie);
 	}
 	else // connection already exists
@@ -280,7 +280,7 @@ TcpReassembly::ReassemblyStatus TcpReassembly::reassemblePacket(Packet& tcpData)
 			tcpReassemblyData->twoSides[sideIndex].sequence++;
 
 		// send data to the callback
-		if (tcpPayloadSize != 0 && m_OnMessageReadyCallback != NULL)
+		if (tcpPayloadSize != 0 && m_OnMessageReadyCallback != nullptr)
 		{
 			TcpStreamData streamData(tcpLayer->getLayerPayload(), tcpPayloadSize, 0, tcpReassemblyData->connData, timestampOfTheReceivedPacket);
 			m_OnMessageReadyCallback(sideIndex, streamData, m_UserCookie);
@@ -315,7 +315,7 @@ TcpReassembly::ReassemblyStatus TcpReassembly::reassemblePacket(Packet& tcpData)
 			tcpReassemblyData->twoSides[sideIndex].sequence += tcpPayloadSize - newLength;
 
 			// send only the new data to the callback
-			if (m_OnMessageReadyCallback != NULL)
+			if (m_OnMessageReadyCallback != nullptr)
 			{
 				TcpStreamData streamData(tcpLayer->getLayerPayload() + newLength, tcpPayloadSize - newLength, 0, tcpReassemblyData->connData, timestampOfTheReceivedPacket);
 				m_OnMessageReadyCallback(sideIndex, streamData, m_UserCookie);
@@ -367,7 +367,7 @@ TcpReassembly::ReassemblyStatus TcpReassembly::reassemblePacket(Packet& tcpData)
 			tcpReassemblyData->twoSides[sideIndex].sequence++;
 
 		// send the data to the callback
-		if (m_OnMessageReadyCallback != NULL)
+		if (m_OnMessageReadyCallback != nullptr)
 		{
 			TcpStreamData streamData(tcpLayer->getLayerPayload(), tcpPayloadSize, 0, tcpReassemblyData->connData,timestampOfTheReceivedPacket);
 			m_OnMessageReadyCallback(sideIndex, streamData, m_UserCookie);
@@ -503,13 +503,13 @@ void TcpReassembly::checkOutOfOrderFragments(TcpReassemblyData* tcpReassemblyDat
 				{
 					// update sequence
 					tcpReassemblyData->twoSides[sideIndex].sequence += curTcpFrag->dataLength;
-					if (curTcpFrag->data != NULL)
+					if (curTcpFrag->data != nullptr)
 					{
 						PCPP_LOG_DEBUG("Found an out-of-order packet matching to the current sequence with size " << curTcpFrag->dataLength << " on side " << sideIndex << ". Pulling it out of the list and sending the data to the callback");
 
 						// send new data to callback
 
-						if (m_OnMessageReadyCallback != NULL)
+						if (m_OnMessageReadyCallback != nullptr)
 						{
 							TcpStreamData streamData(curTcpFrag->data, curTcpFrag->dataLength, 0, tcpReassemblyData->connData, curTcpFrag->timestamp);
 							m_OnMessageReadyCallback(sideIndex, streamData, m_UserCookie);
@@ -544,7 +544,7 @@ void TcpReassembly::checkOutOfOrderFragments(TcpReassemblyData* tcpReassemblyDat
 						tcpReassemblyData->twoSides[sideIndex].sequence += curTcpFrag->dataLength - newLength;
 
 						// send only the new data to the callback
-						if (m_OnMessageReadyCallback != NULL)
+						if (m_OnMessageReadyCallback != nullptr)
 						{
 							TcpStreamData streamData(curTcpFrag->data + newLength, curTcpFrag->dataLength - newLength, 0, tcpReassemblyData->connData, curTcpFrag->timestamp);
 							m_OnMessageReadyCallback(sideIndex, streamData, m_UserCookie);
@@ -616,10 +616,10 @@ void TcpReassembly::checkOutOfOrderFragments(TcpReassemblyData* tcpReassemblyDat
 
 			// update sequence
 			tcpReassemblyData->twoSides[sideIndex].sequence = curTcpFrag->sequence + curTcpFrag->dataLength;
-			if (curTcpFrag->data != NULL)
+			if (curTcpFrag->data != nullptr)
 			{
 				// send new data to callback
-				if (m_OnMessageReadyCallback != NULL)
+				if (m_OnMessageReadyCallback != nullptr)
 				{
 					// prepare missing data text
 					std::string missingDataTextStr = prepareMissingDataMessage(missingDataLen);
@@ -679,7 +679,7 @@ void TcpReassembly::closeConnectionInternal(uint32_t flowKey, ConnectionEndReaso
 	PCPP_LOG_DEBUG("Calling checkOutOfOrderFragments on side 1");
 	checkOutOfOrderFragments(&tcpReassemblyData, 1, true);
 
-	if (m_OnConnEnd != NULL)
+	if (m_OnConnEnd != nullptr)
 		m_OnConnEnd(tcpReassemblyData.connData, reason, m_UserCookie);
 
 	tcpReassemblyData.closed = true; // mark the connection as closed
@@ -709,7 +709,7 @@ void TcpReassembly::closeAllConnections()
 		PCPP_LOG_DEBUG("Calling checkOutOfOrderFragments on side 1");
 		checkOutOfOrderFragments(&tcpReassemblyData, 1, true);
 
-		if (m_OnConnEnd != NULL)
+		if (m_OnConnEnd != nullptr)
 			m_OnConnEnd(tcpReassemblyData.connData, TcpReassemblyConnectionClosedManually, m_UserCookie);
 
 		tcpReassemblyData.closed = true; // mark the connection as closed
@@ -733,7 +733,7 @@ void TcpReassembly::insertIntoCleanupList(uint32_t flowKey)
 	// m_CleanupList is a map with key of type time_t (expiration time). The mapped type is a list that stores the flow keys to be cleared in certain point of time.
 	// m_CleanupList.insert inserts an empty list if the container does not already contain an element with an equivalent key,
 	// otherwise this method returns an iterator to the element that prevents insertion.
-	std::pair<CleanupList::iterator, bool> pair = m_CleanupList.insert(std::make_pair(time(NULL) + m_ClosedConnectionDelay, CleanupList::mapped_type()));
+	std::pair<CleanupList::iterator, bool> pair = m_CleanupList.insert(std::make_pair(time(nullptr) + m_ClosedConnectionDelay, CleanupList::mapped_type()));
 
 	// getting the reference to list
 	CleanupList::mapped_type& keysList = pair.first->second;
@@ -747,7 +747,7 @@ uint32_t TcpReassembly::purgeClosedConnections(uint32_t maxNumToClean)
 	if (maxNumToClean == 0)
 		maxNumToClean = m_MaxNumToClean;
 
-	CleanupList::iterator iterTime = m_CleanupList.begin(), iterTimeEnd = m_CleanupList.upper_bound(time(NULL));
+	CleanupList::iterator iterTime = m_CleanupList.begin(), iterTimeEnd = m_CleanupList.upper_bound(time(nullptr));
 	while (iterTime != iterTimeEnd && count < maxNumToClean)
 	{
 		CleanupList::mapped_type& keysList = iterTime->second;

--- a/Packet++/src/TelnetLayer.cpp
+++ b/Packet++/src/TelnetLayer.cpp
@@ -24,7 +24,7 @@ bool TelnetLayer::isCommandField(uint8_t *pos) const
 
 size_t TelnetLayer::distanceToNextIAC(uint8_t *startPos, size_t maxLength)
 {
-	uint8_t *pos = NULL;
+	uint8_t *pos = nullptr;
 	size_t addition = 0;
 	size_t currentOffset = 0;
 	do
@@ -75,7 +75,7 @@ uint8_t *TelnetLayer::getNextDataField(uint8_t *pos, size_t len)
 			return pos;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 uint8_t *TelnetLayer::getNextCommandField(uint8_t *pos, size_t len)
@@ -92,7 +92,7 @@ uint8_t *TelnetLayer::getNextCommandField(uint8_t *pos, size_t len)
 			return pos;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 int16_t TelnetLayer::getSubCommand(uint8_t *pos, size_t len)
@@ -110,12 +110,12 @@ uint8_t *TelnetLayer::getCommandData(uint8_t *pos, size_t &len)
 		return &pos[3];
 	}
 	len = 0;
-	return NULL;
+	return nullptr;
 }
 
 std::string TelnetLayer::getDataAsString(bool removeEscapeCharacters)
 {
-	uint8_t *dataPos = NULL;
+	uint8_t *dataPos = nullptr;
 	if (isDataField(m_Data))
 		dataPos = m_Data;
 	else
@@ -148,7 +148,7 @@ size_t TelnetLayer::getTotalNumberOfCommands()
 		++ctr;
 
 	uint8_t *pos = m_Data;
-	while (pos != NULL)
+	while (pos != nullptr)
 	{
 		size_t offset = pos - m_Data;
 		pos = getNextCommandField(pos, m_DataLen - offset);
@@ -169,7 +169,7 @@ size_t TelnetLayer::getNumberOfCommands(TelnetCommand command)
 		++ctr;
 
 	uint8_t *pos = m_Data;
-	while (pos != NULL)
+	while (pos != nullptr)
 	{
 		size_t offset = pos - m_Data;
 		pos = getNextCommandField(pos, m_DataLen - offset);
@@ -233,7 +233,7 @@ TelnetLayer::TelnetOption TelnetLayer::getOption(TelnetCommand command)
 		return static_cast<TelnetOption>(getSubCommand(m_Data, getFieldLen(m_Data, m_DataLen)));
 
 	uint8_t *pos = m_Data;
-	while (pos != NULL)
+	while (pos != nullptr)
 	{
 		size_t offset = pos - m_Data;
 		pos = getNextCommandField(pos, m_DataLen - offset);
@@ -256,7 +256,7 @@ uint8_t *TelnetLayer::getOptionData(size_t &length)
 		length = lenBuffer;
 		return posBuffer;
 	}
-	return NULL;
+	return nullptr;
 }
 
 uint8_t *TelnetLayer::getOptionData(TelnetCommand command, size_t &length)
@@ -266,7 +266,7 @@ uint8_t *TelnetLayer::getOptionData(TelnetCommand command, size_t &length)
 	{
 		PCPP_LOG_ERROR("Command type can't be negative");
 		length = 0;
-		return NULL;
+		return nullptr;
 	}
 
 	if (isCommandField(m_Data) && m_Data[1] == command)
@@ -279,7 +279,7 @@ uint8_t *TelnetLayer::getOptionData(TelnetCommand command, size_t &length)
 	}
 
 	uint8_t *pos = m_Data;
-	while (pos != NULL)
+	while (pos != nullptr)
 	{
 		size_t offset = pos - m_Data;
 		pos = getNextCommandField(pos, m_DataLen - offset);
@@ -296,7 +296,7 @@ uint8_t *TelnetLayer::getOptionData(TelnetCommand command, size_t &length)
 
 	PCPP_LOG_DEBUG("Can't find requested command");
 	length = 0;
-	return NULL;
+	return nullptr;
 }
 
 std::string TelnetLayer::getTelnetCommandAsString(TelnetCommand val)

--- a/Packet++/src/TextBasedProtocol.cpp
+++ b/Packet++/src/TextBasedProtocol.cpp
@@ -11,7 +11,7 @@ namespace pcpp
 // this implementation of strnlen is required since mingw doesn't have strnlen
 size_t tbp_my_own_strnlen(const char* s, size_t maxlen)
 {
-	if (s == NULL || maxlen == 0)
+	if (s == nullptr || maxlen == 0)
 		return 0;
 
 	size_t i = 0;
@@ -24,7 +24,7 @@ size_t tbp_my_own_strnlen(const char* s, size_t maxlen)
 
 
 TextBasedProtocolMessage::TextBasedProtocolMessage(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet) : Layer(data, dataLen, prevLayer, packet),
-						m_FieldList(NULL), m_LastField(NULL), m_FieldsOffset(0) {}
+						m_FieldList(nullptr), m_LastField(nullptr), m_FieldsOffset(0) {}
 
 TextBasedProtocolMessage::TextBasedProtocolMessage(const TextBasedProtocolMessage& other) : Layer(other)
 {
@@ -35,7 +35,7 @@ TextBasedProtocolMessage& TextBasedProtocolMessage::operator=(const TextBasedPro
 {
 	Layer::operator=(other);
 	HeaderField* curField = m_FieldList;
-	while (curField != NULL)
+	while (curField != nullptr)
 	{
 		HeaderField* temp = curField;
 		curField = curField->getNextField();
@@ -50,13 +50,13 @@ TextBasedProtocolMessage& TextBasedProtocolMessage::operator=(const TextBasedPro
 void TextBasedProtocolMessage::copyDataFrom(const TextBasedProtocolMessage& other)
 {
 	// copy field list
-	if (other.m_FieldList != NULL)
+	if (other.m_FieldList != nullptr)
 	{
 		m_FieldList = new HeaderField(*(other.m_FieldList));
 		HeaderField* curField = m_FieldList;
 		curField->attachToTextBasedProtocolMessage(this, other.m_FieldList->m_NameOffsetInMessage);
 		HeaderField* curOtherField = other.m_FieldList;
-		while (curOtherField->getNextField() != NULL)
+		while (curOtherField->getNextField() != nullptr)
 		{
 			HeaderField* newField = new HeaderField(*(curOtherField->getNextField()));
 			newField->attachToTextBasedProtocolMessage(this, curOtherField->getNextField()->m_NameOffsetInMessage);
@@ -69,14 +69,14 @@ void TextBasedProtocolMessage::copyDataFrom(const TextBasedProtocolMessage& othe
 	}
 	else
 	{
-		m_FieldList = NULL;
-		m_LastField = NULL;
+		m_FieldList = nullptr;
+		m_LastField = nullptr;
 	}
 
 	m_FieldsOffset = other.m_FieldsOffset;
 
 	// copy map
-	for(HeaderField* field = m_FieldList; field != NULL; field = field->getNextField())
+	for(HeaderField* field = m_FieldList; field != nullptr; field = field->getNextField())
 	{
 		m_FieldNameToFieldMap.insert(std::pair<std::string, HeaderField*>(field->getFieldName(), field));
 	}
@@ -92,7 +92,7 @@ void TextBasedProtocolMessage::parseFields()
 	PCPP_LOG_DEBUG("Added new field: name='" << firstField->getFieldName() << "'; offset in packet=" << firstField->m_NameOffsetInMessage << "; length=" << firstField->getFieldSize());
 	PCPP_LOG_DEBUG("     Field value = " << firstField->getFieldValue());
 
-	if (m_FieldList == NULL)
+	if (m_FieldList == nullptr)
 		m_FieldList = firstField;
 	else
 		m_FieldList->setNextField(firstField);
@@ -134,7 +134,7 @@ void TextBasedProtocolMessage::parseFields()
 
 TextBasedProtocolMessage::~TextBasedProtocolMessage()
 {
-	while (m_FieldList != NULL)
+	while (m_FieldList != nullptr)
 	{
 		HeaderField* temp = m_FieldList;
 		m_FieldList = m_FieldList->getNextField();
@@ -171,13 +171,13 @@ HeaderField* TextBasedProtocolMessage::insertField(std::string prevFieldName, co
 {
 	if (prevFieldName == "")
 	{
-		return insertField(NULL, fieldName, fieldValue);
+		return insertField(nullptr, fieldName, fieldValue);
 	}
 	else
 	{
 		HeaderField* prevField = getFieldByName(prevFieldName);
-		if (prevField == NULL)
-			return NULL;
+		if (prevField == nullptr)
+			return nullptr;
 
 		return insertField(prevField, fieldName, fieldValue);
 	}
@@ -186,22 +186,22 @@ HeaderField* TextBasedProtocolMessage::insertField(std::string prevFieldName, co
 
 HeaderField* TextBasedProtocolMessage::insertField(HeaderField* prevField, const HeaderField& newField)
 {
-	if (newField.m_TextBasedProtocolMessage != NULL)
+	if (newField.m_TextBasedProtocolMessage != nullptr)
 	{
 		PCPP_LOG_ERROR("This field is already associated with another message");
-		return NULL;
+		return nullptr;
 	}
 
-	if (prevField != NULL && prevField->getFieldName() == PCPP_END_OF_TEXT_BASED_PROTOCOL_HEADER)
+	if (prevField != nullptr && prevField->getFieldName() == PCPP_END_OF_TEXT_BASED_PROTOCOL_HEADER)
 	{
 		PCPP_LOG_ERROR("Cannot add a field after end of header");
-		return NULL;
+		return nullptr;
 	}
 
 	HeaderField* newFieldToAdd = new HeaderField(newField);
 
 	int newFieldOffset = m_FieldsOffset;
-	if (prevField != NULL)
+	if (prevField != nullptr)
 		newFieldOffset = prevField->m_NameOffsetInMessage + prevField->getFieldSize();
 
 	// extend layer to make room for the new field. Field will be added just before the last field
@@ -209,11 +209,11 @@ HeaderField* TextBasedProtocolMessage::insertField(HeaderField* prevField, const
 	{
 		PCPP_LOG_ERROR("Cannot extend layer to insert the header");
 		delete newFieldToAdd;
-		return NULL;
+		return nullptr;
 	}
 
 	HeaderField* curField = m_FieldList;
-	if (prevField != NULL)
+	if (prevField != nullptr)
 		curField = prevField->getNextField();
 
 	// go over all fields after prevField and update their offsets
@@ -226,7 +226,7 @@ HeaderField* TextBasedProtocolMessage::insertField(HeaderField* prevField, const
 	newFieldToAdd->attachToTextBasedProtocolMessage(this, newFieldOffset);
 
 	// insert field into fields link list
-	if (prevField == NULL)
+	if (prevField == nullptr)
 	{
 		newFieldToAdd->setNextField(m_FieldList);
 		m_FieldList = newFieldToAdd;
@@ -238,7 +238,7 @@ HeaderField* TextBasedProtocolMessage::insertField(HeaderField* prevField, const
 	}
 
 	// if newField is the last field, update m_LastField
-	if (newFieldToAdd->getNextField() == NULL)
+	if (newFieldToAdd->getNextField() == nullptr)
 		m_LastField = newFieldToAdd;
 
 	// insert the new field into name to field map
@@ -253,7 +253,7 @@ bool TextBasedProtocolMessage::removeField(std::string fieldName, int index)
 {
 	std::transform(fieldName.begin(), fieldName.end(), fieldName.begin(), ::tolower);
 
-	HeaderField* fieldToRemove = NULL;
+	HeaderField* fieldToRemove = nullptr;
 
 	std::pair <std::multimap<std::string,HeaderField*>::iterator, std::multimap<std::string,HeaderField*>::iterator> range;
 	range = m_FieldNameToFieldMap.equal_range(fieldName);
@@ -269,7 +269,7 @@ bool TextBasedProtocolMessage::removeField(std::string fieldName, int index)
 		i++;
 	}
 
-	if (fieldToRemove != NULL)
+	if (fieldToRemove != nullptr)
 		return removeField(fieldToRemove);
 	else
 	{
@@ -280,7 +280,7 @@ bool TextBasedProtocolMessage::removeField(std::string fieldName, int index)
 
 bool TextBasedProtocolMessage::removeField(HeaderField* fieldToRemove)
 {
-	if (fieldToRemove == NULL)
+	if (fieldToRemove == nullptr)
 		return true;
 
 	if (fieldToRemove->m_TextBasedProtocolMessage != this)
@@ -325,12 +325,12 @@ bool TextBasedProtocolMessage::removeField(HeaderField* fieldToRemove)
 	// re-calculate m_LastField if needed
 	if (fieldToRemove == m_LastField)
 	{
-		if (m_FieldList == NULL)
-			m_LastField = NULL;
+		if (m_FieldList == nullptr)
+			m_LastField = nullptr;
 		else
 		{
 			curField = m_FieldList;
-			while (curField->getNextField() != NULL)
+			while (curField->getNextField() != nullptr)
 				curField = curField->getNextField();
 			m_LastField = curField;
 		}
@@ -357,7 +357,7 @@ bool TextBasedProtocolMessage::removeField(HeaderField* fieldToRemove)
 
 bool TextBasedProtocolMessage::isHeaderComplete() const
 {
-	if (m_LastField == NULL)
+	if (m_LastField == nullptr)
 		return false;
 
 	return (m_LastField->getFieldName() == PCPP_END_OF_TEXT_BASED_PROTOCOL_HEADER);
@@ -365,7 +365,7 @@ bool TextBasedProtocolMessage::isHeaderComplete() const
 
 void TextBasedProtocolMessage::shiftFieldsOffset(HeaderField* fromField, int numOfBytesToShift)
 {
-	while (fromField != NULL)
+	while (fromField != nullptr)
 	{
 		fromField->m_NameOffsetInMessage += numOfBytesToShift;
 		if (fromField->m_ValueOffsetInMessage != -1)
@@ -389,7 +389,7 @@ HeaderField* TextBasedProtocolMessage::getFieldByName(std::string fieldName, int
 		i++;
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 int TextBasedProtocolMessage::getFieldCount() const
@@ -397,7 +397,7 @@ int TextBasedProtocolMessage::getFieldCount() const
 	int result = 0;
 
 	HeaderField* curField = getFirstField();
-	while (curField != NULL)
+	while (curField != nullptr)
 	{
 		if (!curField->isEndOfHeader())
 			result++;
@@ -434,12 +434,12 @@ void TextBasedProtocolMessage::computeCalculateFields()
 
 
 HeaderField::HeaderField(TextBasedProtocolMessage* TextBasedProtocolMessage, int offsetInMessage, char nameValueSeparator, bool spacesAllowedBetweenNameAndValue) :
-		m_NewFieldData(NULL), m_TextBasedProtocolMessage(TextBasedProtocolMessage), m_NameOffsetInMessage(offsetInMessage), m_NextField(NULL),
+		m_NewFieldData(nullptr), m_TextBasedProtocolMessage(TextBasedProtocolMessage), m_NameOffsetInMessage(offsetInMessage), m_NextField(nullptr),
 		m_NameValueSeparator(nameValueSeparator), m_SpacesAllowedBetweenNameAndValue(spacesAllowedBetweenNameAndValue)
 {
 	char* fieldData = (char*)(m_TextBasedProtocolMessage->m_Data + m_NameOffsetInMessage);
 	char* fieldEndPtr = (char*)memchr(fieldData, '\n', m_TextBasedProtocolMessage->m_DataLen - (size_t)m_NameOffsetInMessage);
-	if (fieldEndPtr == NULL)
+	if (fieldEndPtr == nullptr)
 		m_FieldSize = tbp_my_own_strnlen(fieldData, m_TextBasedProtocolMessage->m_DataLen - (size_t)m_NameOffsetInMessage);
 	else
 		m_FieldSize = fieldEndPtr - fieldData + 1;
@@ -458,7 +458,7 @@ HeaderField::HeaderField(TextBasedProtocolMessage* TextBasedProtocolMessage, int
 
 	char* fieldValuePtr = (char*)memchr(fieldData, nameValueSeparator, m_TextBasedProtocolMessage->m_DataLen - (size_t)m_NameOffsetInMessage);
 	// could not find the position of the separator, meaning field value position is unknown
-	if (fieldValuePtr == NULL || (fieldEndPtr != NULL && fieldValuePtr >= fieldEndPtr))
+	if (fieldValuePtr == nullptr || (fieldEndPtr != nullptr && fieldValuePtr >= fieldEndPtr))
 	{
 		m_ValueOffsetInMessage = -1;
 		m_FieldValueSize = -1;
@@ -498,7 +498,7 @@ HeaderField::HeaderField(TextBasedProtocolMessage* TextBasedProtocolMessage, int
 		{
 			m_ValueOffsetInMessage = fieldValuePtr - (char*)m_TextBasedProtocolMessage->m_Data;
 			// couldn't find the end of the field, so assuming the field value length is from m_ValueOffsetInMessage until the end of the packet
-			if (fieldEndPtr == NULL)
+			if (fieldEndPtr == nullptr)
 				m_FieldValueSize = (char*)(m_TextBasedProtocolMessage->m_Data + m_TextBasedProtocolMessage->getDataLen()) - fieldValuePtr;
 			else
 			{
@@ -520,9 +520,9 @@ HeaderField::HeaderField(std::string name, std::string value, char nameValueSepa
 
 void HeaderField::initNewField(std::string name, std::string value)
 {
-	m_TextBasedProtocolMessage = NULL;
+	m_TextBasedProtocolMessage = nullptr;
 	m_NameOffsetInMessage = 0;
-	m_NextField = NULL;
+	m_NextField = nullptr;
 
 	// first building the name-value separator
 	std::string nameValueSeparation(1, m_NameValueSeparator);
@@ -563,7 +563,7 @@ void HeaderField::initNewField(std::string name, std::string value)
 
 HeaderField::~HeaderField()
 {
-	if (m_NewFieldData != NULL)
+	if (m_NewFieldData != nullptr)
 		delete [] m_NewFieldData;
 }
 
@@ -578,7 +578,7 @@ HeaderField& HeaderField::operator=(const HeaderField& other)
 {
 	m_NameValueSeparator = other.m_NameValueSeparator;
 	m_SpacesAllowedBetweenNameAndValue = other.m_SpacesAllowedBetweenNameAndValue;
-	if (m_NewFieldData != NULL)
+	if (m_NewFieldData != nullptr)
 		delete [] m_NewFieldData;
 	initNewField(other.getFieldName(), other.getFieldValue());
 
@@ -587,7 +587,7 @@ HeaderField& HeaderField::operator=(const HeaderField& other)
 
 char* HeaderField::getData() const
 {
-	if (m_TextBasedProtocolMessage == NULL)
+	if (m_TextBasedProtocolMessage == nullptr)
 		return (char*)m_NewFieldData;
 	else
 		return (char*)(m_TextBasedProtocolMessage->m_Data);
@@ -624,7 +624,7 @@ std::string HeaderField::getFieldValue() const
 bool HeaderField::setFieldValue(std::string newValue)
 {
 	// Field isn't linked with any message yet
-	if (m_TextBasedProtocolMessage == NULL)
+	if (m_TextBasedProtocolMessage == nullptr)
 	{
 		std::string name = getFieldName();
 		delete [] m_NewFieldData;
@@ -668,20 +668,20 @@ bool HeaderField::setFieldValue(std::string newValue)
 
 void HeaderField::attachToTextBasedProtocolMessage(TextBasedProtocolMessage* message, int fieldOffsetInMessage)
 {
-	if (m_TextBasedProtocolMessage != NULL && m_TextBasedProtocolMessage != message)
+	if (m_TextBasedProtocolMessage != nullptr && m_TextBasedProtocolMessage != message)
 	{
 		PCPP_LOG_ERROR("Header field already associated with another message");
 		return;
 	}
 
-	if (m_NewFieldData == NULL)
+	if (m_NewFieldData == nullptr)
 	{
 		PCPP_LOG_ERROR("Header field doesn't have new field data");
 		return;
 	}
 
 	delete [] m_NewFieldData;
-	m_NewFieldData = NULL;
+	m_NewFieldData = nullptr;
 	m_TextBasedProtocolMessage = message;
 
 	int valueAndNameDifference = m_ValueOffsetInMessage - m_NameOffsetInMessage;

--- a/Packet++/src/UdpLayer.cpp
+++ b/Packet++/src/UdpLayer.cpp
@@ -51,7 +51,7 @@ uint16_t UdpLayer::calculateChecksum(bool writeResultToPacket)
 	uint16_t checksumRes = 0;
 	uint16_t currChecksumValue = udpHdr->headerChecksum;
 
-	if (m_PrevLayer != NULL)
+	if (m_PrevLayer != nullptr)
 	{
 		udpHdr->headerChecksum = 0;
 		ScalarBuffer<uint16_t> vec[2];

--- a/Packet++/src/VlanLayer.cpp
+++ b/Packet++/src/VlanLayer.cpp
@@ -110,7 +110,7 @@ void VlanLayer::parseNextLayer()
 
 void VlanLayer::computeCalculateFields()
 {
-	if (m_NextLayer == NULL)
+	if (m_NextLayer == nullptr)
 		return;
 
 	switch (m_NextLayer->getProtocol())

--- a/Pcap++/src/NetworkUtils.cpp
+++ b/Pcap++/src/NetworkUtils.cpp
@@ -58,7 +58,7 @@ static void arpPacketReceived(RawPacket* rawPacket, PcapLiveDevice* device, void
 
 	// extract the ARP layer from the packet
 	ArpLayer* arpReplyLayer = packet.getLayerOfType<ArpLayer>(true); // lookup in reverse order
-	if (arpReplyLayer == NULL)
+	if (arpReplyLayer == nullptr)
 		return;
 
 	// verify it's the right ARP response
@@ -159,7 +159,7 @@ MacAddress NetworkUtils::getMacAddress(IPv4Address ipAddr, PcapLiveDevice* devic
 	};
 
 	struct timeval now;
-	gettimeofday(&now,NULL);
+	gettimeofday(&now,nullptr);
 
 	// start capturing. The capture is done on another thread, hence "arpPacketReceived" is running on that thread
 	device->startCapture(arpPacketReceived, &data);
@@ -224,7 +224,7 @@ static void dnsResponseReceived(RawPacket* rawPacket, PcapLiveDevice* device, vo
 
 	// extract the DNS layer from the packet
 	DnsLayer* dnsResponseLayer = packet.getLayerOfType<DnsLayer>(true); // lookup in reverse order
-	if (dnsResponseLayer == NULL)
+	if (dnsResponseLayer == nullptr)
 		return;
 
 	// verify it's the right DNS response
@@ -244,14 +244,14 @@ static void dnsResponseReceived(RawPacket* rawPacket, PcapLiveDevice* device, vo
 
 	std::string hostToFind = data->hostname;
 
-	DnsResource* dnsAnswer = NULL;
+	DnsResource* dnsAnswer = nullptr;
 
 	while (true)
 	{
 		dnsAnswer = dnsResponseLayer->getAnswer(hostToFind, true);
 
 		// if response doesn't contain hostname or cname - return
-		if (dnsAnswer == NULL)
+		if (dnsAnswer == nullptr)
 		{
 			PCPP_LOG_DEBUG("DNS answer doesn't contain hostname '" << hostToFind << "'");
 			return;
@@ -409,7 +409,7 @@ IPv4Address NetworkUtils::getIPv4Address(std::string hostname, PcapLiveDevice* d
 
 
 	struct timeval now;
-	gettimeofday(&now,NULL);
+	gettimeofday(&now,nullptr);
 
 	// start capturing. The capture is done on another thread, hence "dnsResponseReceived" is running on that thread
 	device->startCapture(dnsResponseReceived, &data);

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -57,11 +57,11 @@ std::string IFileDevice::getFileName() const
 
 void IFileDevice::close()
 {
-	if (m_PcapDescriptor != NULL)
+	if (m_PcapDescriptor != nullptr)
 	{
 		pcap_close(m_PcapDescriptor);
 		PCPP_LOG_DEBUG("Successfully closed file reader device for filename '" << m_FileName << "'");
-		m_PcapDescriptor = NULL;
+		m_PcapDescriptor = nullptr;
 	}
 
 	m_DeviceOpened = false;
@@ -244,7 +244,7 @@ bool PcapFileReaderDevice::open()
 	m_NumOfPacketsRead = 0;
 	m_NumOfPacketsNotParsed = 0;
 
-	if (m_PcapDescriptor != NULL)
+	if (m_PcapDescriptor != nullptr)
 	{
 		PCPP_LOG_DEBUG("Pcap descriptor already opened. Nothing to do");
 		return true;
@@ -256,7 +256,7 @@ bool PcapFileReaderDevice::open()
 #else
 	m_PcapDescriptor = pcap_open_offline(m_FileName.c_str(), errbuf);
 #endif
-	if (m_PcapDescriptor == NULL)
+	if (m_PcapDescriptor == nullptr)
 	{
 		PCPP_LOG_ERROR("Cannot open file reader device for filename '" << m_FileName << "': " << errbuf);
 		m_DeviceOpened = false;
@@ -268,7 +268,7 @@ bool PcapFileReaderDevice::open()
 	{
 		PCPP_LOG_ERROR("Invalid link layer (" << linkLayer << ") for reader device filename '" << m_FileName << "'");
 		pcap_close(m_PcapDescriptor);
-		m_PcapDescriptor = NULL;
+		m_PcapDescriptor = nullptr;
 		m_DeviceOpened = false;
 		return false;
 	}
@@ -291,14 +291,14 @@ void PcapFileReaderDevice::getStatistics(PcapStats& stats) const
 bool PcapFileReaderDevice::getNextPacket(RawPacket& rawPacket)
 {
 	rawPacket.clear();
-	if (m_PcapDescriptor == NULL)
+	if (m_PcapDescriptor == nullptr)
 	{
 		PCPP_LOG_ERROR("File device '" << m_FileName << "' not opened");
 		return false;
 	}
 	pcap_pkthdr pkthdr;
 	const uint8_t* pPacketData = pcap_next(m_PcapDescriptor, &pkthdr);
-	if (pPacketData == NULL)
+	if (pPacketData == nullptr)
 	{
 		PCPP_LOG_DEBUG("Packet could not be read. Probably end-of-file");
 		return false;
@@ -327,7 +327,7 @@ bool PcapFileReaderDevice::getNextPacket(RawPacket& rawPacket)
 
 PcapNgFileReaderDevice::PcapNgFileReaderDevice(const std::string& fileName) : IFileReaderDevice(fileName)
 {
-	m_LightPcapNg = NULL;
+	m_LightPcapNg = nullptr;
 }
 
 bool PcapNgFileReaderDevice::open()
@@ -335,14 +335,14 @@ bool PcapNgFileReaderDevice::open()
 	m_NumOfPacketsRead = 0;
 	m_NumOfPacketsNotParsed = 0;
 
-	if (m_LightPcapNg != NULL)
+	if (m_LightPcapNg != nullptr)
 	{
 		PCPP_LOG_DEBUG("pcapng descriptor already opened. Nothing to do");
 		return true;
 	}
 
 	m_LightPcapNg = light_pcapng_open_read(m_FileName.c_str(), LIGHT_FALSE);
-	if (m_LightPcapNg == NULL)
+	if (m_LightPcapNg == nullptr)
 	{
 		PCPP_LOG_ERROR("Cannot open pcapng reader device for filename '" << m_FileName << "'");
 		m_DeviceOpened = false;
@@ -359,14 +359,14 @@ bool PcapNgFileReaderDevice::getNextPacket(RawPacket& rawPacket, std::string& pa
 	rawPacket.clear();
 	packetComment = "";
 
-	if (m_LightPcapNg == NULL)
+	if (m_LightPcapNg == nullptr)
 	{
 		PCPP_LOG_ERROR("Pcapng file device '" << m_FileName << "' not opened");
 		return false;
 	}
 
 	light_packet_header pktHeader;
-	const uint8_t* pktData = NULL;
+	const uint8_t* pktData = nullptr;
 
 	if (!light_get_next_packet((light_pcapng_t*)m_LightPcapNg, &pktHeader, &pktData))
 	{
@@ -391,7 +391,7 @@ bool PcapNgFileReaderDevice::getNextPacket(RawPacket& rawPacket, std::string& pa
 		return false;
 	}
 
-	if (pktHeader.comment != NULL && pktHeader.comment_length > 0)
+	if (pktHeader.comment != nullptr && pktHeader.comment_length > 0)
 		packetComment = std::string(pktHeader.comment, pktHeader.comment_length);
 
 	m_NumOfPacketsRead++;
@@ -419,11 +419,11 @@ bool PcapNgFileReaderDevice::setFilter(std::string filterAsString)
 
 void PcapNgFileReaderDevice::close()
 {
-	if (m_LightPcapNg == NULL)
+	if (m_LightPcapNg == nullptr)
 		return;
 
 	light_pcapng_close((light_pcapng_t*)m_LightPcapNg);
-	m_LightPcapNg = NULL;
+	m_LightPcapNg = nullptr;
 
 	m_DeviceOpened = false;
 	PCPP_LOG_DEBUG("File reader closed for file '" << m_FileName << "'");
@@ -432,7 +432,7 @@ void PcapNgFileReaderDevice::close()
 
 std::string PcapNgFileReaderDevice::getOS() const
 {
-	if (m_LightPcapNg == NULL)
+	if (m_LightPcapNg == nullptr)
 	{
 		PCPP_LOG_ERROR("Pcapng file device '" << m_FileName << "' not opened");
 		return "";
@@ -441,7 +441,7 @@ std::string PcapNgFileReaderDevice::getOS() const
 	light_pcapng_file_info* fileInfo = light_pcang_get_file_info((light_pcapng_t*)m_LightPcapNg);
 	char* res = fileInfo->os_desc;
 	size_t len = fileInfo->os_desc_size;
-	if (len == 0 || res == NULL)
+	if (len == 0 || res == nullptr)
 		return "";
 
 	return std::string(res, len);
@@ -449,7 +449,7 @@ std::string PcapNgFileReaderDevice::getOS() const
 
 std::string PcapNgFileReaderDevice::getHardware() const
 {
-	if (m_LightPcapNg == NULL)
+	if (m_LightPcapNg == nullptr)
 	{
 		PCPP_LOG_ERROR("Pcapng file device '" << m_FileName << "' not opened");
 		return "";
@@ -458,7 +458,7 @@ std::string PcapNgFileReaderDevice::getHardware() const
 	light_pcapng_file_info* fileInfo = light_pcang_get_file_info((light_pcapng_t*)m_LightPcapNg);
 	char* res = fileInfo->hardware_desc;
 	size_t len = fileInfo->hardware_desc_size;
-	if (len == 0 || res == NULL)
+	if (len == 0 || res == nullptr)
 		return "";
 
 	return std::string(res, len);
@@ -466,7 +466,7 @@ std::string PcapNgFileReaderDevice::getHardware() const
 
 std::string PcapNgFileReaderDevice::getCaptureApplication() const
 {
-	if (m_LightPcapNg == NULL)
+	if (m_LightPcapNg == nullptr)
 	{
 		PCPP_LOG_ERROR("Pcapng file device '" << m_FileName << "' not opened");
 		return "";
@@ -475,7 +475,7 @@ std::string PcapNgFileReaderDevice::getCaptureApplication() const
 	light_pcapng_file_info* fileInfo = light_pcang_get_file_info((light_pcapng_t*)m_LightPcapNg);
 	char* res = fileInfo->user_app_desc;
 	size_t len = fileInfo->user_app_desc_size;
-	if (len == 0 || res == NULL)
+	if (len == 0 || res == nullptr)
 		return "";
 
 	return std::string(res, len);
@@ -483,7 +483,7 @@ std::string PcapNgFileReaderDevice::getCaptureApplication() const
 
 std::string PcapNgFileReaderDevice::getCaptureFileComment() const
 {
-	if (m_LightPcapNg == NULL)
+	if (m_LightPcapNg == nullptr)
 	{
 		PCPP_LOG_ERROR("Pcapng file device '" << m_FileName << "' not opened");
 		return "";
@@ -492,7 +492,7 @@ std::string PcapNgFileReaderDevice::getCaptureFileComment() const
 	light_pcapng_file_info* fileInfo = light_pcang_get_file_info((light_pcapng_t*)m_LightPcapNg);
 	char* res = fileInfo->file_comment;
 	size_t len = fileInfo->file_comment_size;
-	if (len == 0 || res == NULL)
+	if (len == 0 || res == nullptr)
 		return "";
 
 	return std::string(res, len);
@@ -516,26 +516,26 @@ IFileWriterDevice:: IFileWriterDevice(const std::string& fileName) : IFileDevice
 
 PcapFileWriterDevice::PcapFileWriterDevice(const std::string& fileName, LinkLayerType linkLayerType) : IFileWriterDevice(fileName)
 {
-	m_PcapDumpHandler = NULL;
+	m_PcapDumpHandler = nullptr;
 	m_NumOfPacketsNotWritten = 0;
 	m_NumOfPacketsWritten = 0;
 	m_PcapLinkLayerType = linkLayerType;
 	m_AppendMode = false;
-	m_File = NULL;
+	m_File = nullptr;
 }
 
 void PcapFileWriterDevice::closeFile()
 {
-	if (m_AppendMode && m_File != NULL)
+	if (m_AppendMode && m_File != nullptr)
 	{
 		fclose(m_File);
-		m_File = NULL;
+		m_File = nullptr;
 	}
 }
 
 bool PcapFileWriterDevice::writePacket(RawPacket const& packet)
 {
-	if ((!m_AppendMode && m_PcapDescriptor == NULL) || (m_PcapDumpHandler == NULL))
+	if ((!m_AppendMode && m_PcapDescriptor == nullptr) || (m_PcapDumpHandler == nullptr))
 	{
 		PCPP_LOG_ERROR("Device not opened");
 		m_NumOfPacketsNotWritten++;
@@ -592,7 +592,7 @@ bool PcapFileWriterDevice::writePackets(const RawPacketVector& packets)
 
 bool PcapFileWriterDevice::open()
 {
-	if (m_PcapDescriptor != NULL)
+	if (m_PcapDescriptor != nullptr)
 	{
 		PCPP_LOG_DEBUG("Pcap descriptor already opened. Nothing to do");
 		return true;
@@ -612,7 +612,7 @@ bool PcapFileWriterDevice::open()
 	m_NumOfPacketsWritten = 0;
 
 	m_PcapDescriptor = pcap_open_dead(m_PcapLinkLayerType, PCPP_MAX_PACKET_SIZE);
-	if (m_PcapDescriptor == NULL)
+	if (m_PcapDescriptor == nullptr)
 	{
 		PCPP_LOG_ERROR("Error opening file writer device for file '" << m_FileName << "': pcap_open_dead returned NULL");
 		m_DeviceOpened = false;
@@ -621,7 +621,7 @@ bool PcapFileWriterDevice::open()
 
 
 	m_PcapDumpHandler = pcap_dump_open(m_PcapDescriptor, m_FileName.c_str());
-	if (m_PcapDumpHandler == NULL)
+	if (m_PcapDumpHandler == nullptr)
 	{
 		PCPP_LOG_ERROR("Error opening file writer device for file '" << m_FileName << "': pcap_dump_open returned NULL with error: '" << pcap_geterr(m_PcapDescriptor) << "'");
 		m_DeviceOpened = false;
@@ -659,18 +659,18 @@ void PcapFileWriterDevice::close()
 
 	IFileDevice::close();
 
-	if (!m_AppendMode && m_PcapDumpHandler != NULL)
+	if (!m_AppendMode && m_PcapDumpHandler != nullptr)
 	{
 		pcap_dump_close(m_PcapDumpHandler);
 	}
-	else if (m_AppendMode && m_File != NULL)
+	else if (m_AppendMode && m_File != nullptr)
 	{
 		// in append mode it's impossible to use pcap_dump_close, see comment above pcap_dump
 		fclose(m_File);
 	}
 
-	m_PcapDumpHandler = NULL;
-	m_File = NULL;
+	m_PcapDumpHandler = nullptr;
+	m_File = nullptr;
 	PCPP_LOG_DEBUG("File writer closed for file '" << m_FileName << "'");
 }
 
@@ -695,7 +695,7 @@ bool PcapFileWriterDevice::open(bool appendMode)
 	m_File = fopen(m_FileName.c_str(), "rb+");
 #endif
 
-	if (m_File == NULL)
+	if (m_File == nullptr)
 	{
 		PCPP_LOG_ERROR("Cannot open '" << m_FileName << "' for reading and writing");
 		return false;
@@ -743,13 +743,13 @@ bool PcapFileWriterDevice::open(bool appendMode)
 
 PcapNgFileWriterDevice::PcapNgFileWriterDevice(const std::string& fileName, int compressionLevel) : IFileWriterDevice(fileName)
 {
-	m_LightPcapNg = NULL;
+	m_LightPcapNg = nullptr;
 	m_CompressionLevel = compressionLevel;
 }
 
 bool PcapNgFileWriterDevice::open(const std::string& os, const std::string& hardware, const std::string& captureApp, const std::string& fileComment)
 {
-	if (m_LightPcapNg != NULL)
+	if (m_LightPcapNg != nullptr)
 	{
 		PCPP_LOG_DEBUG("Pcap-ng descriptor already opened. Nothing to do");
 		return true;
@@ -761,7 +761,7 @@ bool PcapNgFileWriterDevice::open(const std::string& os, const std::string& hard
 	light_pcapng_file_info* info = light_create_file_info(os.c_str(), hardware.c_str(), captureApp.c_str(), fileComment.c_str());
 
 	m_LightPcapNg = light_pcapng_open_write(m_FileName.c_str(), info, m_CompressionLevel);
-	if (m_LightPcapNg == NULL)
+	if (m_LightPcapNg == nullptr)
 	{
 		PCPP_LOG_ERROR("Error opening file writer device for file '" << m_FileName << "': light_pcapng_open_write returned NULL");
 
@@ -778,7 +778,7 @@ bool PcapNgFileWriterDevice::open(const std::string& os, const std::string& hard
 
 bool PcapNgFileWriterDevice::writePacket(RawPacket const& packet, const std::string& comment)
 {
-	if (m_LightPcapNg == NULL)
+	if (m_LightPcapNg == nullptr)
 	{
 		PCPP_LOG_ERROR("Device not opened");
 		m_NumOfPacketsNotWritten++;
@@ -803,7 +803,7 @@ bool PcapNgFileWriterDevice::writePacket(RawPacket const& packet, const std::str
 	}
 	else
 	{
-		pktHeader.comment = NULL;
+		pktHeader.comment = nullptr;
 		pktHeader.comment_length = 0;
 	}
 
@@ -832,7 +832,7 @@ bool PcapNgFileWriterDevice::writePackets(const RawPacketVector& packets)
 
 bool PcapNgFileWriterDevice::open()
 {
-	if (m_LightPcapNg != NULL)
+	if (m_LightPcapNg != nullptr)
 	{
 		PCPP_LOG_DEBUG("Pcap-ng descriptor already opened. Nothing to do");
 		return true;
@@ -844,7 +844,7 @@ bool PcapNgFileWriterDevice::open()
 	light_pcapng_file_info* info = light_create_default_file_info();
 
 	m_LightPcapNg = light_pcapng_open_write(m_FileName.c_str(), info, m_CompressionLevel);
-	if (m_LightPcapNg == NULL)
+	if (m_LightPcapNg == nullptr)
 	{
 		PCPP_LOG_ERROR("Error opening file writer device for file '" << m_FileName << "': light_pcapng_open_write returned NULL");
 
@@ -868,7 +868,7 @@ bool PcapNgFileWriterDevice::open(bool appendMode)
 	m_NumOfPacketsWritten = 0;
 
 	m_LightPcapNg = light_pcapng_open_append(m_FileName.c_str());
-	if (m_LightPcapNg == NULL)
+	if (m_LightPcapNg == nullptr)
 	{
 		PCPP_LOG_ERROR("Error opening file writer device in append mode for file '" << m_FileName << "': light_pcapng_open_append returned NULL");
 		m_DeviceOpened = false;
@@ -883,7 +883,7 @@ bool PcapNgFileWriterDevice::open(bool appendMode)
 
 void PcapNgFileWriterDevice::flush()
 {
-	if (!m_DeviceOpened || m_LightPcapNg == NULL)
+	if (!m_DeviceOpened || m_LightPcapNg == nullptr)
 		return;
 
 	light_pcapng_flush((light_pcapng_t*)m_LightPcapNg);
@@ -892,11 +892,11 @@ void PcapNgFileWriterDevice::flush()
 
 void PcapNgFileWriterDevice::close()
 {
-	if (m_LightPcapNg == NULL)
+	if (m_LightPcapNg == nullptr)
 		return;
 
 	light_pcapng_close((light_pcapng_t*)m_LightPcapNg);
-	m_LightPcapNg = NULL;
+	m_LightPcapNg = nullptr;
 
 	m_DeviceOpened = false;
 	PCPP_LOG_DEBUG("File writer closed for file '" << m_FileName << "'");

--- a/Pcap++/src/PcapFilter.cpp
+++ b/Pcap++/src/PcapFilter.cpp
@@ -29,7 +29,7 @@ bool GeneralFilter::matchPacketWithFilter(RawPacket* rawPacket)
 
 BpfFilterWrapper::BpfFilterWrapper()
 {
-	m_Program = NULL;
+	m_Program = nullptr;
 	m_LinkType = LINKTYPE_ETHERNET;
 }
 
@@ -68,11 +68,11 @@ bool BpfFilterWrapper::setFilter(const std::string& filter, LinkLayerType linkTy
 
 void BpfFilterWrapper::freeProgram()
 {
-	if (m_Program != NULL)
+	if (m_Program != nullptr)
 	{
 		pcap_freecode(m_Program);
 		delete m_Program;
-		m_Program = NULL;
+		m_Program = nullptr;
 		m_FilterStr.clear();
 	}
 }

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -72,15 +72,15 @@ PcapLiveDevice::PcapLiveDevice(pcap_if_t* pInterface, bool calculateMTU, bool ca
 	m_IsLoopback = (pInterface->flags & 0x1) == PCAP_IF_LOOPBACK;
 
 	m_Name = pInterface->name;
-	if (pInterface->description != NULL)
+	if (pInterface->description != nullptr)
 		m_Description = pInterface->description;
 	PCPP_LOG_DEBUG("Added live device: name=" << m_Name << "; desc=" << m_Description);
 	PCPP_LOG_DEBUG("   Addresses:");
-	while (pInterface->addresses != NULL)
+	while (pInterface->addresses != nullptr)
 	{
 		m_Addresses.insert(m_Addresses.end(), *(pInterface->addresses));
 		pInterface->addresses = pInterface->addresses->next;
-		if (Logger::getInstance().isDebugEnabled(PcapLogModuleLiveDevice) && pInterface->addresses != NULL && pInterface->addresses->addr != NULL)
+		if (Logger::getInstance().isDebugEnabled(PcapLogModuleLiveDevice) && pInterface->addresses != nullptr && pInterface->addresses->addr != nullptr)
 		{
 			char addrAsString[INET6_ADDRSTRLEN];
 			internal::sockaddr2string(pInterface->addresses->addr, addrAsString);
@@ -107,15 +107,15 @@ PcapLiveDevice::PcapLiveDevice(pcap_if_t* pInterface, bool calculateMTU, bool ca
 	m_StopThread = false;
 	m_CaptureThread = {};
 	m_StatsThread = {};
-	m_cbOnPacketArrives = NULL;
-	m_cbOnStatsUpdate = NULL;
-	m_cbOnPacketArrivesBlockingMode = NULL;
-	m_cbOnPacketArrivesBlockingModeUserCookie = NULL;
+	m_cbOnPacketArrives = nullptr;
+	m_cbOnStatsUpdate = nullptr;
+	m_cbOnPacketArrivesBlockingMode = nullptr;
+	m_cbOnPacketArrivesBlockingModeUserCookie = nullptr;
 	m_IntervalToUpdateStats = 0;
-	m_cbOnPacketArrivesUserCookie = NULL;
-	m_cbOnStatsUpdateUserCookie = NULL;
+	m_cbOnPacketArrivesUserCookie = nullptr;
+	m_cbOnStatsUpdateUserCookie = nullptr;
 	m_CaptureCallbackMode = true;
-	m_CapturedPackets = NULL;
+	m_CapturedPackets = nullptr;
 	if (calculateMacAddress)
 	{
 		setDeviceMacAddress();
@@ -127,7 +127,7 @@ PcapLiveDevice::PcapLiveDevice(pcap_if_t* pInterface, bool calculateMTU, bool ca
 void PcapLiveDevice::onPacketArrives(uint8_t* user, const struct pcap_pkthdr* pkthdr, const uint8_t* packet)
 {
 	PcapLiveDevice* pThis = (PcapLiveDevice*)user;
-	if (pThis == NULL)
+	if (pThis == nullptr)
 	{
 		PCPP_LOG_ERROR("Unable to extract PcapLiveDevice instance");
 		return;
@@ -135,14 +135,14 @@ void PcapLiveDevice::onPacketArrives(uint8_t* user, const struct pcap_pkthdr* pk
 
 	RawPacket rawPacket(packet, pkthdr->caplen, pkthdr->ts, false, pThis->getLinkType());
 
-	if (pThis->m_cbOnPacketArrives != NULL)
+	if (pThis->m_cbOnPacketArrives != nullptr)
 		pThis->m_cbOnPacketArrives(&rawPacket, pThis, pThis->m_cbOnPacketArrivesUserCookie);
 }
 
 void PcapLiveDevice::onPacketArrivesNoCallback(uint8_t* user, const struct pcap_pkthdr* pkthdr, const uint8_t* packet)
 {
 	PcapLiveDevice* pThis = (PcapLiveDevice*)user;
-	if (pThis == NULL)
+	if (pThis == nullptr)
 	{
 		PCPP_LOG_ERROR("Unable to extract PcapLiveDevice instance");
 		return;
@@ -157,7 +157,7 @@ void PcapLiveDevice::onPacketArrivesNoCallback(uint8_t* user, const struct pcap_
 void PcapLiveDevice::onPacketArrivesBlockingMode(uint8_t* user, const struct pcap_pkthdr* pkthdr, const uint8_t* packet)
 {
 	PcapLiveDevice* pThis = (PcapLiveDevice*)user;
-	if (pThis == NULL)
+	if (pThis == nullptr)
 	{
 		PCPP_LOG_ERROR("Unable to extract PcapLiveDevice instance");
 		return;
@@ -165,7 +165,7 @@ void PcapLiveDevice::onPacketArrivesBlockingMode(uint8_t* user, const struct pca
 
 	RawPacket rawPacket(packet, pkthdr->caplen, pkthdr->ts, false, pThis->getLinkType());
 
-	if (pThis->m_cbOnPacketArrivesBlockingMode != NULL)
+	if (pThis->m_cbOnPacketArrivesBlockingMode != nullptr)
 		if (pThis->m_cbOnPacketArrivesBlockingMode(&rawPacket, pThis, pThis->m_cbOnPacketArrivesBlockingModeUserCookie))
 			pThis->m_StopThread = true;
 }
@@ -252,7 +252,7 @@ pcap_t* PcapLiveDevice::doOpen(const DeviceConfiguration& config)
 	{
 		PCPP_LOG_ERROR(pcap_geterr(pcap));
 		pcap_close(pcap);
-		return NULL;
+		return nullptr;
 	}
 
 #ifdef HAS_SET_DIRECTION_ENABLED
@@ -307,7 +307,7 @@ bool PcapLiveDevice::open(const DeviceConfiguration& config)
 
 	m_PcapDescriptor = doOpen(config);
 	m_PcapSendDescriptor = doOpen(config);
-	if (m_PcapDescriptor == NULL || m_PcapSendDescriptor == NULL)
+	if (m_PcapDescriptor == nullptr || m_PcapSendDescriptor == nullptr)
 	{
 		m_DeviceOpened = false;
 		return false;
@@ -328,7 +328,7 @@ bool PcapLiveDevice::open()
 
 void PcapLiveDevice::close()
 {
-	if (m_PcapDescriptor == NULL && m_PcapSendDescriptor == NULL)
+	if (m_PcapDescriptor == nullptr && m_PcapSendDescriptor == nullptr)
 	{
 		PCPP_LOG_DEBUG("Device '" << m_Name << "' already closed");
 		return;
@@ -349,7 +349,7 @@ void PcapLiveDevice::close()
 
 PcapLiveDevice* PcapLiveDevice::clone()
 {
-	PcapLiveDevice *retval = NULL;
+	PcapLiveDevice *retval = nullptr;
 
 	pcap_if_t *interfaceList;
 	char errbuf[PCAP_ERRBUF_SIZE];
@@ -357,11 +357,11 @@ PcapLiveDevice* PcapLiveDevice::clone()
 	if (err < 0)
 	{
 		PCPP_LOG_ERROR("Error searching for devices: " << errbuf);
-		return NULL;
+		return nullptr;
 	}
 
 	pcap_if_t* currInterface = interfaceList;
-	while (currInterface != NULL)
+	while (currInterface != nullptr)
 	{
 		if(!strcmp(currInterface->name, getName().c_str()))
 			break;
@@ -379,17 +379,17 @@ PcapLiveDevice* PcapLiveDevice::clone()
 
 bool PcapLiveDevice::startCapture(OnPacketArrivesCallback onPacketArrives, void* onPacketArrivesUserCookie)
 {
-	return startCapture(onPacketArrives, onPacketArrivesUserCookie, 0, NULL, NULL);
+	return startCapture(onPacketArrives, onPacketArrivesUserCookie, 0, nullptr, nullptr);
 }
 
 bool PcapLiveDevice::startCapture(int intervalInSecondsToUpdateStats, OnStatsUpdateCallback onStatsUpdate, void* onStatsUpdateUserCookie)
 {
-	return startCapture(NULL, NULL, intervalInSecondsToUpdateStats, onStatsUpdate, onStatsUpdateUserCookie);
+	return startCapture(nullptr, nullptr, intervalInSecondsToUpdateStats, onStatsUpdate, onStatsUpdateUserCookie);
 }
 
 bool PcapLiveDevice::startCapture(OnPacketArrivesCallback onPacketArrives, void* onPacketArrivesUserCookie, int intervalInSecondsToUpdateStats, OnStatsUpdateCallback onStatsUpdate, void* onStatsUpdateUserCookie)
 {
-	if (!m_DeviceOpened || m_PcapDescriptor == NULL)
+	if (!m_DeviceOpened || m_PcapDescriptor == nullptr)
 	{
 		PCPP_LOG_ERROR("Device '" << m_Name << "' not opened");
 		return false;
@@ -411,7 +411,7 @@ bool PcapLiveDevice::startCapture(OnPacketArrivesCallback onPacketArrives, void*
 	m_CaptureThreadStarted = true;
 	PCPP_LOG_DEBUG("Successfully created capture thread for device '" << m_Name << "'. Thread id: " << m_CaptureThread.get_id());
 
-	if (onStatsUpdate != NULL && intervalInSecondsToUpdateStats > 0)
+	if (onStatsUpdate != nullptr && intervalInSecondsToUpdateStats > 0)
 	{
 		m_cbOnStatsUpdate = onStatsUpdate;
 		m_cbOnStatsUpdateUserCookie = onStatsUpdateUserCookie;
@@ -425,7 +425,7 @@ bool PcapLiveDevice::startCapture(OnPacketArrivesCallback onPacketArrives, void*
 
 bool PcapLiveDevice::startCapture(RawPacketVector& capturedPacketsVector)
 {
-	if (!m_DeviceOpened || m_PcapDescriptor == NULL)
+	if (!m_DeviceOpened || m_PcapDescriptor == nullptr)
 	{
 		PCPP_LOG_ERROR("Device '" << m_Name << "' not opened");
 		return false;
@@ -451,7 +451,7 @@ bool PcapLiveDevice::startCapture(RawPacketVector& capturedPacketsVector)
 
 int PcapLiveDevice::startCaptureBlockingMode(OnPacketArrivesStopBlocking onPacketArrives, void* userCookie, int timeout)
 {
-	if (!m_DeviceOpened || m_PcapDescriptor == NULL)
+	if (!m_DeviceOpened || m_PcapDescriptor == nullptr)
 	{
 		PCPP_LOG_ERROR("Device '" << m_Name << "' not opened");
 		return 0;
@@ -463,10 +463,10 @@ int PcapLiveDevice::startCaptureBlockingMode(OnPacketArrivesStopBlocking onPacke
 		return 0;
 	}
 
-	m_cbOnPacketArrives = NULL;
-	m_cbOnStatsUpdate = NULL;
-	m_cbOnPacketArrivesUserCookie = NULL;
-	m_cbOnStatsUpdateUserCookie = NULL;
+	m_cbOnPacketArrives = nullptr;
+	m_cbOnStatsUpdate = nullptr;
+	m_cbOnPacketArrivesUserCookie = nullptr;
+	m_cbOnStatsUpdateUserCookie = nullptr;
 
 	m_cbOnPacketArrivesBlockingMode = onPacketArrives;
 	m_cbOnPacketArrivesBlockingModeUserCookie = userCookie;
@@ -501,8 +501,8 @@ int PcapLiveDevice::startCaptureBlockingMode(OnPacketArrivesStopBlocking onPacke
 
 	m_StopThread = false;
 
-	m_cbOnPacketArrivesBlockingMode = NULL;
-	m_cbOnPacketArrivesBlockingModeUserCookie = NULL;
+	m_cbOnPacketArrivesBlockingMode = nullptr;
+	m_cbOnPacketArrivesBlockingModeUserCookie = nullptr;
 
 	if (curTimeSec > (startTimeSec + timeout))
 		return -1;
@@ -512,7 +512,7 @@ int PcapLiveDevice::startCaptureBlockingMode(OnPacketArrivesStopBlocking onPacke
 void PcapLiveDevice::stopCapture()
 {
 	// in blocking mode stop capture isn't relevant
-	if (m_cbOnPacketArrivesBlockingMode != NULL)
+	if (m_cbOnPacketArrivesBlockingMode != nullptr)
 		return;
 
 	m_StopThread = true;
@@ -587,7 +587,7 @@ bool PcapLiveDevice::sendPacket(const uint8_t* packetData, int packetDataLength,
 	if (checkMtu)
 	{
 		timeval time;
-		gettimeofday(&time, NULL);
+		gettimeofday(&time, nullptr);
 		pcpp::RawPacket rawPacket(packetData, packetDataLength, time, false, linkType);
 		Packet parsedPacket = Packet(&rawPacket, pcpp::OsiModelDataLinkLayer);
 		return sendPacket(&parsedPacket, true);
@@ -814,7 +814,7 @@ void PcapLiveDevice::setDeviceMacAddress()
 		return;
 	}
 
-	if (sysctl(mib, 6, NULL, &len, NULL, 0) < 0)
+	if (sysctl(mib, 6, nullptr, &len, nullptr, 0) < 0)
 	{
 		PCPP_LOG_DEBUG("Error in retrieving MAC address: sysctl 1 error");
 		return;
@@ -822,7 +822,7 @@ void PcapLiveDevice::setDeviceMacAddress()
 
 	uint8_t buf[len];
 
-	if (sysctl(mib, 6, buf, &len, NULL, 0) < 0)
+	if (sysctl(mib, 6, buf, &len, nullptr, 0) < 0)
 	{
 		PCPP_LOG_DEBUG("Error in retrieving MAC address: sysctl 2 error");
 		return;
@@ -921,7 +921,7 @@ IPv4Address PcapLiveDevice::getIPv4Address() const
 {
 	for(std::vector<pcap_addr_t>::const_iterator addrIter = m_Addresses.begin(); addrIter != m_Addresses.end(); addrIter++)
 	{
-		if (Logger::getInstance().isDebugEnabled(PcapLogModuleLiveDevice) && addrIter->addr != NULL)
+		if (Logger::getInstance().isDebugEnabled(PcapLogModuleLiveDevice) && addrIter->addr != nullptr)
 		{
 			char addrAsString[INET6_ADDRSTRLEN];
 			internal::sockaddr2string(addrIter->addr, addrAsString);
@@ -929,7 +929,7 @@ IPv4Address PcapLiveDevice::getIPv4Address() const
 		}
 
 		in_addr* currAddr = internal::sockaddr2in_addr(addrIter->addr);
-		if (currAddr == NULL)
+		if (currAddr == nullptr)
 		{
 			PCPP_LOG_DEBUG("Address is NULL");
 			continue;
@@ -946,14 +946,14 @@ IPv6Address PcapLiveDevice::getIPv6Address() const
 	for (std::vector<pcap_addr_t>::const_iterator addrIter = m_Addresses.begin(); addrIter != m_Addresses.end();
 		 addrIter++)
 	{
-		if (Logger::getInstance().isDebugEnabled(PcapLogModuleLiveDevice) && addrIter->addr != NULL)
+		if (Logger::getInstance().isDebugEnabled(PcapLogModuleLiveDevice) && addrIter->addr != nullptr)
 		{
 			char addrAsString[INET6_ADDRSTRLEN];
 			internal::sockaddr2string(addrIter->addr, addrAsString);
 			PCPP_LOG_DEBUG("Searching address " << addrAsString);
 		}
 		in6_addr *currAddr = internal::sockaddr2in6_addr(addrIter->addr);
-		if (currAddr == NULL)
+		if (currAddr == nullptr)
 		{
 			PCPP_LOG_DEBUG("Address is NULL");
 			continue;

--- a/Pcap++/src/PcapLiveDeviceList.cpp
+++ b/Pcap++/src/PcapLiveDeviceList.cpp
@@ -49,7 +49,7 @@ void PcapLiveDeviceList::init()
 	PCPP_LOG_DEBUG("Pcap lib version info: " << IPcapDevice::getPcapLibVersionInfo());
 
 	pcap_if_t* currInterface = interfaceList;
-	while (currInterface != NULL)
+	while (currInterface != nullptr)
 	{
 #if defined(_WIN32)
 		PcapLiveDevice* dev = new WinPcapLiveDevice(currInterface, true, true, true);
@@ -154,8 +154,8 @@ void PcapLiveDeviceList::setDnsServers()
 	}
 #elif defined(__APPLE__)
 
-	SCDynamicStoreRef dynRef = SCDynamicStoreCreate(kCFAllocatorSystemDefault, CFSTR("iked"), NULL, NULL);
-	if (dynRef == NULL)
+	SCDynamicStoreRef dynRef = SCDynamicStoreCreate(kCFAllocatorSystemDefault, CFSTR("iked"), nullptr, nullptr);
+	if (dynRef == nullptr)
 	{
 		PCPP_LOG_DEBUG("Couldn't set DNS server list: failed to retrieve SCDynamicStore");
 		return;
@@ -163,7 +163,7 @@ void PcapLiveDeviceList::setDnsServers()
 
 	CFDictionaryRef dnsDict = (CFDictionaryRef)SCDynamicStoreCopyValue(dynRef,CFSTR("State:/Network/Global/DNS"));
 
-	if (dnsDict == NULL)
+	if (dnsDict == nullptr)
 	{
 		PCPP_LOG_DEBUG("Couldn't set DNS server list: failed to get DNS dictionary");
 		CFRelease(dynRef);
@@ -172,7 +172,7 @@ void PcapLiveDeviceList::setDnsServers()
 
 	CFArrayRef serverAddresses = (CFArrayRef)CFDictionaryGetValue(dnsDict, CFSTR("ServerAddresses"));
 
-	if (serverAddresses == NULL)
+	if (serverAddresses == nullptr)
 	{
 		PCPP_LOG_DEBUG("Couldn't set DNS server list: server addresses array is null");
 		CFRelease(dynRef);
@@ -185,7 +185,7 @@ void PcapLiveDeviceList::setDnsServers()
 	{
 		CFStringRef serverAddress = (CFStringRef)CFArrayGetValueAtIndex(serverAddresses, i);
 
-		if (serverAddress == NULL)
+		if (serverAddress == nullptr)
 			continue;
 
 		uint8_t buf[20];
@@ -236,7 +236,7 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const IPv4Address& ipA
 		PCPP_LOG_DEBUG("Searching device '" << (*devIter)->m_Name << "'. Searching all addresses...");
 		for(std::vector<pcap_addr_t>::iterator addrIter = (*devIter)->m_Addresses.begin(); addrIter != (*devIter)->m_Addresses.end(); addrIter++)
 		{
-			if (Logger::getInstance().isDebugEnabled(PcapLogModuleLiveDevice) && addrIter->addr != NULL)
+			if (Logger::getInstance().isDebugEnabled(PcapLogModuleLiveDevice) && addrIter->addr != nullptr)
 			{
 				char addrAsString[INET6_ADDRSTRLEN];
 				internal::sockaddr2string(addrIter->addr, addrAsString);
@@ -244,7 +244,7 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const IPv4Address& ipA
 			}
 
 			in_addr* currAddr = internal::sockaddr2in_addr(addrIter->addr);
-			if (currAddr == NULL)
+			if (currAddr == nullptr)
 			{
 				PCPP_LOG_DEBUG("Address is NULL");
 				continue;
@@ -258,7 +258,7 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const IPv4Address& ipA
 		}
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const IPv6Address& ip6Addr) const
@@ -269,7 +269,7 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const IPv6Address& ip6
 		PCPP_LOG_DEBUG("Searching device '" << (*devIter)->m_Name << "'. Searching all addresses...");
 		for(std::vector<pcap_addr_t>::iterator addrIter = (*devIter)->m_Addresses.begin(); addrIter != (*devIter)->m_Addresses.end(); addrIter++)
 		{
-			if (Logger::getInstance().isDebugEnabled(PcapLogModuleLiveDevice) && addrIter->addr != NULL)
+			if (Logger::getInstance().isDebugEnabled(PcapLogModuleLiveDevice) && addrIter->addr != nullptr)
 			{
 				char addrAsString[INET6_ADDRSTRLEN];
 				internal::sockaddr2string(addrIter->addr, addrAsString);
@@ -277,7 +277,7 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const IPv6Address& ip6
 			}
 
 			in6_addr* currAddr = internal::sockaddr2in6_addr(addrIter->addr);
-			if (currAddr == NULL)
+			if (currAddr == nullptr)
 			{
 				PCPP_LOG_DEBUG("Address is NULL");
 				continue;
@@ -296,7 +296,7 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const IPv6Address& ip6
 		}
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const std::string& ipAddrAsString) const
@@ -305,7 +305,7 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const std::string& ipA
 	if (!ipAddr.isValid())
 	{
 		PCPP_LOG_ERROR("IP address illegal");
-		return NULL;
+		return nullptr;
 	}
 
 	PcapLiveDevice* result = PcapLiveDeviceList::getPcapLiveDeviceByIp(ipAddr);
@@ -322,7 +322,7 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByName(const std::string& n
 			return (*devIter);
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIpOrName(const std::string& ipOrName) const

--- a/Pcap++/src/RawSocketDevice.cpp
+++ b/Pcap++/src/RawSocketDevice.cpp
@@ -69,7 +69,7 @@ struct SocketContainer
 #endif
 };
 
-RawSocketDevice::RawSocketDevice(const IPAddress& interfaceIP) : IDevice(), m_Socket(NULL)
+RawSocketDevice::RawSocketDevice(const IPAddress& interfaceIP) : IDevice(), m_Socket(nullptr)
 {
 #if defined(_WIN32)
 
@@ -535,7 +535,7 @@ bool RawSocketDevice::open()
 
 void RawSocketDevice::close()
 {
-	if (m_Socket != NULL && isOpened())
+	if (m_Socket != nullptr && isOpened())
 	{
 		SocketContainer* sockContainer = (SocketContainer*)m_Socket;
 #if defined(_WIN32)
@@ -544,7 +544,7 @@ void RawSocketDevice::close()
 		::close(sockContainer->fd);
 #endif
 		delete sockContainer;
-		m_Socket = NULL;
+		m_Socket = nullptr;
 		m_DeviceOpened = false;
 	}
 }

--- a/Tests/Packet++Test/Tests/BgpTests.cpp
+++ b/Tests/Packet++Test/Tests/BgpTests.cpp
@@ -12,7 +12,7 @@
 PTF_TEST_CASE(BgpLayerParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/Bgp_keepalive.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/Bgp_open.dat");
@@ -216,7 +216,7 @@ PTF_TEST_CASE(BgpLayerParsingTest)
 PTF_TEST_CASE(BgpLayerCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/Bgp_keepalive.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/Bgp_route-refresh.dat");
@@ -430,7 +430,7 @@ PTF_TEST_CASE(BgpLayerCreationTest)
 PTF_TEST_CASE(BgpLayerEditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/Bgp_notification.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/Bgp_notification2.dat");
@@ -450,7 +450,7 @@ PTF_TEST_CASE(BgpLayerEditTest)
 	pcpp::Packet bgpNotificationPacket2(&rawPacket2);
 	pcpp::BgpNotificationMessageLayer* bgpNotificationMessage1 = bgpNotificationPacket1.getLayerOfType<pcpp::BgpNotificationMessageLayer>();
 	PTF_ASSERT_NOT_NULL(bgpNotificationMessage1);
-	PTF_ASSERT_TRUE(bgpNotificationMessage1->setNotificationData(NULL, 0));
+	PTF_ASSERT_TRUE(bgpNotificationMessage1->setNotificationData(nullptr, 0));
 	bgpNotificationMessage1->getNotificationMsgHeader()->errorSubCode = 4;
 	bgpNotificationPacket1.computeCalculateFields();
 	pcpp::BgpNotificationMessageLayer* bgpNotificationMessage2 = bgpNotificationPacket2.getLayerOfType<pcpp::BgpNotificationMessageLayer>();

--- a/Tests/Packet++Test/Tests/DhcpTests.cpp
+++ b/Tests/Packet++Test/Tests/DhcpTests.cpp
@@ -12,7 +12,7 @@
 PTF_TEST_CASE(DhcpParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/Dhcp1.dat");
 
@@ -165,7 +165,7 @@ PTF_TEST_CASE(DhcpCreationTest)
 	pcpp::DhcpOption agentOpt = dhcpLayer.addOption(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_DHCP_AGENT_OPTIONS, agentData, 22));
 	PTF_ASSERT_FALSE(agentOpt.isNull());
 
-	pcpp::DhcpOption clientIdOpt = dhcpLayer.addOptionAfter(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_DHCP_CLIENT_IDENTIFIER, NULL, 16), pcpp::DHCPOPT_SIP_SERVERS);
+	pcpp::DhcpOption clientIdOpt = dhcpLayer.addOptionAfter(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_DHCP_CLIENT_IDENTIFIER, nullptr, 16), pcpp::DHCPOPT_SIP_SERVERS);
 	clientIdOpt.setValue<uint8_t>(0);
 	clientIdOpt.setValueString("nathan1clientid", 1);
 	PTF_ASSERT_FALSE(clientIdOpt.isNull());
@@ -190,7 +190,7 @@ PTF_TEST_CASE(DhcpCreationTest)
 	pcpp::DhcpOption tftpServerOpt = dhcpLayer.addOptionAfter(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_TFTP_SERVER_NAME, std::string("172.22.178.234")), pcpp::DHCPOPT_ROUTERS);
 	PTF_ASSERT_FALSE(tftpServerOpt.isNull());
 
-	pcpp::DhcpOption dnsOpt = dhcpLayer.addOptionAfter(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_DOMAIN_NAME_SERVERS, NULL, 8), pcpp::DHCPOPT_ROUTERS);
+	pcpp::DhcpOption dnsOpt = dhcpLayer.addOptionAfter(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_DOMAIN_NAME_SERVERS, nullptr, 8), pcpp::DHCPOPT_ROUTERS);
 	PTF_ASSERT_FALSE(dnsOpt.isNull());
 	pcpp::IPv4Address dns1IP("143.209.4.1");
 	pcpp::IPv4Address dns2IP("143.209.5.1");
@@ -215,7 +215,7 @@ PTF_TEST_CASE(DhcpCreationTest)
 PTF_TEST_CASE(DhcpEditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/Dhcp4.dat");
 
@@ -262,7 +262,7 @@ PTF_TEST_CASE(DhcpEditTest)
 
 	PTF_ASSERT_EQUAL(dhcpLayer->getMessageType(), pcpp::DHCP_UNKNOWN_MSG_TYPE, enum);
 
-	PTF_ASSERT_FALSE(dhcpLayer->addOption(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_END, NULL, 0)).isNull());
+	PTF_ASSERT_FALSE(dhcpLayer->addOption(pcpp::DhcpOptionBuilder(pcpp::DHCPOPT_END, nullptr, 0)).isNull());
 
 	PTF_ASSERT_FALSE(dhcpLayer->setMessageType(pcpp::DHCP_UNKNOWN_MSG_TYPE));
 

--- a/Tests/Packet++Test/Tests/DhcpV6Tests.cpp
+++ b/Tests/Packet++Test/Tests/DhcpV6Tests.cpp
@@ -9,7 +9,7 @@
 PTF_TEST_CASE(DhcpV6ParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/dhcpv6_1.dat");
 
@@ -56,7 +56,7 @@ PTF_TEST_CASE(DhcpV6ParsingTest)
 PTF_TEST_CASE(DhcpV6CreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/dhcpv6_2.dat");
 
@@ -128,7 +128,7 @@ PTF_TEST_CASE(DhcpV6CreationTest)
 PTF_TEST_CASE(DhcpV6EditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/dhcpv6_1.dat");
 

--- a/Tests/Packet++Test/Tests/DnsTests.cpp
+++ b/Tests/Packet++Test/Tests/DnsTests.cpp
@@ -15,7 +15,7 @@
 PTF_TEST_CASE(DnsLayerParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/Dns3.dat");
 
@@ -125,7 +125,7 @@ PTF_TEST_CASE(DnsLayerParsingTest)
 	int answerCount = 2;
 	pcpp::IPv4Address subnet("212.199.219.0");
 	std::string subnetMask = "255.255.255.0";
-	while (curAnswer != NULL)
+	while (curAnswer != nullptr)
 	{
 		PTF_ASSERT_EQUAL(curAnswer->getDnsType(), pcpp::DNS_TYPE_A, enum);
 		PTF_ASSERT_EQUAL(curAnswer->getDnsClass(), pcpp::DNS_CLASS_IN, enum);
@@ -227,7 +227,7 @@ PTF_TEST_CASE(DnsLayerParsingTest)
 PTF_TEST_CASE(DnsLayerQueryCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/DnsEdit2.dat");
 
@@ -290,7 +290,7 @@ PTF_TEST_CASE(DnsLayerQueryCreationTest)
 
 	PTF_ASSERT_TRUE(newQuery->setName("_sleep-proxy._udp.local"));
 
-	PTF_ASSERT_NULL(dns1Layer.addQuery(NULL));
+	PTF_ASSERT_NULL(dns1Layer.addQuery(nullptr));
 	PTF_ASSERT_EQUAL(dns1Layer.getQueryCount(), 2);
 
 	dnsEdit1Packet.computeCalculateFields();
@@ -305,7 +305,7 @@ PTF_TEST_CASE(DnsLayerQueryCreationTest)
 PTF_TEST_CASE(DnsLayerResourceCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(4, "PacketExamples/DnsEdit4.dat");
 
@@ -495,7 +495,7 @@ PTF_TEST_CASE(DnsLayerResourceCreationTest)
 PTF_TEST_CASE(DnsLayerEditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(3, "PacketExamples/DnsEdit3.dat");
 	READ_FILE_AND_CREATE_PACKET(5, "PacketExamples/DnsEdit5.dat");
@@ -530,7 +530,7 @@ PTF_TEST_CASE(DnsLayerEditTest)
 PTF_TEST_CASE(DnsLayerRemoveResourceTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(6, "PacketExamples/DnsEdit6.dat");
 
@@ -574,7 +574,7 @@ PTF_TEST_CASE(DnsLayerRemoveResourceTest)
 
 	PTF_ASSERT_FALSE(dnsLayer6->removeQuery("BlaBla", true));
 	PTF_ASSERT_FALSE(dnsLayer6->removeAuthority(secondAuthority));
-	PTF_ASSERT_FALSE(dnsLayer6->removeAdditionalRecord(NULL));
+	PTF_ASSERT_FALSE(dnsLayer6->removeAdditionalRecord(nullptr));
 
 	size_t additionalRecordSize = dnsLayer6->getFirstAdditionalRecord()->getSize();
 	PTF_ASSERT_TRUE(dnsLayer6->removeAdditionalRecord(dnsLayer6->getFirstAdditionalRecord()));
@@ -634,7 +634,7 @@ PTF_TEST_CASE(DnsLayerRemoveResourceTest)
 PTF_TEST_CASE(DnsOverTcpParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/dns_over_tcp_query.dat");
 	pcpp::Packet dnsPacket(&rawPacket1);
@@ -696,7 +696,7 @@ PTF_TEST_CASE(DnsOverTcpParsingTest)
 	};
 
 	int i = 0;
-	for (pcpp::DnsResource* authority = dnsLayer->getFirstAuthority(); authority != NULL; authority = dnsLayer->getNextAuthority(authority))
+	for (pcpp::DnsResource* authority = dnsLayer->getFirstAuthority(); authority != nullptr; authority = dnsLayer->getNextAuthority(authority))
 	{
 		PTF_ASSERT_EQUAL(authority->getName(), expectedNames[i]);
 		PTF_ASSERT_EQUAL(authority->getDnsType(), expectedTypes[i], enum);
@@ -727,7 +727,7 @@ PTF_TEST_CASE(DnsOverTcpParsingTest)
 PTF_TEST_CASE(DnsOverTcpCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/dns_over_tcp_answer2.dat");
 	pcpp::Packet dnsPacket(&rawPacket1);
@@ -752,7 +752,7 @@ PTF_TEST_CASE(DnsOverTcpCreationTest)
 PTF_TEST_CASE(DnsNXDomainTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/DNS_NXDomain.dat");
 	pcpp::Packet dnsPacket(&rawPacket1);

--- a/Tests/Packet++Test/Tests/EthAndArpTests.cpp
+++ b/Tests/Packet++Test/Tests/EthAndArpTests.cpp
@@ -70,7 +70,7 @@ PTF_TEST_CASE(EthPacketPointerCreation)
 PTF_TEST_CASE(EthAndArpPacketParsing)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/ArpResponsePacket.dat");
 
@@ -130,7 +130,7 @@ PTF_TEST_CASE(ArpPacketCreation)
 PTF_TEST_CASE(EthDot3LayerParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/EthDot3.dat");
 	pcpp::Packet ethDot3Packet(&rawPacket1);
@@ -151,7 +151,7 @@ PTF_TEST_CASE(EthDot3LayerParsingTest)
 PTF_TEST_CASE(EthDot3LayerCreateEditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_INTO_BUFFER(1, "PacketExamples/EthDot3.dat");
 	READ_FILE_INTO_BUFFER(2, "PacketExamples/EthDot3_2.dat");

--- a/Tests/Packet++Test/Tests/FtpTests.cpp
+++ b/Tests/Packet++Test/Tests/FtpTests.cpp
@@ -12,7 +12,7 @@
 PTF_TEST_CASE(FtpParsingTests)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	// Test IPv4 packets
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/ftpIpv4Req.dat");
@@ -101,7 +101,7 @@ PTF_TEST_CASE(FtpParsingTests)
 PTF_TEST_CASE(FtpCreationTests)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	// Craft packets
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/ftpIpv4Req.dat");
@@ -150,7 +150,7 @@ PTF_TEST_CASE(FtpCreationTests)
 PTF_TEST_CASE(FtpEditTests)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	// Modify existing request packets
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/ftpIpv4Req.dat");

--- a/Tests/Packet++Test/Tests/GreTests.cpp
+++ b/Tests/Packet++Test/Tests/GreTests.cpp
@@ -16,7 +16,7 @@
 PTF_TEST_CASE(GreParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/GREv0_1.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/GREv0_2.dat");
@@ -24,9 +24,9 @@ PTF_TEST_CASE(GreParsingTest)
 	READ_FILE_AND_CREATE_PACKET(4, "PacketExamples/GREv1_2.dat");
 	READ_FILE_AND_CREATE_PACKET(5, "PacketExamples/GREv0_4.dat");
 
-	pcpp::GREv0Layer* grev0Layer = NULL;
-	pcpp::GREv1Layer* grev1Layer = NULL;
-	pcpp::TcpLayer* tcpLayer = NULL;
+	pcpp::GREv0Layer* grev0Layer = nullptr;
+	pcpp::GREv1Layer* grev1Layer = nullptr;
+	pcpp::TcpLayer* tcpLayer = nullptr;
 
 	pcpp::Packet grev0Packet1(&rawPacket1);
 	pcpp::Packet grev0Packet2(&rawPacket2);
@@ -61,7 +61,7 @@ PTF_TEST_CASE(GreParsingTest)
 	PTF_ASSERT_EQUAL(value32, 40000);
 	PTF_ASSERT_NOT_NULL(grev0Layer->getNextLayer());
 	PTF_ASSERT_EQUAL(grev0Layer->getNextLayer()->getProtocol(), pcpp::IPv4, enum);
-	grev0Layer = NULL;
+	grev0Layer = nullptr;
 
 	// GREv0 packet 2
 	PTF_ASSERT_TRUE(grev0Packet2.isPacketOfType(pcpp::GRE) && grev0Packet2.isPacketOfType(pcpp::GREv0));
@@ -89,7 +89,7 @@ PTF_TEST_CASE(GreParsingTest)
 	PTF_ASSERT_EQUAL(grev0Layer->getGreHeader()->protocol, htobe16(PCPP_ETHERTYPE_IP));
 	PTF_ASSERT_NOT_NULL(grev0Layer->getNextLayer());
 	PTF_ASSERT_EQUAL(grev0Layer->getNextLayer()->getProtocol(), pcpp::IPv4, enum);
-	grev0Layer = NULL;
+	grev0Layer = nullptr;
 
 	// GREv1 packet 1
 	PTF_ASSERT_TRUE(grev1Packet1.isPacketOfType(pcpp::GRE) && grev1Packet1.isPacketOfType(pcpp::GREv1));
@@ -108,7 +108,7 @@ PTF_TEST_CASE(GreParsingTest)
 	PTF_ASSERT_TRUE(grev1Layer->getAcknowledgmentNum(value32));
 	PTF_ASSERT_EQUAL(value32, 26);
 	PTF_ASSERT_NULL(grev1Layer->getNextLayer());
-	grev1Layer = NULL;
+	grev1Layer = nullptr;
 
 	// GREv1 packet 2
 	PTF_ASSERT_TRUE(grev1Packet2.isPacketOfType(pcpp::GRE) && grev1Packet2.isPacketOfType(pcpp::GREv1));
@@ -139,7 +139,7 @@ PTF_TEST_CASE(GreParsingTest)
 	PTF_ASSERT_EQUAL(pppLayer->getPPP_PPTPHeader()->protocol, htobe16(PCPP_PPP_IP));
 	PTF_ASSERT_NOT_NULL(pppLayer->getNextLayer());
 	PTF_ASSERT_EQUAL(pppLayer->getNextLayer()->getProtocol(), pcpp::IPv4, enum);
-	grev1Layer = NULL;
+	grev1Layer = nullptr;
 
 	// GREv0 packet 4 - Transparent Ethernet Bridging
 	PTF_ASSERT_TRUE(grev0Packet4.isPacketOfType(pcpp::GRE) && grev0Packet4.isPacketOfType(pcpp::GREv0));
@@ -153,8 +153,8 @@ PTF_TEST_CASE(GreParsingTest)
 	tcpLayer = grev0Packet4.getLayerOfType<pcpp::TcpLayer>(true /* reverse */);
 	PTF_ASSERT_NOT_NULL(tcpLayer);
 	PTF_ASSERT_EQUAL(tcpLayer->getSrcPort(), 1232);
-	grev0Layer = NULL;
-	tcpLayer = NULL;
+	grev0Layer = nullptr;
+	tcpLayer = nullptr;
 } // GreParsingTest
 
 
@@ -233,7 +233,7 @@ PTF_TEST_CASE(GreEditTest)
 	// GREv0 packet edit
 
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/GREv0_3.dat");
 

--- a/Tests/Packet++Test/Tests/GtpTests.cpp
+++ b/Tests/Packet++Test/Tests/GtpTests.cpp
@@ -14,7 +14,7 @@
 PTF_TEST_CASE(GtpLayerParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/gtp-u1.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/gtp-u2.dat");
@@ -174,7 +174,7 @@ PTF_TEST_CASE(GtpLayerParsingTest)
 PTF_TEST_CASE(GtpLayerCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/gtp-u1.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/gtp-u-1ext.dat");
@@ -246,7 +246,7 @@ PTF_TEST_CASE(GtpLayerCreationTest)
 PTF_TEST_CASE(GtpLayerEditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/gtp-u-ipv6.dat");
 	READ_FILE_INTO_BUFFER(2, "PacketExamples/gtp-u-ipv6-edited.dat");

--- a/Tests/Packet++Test/Tests/HttpTests.cpp
+++ b/Tests/Packet++Test/Tests/HttpTests.cpp
@@ -16,7 +16,7 @@ PTF_TEST_CASE(HttpRequestLayerParsingTest)
 	// A much wider test is in Pcap++Test
 
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/TwoHttpRequests1.dat");
 
@@ -68,7 +68,7 @@ PTF_TEST_CASE(HttpRequestLayerParsingTest)
 PTF_TEST_CASE(HttpRequestLayerCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/TwoHttpRequests1.dat");
 
@@ -89,7 +89,7 @@ PTF_TEST_CASE(HttpRequestLayerCreationTest)
 	pcpp::HttpRequestLayer httpLayer(pcpp::HttpRequestLayer::HttpOPTIONS, "/home/0,7340,L-8,00", pcpp::OneDotOne);
 	PTF_ASSERT_NOT_NULL(httpLayer.addField(PCPP_HTTP_ACCEPT_FIELD, "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"));
 	PTF_ASSERT_NOT_NULL(httpLayer.addField("Dummy-Field", "some value"));
-	pcpp::HeaderField* hostField = httpLayer.insertField(NULL, PCPP_HTTP_HOST_FIELD, "www.ynet-ynet.co.il");
+	pcpp::HeaderField* hostField = httpLayer.insertField(nullptr, PCPP_HTTP_HOST_FIELD, "www.ynet-ynet.co.il");
 	PTF_ASSERT_NOT_NULL(hostField);
 	PTF_ASSERT_NOT_NULL(httpLayer.insertField(hostField, PCPP_HTTP_CONNECTION_FIELD, "keep-alive"));
 	pcpp::HeaderField* userAgentField = httpLayer.addField(PCPP_HTTP_USER_AGENT_FIELD, "(Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.104 Safari/537.36");
@@ -131,7 +131,7 @@ PTF_TEST_CASE(HttpRequestLayerCreationTest)
 PTF_TEST_CASE(HttpRequestLayerEditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/TwoHttpRequests1.dat");
 
@@ -175,7 +175,7 @@ PTF_TEST_CASE(HttpResponseLayerParsingTest)
 	// A much wider test is in Pcap++Test
 
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/TwoHttpResponses1.dat");
 
@@ -203,7 +203,7 @@ PTF_TEST_CASE(HttpResponseLayerParsingTest)
 PTF_TEST_CASE(HttpResponseLayerCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/TwoHttpResponses1.dat");
 
@@ -268,7 +268,7 @@ PTF_TEST_CASE(HttpResponseLayerCreationTest)
 PTF_TEST_CASE(HttpResponseLayerEditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/TwoHttpResponses2.dat");
 
@@ -305,7 +305,7 @@ PTF_TEST_CASE(HttpResponseLayerEditTest)
 PTF_TEST_CASE(HttpMalformedResponseTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/HttpMalformedResponse.dat");
 
@@ -316,7 +316,7 @@ PTF_TEST_CASE(HttpMalformedResponseTest)
 	std::string fieldNames[] = {"x-amz-request-id2 CA4DB8F36423461F\r\n", "x-amz-id-2", PCPP_HTTP_CONTENT_TYPE_FIELD, PCPP_HTTP_TRANSFER_ENCODING_FIELD, "Date", PCPP_HTTP_SERVER_FIELD};
 	std::string fieldValues[] = {"", "xcjboWLTcibyztI2kdnRoUvPdimtSPdYQYsQ4pHAebH4miKlux4Am0SBZrvVxsHN", "application/xml", "chunked", "Thu, 21 Feb 2013 06:27:11 GMT", "AmazonS3"};
 	int index = 0;
-	for (pcpp::HeaderField* field = httpResp->getFirstField(); field != NULL && !field->isEndOfHeader(); field = httpResp->getNextField(field))
+	for (pcpp::HeaderField* field = httpResp->getFirstField(); field != nullptr && !field->isEndOfHeader(); field = httpResp->getNextField(field))
 	{
 		PTF_ASSERT_EQUAL(field->getFieldName(), fieldNames[index]);
 		PTF_ASSERT_EQUAL(field->getFieldValue(), fieldValues[index]);

--- a/Tests/Packet++Test/Tests/IPSecTests.cpp
+++ b/Tests/Packet++Test/Tests/IPSecTests.cpp
@@ -8,7 +8,7 @@
 PTF_TEST_CASE(IPSecParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/ipsec_ah_esp.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/ipsec_ah_icmp.dat");

--- a/Tests/Packet++Test/Tests/IPv4Tests.cpp
+++ b/Tests/Packet++Test/Tests/IPv4Tests.cpp
@@ -60,7 +60,7 @@ PTF_TEST_CASE(IPv4PacketCreation)
 PTF_TEST_CASE(IPv4PacketParsing)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/IcmpPacket.dat");
 
@@ -119,7 +119,7 @@ PTF_TEST_CASE(IPv4PacketParsing)
 PTF_TEST_CASE(IPv4FragmentationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/IPv4Frag1.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/IPv4Frag2.dat");
@@ -166,7 +166,7 @@ PTF_TEST_CASE(IPv4FragmentationTest)
 PTF_TEST_CASE(IPv4OptionsParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/IPv4Option1.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/IPv4Option2.dat");
@@ -323,7 +323,7 @@ PTF_TEST_CASE(IPv4OptionsParsingTest)
 PTF_TEST_CASE(IPv4OptionsEditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/IPv4-NoOptions1.dat");
 	READ_FILE_INTO_BUFFER(11, "PacketExamples/IPv4Option1.dat");
@@ -351,8 +351,8 @@ PTF_TEST_CASE(IPv4OptionsEditTest)
 	pcpp::IPv4Layer* ipLayer = ipOpt1.getLayerOfType<pcpp::IPv4Layer>();
 	uint8_t commSecOptionData[] = { 0x00, 0x00, 0x00, 0x02, 0x02, 0x10, 0x00, 0x02, 0x00, 0x00, 0x00, 0x02, 0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0xef };
 	PTF_ASSERT_FALSE(ipLayer->addOption(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_CommercialSecurity, commSecOptionData, 20)).isNull());
-	PTF_ASSERT_FALSE(ipLayer->addOption(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_EndOfOptionsList, NULL, 0)).isNull());
-	PTF_ASSERT_FALSE(ipLayer->addOptionAfter(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_EndOfOptionsList, NULL, 0), pcpp::IPV4OPT_CommercialSecurity).isNull());
+	PTF_ASSERT_FALSE(ipLayer->addOption(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_EndOfOptionsList, nullptr, 0)).isNull());
+	PTF_ASSERT_FALSE(ipLayer->addOptionAfter(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_EndOfOptionsList, nullptr, 0), pcpp::IPV4OPT_CommercialSecurity).isNull());
 	ipOpt1.computeCalculateFields();
 
 
@@ -389,7 +389,7 @@ PTF_TEST_CASE(IPv4OptionsEditTest)
 	for (int i = 0; i < 6; i++)
 		ipListValue.push_back(pcpp::IPv4Address::Zero);
 	PTF_ASSERT_FALSE(ipLayer->addOption(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_RecordRoute, ipListValue)).isNull());
-	PTF_ASSERT_FALSE(ipLayer->addOption(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_EndOfOptionsList, NULL, 0)).isNull());
+	PTF_ASSERT_FALSE(ipLayer->addOption(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_EndOfOptionsList, nullptr, 0)).isNull());
 	ipOpt4.computeCalculateFields();
 	PTF_ASSERT_EQUAL(ipOpt4.getRawPacket()->getRawDataLen(), bufferLength44);
 	PTF_ASSERT_BUF_COMPARE(ipOpt4.getRawPacket()->getRawData(), buffer44, ipOpt4.getRawPacket()->getRawDataLen());
@@ -436,7 +436,7 @@ PTF_TEST_CASE(IPv4OptionsEditTest)
 	PTF_ASSERT_EQUAL(optData.getTotalSize(), 7);
 	ipListValue = optData.getValueAsIpList();
 	PTF_ASSERT_EQUAL(ipListValue.size(), 0);
-	optData = ipLayer->addOptionAfter(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_NOP, NULL, 0));
+	optData = ipLayer->addOptionAfter(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_NOP, nullptr, 0));
 	PTF_ASSERT_FALSE(optData.isNull());
 	PTF_ASSERT_EQUAL(optData.getIPv4OptionType(), pcpp::IPV4OPT_NOP, enum);
 	PTF_ASSERT_EQUAL(optData.getTotalSize(), 1);
@@ -445,7 +445,7 @@ PTF_TEST_CASE(IPv4OptionsEditTest)
 	PTF_ASSERT_BUF_COMPARE(ipOpt6.getRawPacket()->getRawData(), buffer66, ipOpt6.getRawPacket()->getRawDataLen());
 
 	ipLayer = ipOpt7.getLayerOfType<pcpp::IPv4Layer>();
-	PTF_ASSERT_FALSE(ipLayer->addOption(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_NOP, NULL, 0)).isNull());
+	PTF_ASSERT_FALSE(ipLayer->addOption(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_NOP, nullptr, 0)).isNull());
 	ipListValue.clear();
 	ipListValue.push_back(pcpp::IPv4Address::Zero);
 	PTF_ASSERT_FALSE(ipLayer->addOption(pcpp::IPv4OptionBuilder(pcpp::IPV4OPT_LooseSourceRoute, ipListValue)).isNull());
@@ -512,7 +512,7 @@ PTF_TEST_CASE(IPv4UdpChecksum)
 		std::string fileName = strStream.str();
 
 		timeval time;
-		gettimeofday(&time, NULL);
+		gettimeofday(&time, nullptr);
 
 		READ_FILE_AND_CREATE_PACKET(1, fileName.c_str());
 

--- a/Tests/Packet++Test/Tests/IPv6Tests.cpp
+++ b/Tests/Packet++Test/Tests/IPv6Tests.cpp
@@ -14,14 +14,14 @@
 PTF_TEST_CASE(IPv6UdpPacketParseAndCreate)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/IPv6UdpPacket.dat");
 
 	pcpp::Packet ip6UdpPacket(&rawPacket1);
 	PTF_ASSERT_FALSE(ip6UdpPacket.isPacketOfType(pcpp::IPv4));
 	PTF_ASSERT_FALSE(ip6UdpPacket.isPacketOfType(pcpp::TCP));
-	pcpp::IPv6Layer* ipv6Layer = NULL;
+	pcpp::IPv6Layer* ipv6Layer = nullptr;
 	ipv6Layer = ip6UdpPacket.getLayerOfType<pcpp::IPv6Layer>();
 	PTF_ASSERT_NOT_NULL(ipv6Layer);
 	PTF_ASSERT_EQUAL(ipv6Layer->getIPv6Header()->nextHeader, 17);
@@ -30,7 +30,7 @@ PTF_TEST_CASE(IPv6UdpPacketParseAndCreate)
 	pcpp::IPv6Address dstIP("ff02::c");
 	PTF_ASSERT_EQUAL(ipv6Layer->getSrcIPAddress(), srcIP);
 	PTF_ASSERT_EQUAL(ipv6Layer->getDstIPAddress(), dstIP);
-	pcpp::UdpLayer* pUdpLayer = NULL;
+	pcpp::UdpLayer* pUdpLayer = nullptr;
 	pUdpLayer = ip6UdpPacket.getLayerOfType<pcpp::UdpLayer>();
 	PTF_ASSERT_NOT_NULL(pUdpLayer);
 	PTF_ASSERT_EQUAL(pUdpLayer->getDstPort(), 1900);
@@ -77,7 +77,7 @@ PTF_TEST_CASE(IPv6UdpPacketParseAndCreate)
 PTF_TEST_CASE(IPv6FragmentationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/IPv6Frag1.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/IPv6Frag2.dat");
@@ -159,7 +159,7 @@ PTF_TEST_CASE(IPv6FragmentationTest)
 PTF_TEST_CASE(IPv6ExtensionsTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/ipv6_options_destination.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/ipv6_options_hop_by_hop.dat");
@@ -321,7 +321,7 @@ PTF_TEST_CASE(IPv6ExtensionsTest)
 
 	std::vector<pcpp::IPv6TLVOptionHeader::IPv6TLVOptionBuilder> hopByHopExtOptions;
 	hopByHopExtOptions.push_back(pcpp::IPv6TLVOptionHeader::IPv6TLVOptionBuilder(5, (uint16_t)0));
-	hopByHopExtOptions.push_back(pcpp::IPv6TLVOptionHeader::IPv6TLVOptionBuilder(1, NULL, 0));
+	hopByHopExtOptions.push_back(pcpp::IPv6TLVOptionHeader::IPv6TLVOptionBuilder(1, nullptr, 0));
 	pcpp::IPv6HopByHopHeader newHopByHopHeader(hopByHopExtOptions);
 	newIPv6Layer2.addExtension<pcpp::IPv6HopByHopHeader>(newHopByHopHeader);
 

--- a/Tests/Packet++Test/Tests/IcmpTests.cpp
+++ b/Tests/Packet++Test/Tests/IcmpTests.cpp
@@ -13,7 +13,7 @@
 PTF_TEST_CASE(IcmpParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/IcmpEchoRequest.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/IcmpEchoReply.dat");
@@ -47,7 +47,7 @@ PTF_TEST_CASE(IcmpParsingTest)
 	pcpp::Packet icmpAddrMaskReq(&rawPacket14);
 	pcpp::Packet icmpAddrMaskRep(&rawPacket15);
 
-	pcpp::IcmpLayer* icmpLayer = NULL;
+	pcpp::IcmpLayer* icmpLayer = nullptr;
 
 	PTF_ASSERT_TRUE(icmpEchoRequest.isPacketOfType(pcpp::ICMP));
 	PTF_ASSERT_TRUE(icmpEchoReply.isPacketOfType(pcpp::ICMP));
@@ -263,7 +263,7 @@ PTF_TEST_CASE(IcmpParsingTest)
 PTF_TEST_CASE(IcmpCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_INTO_BUFFER(1, "PacketExamples/IcmpEchoRequest.dat");
 	READ_FILE_INTO_BUFFER(2, "PacketExamples/IcmpEchoReply.dat");
@@ -318,7 +318,7 @@ PTF_TEST_CASE(IcmpCreationTest)
 	pcpp::IPv4Layer ipLayer3(ipLayer);
 	pcpp::IcmpLayer timeExceededLayer;
 	pcpp::Logger::getInstance().suppressLogs();
-	PTF_ASSERT_NULL(timeExceededLayer.setTimeExceededData(1, NULL, NULL));
+	PTF_ASSERT_NULL(timeExceededLayer.setTimeExceededData(1, nullptr, nullptr));
 	pcpp::Logger::getInstance().enableLogs();
 	pcpp::Packet timeExceededPacket(10);
 	PTF_ASSERT_TRUE(timeExceededPacket.addLayer(&ethLayer3));
@@ -340,7 +340,7 @@ PTF_TEST_CASE(IcmpCreationTest)
 	pcpp::IPv4Layer ipLayer4(ipLayer);
 	pcpp::IcmpLayer destUnreachableLayer;
 	pcpp::Logger::getInstance().suppressLogs();
-	PTF_ASSERT_NULL(destUnreachableLayer.setDestUnreachableData(pcpp::IcmpHostUnreachable, 0, NULL, NULL));
+	PTF_ASSERT_NULL(destUnreachableLayer.setDestUnreachableData(pcpp::IcmpHostUnreachable, 0, nullptr, nullptr));
 	pcpp::Logger::getInstance().enableLogs();
 	pcpp::Packet destUnreachablePacket(10);
 	PTF_ASSERT_TRUE(destUnreachablePacket.addLayer(&ethLayer4));
@@ -388,7 +388,7 @@ PTF_TEST_CASE(IcmpCreationTest)
 	pcpp::IPv4Layer ipLayer7(ipLayer);
 	pcpp::IcmpLayer redirectLayer;
 	pcpp::Logger::getInstance().suppressLogs();
-	PTF_ASSERT_NULL(redirectLayer.setDestUnreachableData(pcpp::IcmpHostUnreachable, 0, NULL, NULL));
+	PTF_ASSERT_NULL(redirectLayer.setDestUnreachableData(pcpp::IcmpHostUnreachable, 0, nullptr, nullptr));
 	pcpp::Logger::getInstance().enableLogs();
 	pcpp::Packet redirectPacket(13);
 	PTF_ASSERT_TRUE(redirectPacket.addLayer(&ethLayer7));
@@ -398,7 +398,7 @@ PTF_TEST_CASE(IcmpCreationTest)
 	ipLayerForRedirect.getIPv4Header()->ipId = be16toh(14848);
 	ipLayerForRedirect.getIPv4Header()->timeToLive = 31;
 	pcpp::IcmpLayer icmpLayerForRedirect;
-	icmpLayerForRedirect.setEchoRequestData(512, 12544, 0, NULL, 0);
+	icmpLayerForRedirect.setEchoRequestData(512, 12544, 0, nullptr, 0);
 	PTF_ASSERT_NOT_NULL(redirectLayer.setRedirectData(1, pcpp::IPv4Address("10.2.99.98"), &ipLayerForRedirect, &icmpLayerForRedirect));
 	redirectPacket.computeCalculateFields();
 	PTF_ASSERT_EQUAL(redirectPacket.getRawPacket()->getRawDataLen(), bufferLength5+8);
@@ -449,7 +449,7 @@ PTF_TEST_CASE(IcmpCreationTest)
 PTF_TEST_CASE(IcmpEditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/IcmpRouterAdv1.dat");
 	READ_FILE_INTO_BUFFER(2, "PacketExamples/IcmpEchoRequest.dat");

--- a/Tests/Packet++Test/Tests/IcmpV6Tests.cpp
+++ b/Tests/Packet++Test/Tests/IcmpV6Tests.cpp
@@ -15,7 +15,7 @@
 PTF_TEST_CASE(IcmpV6ParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/IcmpV6_EchoRequest.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/IcmpV6_EchoReply.dat");
@@ -148,7 +148,7 @@ PTF_TEST_CASE(IcmpV6ParsingTest)
 PTF_TEST_CASE(IcmpV6CreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_INTO_BUFFER(1, "PacketExamples/IcmpV6_EchoRequest.dat");
 	READ_FILE_INTO_BUFFER(2, "PacketExamples/IcmpV6_EchoReply.dat");
@@ -274,7 +274,7 @@ PTF_TEST_CASE(IcmpV6CreationTest)
 
 	std::vector<pcpp::IPv6TLVOptionHeader::IPv6TLVOptionBuilder> hopByHopExtOptions;
 	hopByHopExtOptions.push_back(pcpp::IPv6TLVOptionHeader::IPv6TLVOptionBuilder(5, (uint16_t)0));
-	hopByHopExtOptions.push_back(pcpp::IPv6TLVOptionHeader::IPv6TLVOptionBuilder(1, NULL, 0));
+	hopByHopExtOptions.push_back(pcpp::IPv6TLVOptionHeader::IPv6TLVOptionBuilder(1, nullptr, 0));
 	pcpp::IPv6HopByHopHeader newHopByHopHeader(hopByHopExtOptions);
 	ipv6Layer2->addExtension<pcpp::IPv6HopByHopHeader>(newHopByHopHeader);
 	ipv6Layer2->getDataPtr(40)[0] = 0x3a;

--- a/Tests/Packet++Test/Tests/IgmpTests.cpp
+++ b/Tests/Packet++Test/Tests/IgmpTests.cpp
@@ -12,7 +12,7 @@
 PTF_TEST_CASE(IgmpParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/IGMPv1_1.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/IGMPv2_1.dat");
@@ -106,7 +106,7 @@ PTF_TEST_CASE(IgmpCreateAndEditTest)
 PTF_TEST_CASE(Igmpv3ParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/igmpv3_query.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/igmpv3_report.dat");

--- a/Tests/Packet++Test/Tests/LLCTests.cpp
+++ b/Tests/Packet++Test/Tests/LLCTests.cpp
@@ -10,7 +10,7 @@
 PTF_TEST_CASE(LLCParsingTests)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/StpConf.dat");
 
@@ -45,7 +45,7 @@ PTF_TEST_CASE(LLCParsingTests)
 PTF_TEST_CASE(LLCCreationTests)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/StpConf.dat");
 

--- a/Tests/Packet++Test/Tests/NtpTests.cpp
+++ b/Tests/Packet++Test/Tests/NtpTests.cpp
@@ -39,7 +39,7 @@ PTF_TEST_CASE(NtpParsingV3Tests)
 {
 
     timeval time;
-    gettimeofday(&time, NULL);
+    gettimeofday(&time, nullptr);
 
     READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/ntpv3.dat");
 
@@ -91,7 +91,7 @@ PTF_TEST_CASE(NtpParsingV4Tests)
 {
 
     timeval time;
-    gettimeofday(&time, NULL);
+    gettimeofday(&time, nullptr);
 
     READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/ntpv4.dat");
 
@@ -224,7 +224,7 @@ PTF_TEST_CASE(NtpCreationTests)
 {
 
     timeval time;
-    gettimeofday(&time, NULL);
+    gettimeofday(&time, nullptr);
 
     READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/ntpv4.dat");
 

--- a/Tests/Packet++Test/Tests/PPPoETests.cpp
+++ b/Tests/Packet++Test/Tests/PPPoETests.cpp
@@ -14,7 +14,7 @@
 PTF_TEST_CASE(PPPoESessionLayerParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/PPPoESession1.dat");
 
@@ -45,7 +45,7 @@ PTF_TEST_CASE(PPPoESessionLayerParsingTest)
 PTF_TEST_CASE(PPPoESessionLayerCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/PPPoESession2.dat");
 
@@ -79,7 +79,7 @@ PTF_TEST_CASE(PPPoESessionLayerCreationTest)
 PTF_TEST_CASE(PPPoEDiscoveryLayerParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/PPPoEDiscovery2.dat");
 
@@ -138,7 +138,7 @@ PTF_TEST_CASE(PPPoEDiscoveryLayerParsingTest)
 PTF_TEST_CASE(PPPoEDiscoveryLayerCreateTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/PPPoEDiscovery1.dat");
 

--- a/Tests/Packet++Test/Tests/PacketTests.cpp
+++ b/Tests/Packet++Test/Tests/PacketTests.cpp
@@ -64,7 +64,7 @@ PTF_TEST_CASE(InsertDataToPacket)
 	pcpp::MacAddress srcMac2("cc:cc:cc:cc:cc:cc");
 	pcpp::MacAddress dstMac2("dd:dd:dd:dd:dd:dd");
 	pcpp::EthLayer ethLayer2(srcMac2, dstMac2, PCPP_ETHERTYPE_IP);
-	PTF_ASSERT_TRUE(ip4Packet.insertLayer(NULL, &ethLayer2));
+	PTF_ASSERT_TRUE(ip4Packet.insertLayer(nullptr, &ethLayer2));
 
 	PTF_ASSERT_EQUAL(ip4Packet.getFirstLayer(), &ethLayer2, ptr);
 	PTF_ASSERT_EQUAL(ip4Packet.getFirstLayer()->getNextLayer(), &ethLayer, ptr);
@@ -88,7 +88,7 @@ PTF_TEST_CASE(InsertDataToPacket)
 
 	pcpp::Packet testPacket(1);
 	pcpp::EthLayer ethLayer3(srcMac2, dstMac2, PCPP_ETHERTYPE_IP);
-	PTF_ASSERT_TRUE(testPacket.insertLayer(NULL, &ethLayer3));
+	PTF_ASSERT_TRUE(testPacket.insertLayer(nullptr, &ethLayer3));
 	PTF_ASSERT_EQUAL(testPacket.getFirstLayer(), &ethLayer3, ptr);
 	PTF_ASSERT_NULL(testPacket.getFirstLayer()->getNextLayer());
 	PTF_ASSERT_EQUAL(ethLayer3.getDestMac(), dstMac2);
@@ -149,7 +149,7 @@ PTF_TEST_CASE(CreatePacketFromBuffer)
 PTF_TEST_CASE(InsertVlanToPacket)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/TcpPacketWithOptions3.dat");
 
@@ -171,7 +171,7 @@ PTF_TEST_CASE(RemoveLayerTest)
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/TcpPacketNoOptions.dat");
 
@@ -284,7 +284,7 @@ PTF_TEST_CASE(RemoveLayerTest)
 	// ~~~~~~~~~~~~~~~~~
 
 	pcpp::VlanLayer vlanLayer(4001, 0, 0, PCPP_ETHERTYPE_IP);
-	PTF_ASSERT_TRUE(testPacket.insertLayer(NULL, &vlanLayer));
+	PTF_ASSERT_TRUE(testPacket.insertLayer(nullptr, &vlanLayer));
 	PTF_ASSERT_EQUAL(testPacket.getFirstLayer(), &vlanLayer, ptr);
 	PTF_ASSERT_EQUAL(testPacket.getFirstLayer()->getNextLayer(), &ip4Layer, ptr);
 	PTF_ASSERT_TRUE(testPacket.isPacketOfType(pcpp::VLAN));
@@ -362,7 +362,7 @@ PTF_TEST_CASE(RemoveLayerTest)
 PTF_TEST_CASE(CopyLayerAndPacketTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/TwoHttpResponses1.dat");
 
@@ -408,7 +408,7 @@ PTF_TEST_CASE(CopyLayerAndPacketTest)
 
 	pcpp::HeaderField* curFieldInSample = sampleHttpLayer->getFirstField();
 	pcpp::HeaderField* curFieldInCopy = httpResLayer.getFirstField();
-	while (curFieldInSample != NULL && curFieldInCopy != NULL)
+	while (curFieldInSample != nullptr && curFieldInCopy != nullptr)
 	{
 		PTF_ASSERT_TRUE(curFieldInCopy != curFieldInSample);
 		PTF_ASSERT_EQUAL(curFieldInSample->getFieldName(), curFieldInCopy->getFieldName());
@@ -438,7 +438,7 @@ PTF_TEST_CASE(CopyLayerAndPacketTest)
 	PTF_ASSERT_TRUE(samplePacketCopy.isPacketOfType(pcpp::HTTPResponse));
 	pcpp::Layer* curSamplePacketLayer = sampleHttpPacket.getFirstLayer();
 	pcpp::Layer* curPacketCopyLayer = samplePacketCopy.getFirstLayer();
-	while (curSamplePacketLayer != NULL && curPacketCopyLayer != NULL)
+	while (curSamplePacketLayer != nullptr && curPacketCopyLayer != nullptr)
 	{
 		PTF_ASSERT_EQUAL(curSamplePacketLayer->getProtocol(), curPacketCopyLayer->getProtocol(), enum);
 		PTF_ASSERT_EQUAL(curSamplePacketLayer->getHeaderLen(), curPacketCopyLayer->getHeaderLen());
@@ -472,7 +472,7 @@ PTF_TEST_CASE(CopyLayerAndPacketTest)
 
 	curSamplePacketLayer = nullLoopbackPacket.getFirstLayer();
 	curPacketCopyLayer = nullLoopbackPacketCopy.getFirstLayer();
-	while (curSamplePacketLayer != NULL && curPacketCopyLayer != NULL)
+	while (curSamplePacketLayer != nullptr && curPacketCopyLayer != nullptr)
 	{
 		PTF_ASSERT_EQUAL(curSamplePacketLayer->getProtocol(), curPacketCopyLayer->getProtocol(), enum);
 		PTF_ASSERT_EQUAL(curSamplePacketLayer->getHeaderLen(), curPacketCopyLayer->getHeaderLen());
@@ -502,7 +502,7 @@ PTF_TEST_CASE(CopyLayerAndPacketTest)
 
 	curSamplePacketLayer = sllPacket.getFirstLayer();
 	curPacketCopyLayer = sllPacketCopy.getFirstLayer();
-	while (curSamplePacketLayer != NULL && curPacketCopyLayer != NULL)
+	while (curSamplePacketLayer != nullptr && curPacketCopyLayer != nullptr)
 	{
 		PTF_ASSERT_EQUAL(curSamplePacketLayer->getProtocol(), curPacketCopyLayer->getProtocol(), enum);
 		PTF_ASSERT_EQUAL(curSamplePacketLayer->getHeaderLen(), curPacketCopyLayer->getHeaderLen());
@@ -555,7 +555,7 @@ PTF_TEST_CASE(CopyLayerAndPacketTest)
 PTF_TEST_CASE(PacketLayerLookupTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	{
 		READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/radius_1.dat");
@@ -608,7 +608,7 @@ PTF_TEST_CASE(PacketLayerLookupTest)
 PTF_TEST_CASE(RawPacketTimeStampSetterTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/IPv6UdpPacket.dat");
 
@@ -640,7 +640,7 @@ PTF_TEST_CASE(RawPacketTimeStampSetterTest)
 PTF_TEST_CASE(ParsePartialPacketTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SSL-ClientHello1.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/IGMPv1_1.dat");
@@ -734,7 +734,7 @@ PTF_TEST_CASE(ParsePartialPacketTest)
 PTF_TEST_CASE(PacketTrailerTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/packet_trailer_arp.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/packet_trailer_ipv4.dat");
@@ -850,7 +850,7 @@ PTF_TEST_CASE(PacketTrailerTest)
 
 	// rebuild packet starting from trailer
 	pcpp::EthLayer newEthLayer(pcpp::MacAddress("30:46:9a:23:fb:fa"), pcpp::MacAddress("6c:f0:49:b2:de:6e"), PCPP_ETHERTYPE_IP);
-	PTF_ASSERT_TRUE(trailerIPv4Packet.insertLayer(NULL, &newEthLayer));
+	PTF_ASSERT_TRUE(trailerIPv4Packet.insertLayer(nullptr, &newEthLayer));
 	pcpp::IPv4Layer newIp4Layer(pcpp::IPv4Address("173.194.78.104"), pcpp::IPv4Address("10.0.0.1"));
 	newIp4Layer.getIPv4Header()->ipId = htobe16(40382);
 	newIp4Layer.getIPv4Header()->timeToLive = 46;
@@ -869,7 +869,7 @@ PTF_TEST_CASE(PacketTrailerTest)
 
 	// extend layer before trailer
 	ip6Layer = trailerIPv6Packet.getLayerOfType<pcpp::IPv6Layer>();
-	pcpp::IPv6RoutingHeader routingExt(4, 3, NULL, 0);
+	pcpp::IPv6RoutingHeader routingExt(4, 3, nullptr, 0);
 	ip6Layer->addExtension<pcpp::IPv6RoutingHeader>(routingExt);
 	trailerIPv6Packet.computeCalculateFields();
 	PTF_ASSERT_EQUAL(trailerIPv6Packet.getLayerOfType<pcpp::EthLayer>()->getDataLen(), 476);
@@ -970,7 +970,7 @@ PTF_TEST_CASE(PrintPacketAndLayers)
 
 	// convert the timestamp to a printable format
 	time_t nowtime = time.tv_sec;
-	struct tm *nowtm = NULL;
+	struct tm *nowtm = nullptr;
 #if __cplusplus > 199711L && !defined(_WIN32)
   // localtime_r is a thread-safe versions of localtime,
 	// but they're defined only in newer compilers (>= C++0x).
@@ -1002,7 +1002,7 @@ PTF_TEST_CASE(PrintPacketAndLayers)
 
 	// test print layers
 	std::vector<std::string>::iterator iter = expectedLayerStrings.begin();
-	for (pcpp::Layer* layer = packet.getFirstLayer(); layer != NULL; layer = layer->getNextLayer())
+	for (pcpp::Layer* layer = packet.getFirstLayer(); layer != nullptr; layer = layer->getNextLayer())
 	{
 		PTF_ASSERT_EQUAL(layer->toString(), *iter);
 		std::ostringstream layerStream;

--- a/Tests/Packet++Test/Tests/RadiusTests.cpp
+++ b/Tests/Packet++Test/Tests/RadiusTests.cpp
@@ -12,7 +12,7 @@
 PTF_TEST_CASE(RadiusLayerParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/radius_1.dat");
 	pcpp::Packet radiusPacket(&rawPacket1);
@@ -85,7 +85,7 @@ PTF_TEST_CASE(RadiusLayerParsingTest)
 PTF_TEST_CASE(RadiusLayerCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/radius_11.dat");
 
@@ -155,7 +155,7 @@ PTF_TEST_CASE(RadiusLayerCreationTest)
 PTF_TEST_CASE(RadiusLayerEditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(11, "PacketExamples/radius_11.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/radius_2.dat");

--- a/Tests/Packet++Test/Tests/SSHTests.cpp
+++ b/Tests/Packet++Test/Tests/SSHTests.cpp
@@ -7,7 +7,7 @@
 PTF_TEST_CASE(SSHParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SSHIdentification.dat");
 	pcpp::Packet sshIdentificationPacket(&rawPacket1);
@@ -97,7 +97,7 @@ PTF_TEST_CASE(SSHParsingTest)
 PTF_TEST_CASE(SSHMalformedParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	// SSH identification message that ends with "\r" instead of "\n" or "\r\n"
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SSHIdentification_Malformed.dat");

--- a/Tests/Packet++Test/Tests/SSLTests.cpp
+++ b/Tests/Packet++Test/Tests/SSLTests.cpp
@@ -11,7 +11,7 @@
 PTF_TEST_CASE(SSLClientHelloParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SSL-ClientHello1.dat");
 
 	pcpp::Packet clientHelloPacket(&rawPacket1);
@@ -168,7 +168,7 @@ PTF_TEST_CASE(SSLClientHelloParsingTest)
 PTF_TEST_CASE(SSLExtensionWithZeroSizeTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/tls_zero_size_ext.dat");
 
 	pcpp::Packet clientHelloPacket(&rawPacket1);
@@ -192,7 +192,7 @@ PTF_TEST_CASE(SSLExtensionWithZeroSizeTest)
 PTF_TEST_CASE(SSLAppDataParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SSL-MultipleAppData.dat");
 
 	pcpp::Packet appDataPacket(&rawPacket1);
@@ -229,7 +229,7 @@ PTF_TEST_CASE(SSLAppDataParsingTest)
 PTF_TEST_CASE(SSLAlertParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SSL-AlertClear.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/SSL-AlertEnc.dat");
 
@@ -265,7 +265,7 @@ PTF_TEST_CASE(SSLAlertParsingTest)
 PTF_TEST_CASE(SSLMultipleRecordParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SSL-MultipleRecords1.dat");
 
 	pcpp::Packet multipleRecordsPacket(&rawPacket1);
@@ -336,7 +336,7 @@ PTF_TEST_CASE(SSLMultipleRecordParsingTest)
 PTF_TEST_CASE(SSLMultipleRecordParsing2Test)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SSL-MultipleRecords2.dat");
 
@@ -365,7 +365,7 @@ PTF_TEST_CASE(SSLMultipleRecordParsing2Test)
 PTF_TEST_CASE(SSLMultipleRecordParsing3Test)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SSL-MultipleRecords3.dat");
 
@@ -429,7 +429,7 @@ PTF_TEST_CASE(SSLMultipleRecordParsing3Test)
 PTF_TEST_CASE(SSLMultipleRecordParsing4Test)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SSL-MultipleRecords4.dat");
 
@@ -464,7 +464,7 @@ PTF_TEST_CASE(SSLMultipleRecordParsing4Test)
 PTF_TEST_CASE(SSLPartialCertificateParseTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SSL-PartialCertificate1.dat");
 
@@ -506,7 +506,7 @@ PTF_TEST_CASE(SSLPartialCertificateParseTest)
 PTF_TEST_CASE(SSLNewSessionTicketParseTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SSL-NewSessionTicket.dat");
 
@@ -531,7 +531,7 @@ PTF_TEST_CASE(SSLNewSessionTicketParseTest)
 PTF_TEST_CASE(SSLMalformedPacketParsing)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/ssl-malformed1.dat");
 
@@ -548,7 +548,7 @@ PTF_TEST_CASE(SSLMalformedPacketParsing)
 PTF_TEST_CASE(TLS1_3ParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/tls1_3_client_hello1.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/tls1_3_client_hello2.dat");
@@ -702,7 +702,7 @@ PTF_TEST_CASE(TLSCipherSuiteTest)
 PTF_TEST_CASE(ClientHelloTLSFingerprintTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/tls1_3_client_hello1.dat");
 	pcpp::Packet tls13ClientHello1(&rawPacket1);
@@ -734,7 +734,7 @@ PTF_TEST_CASE(ClientHelloTLSFingerprintTest)
 PTF_TEST_CASE(ServerHelloTLSFingerprintTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SSL-MultipleRecords1.dat");
 

--- a/Tests/Packet++Test/Tests/SipSdpTests.cpp
+++ b/Tests/Packet++Test/Tests/SipSdpTests.cpp
@@ -15,7 +15,7 @@
 PTF_TEST_CASE(SipRequestLayerParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/sip_req1.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/sip_req2.dat");
@@ -124,7 +124,7 @@ PTF_TEST_CASE(SipRequestLayerParsingTest)
 PTF_TEST_CASE(SipRequestLayerCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/sip_req1.dat");
 
@@ -147,8 +147,8 @@ PTF_TEST_CASE(SipRequestLayerCreationTest)
 	PTF_ASSERT_NOT_NULL(sipReqLayer.addField(PCPP_SIP_CALL_ID_FIELD, "12013223@200.57.7.195"));
 	PTF_ASSERT_NOT_NULL(sipReqLayer.addField(PCPP_SIP_CONTENT_TYPE_FIELD, "application/sdp"));
 	PTF_ASSERT_TRUE(sipReqLayer.addEndOfHeader());
-	PTF_ASSERT_NOT_NULL(sipReqLayer.insertField(NULL, PCPP_SIP_VIA_FIELD, "SIP/2.0/UDP 200.57.7.195:55061;branch=z9hG4bK291d90e31a47b225bd0ddff4353e9cc0"));
-	PTF_ASSERT_NOT_NULL(sipReqLayer.insertField(NULL, PCPP_SIP_VIA_FIELD, "SIP/2.0/UDP 200.57.7.195;branch=z9hG4bKff9b46fb055c0521cc24024da96cd290"));
+	PTF_ASSERT_NOT_NULL(sipReqLayer.insertField(nullptr, PCPP_SIP_VIA_FIELD, "SIP/2.0/UDP 200.57.7.195:55061;branch=z9hG4bK291d90e31a47b225bd0ddff4353e9cc0"));
+	PTF_ASSERT_NOT_NULL(sipReqLayer.insertField(nullptr, PCPP_SIP_VIA_FIELD, "SIP/2.0/UDP 200.57.7.195;branch=z9hG4bKff9b46fb055c0521cc24024da96cd290"));
 	pcpp::HeaderField* callIDField = sipReqLayer.getFieldByName(PCPP_SIP_CALL_ID_FIELD);
 	PTF_ASSERT_NOT_NULL(callIDField);
 	pcpp::HeaderField* newField = sipReqLayer.insertField(callIDField, PCPP_SIP_CSEQ_FIELD, "1 INVITE");
@@ -183,7 +183,7 @@ PTF_TEST_CASE(SipRequestLayerCreationTest)
 PTF_TEST_CASE(SipRequestLayerEditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/sip_req2.dat");
 	READ_FILE_AND_CREATE_PACKET(3, "PacketExamples/sip_req3.dat");
@@ -239,7 +239,7 @@ PTF_TEST_CASE(SipRequestLayerEditTest)
 PTF_TEST_CASE(SipResponseLayerParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/sip_resp1.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/sip_resp2.dat");
@@ -347,7 +347,7 @@ PTF_TEST_CASE(SipResponseLayerParsingTest)
 PTF_TEST_CASE(SipResponseLayerCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(6, "PacketExamples/sip_resp6.dat");
 
@@ -373,8 +373,8 @@ PTF_TEST_CASE(SipResponseLayerCreationTest)
 	PTF_ASSERT_NOT_NULL(contentLengthField);
 	contentLengthField->setFieldValue(" 0");
 	PTF_ASSERT_NOT_NULL(sipRespLayer.addEndOfHeader());
-	PTF_ASSERT_NOT_NULL(sipRespLayer.insertField(NULL, PCPP_SIP_CALL_ID_FIELD, "93803593"));
-	PTF_ASSERT_NOT_NULL(sipRespLayer.insertField(NULL, PCPP_SIP_VIA_FIELD, "SIP/2.0/UDP 10.3.160.214:5060;rport=5060;received=10.3.160.214;branch=z9hG4bK19266132"));
+	PTF_ASSERT_NOT_NULL(sipRespLayer.insertField(nullptr, PCPP_SIP_CALL_ID_FIELD, "93803593"));
+	PTF_ASSERT_NOT_NULL(sipRespLayer.insertField(nullptr, PCPP_SIP_VIA_FIELD, "SIP/2.0/UDP 10.3.160.214:5060;rport=5060;received=10.3.160.214;branch=z9hG4bK19266132"));
 	pcpp::HeaderField* fromField = sipRespLayer.getFieldByName(PCPP_SIP_FROM_FIELD);
 	PTF_ASSERT_NOT_NULL(fromField);
 	PTF_ASSERT_NOT_NULL(sipRespLayer.insertField(fromField, PCPP_SIP_TO_FIELD, "<sip:user103@ims.hom>;tag=z9hG4bKPjoKb0QlsN0Z-v4iW63WRm5UfjLn.Gm81V"));
@@ -394,7 +394,7 @@ PTF_TEST_CASE(SipResponseLayerCreationTest)
 PTF_TEST_CASE(SipResponseLayerEditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(3, "PacketExamples/sip_resp3.dat");
 	READ_FILE_AND_CREATE_PACKET(4, "PacketExamples/sip_resp4.dat");
@@ -455,7 +455,7 @@ PTF_TEST_CASE(SipResponseLayerEditTest)
 PTF_TEST_CASE(SdpLayerParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/sip_req1.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/sdp.dat");
@@ -509,7 +509,7 @@ PTF_TEST_CASE(SdpLayerParsingTest)
 PTF_TEST_CASE(SdpLayerCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/sdp.dat");
 
@@ -575,7 +575,7 @@ PTF_TEST_CASE(SdpLayerCreationTest)
 PTF_TEST_CASE(SdpLayerEditTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/sdp.dat");
 	READ_FILE_AND_CREATE_PACKET(3, "PacketExamples/sip_resp3.dat");
@@ -590,7 +590,7 @@ PTF_TEST_CASE(SdpLayerEditTest)
 	PTF_ASSERT_TRUE(sdpLayer->getFieldByName(PCPP_SDP_SESSION_NAME_FIELD)->setFieldValue("Phone-Call"));
 	PTF_ASSERT_TRUE(sdpLayer->getFieldByName(PCPP_SDP_CONNECTION_INFO_FIELD)->setFieldValue("IN IP4 10.33.6.100"));
 	PTF_ASSERT_TRUE(sdpLayer->removeField(PCPP_SDP_MEDIA_NAME_FIELD));
-	while (sdpLayer->getFieldByName(PCPP_SDP_MEDIA_ATTRIBUTE_FIELD) != NULL)
+	while (sdpLayer->getFieldByName(PCPP_SDP_MEDIA_ATTRIBUTE_FIELD) != nullptr)
 	{
 		sdpLayer->removeField(PCPP_SDP_MEDIA_ATTRIBUTE_FIELD);
 	}

--- a/Tests/Packet++Test/Tests/SllNullLoopbackTests.cpp
+++ b/Tests/Packet++Test/Tests/SllNullLoopbackTests.cpp
@@ -16,7 +16,7 @@
 PTF_TEST_CASE(SllPacketParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET_LINKTYPE(1, "PacketExamples/SllPacket.dat", pcpp::LINKTYPE_LINUX_SLL);
 
@@ -60,7 +60,7 @@ PTF_TEST_CASE(SllPacketCreationTest)
 	tcpLayer.getTcpHeader()->windowSize = htobe16(4098);
 	PTF_ASSERT_TRUE(tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TcpOptionBuilder::NOP)).isNotNull());
 	PTF_ASSERT_TRUE(tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TcpOptionBuilder::NOP)).isNotNull());
-	pcpp::TcpOption tsOption = tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::PCPP_TCPOPT_TIMESTAMP, NULL, PCPP_TCPOLEN_TIMESTAMP-2));
+	pcpp::TcpOption tsOption = tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::PCPP_TCPOPT_TIMESTAMP, nullptr, PCPP_TCPOLEN_TIMESTAMP-2));
 	PTF_ASSERT_TRUE(tsOption.isNotNull());
 	tsOption.setValue<uint32_t>(htobe32(0x0402383b));
 	tsOption.setValue<uint32_t>(htobe32(0x03ff37f5), 4);
@@ -86,7 +86,7 @@ PTF_TEST_CASE(SllPacketCreationTest)
 PTF_TEST_CASE(NullLoopbackTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET_LINKTYPE(1, "PacketExamples/NullLoopback1.dat", pcpp::LINKTYPE_NULL);
 	READ_FILE_AND_CREATE_PACKET_LINKTYPE(2, "PacketExamples/NullLoopback2.dat", pcpp::LINKTYPE_NULL);

--- a/Tests/Packet++Test/Tests/SomeIpSdTests.cpp
+++ b/Tests/Packet++Test/Tests/SomeIpSdTests.cpp
@@ -10,7 +10,7 @@
 PTF_TEST_CASE(SomeIpSdParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/SomeIpSdOffer.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/SomeIpSdOffer2.dat");
@@ -221,7 +221,7 @@ PTF_TEST_CASE(SomeIpSdParsingTest)
 PTF_TEST_CASE(SomeIpSdCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_INTO_BUFFER(1, "PacketExamples/SomeIpSdOffer.dat");
 	READ_FILE_INTO_BUFFER(2, "PacketExamples/SomeIpSdSubscribe.dat");

--- a/Tests/Packet++Test/Tests/SomeIpTests.cpp
+++ b/Tests/Packet++Test/Tests/SomeIpTests.cpp
@@ -42,7 +42,7 @@ PTF_TEST_CASE(SomeIpPortTest)
 PTF_TEST_CASE(SomeIpParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	// cppcheck-suppress unusedVariable
 	SomeIpTeardown someIpTeardown;
@@ -123,7 +123,7 @@ PTF_TEST_CASE(SomeIpParsingTest)
 PTF_TEST_CASE(SomeIpCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_INTO_BUFFER(1, "PacketExamples/someip.dat");
 	READ_FILE_INTO_BUFFER(2, "PacketExamples/someip2.dat");
@@ -170,7 +170,7 @@ PTF_TEST_CASE(SomeIpCreationTest)
 PTF_TEST_CASE(SomeIpTpParsingTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	// cppcheck-suppress unusedVariable
 	SomeIpTeardown someIpTeardown;
@@ -234,7 +234,7 @@ PTF_TEST_CASE(SomeIpTpParsingTest)
 PTF_TEST_CASE(SomeIpTpCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_INTO_BUFFER(1, "PacketExamples/SomeIpTp1.dat");
 	READ_FILE_INTO_BUFFER(2, "PacketExamples/SomeIpTp2.dat");

--- a/Tests/Packet++Test/Tests/StpTests.cpp
+++ b/Tests/Packet++Test/Tests/StpTests.cpp
@@ -9,7 +9,7 @@
 PTF_TEST_CASE(StpConfigurationParsingTests)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/StpConf.dat");
 
@@ -45,7 +45,7 @@ PTF_TEST_CASE(StpConfigurationParsingTests)
 PTF_TEST_CASE(StpTopologyChangeParsingTests)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/StpTcn.dat");
 
@@ -66,7 +66,7 @@ PTF_TEST_CASE(StpTopologyChangeParsingTests)
 PTF_TEST_CASE(RapidStpParsingTests)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/StpRapid.dat");
 
@@ -103,7 +103,7 @@ PTF_TEST_CASE(RapidStpParsingTests)
 PTF_TEST_CASE(MultipleStpParsingTests)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/StpMultiple.dat");
 

--- a/Tests/Packet++Test/Tests/TcpTests.cpp
+++ b/Tests/Packet++Test/Tests/TcpTests.cpp
@@ -12,7 +12,7 @@
 PTF_TEST_CASE(TcpPacketNoOptionsParsing)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/TcpPacketNoOptions.dat");
 
@@ -57,7 +57,7 @@ PTF_TEST_CASE(TcpPacketNoOptionsParsing)
 PTF_TEST_CASE(TcpPacketWithOptionsParsing)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/TcpPacketWithOptions.dat");
 
@@ -92,7 +92,7 @@ PTF_TEST_CASE(TcpPacketWithOptionsParsing)
 PTF_TEST_CASE(TcpPacketWithOptionsParsing2)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/TcpPacketWithOptions3.dat");
 
@@ -142,7 +142,7 @@ PTF_TEST_CASE(TcpPacketWithOptionsParsing2)
 PTF_TEST_CASE(TcpMalformedPacketParsing)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/tcp-malformed1.dat");
 
@@ -175,7 +175,7 @@ PTF_TEST_CASE(TcpPacketCreation)
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 24);
 	PTF_ASSERT_TRUE(tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TcpOptionBuilder::NOP)).isNotNull());
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 24);
-	PTF_ASSERT_TRUE(tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::PCPP_TCPOPT_TIMESTAMP, NULL, PCPP_TCPOLEN_TIMESTAMP-2)).isNotNull());
+	PTF_ASSERT_TRUE(tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::PCPP_TCPOPT_TIMESTAMP, nullptr, PCPP_TCPOLEN_TIMESTAMP-2)).isNotNull());
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 32);
 	PTF_ASSERT_EQUAL(tcpLayer.getTcpOptionCount(), 3);
 
@@ -231,7 +231,7 @@ PTF_TEST_CASE(TcpPacketCreation2)
 	PTF_ASSERT_TRUE(tcpLayer.addTcpOptionAfter(pcpp::TcpOptionBuilder(pcpp::TCPOPT_MSS, (uint16_t)1460)).isNotNull());
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 28);
 
-	pcpp::TcpOption tsOption = tcpLayer.addTcpOptionAfter(pcpp::TcpOptionBuilder(pcpp::PCPP_TCPOPT_TIMESTAMP, NULL, PCPP_TCPOLEN_TIMESTAMP-2), pcpp::TCPOPT_MSS);
+	pcpp::TcpOption tsOption = tcpLayer.addTcpOptionAfter(pcpp::TcpOptionBuilder(pcpp::PCPP_TCPOPT_TIMESTAMP, nullptr, PCPP_TCPOLEN_TIMESTAMP-2), pcpp::TCPOPT_MSS);
 	PTF_ASSERT_TRUE(tsOption.isNotNull());
 	tsOption.setValue<uint32_t>(htobe32(197364));
 	tsOption.setValue<uint32_t>(0, 4);
@@ -241,7 +241,7 @@ PTF_TEST_CASE(TcpPacketCreation2)
 	PTF_ASSERT_TRUE(winScaleOption.isNotNull());
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 40);
 
-	PTF_ASSERT_TRUE(tcpLayer.addTcpOptionAfter(pcpp::TcpOptionBuilder(pcpp::TCPOPT_SACK_PERM, NULL, 0), pcpp::TCPOPT_MSS).isNotNull());
+	PTF_ASSERT_TRUE(tcpLayer.addTcpOptionAfter(pcpp::TcpOptionBuilder(pcpp::TCPOPT_SACK_PERM, nullptr, 0), pcpp::TCPOPT_MSS).isNotNull());
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 40);
 
 	PTF_ASSERT_EQUAL(tcpLayer.getTcpOptionCount(), 5);
@@ -259,7 +259,7 @@ PTF_TEST_CASE(TcpPacketCreation2)
 
 	PTF_ASSERT_BUF_COMPARE(tcpPacket.getRawPacket()->getRawData(), buffer1, bufferLength1);
 
-	pcpp::TcpOption qsOption = tcpLayer.addTcpOptionAfter(pcpp::TcpOptionBuilder(pcpp::TCPOPT_QS, NULL, PCPP_TCPOLEN_QS), pcpp::TCPOPT_MSS);
+	pcpp::TcpOption qsOption = tcpLayer.addTcpOptionAfter(pcpp::TcpOptionBuilder(pcpp::TCPOPT_QS, nullptr, PCPP_TCPOLEN_QS), pcpp::TCPOPT_MSS);
 	PTF_ASSERT_TRUE(qsOption.isNotNull());
 	PTF_ASSERT_TRUE(qsOption.setValue(htobe32(9999)));
 	PTF_ASSERT_TRUE(tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TCPOPT_SNACK, (uint32_t)htobe32(1000))).isNotNull());
@@ -283,7 +283,7 @@ PTF_TEST_CASE(TcpPacketCreation2)
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 20);
 	PTF_ASSERT_TRUE(tcpLayer.getTcpOption(pcpp::PCPP_TCPOPT_TIMESTAMP).isNull());
 
-	pcpp::TcpOption tcpSnackOption = tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TCPOPT_SNACK, NULL, PCPP_TCPOLEN_SNACK));
+	pcpp::TcpOption tcpSnackOption = tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TCPOPT_SNACK, nullptr, PCPP_TCPOLEN_SNACK));
 	PTF_ASSERT_TRUE(tcpSnackOption.isNotNull());
 	PTF_ASSERT_TRUE(tcpSnackOption.setValue(htobe32(1000)));
 } // TcpPacketCreation2

--- a/Tests/Packet++Test/Tests/TelnetTests.cpp
+++ b/Tests/Packet++Test/Tests/TelnetTests.cpp
@@ -12,7 +12,7 @@ PTF_TEST_CASE(TelnetCommandParsingTests)
 {
 
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/telnetCommand.dat");
 
@@ -147,7 +147,7 @@ PTF_TEST_CASE(TelnetDataParsingTests)
 {
 
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/telnetData.dat");
 

--- a/Tests/Packet++Test/Tests/VlanMplsTests.cpp
+++ b/Tests/Packet++Test/Tests/VlanMplsTests.cpp
@@ -29,7 +29,7 @@ PTF_TEST_CASE(VlanParseAndCreation)
 	}
 
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/ArpRequestWithVlan.dat");
 
@@ -71,7 +71,7 @@ PTF_TEST_CASE(VlanParseAndCreation)
 PTF_TEST_CASE(QinQ802_1adParse)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/QinQ_802.1_AD.dat");
 	pcpp::Packet qinq8021adPacket(&rawPacket1);
@@ -95,7 +95,7 @@ PTF_TEST_CASE(QinQ802_1adParse)
 PTF_TEST_CASE(MplsLayerTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/MplsPackets1.dat");
 	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/MplsPackets2.dat");
@@ -180,7 +180,7 @@ PTF_TEST_CASE(MplsLayerTest)
 PTF_TEST_CASE(VxlanParsingAndCreationTest)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/Vxlan1.dat");
 	READ_FILE_INTO_BUFFER(2, "PacketExamples/Vxlan2.dat");

--- a/Tests/Packet++Test/Tests/WakeOnLanTests.cpp
+++ b/Tests/Packet++Test/Tests/WakeOnLanTests.cpp
@@ -9,7 +9,7 @@
 PTF_TEST_CASE(WakeOnLanParsingTests)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/WoL_ether.dat");
 
@@ -39,7 +39,7 @@ PTF_TEST_CASE(WakeOnLanParsingTests)
 PTF_TEST_CASE(WakeOnLanCreationTests)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/WoL_ether.dat");
 
@@ -73,7 +73,7 @@ PTF_TEST_CASE(WakeOnLanCreationTests)
 PTF_TEST_CASE(WakeOnLanEditTests)
 {
 	timeval time;
-	gettimeofday(&time, NULL);
+	gettimeofday(&time, nullptr);
 
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/WoL_ether.dat");
 

--- a/Tests/Packet++Test/Utils/TestUtils.cpp
+++ b/Tests/Packet++Test/Utils/TestUtils.cpp
@@ -24,11 +24,11 @@ uint8_t* readFileIntoBuffer(const char* filename, int& bufferLength)
 {
 	int fileLength = getFileLength(filename);
 	if (fileLength == -1)
-		return NULL;
+		return nullptr;
 
 	std::ifstream infile(filename);
 	if (!infile)
-		return NULL;
+		return nullptr;
 
 	bufferLength = fileLength/2 + 2;
 	uint8_t* result = new uint8_t[bufferLength];
@@ -38,7 +38,7 @@ uint8_t* readFileIntoBuffer(const char* filename, int& bufferLength)
 		char byte[3];
 		memset(byte, 0, 3);
 		infile.read(byte, 2);
-		result[i] = (uint8_t)strtol(byte, NULL, 16);
+		result[i] = (uint8_t)strtol(byte, nullptr, 16);
 		i++;
 	}
 	infile.close();

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -9,14 +9,14 @@
 
 static struct option PacketTestOptions[] =
 {
-	{"include-tags",  required_argument, 0, 't'},
-	{"exclude-tags",  required_argument, 0, 'x'},
-	{"show-skipped-tests", no_argument, 0, 'w' },
-	{"mem-verbose", no_argument, 0, 'm' },
-	{"verbose", no_argument, 0, 'v' },
-	{"skip-mem-leak-check", no_argument, 0, 's' },
-	{"help", no_argument, 0, 'h' },
-	{0, 0, 0, 0}
+	{"include-tags",  required_argument, nullptr, 't'},
+	{"exclude-tags",  required_argument, nullptr, 'x'},
+	{"show-skipped-tests", no_argument, nullptr, 'w' },
+	{"mem-verbose", no_argument, nullptr, 'm' },
+	{"verbose", no_argument, nullptr, 'v' },
+	{"skip-mem-leak-check", no_argument, nullptr, 's' },
+	{"help", no_argument, nullptr, 'h' },
+	{nullptr, 0, nullptr, 0}
 };
 
 void printUsage()

--- a/Tests/Pcap++Test/Common/TestUtils.cpp
+++ b/Tests/Pcap++Test/Common/TestUtils.cpp
@@ -68,11 +68,11 @@ uint8_t* readFileIntoBuffer(const std::string &filename, int& bufferLength)
 {
 	int fileLength = getFileLength(filename);
 	if (fileLength == -1)
-		return NULL;
+		return nullptr;
 
 	std::ifstream infile(filename.c_str());
 	if (!infile)
-		return NULL;
+		return nullptr;
 
 	bufferLength = fileLength/2 + 2;
 	uint8_t* result = new uint8_t[bufferLength];
@@ -82,7 +82,7 @@ uint8_t* readFileIntoBuffer(const std::string &filename, int& bufferLength)
 		char byte[3];
 		memset(byte, 0, 3);
 		infile.read(byte, 2);
-		result[i] = (uint8_t)strtol(byte, NULL, 16);
+		result[i] = (uint8_t)strtol(byte, nullptr, 16);
 		i++;
 	}
 	infile.close();

--- a/Tests/Pcap++Test/Tests/FileTests.cpp
+++ b/Tests/Pcap++Test/Tests/FileTests.cpp
@@ -19,7 +19,7 @@ public:
 
 	~FileReaderTeardown()
 	{
-		if (m_Reader != NULL)
+		if (m_Reader != nullptr)
 		{
 			delete m_Reader;
 		}

--- a/Tests/Pcap++Test/Tests/FilterTests.cpp
+++ b/Tests/Pcap++Test/Tests/FilterTests.cpp
@@ -36,7 +36,7 @@ static int incSleep(const pcpp::RawPacketVector& capturedPackets, size_t expecte
 
 PTF_TEST_CASE(TestPcapFiltersLive)
 {
-	pcpp::PcapLiveDevice* liveDev = NULL;
+	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
 	PTF_ASSERT_NOT_NULL(liveDev);
@@ -155,7 +155,7 @@ PTF_TEST_CASE(TestPcapFiltersLive)
 			bool srcPortMatch = tcpLayer->getSrcPort() == 80;
 			bool srcIpMatch = false;
 			pcpp::IPv4Layer* ip4Layer = packet.getLayerOfType<pcpp::IPv4Layer>();
-			if (ip4Layer != NULL)
+			if (ip4Layer != nullptr)
 			{
 				srcIpMatch = ip4Layer->getSrcIPAddress() == ipToSearch;
 			}

--- a/Tests/Pcap++Test/Tests/IPFragmentationTests.cpp
+++ b/Tests/Pcap++Test/Tests/IPFragmentationTests.cpp
@@ -30,7 +30,7 @@ PTF_TEST_CASE(TestIPFragmentationSanity)
 	PTF_ASSERT_EQUAL(ipReassembly.getMaxCapacity(), PCPP_IP_REASSEMBLY_DEFAULT_MAX_PACKETS_TO_STORE);
 	PTF_ASSERT_EQUAL(ipReassembly.getCurrentCapacity(), 0);
 
-	pcpp::Packet* result = NULL;
+	pcpp::Packet* result = nullptr;
 
 	PTF_PRINT_VERBOSE("basic IPv4 reassembly test - iterating over packet stream");
 	for (size_t i = 0; i < packetStream.size(); i++)
@@ -90,7 +90,7 @@ PTF_TEST_CASE(TestIPFragmentationSanity)
 
 	reader.close();
 
-	result = NULL;
+	result = nullptr;
 
 	PTF_PRINT_VERBOSE("basic IPv6 reassembly test - iterating over packet stream");
 	for (size_t i = 0; i < packet1Frags.size(); i++)
@@ -176,7 +176,7 @@ PTF_TEST_CASE(TestIPFragOutOfOrder)
 	pcpp::IPReassembly ipReassembly;
 	pcpp::IPReassembly::ReassemblyStatus status;
 
-	pcpp::Packet* result = NULL;
+	pcpp::Packet* result = nullptr;
 
 	int bufferLength = 0;
 	uint8_t* buffer = readFileIntoBuffer("PcapExamples/frag_http_req_reassembled.txt", bufferLength);
@@ -222,7 +222,7 @@ PTF_TEST_CASE(TestIPFragOutOfOrder)
 	PTF_ASSERT_BUF_COMPARE(result->getRawPacket()->getRawData(), buffer, bufferLength);
 
 	delete result;
-	result = NULL;
+	result = nullptr;
 
 	packetStream.clear();
 
@@ -271,7 +271,7 @@ PTF_TEST_CASE(TestIPFragOutOfOrder)
 	PTF_ASSERT_BUF_COMPARE(result->getRawPacket()->getRawData(), buffer, bufferLength);
 
 	delete result;
-	result = NULL;
+	result = nullptr;
 
 	packetStream.clear();
 
@@ -317,7 +317,7 @@ PTF_TEST_CASE(TestIPFragOutOfOrder)
 	PTF_ASSERT_BUF_COMPARE(result->getRawPacket()->getRawData(), buffer, bufferLength);
 
 	delete result;
-	result = NULL;
+	result = nullptr;
 
 	packetStream.clear();
 
@@ -365,7 +365,7 @@ PTF_TEST_CASE(TestIPFragOutOfOrder)
 	PTF_ASSERT_BUF_COMPARE(result->getRawPacket()->getRawData(), buffer, bufferLength);
 
 	delete result;
-	result = NULL;
+	result = nullptr;
 
 	packetStream.clear();
 
@@ -425,7 +425,7 @@ PTF_TEST_CASE(TestIPFragOutOfOrder)
 
 	reader.close();
 
-	result = NULL;
+	result = nullptr;
 
 	result = ipReassembly.processPacket(packet1Frags.at(2), status);
 	PTF_ASSERT_NULL(result);
@@ -938,8 +938,8 @@ PTF_TEST_CASE(TestIPFragMapOverflow)
 
 	PTF_ASSERT_EQUAL(packetsRemovedFromIPReassemblyEngine.size(), 5);
 
-	pcpp::IPReassembly::IPv4PacketKey* ip4Key = NULL;
-	pcpp::IPReassembly::IPv6PacketKey* ip6Key = NULL;
+	pcpp::IPReassembly::IPv4PacketKey* ip4Key = nullptr;
+	pcpp::IPReassembly::IPv6PacketKey* ip6Key = nullptr;
 
 	// 1st packet removed should be ip6Packet1Frags
 	ip6Key = dynamic_cast<pcpp::IPReassembly::IPv6PacketKey*>(packetsRemovedFromIPReassemblyEngine.at(0));

--- a/Tests/Pcap++Test/Tests/IpMacTests.cpp
+++ b/Tests/Pcap++Test/Tests/IpMacTests.cpp
@@ -188,7 +188,7 @@ PTF_TEST_CASE(TestMacAddress)
 	oss << macAddr1;
 	PTF_ASSERT_EQUAL(oss.str(), "11:02:33:04:55:06");
 
-	uint8_t* arrToCopyTo = NULL;
+	uint8_t* arrToCopyTo = nullptr;
 	macAddr3.copyTo(&arrToCopyTo);
 	PTF_ASSERT_EQUAL(arrToCopyTo[0], 0x11, hex);
 	PTF_ASSERT_EQUAL(arrToCopyTo[1], 0x02, hex);
@@ -235,7 +235,7 @@ PTF_TEST_CASE(TestLRUList)
 	PTF_ASSERT_EQUAL(lruList.put(1, &deletedValue), 0);
 	PTF_ASSERT_EQUAL(deletedValue, 0);
 
-	PTF_ASSERT_EQUAL(lruList.put(2, NULL), 0);
+	PTF_ASSERT_EQUAL(lruList.put(2, nullptr), 0);
 
 	PTF_ASSERT_EQUAL(lruList.put(3, &deletedValue), 1);
 	PTF_ASSERT_EQUAL(deletedValue, 1);
@@ -276,7 +276,7 @@ PTF_TEST_CASE(TestGeneralUtils)
 
 PTF_TEST_CASE(TestGetMacAddress)
 {
-	pcpp::PcapLiveDevice* liveDev = NULL;
+	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
 	PTF_ASSERT_NOT_NULL(liveDev);

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -48,7 +48,7 @@ static bool packetArrivesBlockingModeNoTimeout(pcpp::RawPacket* rawPacket, pcpp:
 static bool packetArrivesBlockingModeStartCapture(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev, void* userCookie)
 {
 	pcpp::Logger::getInstance().suppressLogs();
-	if (dev->startCaptureBlockingMode(packetArrivesBlockingModeTimeout, NULL, 5) != 0)
+	if (dev->startCaptureBlockingMode(packetArrivesBlockingModeTimeout, nullptr, 5) != 0)
 		return false;
 
 	int temp = 0;
@@ -197,12 +197,12 @@ PTF_TEST_CASE(TestPcapLiveDeviceList)
 
 PTF_TEST_CASE(TestPcapLiveDeviceListSearch)
 {
-	pcpp::PcapLiveDevice* liveDev = NULL;
+	pcpp::PcapLiveDevice* liveDev = nullptr;
 	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(liveDev);
 
 	std::string devName(liveDev->getName());
-	pcpp::PcapLiveDevice* liveDev2 = NULL;
+	pcpp::PcapLiveDevice* liveDev2 = nullptr;
 	liveDev2 = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByName(devName);
 	PTF_ASSERT_NOT_NULL(liveDev2);
 	PTF_ASSERT_EQUAL(liveDev->getName(), liveDev2->getName());
@@ -220,7 +220,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceListSearch)
 
 PTF_TEST_CASE(TestPcapLiveDevice)
 {
-	pcpp::PcapLiveDevice* liveDev = NULL;
+	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
 	PTF_ASSERT_NOT_NULL(liveDev);
@@ -263,7 +263,7 @@ PTF_TEST_CASE(TestPcapLiveDevice)
 PTF_TEST_CASE(TestPcapLiveDeviceClone)
 {
 	// Test of clone device should be same with original
-	pcpp::PcapLiveDevice* liveDev = NULL;
+	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch)->clone();
 	PTF_ASSERT_NOT_NULL(liveDev);
@@ -307,7 +307,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceNoNetworking)
 {
 	PTF_ASSERT_NOT_EQUAL(pcpp::IPcapDevice::getPcapLibVersionInfo(), "");
 
-	pcpp::PcapLiveDevice* liveDev = NULL;
+	pcpp::PcapLiveDevice* liveDev = nullptr;
 
 	std::vector<pcpp::PcapLiveDevice*> devList = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDevicesList();
 	PTF_ASSERT_FALSE(devList.empty());
@@ -327,7 +327,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceNoNetworking)
 	PTF_ASSERT_NOT_EQUAL(liveDev->getMacAddress(), pcpp::MacAddress::Zero);
 
 	// a negative test - check invalid IP address
-	liveDev = NULL;
+	liveDev = nullptr;
 	pcpp::Logger::getInstance().suppressLogs();
 	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp("eth0");
 	pcpp::Logger::getInstance().enableLogs();
@@ -386,7 +386,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceBlockingMode)
 	DeviceTeardown devTeardown(liveDev);
 
 	// sanity - test blocking mode returns with timeout
-	PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeTimeout, NULL, 5), -1);
+	PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeTimeout, nullptr, 5), -1);
 
 	// sanity - test blocking mode returns before timeout
 	int packetCount = 0;
@@ -395,7 +395,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceBlockingMode)
 
 	// verify stop capture doesn't do any effect on blocking mode
 	liveDev->stopCapture();
-	PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeTimeout, NULL, 1), -1);
+	PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeTimeout, nullptr, 1), -1);
 	packetCount = 0;
 	PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeNoTimeout, &packetCount, 30), 1);
 	PTF_ASSERT_EQUAL(packetCount, 5);
@@ -440,7 +440,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceBlockingMode)
 
 	// verify an error returns if trying capture blocking while non-blocking is running
 	pcpp::Logger::getInstance().suppressLogs();
-	PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeTimeout, NULL, 1), 0);
+	PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeTimeout, nullptr, 1), 0);
 	pcpp::Logger::getInstance().enableLogs();
 
 	totalSleepTime = 0;
@@ -583,7 +583,7 @@ PTF_TEST_CASE(TestWinPcapLiveDevice)
 
 PTF_TEST_CASE(TestSendPacket)
 {
-	pcpp::PcapLiveDevice* liveDev = NULL;
+	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
 	PTF_ASSERT_NOT_NULL(liveDev);
@@ -635,7 +635,7 @@ PTF_TEST_CASE(TestSendPacket)
 
 PTF_TEST_CASE(TestSendPackets)
 {
-	pcpp::PcapLiveDevice* liveDev = NULL;
+	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
 	PTF_ASSERT_NOT_NULL(liveDev);
@@ -674,7 +674,7 @@ PTF_TEST_CASE(TestSendPackets)
 
 PTF_TEST_CASE(TestMtuSize)
 {
-	pcpp::PcapLiveDevice* liveDev = NULL;
+	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
 	PTF_ASSERT_NOT_NULL(liveDev);

--- a/Tests/Pcap++Test/Tests/LoggerTests.cpp
+++ b/Tests/Pcap++Test/Tests/LoggerTests.cpp
@@ -46,29 +46,29 @@ class LogPrinter
 		{
 			LogPrinter::lastLogLevelSeen = 999;
 			LogPrinter::lastLineSeen = 99999;
-			if (LogPrinter::lastLogMessageSeen != NULL)
+			if (LogPrinter::lastLogMessageSeen != nullptr)
 			{
 				delete LogPrinter::lastLogMessageSeen;
-				LogPrinter::lastLogMessageSeen = NULL;
+				LogPrinter::lastLogMessageSeen = nullptr;
 			}
-			if (LogPrinter::lastFilenameSeen != NULL)
+			if (LogPrinter::lastFilenameSeen != nullptr)
 			{
 				delete LogPrinter::lastFilenameSeen;
-				LogPrinter::lastFilenameSeen = NULL;
+				LogPrinter::lastFilenameSeen = nullptr;
 			}
 
-			if (LogPrinter::lastMethodSeen != NULL)
+			if (LogPrinter::lastMethodSeen != nullptr)
 			{
 				delete LogPrinter::lastMethodSeen;
-				LogPrinter::lastMethodSeen = NULL;
+				LogPrinter::lastMethodSeen = nullptr;
 			}
 		}
 };
 
 int LogPrinter::lastLogLevelSeen = 999;
-std::string* LogPrinter::lastLogMessageSeen = NULL;
-std::string* LogPrinter::lastFilenameSeen = NULL;
-std::string* LogPrinter::lastMethodSeen = NULL;
+std::string* LogPrinter::lastLogMessageSeen = nullptr;
+std::string* LogPrinter::lastFilenameSeen = nullptr;
+std::string* LogPrinter::lastMethodSeen = nullptr;
 int LogPrinter::lastLineSeen = 99999;
 
 

--- a/Tests/Pcap++Test/Tests/PacketParsingTests.cpp
+++ b/Tests/Pcap++Test/Tests/PacketParsingTests.cpp
@@ -75,7 +75,7 @@ PTF_TEST_CASE(TestHttpRequestParsing)
 			homeReqs++;
 
 		pcpp::HeaderField* hostField = httpReqLayer->getFieldByName("Host");
-		if (hostField != NULL)
+		if (hostField != nullptr)
 		{
 			std::string host = hostField->getFieldValue();
 			if (host == "www.winwin.co.il")
@@ -87,7 +87,7 @@ PTF_TEST_CASE(TestHttpRequestParsing)
 		}
 
 		pcpp::HeaderField* userAgentField = httpReqLayer->getFieldByName("User-Agent");
-		if (userAgentField == NULL)
+		if (userAgentField == nullptr)
 			continue;
 
 		std::string userAgent = userAgentField->getFieldValue();
@@ -177,7 +177,7 @@ PTF_TEST_CASE(TestHttpResponseParsing)
 		statusCodes[httpResLayer->getFirstLine()->getStatusCode()]++;
 
 		pcpp::HeaderField* contentTypeField = httpResLayer->getFieldByName(PCPP_HTTP_CONTENT_TYPE_FIELD);
-		if (contentTypeField != NULL)
+		if (contentTypeField != nullptr)
 		{
 			std::string contentType = contentTypeField->getFieldValue();
 			if (contentType.find("image/") != std::string::npos)
@@ -187,15 +187,15 @@ PTF_TEST_CASE(TestHttpResponseParsing)
 		}
 
 		pcpp::HeaderField* contentEncodingField = httpResLayer->getFieldByName(PCPP_HTTP_CONTENT_ENCODING_FIELD);
-		if (contentEncodingField != NULL && contentEncodingField->getFieldValue() == "gzip")
+		if (contentEncodingField != nullptr && contentEncodingField->getFieldValue() == "gzip")
 			gzipCount++;
 
 		pcpp::HeaderField* transferEncodingField = httpResLayer->getFieldByName(PCPP_HTTP_TRANSFER_ENCODING_FIELD);
-		if (transferEncodingField != NULL && transferEncodingField->getFieldValue() == "chunked")
+		if (transferEncodingField != nullptr && transferEncodingField->getFieldValue() == "chunked")
 			chunkedCount++;
 
 		pcpp::HeaderField* contentLengthField = httpResLayer->getFieldByName(PCPP_HTTP_CONTENT_LENGTH_FIELD);
-		if (contentLengthField != NULL)
+		if (contentLengthField != nullptr)
 		{
 			std::string lengthAsString = contentLengthField->getFieldValue();
 			int length = atoi(lengthAsString.c_str());
@@ -319,15 +319,15 @@ PTF_TEST_CASE(TestDnsParsing)
 		{
 			packetsContainingDnsQuery++;
 
-			if (dnsLayer->getQuery("aus3.mozilla.org", true) != NULL)
+			if (dnsLayer->getQuery("aus3.mozilla.org", true) != nullptr)
 				queriesWithNameMozillaOrg++;
-			if (dnsLayer->getQuery("www.google.com", true) != NULL)
+			if (dnsLayer->getQuery("www.google.com", true) != nullptr)
 				queriesWithNameGoogle++;
 
 			bool isTypeA = false;
 			bool isClassIN = false;
 
-			for (pcpp::DnsQuery* query = dnsLayer->getFirstQuery(); query != NULL; query = dnsLayer->getNextQuery(query))
+			for (pcpp::DnsQuery* query = dnsLayer->getFirstQuery(); query != nullptr; query = dnsLayer->getNextQuery(query))
 			{
 				if (query->getDnsType() == pcpp::DNS_TYPE_A)
 					isTypeA = true;
@@ -347,14 +347,14 @@ PTF_TEST_CASE(TestDnsParsing)
 		{
 			packetsContainingDnsAnswer++;
 
-			if (dnsLayer->getAnswer("www.google-analytics.com", true) != NULL)
+			if (dnsLayer->getAnswer("www.google-analytics.com", true) != nullptr)
 				answersWithNameGoogleAnalytics++;
 
 			bool isTypeCNAME = false;
 			bool isTypePTR = false;
 			bool isTtlLessThan30 = false;
 
-			for (pcpp::DnsResource* answer = dnsLayer->getFirstAnswer(); answer != NULL; answer = dnsLayer->getNextAnswer(answer))
+			for (pcpp::DnsResource* answer = dnsLayer->getFirstAnswer(); answer != nullptr; answer = dnsLayer->getNextAnswer(answer))
 			{
 				if (answer->getTTL() < 30)
 					isTtlLessThan30 = true;
@@ -378,10 +378,10 @@ PTF_TEST_CASE(TestDnsParsing)
 		{
 			packetsContainingDnsAuthority++;
 
-			if (dnsLayer->getAuthority("Yaels-iPhone.local", true) != NULL)
+			if (dnsLayer->getAuthority("Yaels-iPhone.local", true) != nullptr)
 				authoritiesWithNameYaelPhone++;
 
-			for (pcpp::DnsResource* auth = dnsLayer->getFirstAuthority(); auth != NULL; auth = dnsLayer->getNextAuthority(auth))
+			for (pcpp::DnsResource* auth = dnsLayer->getFirstAuthority(); auth != nullptr; auth = dnsLayer->getNextAuthority(auth))
 			{
 				if (auth->getData()->toString() == "10.0.0.2")
 				{
@@ -395,15 +395,15 @@ PTF_TEST_CASE(TestDnsParsing)
 		{
 			packetsContainingDnsAdditional++;
 
-			if (dnsLayer->getAdditionalRecord("", true) != NULL)
+			if (dnsLayer->getAdditionalRecord("", true) != nullptr)
 				additionalWithEmptyName++;
 
-			if (dnsLayer->getAdditionalRecord("D.9.F.3.F.4.E.F.F.F.A.A.F.1.A.5.0.0.0.0.0.0.0.0.0.0.0.0.0.8.E.F.ip6.arpa", true) != NULL)
+			if (dnsLayer->getAdditionalRecord("D.9.F.3.F.4.E.F.F.F.A.A.F.1.A.5.0.0.0.0.0.0.0.0.0.0.0.0.0.8.E.F.ip6.arpa", true) != nullptr)
 				additionalWithLongUglyName++;
 
 			bool isTypeNSEC = false;
 
-			for (pcpp::DnsResource* add = dnsLayer->getFirstAdditionalRecord(); add != NULL; add = dnsLayer->getNextAdditionalRecord(add))
+			for (pcpp::DnsResource* add = dnsLayer->getFirstAdditionalRecord(); add != nullptr; add = dnsLayer->getNextAdditionalRecord(add))
 			{
 				if (add->getDnsType() == pcpp::DNS_TYPE_NSEC)
 					isTypeNSEC = true;

--- a/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
+++ b/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
@@ -80,11 +80,11 @@ static size_t getPayloadLen(pcpp::RawPacket& rawPacket)
 	pcpp::Packet packet(&rawPacket);
 
 	pcpp::TcpLayer* tcpLayer = packet.getLayerOfType<pcpp::TcpLayer>();
-	if (tcpLayer == NULL)
+	if (tcpLayer == nullptr)
 		throw std::runtime_error("TCP Layer not found");
 
 	pcpp::IPv4Layer* ipLayer = packet.getLayerOfType<pcpp::IPv4Layer>();
-	if (ipLayer == NULL)
+	if (ipLayer == nullptr)
 		throw std::runtime_error("IPv4 Layer not found");
 
 	return be16toh(ipLayer->getIPv4Header()->totalLength)-ipLayer->getHeaderLen()-tcpLayer->getHeaderLen();
@@ -176,7 +176,7 @@ static void tcpReassemblyConnectionEndCallback(const pcpp::ConnectionData& conne
 
 static bool tcpReassemblyTest(std::vector<pcpp::RawPacket>& packetStream, TcpReassemblyMultipleConnStats& results, bool monitorOpenCloseConns, bool closeConnsManually)
 {
-	pcpp::TcpReassembly* tcpReassembly = NULL;
+	pcpp::TcpReassembly* tcpReassembly = nullptr;
 
 	if (monitorOpenCloseConns)
 		tcpReassembly = new pcpp::TcpReassembly(tcpReassemblyMsgReadyCallback, &results, tcpReassemblyConnectionStartCallback, tcpReassemblyConnectionEndCallback);
@@ -220,11 +220,11 @@ static pcpp::RawPacket tcpReassemblyAddRetransmissions(pcpp::RawPacket rawPacket
 	pcpp::Packet packet(&rawPacket);
 
 	pcpp::TcpLayer* tcpLayer = packet.getLayerOfType<pcpp::TcpLayer>();
-	if (tcpLayer == NULL)
+	if (tcpLayer == nullptr)
 		throw std::runtime_error("TCP Layer not found");
 
 	pcpp::IPv4Layer* ipLayer = packet.getLayerOfType<pcpp::IPv4Layer>();
-	if (ipLayer == NULL)
+	if (ipLayer == nullptr)
 		throw std::runtime_error("IPv4 Layer not found");
 
 	int tcpPayloadSize = be16toh(ipLayer->getIPv4Header()->totalLength)-ipLayer->getHeaderLen()-tcpLayer->getHeaderLen();
@@ -249,7 +249,7 @@ static pcpp::RawPacket tcpReassemblyAddRetransmissions(pcpp::RawPacket rawPacket
 	}
 
 	pcpp::Layer* layerToRemove = tcpLayer->getNextLayer();
-	if (layerToRemove != NULL)
+	if (layerToRemove != nullptr)
 		packet.removeLayer(layerToRemove->getProtocol());
 
 	tcpLayer->getTcpHeader()->sequenceNumber = htobe32(be32toh(tcpLayer->getTcpHeader()->sequenceNumber) + beginning);

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -10,21 +10,21 @@
 
 static struct option PcapTestOptions[] =
 {
-	{"debug-mode", no_argument, 0, 'b'},
-	{"use-ip",  required_argument, 0, 'i'},
-	{"remote-ip", required_argument, 0, 'r'},
-	{"remote-port", required_argument, 0, 'p'},
-	{"dpdk-port", required_argument, 0, 'd' },
-	{"no-networking", no_argument, 0, 'n' },
-	{"verbose", no_argument, 0, 'v' },
-	{"mem-verbose", no_argument, 0, 'm' },
-	{"kni-ip", no_argument, 0, 'k' },
-	{"skip-mem-leak-check", no_argument, 0, 's' },
-	{"include-tags",  required_argument, 0, 't'},
-	{"exclude-tags",  required_argument, 0, 'x'},
-	{"show-skipped-tests", no_argument, 0, 'w' },
-	{"help", no_argument, 0, 'h'},
-	{0, 0, 0, 0}
+	{"debug-mode", no_argument, nullptr, 'b'},
+	{"use-ip",  required_argument, nullptr, 'i'},
+	{"remote-ip", required_argument, nullptr, 'r'},
+	{"remote-port", required_argument, nullptr, 'p'},
+	{"dpdk-port", required_argument, nullptr, 'd' },
+	{"no-networking", no_argument, nullptr, 'n' },
+	{"verbose", no_argument, nullptr, 'v' },
+	{"mem-verbose", no_argument, nullptr, 'm' },
+	{"kni-ip", no_argument, nullptr, 'k' },
+	{"skip-mem-leak-check", no_argument, nullptr, 's' },
+	{"include-tags",  required_argument, nullptr, 't'},
+	{"exclude-tags",  required_argument, nullptr, 'x'},
+	{"show-skipped-tests", no_argument, nullptr, 'w' },
+	{"help", no_argument, nullptr, 'h'},
+	{nullptr, 0, nullptr, 0}
 };
 
 


### PR DESCRIPTION
This MR add the clang-tidy support + convert NULL to nullptr.

This superseed https://github.com/seladb/PcapPlusPlus/pull/1020