### PR TITLE
When uploading packages create a new release as draft

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -56,7 +56,9 @@ jobs:
       - name: Upload binaries to release
         uses: ncipollo/release-action@v1
         with:
+          draft: true
           allowUpdates: true
+          updateOnlyUnreleased: true
           artifacts: "${{ env.BUILD_DIR }}/*.tar.gz,${{ env.BUILD_DIR }}/*.deb,${{ env.BUILD_DIR }}/*.rpm"
 
   freebsd:
@@ -86,7 +88,9 @@ jobs:
       - name: Upload binaries to release
         uses: ncipollo/release-action@v1
         with:
+          draft: true
           allowUpdates: true
+          updateOnlyUnreleased: true
           artifacts: ${{ env.BUILD_DIR }}/*.tar.gz
 
   macos:
@@ -117,7 +121,9 @@ jobs:
       - name: Upload binaries to release
         uses: ncipollo/release-action@v1
         with:
+          draft: true
           allowUpdates: true
+          updateOnlyUnreleased: true
           artifacts: "${{ env.BUILD_DIR }}/*.tar.gz,${{ env.BUILD_DIR }}/*.pkg"
 
   mingw-w64:
@@ -175,7 +181,9 @@ jobs:
       - name: Upload binaries to release
         uses: ncipollo/release-action@v1
         with:
+          draft: true
           allowUpdates: true
+          updateOnlyUnreleased: true
           artifacts: ${{ env.BUILD_DIR }}/*.zip
 
   visual-studio:
@@ -212,7 +220,9 @@ jobs:
       - name: Upload binaries to release
         uses: ncipollo/release-action@v1
         with:
+          draft: true
           allowUpdates: true
+          updateOnlyUnreleased: true
           artifacts: ${{ env.BUILD_DIR }}/*.zip
 
   android-build:
@@ -288,5 +298,7 @@ jobs:
       - name: Upload binaries to release
         uses: ncipollo/release-action@v1
         with:
+          draft: true
           allowUpdates: true
+          updateOnlyUnreleased: true
           artifacts: ${{ env.PACKAGE_DIR }}.tar.gz


### PR DESCRIPTION
When creating and uploading packages, create the new release to be in draft so we can later add release notes etc.