### PR TITLE
Properly support no RSS mode in `DpdkDevice`

### DIFF
--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -50,9 +50,11 @@ namespace pcpp
 #define DPDK_COFIG_JUMBO_FRAME			0 /**< Jumbo Frame Support disabled */
 #define DPDK_COFIG_HW_STRIP_CRC			0 /**< CRC stripped by hardware disabled */
 #if (RTE_VER_YEAR < 21) || (RTE_VER_YEAR == 21 && RTE_VER_MONTH < 11)
-#define DPDK_CONFIG_MQ_MODE				ETH_RSS
+#define DPDK_CONFIG_MQ_RSS				ETH_RSS
+#define DPDK_CONFIG_MQ_NO_RSS			ETH_MQ_RX_NONE
 #else
-#define DPDK_CONFIG_MQ_MODE				RTE_ETH_MQ_RX_RSS
+#define DPDK_CONFIG_MQ_RSS				RTE_ETH_MQ_RX_RSS
+#define DPDK_CONFIG_MQ_NO_RSS			RTE_ETH_MQ_RX_NONE
 #endif
 
 
@@ -259,7 +261,15 @@ bool DpdkDevice::configurePort(uint8_t numOfRxQueues, uint8_t numOfTxQueues)
 	portConf.rxmode.jumbo_frame = DPDK_COFIG_JUMBO_FRAME;
 	portConf.rxmode.hw_strip_crc = DPDK_COFIG_HW_STRIP_CRC;
 #endif
-	portConf.rxmode.mq_mode = DPDK_CONFIG_MQ_MODE;
+	if (m_Config.rssHashFunction == RSS_NONE)
+	{
+		portConf.rxmode.mq_mode = DPDK_CONFIG_MQ_NO_RSS;
+	}
+	else
+	{
+		portConf.rxmode.mq_mode = DPDK_CONFIG_MQ_RSS;
+	}
+
 	portConf.rx_adv_conf.rss_conf.rss_key = m_Config.rssKey;
 	portConf.rx_adv_conf.rss_conf.rss_key_len = m_Config.rssKeyLength;
 	portConf.rx_adv_conf.rss_conf.rss_hf = convertRssHfToDpdkRssHf(getConfiguredRssHashFunction());

--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -261,6 +261,7 @@ bool DpdkDevice::configurePort(uint8_t numOfRxQueues, uint8_t numOfTxQueues)
 	portConf.rxmode.jumbo_frame = DPDK_COFIG_JUMBO_FRAME;
 	portConf.rxmode.hw_strip_crc = DPDK_COFIG_HW_STRIP_CRC;
 #endif
+	// Enable RSS only if hardware supports it and the user wants to use it
 	if (m_Config.rssHashFunction == RSS_NONE)
 	{
 		portConf.rxmode.mq_mode = DPDK_CONFIG_MQ_NO_RSS;


### PR DESCRIPTION
Should fix issue https://github.com/seladb/PcapPlusPlus/issues/1125

The issue is caused because we always enforce RSS (Receive side scaling) even if the NIC doesn't support it or the user doesn't want to use it.

The fix follows what Open vSwitch is doing: https://github.com/openvswitch/ovs/blob/master/lib/netdev-dpdk.c#L1135-L1138
And what Cisco TRex is doing: https://github.com/cisco-system-traffic-generator/trex-core/blob/master/src/main_dpdk.cpp#L5837-L5840