### PR TITLE
Remove deprecated methods

### DIFF
--- a/Packet++/header/DhcpLayer.h
+++ b/Packet++/header/DhcpLayer.h
@@ -7,17 +7,6 @@
 #include "MacAddress.h"
 #include <string.h>
 
-#ifndef PCPP_DEPRECATED
-#if defined(__GNUC__) || defined(__clang__)
-#define PCPP_DEPRECATED __attribute__((deprecated))
-#elif defined(_MSC_VER)
-#define PCPP_DEPRECATED __declspec(deprecated)
-#else
-#pragma message("WARNING: DEPRECATED feature is not implemented for this compiler")
-#define PCPP_DEPRECATED
-#endif
-#endif
-
 /// @file
 
 /**
@@ -702,20 +691,10 @@ namespace pcpp
 		void setClientHardwareAddress(const MacAddress& addr);
 
 		/**
-		 * @deprecated Deprecated due to typo. Please use getMessageType()
-		 */
-		PCPP_DEPRECATED DhcpMessageType getMesageType() const { return getMessageType(); };
-
-		/**
 		 * @return DHCP message type as extracted from ::DHCPOPT_DHCP_MESSAGE_TYPE option. If this option doesn't exist the value of
 		 * ::DHCP_UNKNOWN_MSG_TYPE is returned
 		 */
 		DhcpMessageType getMessageType() const;
-
-		/**
-		 * @deprecated Deprecated due to typo. Please use setMessageType()
-		 */
-		bool setMesageType(DhcpMessageType msgType) { return setMessageType(msgType); };
 
 		/**
 		 * Set DHCP message type. This method searches for existing ::DHCPOPT_DHCP_MESSAGE_TYPE option. If found, it sets the requested

--- a/Packet++/header/HttpLayer.h
+++ b/Packet++/header/HttpLayer.h
@@ -572,7 +572,6 @@ namespace pcpp
 	private:
 		HttpRequestFirstLine(HttpRequestLayer* httpRequest);
 		HttpRequestFirstLine(HttpRequestLayer* httpRequest, HttpRequestLayer::HttpMethod method, HttpVersion version, const std::string& uri = "/");
-			//throw(HttpRequestFirstLineException); // Deprecated in C++17
 
 		void parseVersion();
 

--- a/Packet++/header/SSLHandshake.h
+++ b/Packet++/header/SSLHandshake.h
@@ -5,17 +5,6 @@
 #include "SSLCommon.h"
 #include "PointerVector.h"
 
-#ifndef PCPP_DEPRECATED
-#if defined(__GNUC__) || defined(__clang__)
-#define PCPP_DEPRECATED __attribute__((deprecated))
-#elif defined(_MSC_VER)
-#define PCPP_DEPRECATED __declspec(deprecated)
-#else
-#pragma message("WARNING: DEPRECATED feature is not implemented for this compiler")
-#define PCPP_DEPRECATED
-#endif
-#endif
-
 /**
  * @file
  * See detailed explanation of the TLS/SSL protocol support in PcapPlusPlus in SSLLayer.h
@@ -322,11 +311,6 @@ public:
 	virtual ~SSLHandshakeMessage() {}
 
 	/**
-	 * @deprecated Deprecated due to typo. Please use createHandshakeMessage()
-	 */
-	PCPP_DEPRECATED static SSLHandshakeMessage* createHandhakeMessage(uint8_t* data, size_t dataLen, SSLHandshakeLayer* container) { return createHandshakeMessage(data, dataLen, container);}
-
-	/**
 	 * A factory method for creating instances of handshake messages from raw data
 	 * @param[in] data The raw data containing 1 handshake message
 	 * @param[in] dataLen Raw data length in bytes
@@ -499,11 +483,6 @@ public:
 	int getExtensionCount() const;
 
 	/**
-	 * @deprecated Deprecated due to typo. Please use getExtensionsLength()
-	 */
-	PCPP_DEPRECATED uint16_t getExtensionsLenth() const { return getExtensionsLength(); };
-
-	/**
 	 * @return The size (in bytes) of all extensions data in this message. Extracted from the "extensions length" field
 	 */
 	uint16_t getExtensionsLength() const;
@@ -673,11 +652,6 @@ public:
 	 * @return The number of extensions in this message
 	 */
 	int getExtensionCount() const;
-
-	/**
-	 * @deprecated Deprecated due to typo. Please use getExtensionLength()
-	 */
-	PCPP_DEPRECATED uint16_t getExtensionsLenth() const { return getExtensionsLength(); };
 
 	/**
 	 * @return The size (in bytes) of all extensions data in this message. Extracted from the "extensions length" field

--- a/Packet++/header/SipLayer.h
+++ b/Packet++/header/SipLayer.h
@@ -551,7 +551,6 @@ namespace pcpp
 	private:
 		SipRequestFirstLine(SipRequestLayer* sipRequest);
 		SipRequestFirstLine(SipRequestLayer* sipRequest, SipRequestLayer::SipMethod method, const std::string& version, const std::string& uri);
-			//throw(SipRequestFirstLineException); // Deprecated in C++17
 
 		void parseVersion();
 


### PR DESCRIPTION
Removing methods that had a typo so we created new methods for them and marked them as deprecated