### PR TITLE
Increase `test_split_by_connection` timeout to 20 secs

### DIFF
--- a/Tests/ExamplesTest/tests/test_pcapsplitter.py
+++ b/Tests/ExamplesTest/tests/test_pcapsplitter.py
@@ -202,7 +202,7 @@ class TestPcapSplitter(ExampleTest):
             "-o": tmpdir,
             "-m": "connection",
         }
-        self.run_example(args=args)
+        self.run_example(args=args, timeout=20)
         assert len(os.listdir(tmpdir)) == 254
         connection_map = {}
         for filename in os.listdir(tmpdir):


### PR DESCRIPTION
This should hopefully solve this randomly failing test: https://github.com/seladb/PcapPlusPlus/actions/runs/3917697268/jobs/6697646189