### PR TITLE
Log avoid leaking full path

### DIFF
--- a/Common++/header/Logger.h
+++ b/Common++/header/Logger.h
@@ -11,6 +11,33 @@
 #define LOG_MODULE UndefinedLogModule
 #endif
 
+// Use __FILE_NAME__ to avoid leaking complete full path
+#ifdef __FILE_NAME__
+#define PCAPPP_FILENAME __FILE_NAME__
+#else
+#define PCAPPP_FILENAME __FILE__
+#endif
+
+#define PCPP_LOG(level, message) do \
+	{ \
+		std::ostringstream* sstream = pcpp::Logger::getInstance().internalCreateLogStream(); \
+		(*sstream) << message; \
+		pcpp::Logger::getInstance().internalPrintLogMessage(sstream, level, PCAPPP_FILENAME, __FUNCTION__, __LINE__); \
+	} while(0)
+
+#define PCPP_LOG_DEBUG(message) do \
+	{ \
+		if (pcpp::Logger::getInstance().logsEnabled() && pcpp::Logger::getInstance().isDebugEnabled(LOG_MODULE)) \
+		{ \
+			PCPP_LOG(pcpp::Logger::Debug, message); \
+		} \
+	} while(0)
+
+#define PCPP_LOG_ERROR(message) do \
+	{ \
+		PCPP_LOG(pcpp::Logger::Error, message); \
+	} while (0)
+
 /// @file
 
 /**
@@ -230,24 +257,6 @@ namespace pcpp
 
 		static void defaultLogPrinter(LogLevel logLevel, const std::string& logMessage, const std::string& file, const std::string& method, const int line);
 	};
-
-#define PCPP_LOG_DEBUG(message) do \
-	{ \
-		if (pcpp::Logger::getInstance().logsEnabled() && pcpp::Logger::getInstance().isDebugEnabled(LOG_MODULE)) \
-		{ \
-			std::ostringstream* sstream = pcpp::Logger::getInstance().internalCreateLogStream(); \
-			(*sstream) << message; \
-			pcpp::Logger::getInstance().internalPrintLogMessage(sstream, pcpp::Logger::Debug, __FILE__, __FUNCTION__, __LINE__); \
-		} \
-	} while(0)
-
-#define PCPP_LOG_ERROR(message) do \
-	{ \
-        std::ostringstream* sstream = pcpp::Logger::getInstance().internalCreateLogStream(); \
-  		(*sstream) << message; \
-		pcpp::Logger::getInstance().internalPrintLogMessage(sstream, pcpp::Logger::Error, __FILE__, __FUNCTION__, __LINE__); \
-	} while (0)
-
 } // namespace pcpp
 
 #endif /* PCAPPP_LOGGER */


### PR DESCRIPTION
at the moment the Logger use __FILE__ that would get the complete path of the file.

```
$> strings libpcapplusplus.a | grep "\.cpp"
/tmp/PcapPlusPlus-23.09/Pcap++/src/PcapFileDevice.cpp
/tmp/PcapPlusPlus-23.09/Pcap++/src/PcapDevice.cpp
/tmp/PcapPlusPlus-23.09/Pcap++/src/PcapFilter.cpp
/tmp/PcapPlusPlus-23.09/Packet++/src/IcmpLayer.cpp
/tmp/PcapPlusPlus-23.09/Packet++/src/IPReassembly.cpp
/tmp/PcapPlusPlus-23.09/Packet++/src/IPv4Layer.cpp
/tmp/PcapPlusPlus-23.09/Packet++/src/Layer.cpp
/tmp/PcapPlusPlus-23.09/Packet++/src/Packet.cpp
/tmp/PcapPlusPlus-23.09/Packet++/src/PacketUtils.cpp
/tmp/PcapPlusPlus-23.09/Packet++/src/RawPacket.cpp
/tmp/PcapPlusPlus-23.09/Packet++/src/Sll2Layer.cpp
```

Instead use __FILE_NAME__ when available: GCC > 12 or Clang

I have also move this out of the namespace as it's a global macro and refactor introduce a PCPP_LOG(level, message) macro.