### PR TITLE
Delay `codecov` report until most of CI is done

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,7 @@ coverage:
       default:
         threshold: 1%
     patch: off
+
+codecov:
+  notify:
+    after_n_builds: 16


### PR DESCRIPTION
When a PR is running codecov always shows as failing until enough reports are being uploaded.
This PR should fix it.

**NOTE:** we currently have 18 jobs, but report uploads sometimes fail so setting the threshold to 16

Here are a few references:
https://docs.codecov.com/docs/notifications#preventing-notifications-until-after-n-builds
https://community.codecov.com/t/github-status-notification-isnt-delayed-should-wait-all-ci-jobs-to-finish/3708/9

