### PR TITLE
Allow building fuzzers independently from tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,12 +81,7 @@ cmake_dependent_option(
   OFF)
 option(PCAPPP_BUILD_TESTS "Build Tests" ${PCAPPP_MAIN_PROJECT})
 option(PCAPPP_BUILD_COVERAGE "Generate Coverage Report" OFF)
-cmake_dependent_option(
-  PCAPPP_BUILD_FUZZERS
-  "Build Fuzzers binaries"
-  OFF
-  "PCAPPP_BUILD_TESTS"
-  OFF)
+option(PCAPPP_BUILD_FUZZERS "Build Tests" ${PCAPPP_BUILD_TESTS})
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
 
@@ -241,6 +236,10 @@ endif()
 if(PCAPPP_BUILD_TESTS)
   include(CTest)
   add_subdirectory(Tests)
+endif()
+
+if(PCAPPP_BUILD_FUZZERS)
+  add_subdirectory(Tests/Fuzzers)
 endif()
 
 if(PCAPPP_INSTALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ cmake_dependent_option(
   OFF)
 option(PCAPPP_BUILD_TESTS "Build Tests" ${PCAPPP_MAIN_PROJECT})
 option(PCAPPP_BUILD_COVERAGE "Generate Coverage Report" OFF)
-option(PCAPPP_BUILD_FUZZERS "Build Tests" ${PCAPPP_BUILD_TESTS})
+option(PCAPPP_BUILD_FUZZERS "Build Tests" OFF)
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,9 @@ if(PCAPPP_BUILD_EXAMPLES)
   add_subdirectory(Examples)
 endif()
 
-if(PCAPPP_BUILD_TESTS)
+if(PCAPPP_BUILD_TESTS
+   OR PCAPPP_BUILD_FUZZERS
+   OR PCAPPP_BUILD_EXAMPLES)
   include(CTest)
   add_subdirectory(Tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ cmake_dependent_option(
   OFF)
 option(PCAPPP_BUILD_TESTS "Build Tests" ${PCAPPP_MAIN_PROJECT})
 option(PCAPPP_BUILD_COVERAGE "Generate Coverage Report" OFF)
-option(PCAPPP_BUILD_FUZZERS "Build Tests" OFF)
+option(PCAPPP_BUILD_FUZZERS "Build Fuzzers binaries" OFF)
 
 option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,10 +238,6 @@ if(PCAPPP_BUILD_TESTS)
   add_subdirectory(Tests)
 endif()
 
-if(PCAPPP_BUILD_FUZZERS)
-  add_subdirectory(Tests/Fuzzers)
-endif()
-
 if(PCAPPP_INSTALL)
   set(CPACK_DEBIAN_PACKAGE_MAINTAINER "seladb")
   set(CPACK_PACKAGE_FILE_NAME PcapPlusPlus-${PCAPPP_VERSION})

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,6 +1,8 @@
-add_subdirectory(Packet++Test)
-add_subdirectory(Pcap++Test)
-add_subdirectory(PcppTestFramework)
+if(PCAPPP_BUILD_TESTS)
+  add_subdirectory(Packet++Test)
+  add_subdirectory(Pcap++Test)
+  add_subdirectory(PcppTestFramework)
+endif()
 
 if(PCAPPP_BUILD_EXAMPLES)
   add_subdirectory(ExamplesTest)

--- a/Tests/Fuzzers/FuzzTarget.cpp
+++ b/Tests/Fuzzers/FuzzTarget.cpp
@@ -23,7 +23,7 @@ int dumpDataToPcapFile(const uint8_t *data, size_t size)
 	}
 
 	written = fwrite(data, 1, size, fd);
-	if (written != size)
+	if (static_cast<size_t>(written) != size)
 	{
 		std::cerr << "Error writing pcap file\n";
 		fclose(fd);


### PR DESCRIPTION
Building tests takes time every time I need to rebuild the fuzzing harness. It should be possible to build them independently.

Adding subdirectory of subdirectory maybe not elegant. Another option is to move the whole fuzzers directory one level up.