### PR TITLE
FTP command string fix for short commands

### DIFF
--- a/Packet++/src/FtpLayer.cpp
+++ b/Packet++/src/FtpLayer.cpp
@@ -205,7 +205,13 @@ namespace pcpp
 	{
 		std::stringstream oss;
 		for (size_t idx = 0; idx < 4; ++idx)
-			oss << char((int(code) >> (8 * idx)) & UINT8_MAX);
+		{
+			char val = (uint64_t(code) >> (8 * idx)) & UINT8_MAX;
+			if (val) // Dont push if it is a null character
+			{
+				oss << val;
+			}
+		}
 		return oss.str();
 	}
 


### PR DESCRIPTION
If the command string is shorter than 4 characters currently getCommandAsString function appends unneccessary null characters. This PR fixes situation by preventing pushing of null characters to stringstream