### PR TITLE
cmake: build static libraries with position independent code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,8 @@ option(PCAPPP_PACKAGE "Package Pcap++ could require a recent version of CMake" O
 set(CMAKE_CXX_STANDARD 11)
 # popen()/pclose() are not C++ standards
 set(CMAKE_CXX_EXTENSIONS ON)
+# Set Position Independent Code for static libraries
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Usually on Windows PCAP_ROOT and Packet_ROOT are at the same location
 if(WIN32


### PR DESCRIPTION
From https://github.com/seladb/PcapPlusPlus/issues/1216 issue during the CMake migration we have forgotten to enable the PIC option that was previously enabled see:
 https://github.com/seladb/PcapPlusPlus/blob/v22.11/mk/PcapPlusPlus.mk.common#L16

This option allow the final user to freely build a position independent library or executable.  

