### PR TITLE
remove unnecessary sleep

### DIFF
--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -550,7 +550,6 @@ void PcapLiveDevice::stopCapture()
 		PCPP_LOG_DEBUG("Stats thread stopped for device '" << m_Name << "'");
 	}
 
-	multiPlatformSleep(1);
 	m_StopThread = false;
 }
 


### PR DESCRIPTION
fixed #1246

it's unnecessary to use `sleep`.