### PR TITLE
Build examples cxx11

### DIFF
--- a/Examples/Tutorials/Tutorial-DpdkL2Fwd/CMakeLists.txt
+++ b/Examples/Tutorials/Tutorial-DpdkL2Fwd/CMakeLists.txt
@@ -12,4 +12,9 @@ else()
   set_target_properties("${PROJECT_NAME}" PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PCAPPP_BINARY_TUTORIAL_DIR}")
 endif()
 
+# Set C++11
+set(CMAKE_CXX_STANDARD 11)
+# popen()/pclose() are not C++ standards
+set(CMAKE_CXX_EXTENSIONS ON)
+
 target_link_libraries("${PROJECT_NAME}" PUBLIC PcapPlusPlus::Pcap++)

--- a/Examples/Tutorials/Tutorial-HelloWorld/CMakeLists.txt
+++ b/Examples/Tutorials/Tutorial-HelloWorld/CMakeLists.txt
@@ -14,4 +14,9 @@ else()
   file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/1_packet.pcap" DESTINATION "${PCAPPP_BINARY_TUTORIAL_DIR}")
 endif()
 
+# Set C++11
+set(CMAKE_CXX_STANDARD 11)
+# popen()/pclose() are not C++ standards
+set(CMAKE_CXX_EXTENSIONS ON)
+
 target_link_libraries("${PROJECT_NAME}" PUBLIC PcapPlusPlus::Pcap++)

--- a/Examples/Tutorials/Tutorial-LiveTraffic/CMakeLists.txt
+++ b/Examples/Tutorials/Tutorial-LiveTraffic/CMakeLists.txt
@@ -12,4 +12,9 @@ else()
   set_target_properties("${PROJECT_NAME}" PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PCAPPP_BINARY_TUTORIAL_DIR}")
 endif()
 
+# Set C++11
+set(CMAKE_CXX_STANDARD 11)
+# popen()/pclose() are not C++ standards
+set(CMAKE_CXX_EXTENSIONS ON)
+
 target_link_libraries("${PROJECT_NAME}" PUBLIC PcapPlusPlus::Pcap++)

--- a/Examples/Tutorials/Tutorial-PacketCraftAndEdit/CMakeLists.txt
+++ b/Examples/Tutorials/Tutorial-PacketCraftAndEdit/CMakeLists.txt
@@ -14,4 +14,9 @@ else()
   file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/1_http_packet.pcap" DESTINATION "${PCAPPP_BINARY_TUTORIAL_DIR}")
 endif()
 
+# Set C++11
+set(CMAKE_CXX_STANDARD 11)
+# popen()/pclose() are not C++ standards
+set(CMAKE_CXX_EXTENSIONS ON)
+
 target_link_libraries("${PROJECT_NAME}" PUBLIC PcapPlusPlus::Pcap++)

--- a/Examples/Tutorials/Tutorial-PacketParsing/CMakeLists.txt
+++ b/Examples/Tutorials/Tutorial-PacketParsing/CMakeLists.txt
@@ -14,4 +14,9 @@ else()
   file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/1_http_packet.pcap" DESTINATION "${PCAPPP_BINARY_TUTORIAL_DIR}")
 endif()
 
+# Set C++11
+set(CMAKE_CXX_STANDARD 11)
+# popen()/pclose() are not C++ standards
+set(CMAKE_CXX_EXTENSIONS ON)
+
 target_link_libraries("${PROJECT_NAME}" PUBLIC PcapPlusPlus::Pcap++)

--- a/Examples/Tutorials/Tutorial-PcapFiles/CMakeLists.txt
+++ b/Examples/Tutorials/Tutorial-PcapFiles/CMakeLists.txt
@@ -14,4 +14,9 @@ else()
   file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/input.pcap" DESTINATION "${PCAPPP_BINARY_TUTORIAL_DIR}")
 endif()
 
+# Set C++11
+set(CMAKE_CXX_STANDARD 11)
+# popen()/pclose() are not C++ standards
+set(CMAKE_CXX_EXTENSIONS ON)
+
 target_link_libraries("${PROJECT_NAME}" PUBLIC PcapPlusPlus::Pcap++)


### PR DESCRIPTION
Centos7 have an old gcc compiler, that doesn't enable C++11 by default.

Let's make it explicit in case we build Examples out of tree