### PR TITLE
Skip network tests in CirrusCI Linux

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,7 +38,7 @@ task:
   test_pcapplusplus_script:
     - python3 -m pip install gcovr
     - python3 -m pip install -r ci/run_tests/requirements.txt
-    - python3 ci/run_tests/run_tests.py --interface eth0
+    - python3 ci/run_tests/run_tests.py --interface eth0 --use-sudo
   coverage_report_script:
     - gcovr -v -r . $GCOVR_FLAGS -o coverage.xml
     - curl -Os https://uploader.codecov.io/latest/linux/codecov

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,7 +38,7 @@ task:
   test_pcapplusplus_script:
     - python3 -m pip install gcovr
     - python3 -m pip install -r ci/run_tests/requirements.txt
-    - python3 ci/run_tests/run_tests.py --interface eth0 --test-args="-n"
+    - python3 ci/run_tests/run_tests.py --interface eth0 --pcap-test-args="-n"
   coverage_report_script:
     - gcovr -v -r . $GCOVR_FLAGS -o coverage.xml
     - curl -Os https://uploader.codecov.io/latest/linux/codecov
@@ -61,7 +61,7 @@ task:
   test_pcapplusplus_script:
     - python3 -m ensurepip
     - python3 -m pip install -r ci/run_tests/requirements.txt
-    - python3 ci/run_tests/run_tests.py --interface en0 --test-args="-x TestPcapLiveDeviceSpecialCfg"
+    - python3 ci/run_tests/run_tests.py --interface en0 --pcap-test-args="-x TestPcapLiveDeviceSpecialCfg"
   coverage_report_script:
     - gcovr -v -r . $GCOVR_FLAGS -o coverage.xml
     - curl -Os https://uploader.codecov.io/latest/macos/codecov

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,7 +36,7 @@ task:
   build_script:
     - cmake --build Dist -j 2
   test_pcapplusplus_script:
-    - apt install sudo
+    - apt update && apt install sudo
     - python3 -m pip install gcovr
     - python3 -m pip install -r ci/run_tests/requirements.txt
     - python3 ci/run_tests/run_tests.py --interface eth0 --use-sudo

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,10 +36,9 @@ task:
   build_script:
     - cmake --build Dist -j 2
   test_pcapplusplus_script:
-    - apt update && apt install sudo
     - python3 -m pip install gcovr
     - python3 -m pip install -r ci/run_tests/requirements.txt
-    - python3 ci/run_tests/run_tests.py --interface eth0 --use-sudo
+    - python3 ci/run_tests/run_tests.py --interface eth0 --test-args="-n"
   coverage_report_script:
     - gcovr -v -r . $GCOVR_FLAGS -o coverage.xml
     - curl -Os https://uploader.codecov.io/latest/linux/codecov

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,6 +36,7 @@ task:
   build_script:
     - cmake --build Dist -j 2
   test_pcapplusplus_script:
+    - apt install sudo
     - python3 -m pip install gcovr
     - python3 -m pip install -r ci/run_tests/requirements.txt
     - python3 ci/run_tests/run_tests.py --interface eth0 --use-sudo

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -60,6 +60,7 @@ jobs:
             config-zstd: OFF
           - image: centos7
             python: python3.8
+            # TODO: TestLoggerMultiThread sometimes fail in CI so we exclude it for now, need to look into it
             test-flags: --pcap-test-args="-s -x TestLoggerMultiThread"
             config-zstd: OFF
           - image: fedora34

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -60,7 +60,7 @@ jobs:
             config-zstd: OFF
           - image: centos7
             python: python3.8
-            test-flags: --test-args="-s"
+            test-flags: --pcap-test-args="-s -x TestLoggerMultiThread"
             config-zstd: OFF
           - image: fedora34
             python: python3

--- a/ci/run_tests/run_tests.py
+++ b/ci/run_tests/run_tests.py
@@ -8,22 +8,24 @@ PCAP_FILE_PATH = os.path.join("Tests", "Pcap++Test", "PcapExamples", "example.pc
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument("--interface", type=str, required=True, help="interface to use")
     parser.add_argument(
-        "--interface", "-i", type=str, required=True, help="interface to use"
+        "--use-sudo", action="store_true", help="use sudo when running tests"
     )
     parser.add_argument(
-        "--use-sudo", "-s", action="store_true", help="use sudo when running tests"
-    )
-    parser.add_argument(
-        "--test-args",
-        "-t",
+        "--packet-test-args",
         type=str,
         default="",
-        help="test arguments",
+        help="packet++ test arguments",
+    )
+    parser.add_argument(
+        "--pcap-test-args",
+        type=str,
+        default="",
+        help="pcap++ test arguments",
     )
     parser.add_argument(
         "--tcpreplay-dir",
-        "-d",
         type=str,
         default=None,
         help="tcpreplay directory",
@@ -41,7 +43,9 @@ def main():
 
         use_sudo = ["sudo"] if args.use_sudo else []
         completed_process = subprocess.run(
-            use_sudo + [os.path.join("Bin", "Packet++Test")] + args.test_args.split(),
+            use_sudo
+            + [os.path.join("Bin", "Packet++Test")]
+            + args.packet_test_args.split(),
             cwd="Tests/Packet++Test",
         )
         if completed_process.returncode != 0:
@@ -50,7 +54,7 @@ def main():
         completed_process = subprocess.run(
             use_sudo
             + [os.path.join("Bin", "Pcap++Test"), "-i", ip_address]
-            + args.test_args.split(),
+            + args.pcap_test_args.split(),
             cwd="Tests/Pcap++Test",
         )
         if completed_process.returncode != 0:


### PR DESCRIPTION
For some reason, CirrusCI Linux Zstd tests started to fail with `socket: Operation not permitted` error, probably related to something that changes in CirrusCI docker runners. Here is an example: https://cirrus-ci.com/task/5529878364160000?logs=test_pcapplusplus#L272

I opened a ticket for CirrusCI and waiting for their response: https://github.com/cirruslabs/cirrus-ci-docs/issues/1229

In the meantime, since we run network tests in many other CI tests, I think we can skip it.
