### PR TITLE
Add PAT

### DIFF
--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ secrets.PAT }}
           author: GitHub <noreply@github.com>
           add-paths: .pre-commit-config.yaml
           commit-message: Auto pre-commit update
@@ -56,6 +57,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ secrets.PAT }}
           author: GitHub <noreply@github.com>
           add-paths: 3rdParty/OUIDataset/PCPP_OUIDataset.json
           commit-message: Auto OUI Database Update


### PR DESCRIPTION
For triggering workflow actions automated PRs requires PAT (Mentioned [here](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs)). After merge all of the workflows should be triggered and coverage report should be fixed