### PR TITLE
Fix clang warnings

### DIFF
--- a/Packet++/header/IPReassembly.h
+++ b/Packet++/header/IPReassembly.h
@@ -76,7 +76,7 @@ namespace pcpp
 			/**
 			 * A default virtual d'tor
 			 */
-			virtual ~PacketKey() {}
+			virtual ~PacketKey() = default;
 
 			/**
 			 * @return A 4-byte hash value of the packet key
@@ -95,10 +95,10 @@ namespace pcpp
 
 		protected:
 			// private c'tor
-			PacketKey() {}
+			PacketKey() = default;
 
 			// private copy c'tor
-			PacketKey(const PacketKey& other) {}
+			PacketKey(const PacketKey& other) = default;
 		};
 
 

--- a/Packet++/header/TcpReassembly.h
+++ b/Packet++/header/TcpReassembly.h
@@ -100,15 +100,15 @@ struct ConnectionData
 
 	/**
 	 * Set startTime of Connection
-	 * @param[in] startTime integer value
+	 * @param[in] startTimeValue integer value
 	 */
-	void setStartTime(const timeval &startTime) { this->startTime = startTime; }
+	void setStartTime(const timeval &startTimeValue) { startTime = startTimeValue; }
 
 	/**
 	 * Set endTime of Connection
-	 * @param[in] endTime integer value
+	 * @param[in] endTimeValue integer value
 	 */
-	void setEndTime(const timeval &endTime) { this->endTime = endTime; }
+	void setEndTime(const timeval &endTimeValue) { endTime = endTimeValue; }
 };
 
 


### PR DESCRIPTION
Clang complain about unused variable other and shadowing variable