### PR TITLE
Add IP network

### DIFF
--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -760,10 +760,30 @@ namespace pcpp
 				m_IPv4Network = new IPv4Network(addressAndNetmask);
 				m_IPv6Network = nullptr;
 			}
-			catch (const std::invalid_argument& e)
+			catch (const std::invalid_argument&)
 			{
 				m_IPv6Network = new IPv6Network(addressAndNetmask);
 				m_IPv4Network = nullptr;
+			}
+		}
+
+		/**
+		 * A copy c'tor for this class
+		 * @param other The instance to copy from
+		 */
+		IPNetwork(const IPNetwork& other)
+		{
+			m_IPv4Network = nullptr;
+			m_IPv6Network = nullptr;
+
+			if (other.m_IPv4Network)
+			{
+				m_IPv4Network = new IPv4Network(*other.m_IPv4Network);
+			}
+
+			if (other.m_IPv6Network)
+			{
+				m_IPv6Network = new IPv6Network(*other.m_IPv6Network);
 			}
 		}
 
@@ -781,6 +801,54 @@ namespace pcpp
 			{
 				delete m_IPv6Network;
 			}
+		}
+
+		/**
+		 * Overload of an assignment operator.
+		 * @param[in] other An instance of IPv4Network to assign
+		 * @return A reference to the assignee
+		 */
+		IPNetwork& operator=(const IPv4Network& other)
+		{
+			if (m_IPv4Network)
+			{
+				delete m_IPv4Network;
+				m_IPv4Network = nullptr;
+			}
+
+			if (m_IPv6Network)
+			{
+				delete m_IPv6Network;
+				m_IPv6Network = nullptr;
+			}
+
+			m_IPv4Network = new IPv4Network(other);
+
+			return *this;
+		}
+
+		/**
+		 * Overload of an assignment operator.
+		 * @param[in] other An instance of IPv6Network to assign
+		 * @return A reference to the assignee
+		 */
+		IPNetwork& operator=(const IPv6Network& other)
+		{
+			if (m_IPv4Network)
+			{
+				delete m_IPv4Network;
+				m_IPv4Network = nullptr;
+			}
+
+			if (m_IPv6Network)
+			{
+				delete m_IPv6Network;
+				m_IPv6Network = nullptr;
+			}
+
+			m_IPv6Network = new IPv6Network(other);
+
+			return *this;
 		}
 
 		/**

--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -805,6 +805,23 @@ namespace pcpp
 
 		/**
 		 * Overload of an assignment operator.
+		 * @param[in] other An instance of IPNetwork to assign
+		 * @return A reference to the assignee
+		 */
+		IPNetwork& operator=(const IPNetwork& other)
+		{
+			if (other.isIPv4Network())
+			{
+				return this->operator=(*other.m_IPv4Network);
+			}
+			else
+			{
+				return this->operator=(*other.m_IPv6Network);
+			}
+		}
+
+		/**
+		 * Overload of an assignment operator.
 		 * @param[in] other An instance of IPv4Network to assign
 		 * @return A reference to the assignee
 		 */

--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -689,9 +689,21 @@ namespace pcpp
 	};
 
 
+	/**
+	 * @class IPNetwork
+	 * A class representing version independent IP network definition, both IPv4 and IPv6 are included
+	 */
 	class IPNetwork
 	{
 	public:
+		/**
+		 * A constructor that creates an instance of the class out of an address representing the network prefix
+		 * and a prefix length
+		 * @param address An address representing the network prefix. If the address is invalid std::invalid_argument
+		 * exception is thrown
+		 * @param prefixLen A number representing the prefix length. If the value isn't in the range allowed for the
+		 * network (0 - 32 for IPv4 networks or 0 - 128 for IPv6 networks) and std::invalid_argument exception is thrown
+		 */
 		IPNetwork(const IPAddress& address, uint8_t prefixLen)
 		{
 			if (address.isIPv4())
@@ -706,6 +718,17 @@ namespace pcpp
 			}
 		}
 
+		/**
+		 * A constructor that creates an instance of the class out of an address representing the network prefix
+		 * and a netmask
+		 * @param address An address representing the network prefix. If the address is invalid std::invalid_argument
+		 * exception is thrown
+		 * @param netmask A string representing a netmask in valid format, for example: ffff:ffff:: for IPv6 networks
+		 * or 255.255.0.0 for IPv4 networks.
+		 * Please notice that netmasks that start with zeros are invalid, for example: 0:ffff:: or 0.255.255.255.
+		 * The only netmask starting with zeros that is valid is all zeros (:: or 0.0.0.0).
+		 * If the netmask is invalid std::invalid_argument exception is thrown
+		 */
 		IPNetwork(const IPAddress& address, const std::string& netmask)
 		{
 			if (address.isIPv4())
@@ -720,6 +743,16 @@ namespace pcpp
 			}
 		}
 
+		/**
+		 * A constructor that creates an instance of the class out of a string representing the network prefix and
+		 * a prefix length or a netmask
+		 * @param addressAndNetmask A string in one of these formats:
+		 *  - IP_ADDRESS/Y where IP_ADDRESS is a valid IP address representing the network prefix and Y is
+		 *    a number representing the network prefix
+		 *  - IP_ADDRESS/NETMASK where IP_ADDRESS is a valid IP address representing the network prefix and NETMASK
+		 *    is a valid netmask for this type of network (IPv4 or IPv6 network)
+		 *  For any invalid value std::invalid_argument is thrown
+		 */
 		IPNetwork(const std::string& addressAndNetmask)
 		{
 			try
@@ -734,6 +767,9 @@ namespace pcpp
 			}
 		}
 
+		/**
+		 * A destructor for this class
+		 */
 		~IPNetwork()
 		{
 			if (m_IPv4Network)
@@ -747,46 +783,80 @@ namespace pcpp
 			}
 		}
 
+		/**
+		 * @return The prefix length, for example: the prefix length of 3546::/ffff:: is 16, the prefix length of
+		 * 10.10.10.10/255.0.0.0 is 8
+		 */
 		uint8_t getPrefixLen() const
 		{
 			return (m_IPv4Network != nullptr ? m_IPv4Network->getPrefixLen() : m_IPv6Network->getPrefixLen());
 		}
 
+		/**
+ 		* @return The netmask, for example: the netmask of 3546::/16 is ffff::, the netmask of 10.10.10.10/8 is 255.0.0.0
+ 		*/
 		std::string getNetmask() const
 		{
 			return (m_IPv4Network != nullptr ? m_IPv4Network->getNetmask() : m_IPv6Network->getNetmask());
 		}
 
+		/**
+		 * @return The network prefix, for example: the network prefix of 3546:f321::/16 is 3546::, the network prefix
+		 * of 10.10.10.10/16 is 10.10.0.0
+		*/
 		IPAddress getNetworkPrefix() const
 		{
 			return (m_IPv4Network != nullptr ? IPAddress(m_IPv4Network->getNetworkPrefix()) : IPAddress(m_IPv6Network->getNetworkPrefix()));
 		}
 
+		/**
+		* @return The lowest non-reserved IP address in this network, for example: the lowest address in 3546::/16 is
+		* 3546::1, the lowest address in 10.10.10.10/16 is 10.10.0.1
+		*/
 		IPAddress getLowestAddress() const
 		{
 			return (m_IPv4Network != nullptr ? IPAddress(m_IPv4Network->getLowestAddress()) : IPAddress(m_IPv6Network->getLowestAddress()));
 		}
 
+		/**
+		 * @return The highest non-reserved IP address in this network, for example: the highest address in 3546::/16 is
+		 * 3546:ffff:ffff:ffff:ffff:ffff:ffff:ffff, the highest address in 10.10.10.10/16 is 10.10.255.254
+		 */
 		IPAddress getHighestAddress() const
 		{
 			return (m_IPv4Network != nullptr ? IPAddress(m_IPv4Network->getHighestAddress()) : IPAddress(m_IPv6Network->getHighestAddress()));
 		}
 
+		/**
+		 * @return The number of addresses in this network, for example: the number of addresses in 16ff::/120 is 256,
+		 * the number of addresses in 10.10.0.0/24 is 256. If the number of addresses exceeds the size of uint64_t
+		 * a std::out_of_range exception is thrown
+		 */
 		uint64_t getTotalAddressCount() const
 		{
 			return (m_IPv4Network != nullptr ? m_IPv4Network->getTotalAddressCount() : m_IPv6Network->getTotalAddressCount());
 		}
 
+		/**
+		 * @return True if this is an IPv4 network, false otherwise
+		 */
 		bool isIPv4Network() const
 		{
 			return m_IPv4Network != nullptr;
 		}
 
+		/**
+		 * @return True if this is an IPv6 network, false otherwise
+		 */
 		bool isIPv6Network() const
 		{
 			return m_IPv6Network != nullptr;
 		}
 
+		/**
+		 * @param address An IP address
+		 * @return True is the address belongs to the network, false otherwise or if the address isn't valid
+		 */
 		bool includes(const IPAddress& address) const
 		{
 			if (m_IPv4Network != nullptr)
@@ -809,6 +879,10 @@ namespace pcpp
 			}
 		}
 
+		/**
+		 * @param network An IP network
+		 * @return True is the input network is completely included within this network, false otherwise
+		 */
 		bool includes(const IPNetwork& network) const
 		{
 			if (m_IPv4Network != nullptr)
@@ -831,6 +905,10 @@ namespace pcpp
 			}
 		}
 
+		/**
+		 * @return A string representation of the network in a format of NETWORK_PREFIX/PREFIX_LEN, for example:
+		 * fda7:9f81:6c23:275::/64 or 192.168.0.0/16
+		 */
 		std::string toString() const
 		{
 			return (m_IPv4Network != nullptr ? m_IPv4Network->toString() : m_IPv6Network->toString());

--- a/Tests/Pcap++Test/TestDefinition.h
+++ b/Tests/Pcap++Test/TestDefinition.h
@@ -10,6 +10,7 @@ PTF_TEST_CASE(TestGeneralUtils);
 PTF_TEST_CASE(TestGetMacAddress);
 PTF_TEST_CASE(TestIPv4Network);
 PTF_TEST_CASE(TestIPv6Network);
+PTF_TEST_CASE(TestIPNetwork);
 
 // Implemented in LoggerTests.cpp
 PTF_TEST_CASE(TestLogger);

--- a/Tests/Pcap++Test/Tests/IpMacTests.cpp
+++ b/Tests/Pcap++Test/Tests/IpMacTests.cpp
@@ -657,4 +657,17 @@ PTF_TEST_CASE(TestIPNetwork)
 	stream.str("");
 	stream << ipv6Network;
 	PTF_ASSERT_EQUAL(stream.str(), "4348:58d6::/32")
+
+	// copy c'tor
+	auto ipv4NetworkCopy = pcpp::IPNetwork(ipv4Network);
+	PTF_ASSERT_EQUAL(ipv4NetworkCopy.toString(), "10.1.2.0/24");
+
+	auto ipv6NetworkCopy = pcpp::IPNetwork(ipv6Network);
+	PTF_ASSERT_EQUAL(ipv6NetworkCopy.toString(), "4348:58d6::/32");
+
+	// assignment operator
+	ipv4NetworkCopy = ipv6Network;
+	PTF_ASSERT_EQUAL(ipv4NetworkCopy.toString(), "4348:58d6::/32");
+	ipv6NetworkCopy = ipv4Network;
+	PTF_ASSERT_EQUAL(ipv6NetworkCopy.toString(), "10.1.2.0/24");
 } // TestIPNetwork

--- a/Tests/Pcap++Test/Tests/IpMacTests.cpp
+++ b/Tests/Pcap++Test/Tests/IpMacTests.cpp
@@ -670,4 +670,9 @@ PTF_TEST_CASE(TestIPNetwork)
 	PTF_ASSERT_EQUAL(ipv4NetworkCopy.toString(), "4348:58d6::/32");
 	ipv6NetworkCopy = ipv4Network;
 	PTF_ASSERT_EQUAL(ipv6NetworkCopy.toString(), "10.1.2.0/24");
+
+	ipv4Network = ipv6NetworkCopy;
+	PTF_ASSERT_EQUAL(ipv4Network.toString(), "10.1.2.0/24");
+	ipv6Network = ipv4NetworkCopy;
+	PTF_ASSERT_EQUAL(ipv6Network.toString(), "4348:58d6::/32");
 } // TestIPNetwork

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -206,6 +206,7 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(TestGetMacAddress, "mac");
 	PTF_RUN_TEST(TestIPv4Network, "no_network;ip");
 	PTF_RUN_TEST(TestIPv6Network, "no_network;ip");
+	PTF_RUN_TEST(TestIPNetwork, "no_network;ip");
 
 	PTF_RUN_TEST(TestLogger, "no_network;logger");
 	PTF_RUN_TEST(TestLoggerMultiThread, "no_network;logger;skip_mem_leak_check");


### PR DESCRIPTION
Addresses issue: https://github.com/seladb/PcapPlusPlus/issues/1009

Adds an `IPNetwork` class that generalizes `IPv4Network` and `IPv6Network`, in a similar way that `IPAddress` generalizes `IPv4Address` and `IPv6Address`