### PR TITLE
Remove usage of pcap_compile_nopcap() because it's deprecated

### DIFF
--- a/Pcap++/src/PcapFilter.cpp
+++ b/Pcap++/src/PcapFilter.cpp
@@ -48,19 +48,25 @@ bool BpfFilterWrapper::setFilter(const std::string& filter, LinkLayerType linkTy
 
 	if (filter != m_FilterStr || linkType != m_LinkType)
 	{
+		pcap_t* pcap = pcap_open_dead(linkType, DEFAULT_SNAPLEN);
+		if (pcap == nullptr)
+		{
+			return false;
+		}
+
 		bpf_program* newProg = new bpf_program;
-		if (pcap_compile_nopcap(DEFAULT_SNAPLEN, linkType, newProg, filter.c_str(), 1, 0) < 0)
+		int ret = pcap_compile(pcap, newProg, filter.c_str(), 1, 0);
+		pcap_close(pcap);
+		if (ret < 0)
 		{
 			delete newProg;
 			return false;
 		}
-		else
-		{
-			freeProgram();
-			m_Program = newProg;
-			m_FilterStr = filter;
-			m_LinkType = linkType;
-		}
+
+		freeProgram();
+		m_Program = newProg;
+		m_FilterStr = filter;
+		m_LinkType = linkType;
 	}
 
 	return true;


### PR DESCRIPTION
`pcap_compile_nopcap()` is deprecated in https://github.com/the-tcpdump-group/libpcap/commit/1a9c39a597b498b020764d7fdb2d957bafd2d034.