### PR TITLE
Add back network tests in CirrusCI Linux

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -38,7 +38,7 @@ task:
   test_pcapplusplus_script:
     - python3 -m pip install gcovr
     - python3 -m pip install -r ci/run_tests/requirements.txt
-    - python3 ci/run_tests/run_tests.py --interface eth0 --pcap-test-args="-n"
+    - python3 ci/run_tests/run_tests.py --interface eth0
   coverage_report_script:
     - gcovr -v -r . $GCOVR_FLAGS -o coverage.xml
     - curl -Os https://uploader.codecov.io/latest/linux/codecov


### PR DESCRIPTION
It seems like the issue was fixed: https://github.com/cirruslabs/cirrus-ci-docs/issues/1229#issuecomment-1715700458