### PR TITLE
Upgrade FreeBSD to 13.1 to fix CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,7 @@ task:
   freebsd_instance:
     matrix:
       image_family: freebsd-12-3
-      image_family: freebsd-13-0
+      image_family: freebsd-13-1
   install_script:
     - pkg install -y bash cmake git gmake gsed libpcap tcpreplay
   configure_script:


### PR DESCRIPTION
We currently see this issue while running CMake on FreeBSD 13.0:
```shell
cmake -S . -B Dist
ld-elf.so.1: /lib/libc.so.7: version FBSD_1.7 required by /usr/local/lib/libuv.so.1 not found
```
https://cirrus-ci.com/task/6391796880637952

Upgrading to FreeBSD 13.1 seems to fix it