### PR TITLE
Fix GitHub Actions workflow triggers

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,5 +1,9 @@
 name: Build and test
-on: [push, pull_request]
+on:
+  push:
+    branches: [ "master", "dev" ]
+  pull_request:
+    branches: [ "dev" ]
 
 env:
   BUILD_DIR: Dist


### PR DESCRIPTION
- Previously: a build would trigger on push to every branch and on pull requests. As a result - every commit in an open PR would trigger the CI twice (once for `push` and another for `pull_request`)
- With this change: a build will be triggered only when:
  - Pushing to `dev` -> e.g merging a PR
  - Pushing from `dev` to `master`
  - When opening a PR that will be merged to `dev` (and on every commit in this PR)