### PR TITLE
Check `pcap_dispatch` return value

### DIFF
--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -177,7 +177,7 @@ void PcapLiveDevice::captureThreadMain()
 	{
 		while (!m_StopThread)
 		{
-			if (pcap_dispatch(m_PcapDescriptor, -1, onPacketArrives, (uint8_t*)this) == -1)
+			if (pcap_dispatch(m_PcapDescriptor, -1, onPacketArrives, reinterpret_cast<uint8_t*>(this)) == -1)
 			{
 				PCPP_LOG_ERROR("pcap_dispatch returned an error: " << pcap_geterr(m_PcapDescriptor));
 				m_StopThread = true;
@@ -188,7 +188,7 @@ void PcapLiveDevice::captureThreadMain()
 	{
 		while (!m_StopThread)
 		{
-			if (pcap_dispatch(m_PcapDescriptor, 100, onPacketArrivesNoCallback, (uint8_t*)this) == -1)
+			if (pcap_dispatch(m_PcapDescriptor, 100, onPacketArrivesNoCallback, reinterpret_cast<uint8_t*>(this)) == -1)
 			{
 				PCPP_LOG_ERROR("pcap_dispatch returned an error: " << pcap_geterr(m_PcapDescriptor));
 				m_StopThread = true;
@@ -514,7 +514,7 @@ int PcapLiveDevice::startCaptureBlockingMode(OnPacketArrivesStopBlocking onPacke
 	{
 		while (!m_StopThread)
 		{
-			if (pcap_dispatch(m_PcapDescriptor, -1, onPacketArrivesBlockingMode, (uint8_t*)this) == -1)
+			if (pcap_dispatch(m_PcapDescriptor, -1, onPacketArrivesBlockingMode, reinterpret_cast<uint8_t*>(this)) == -1)
 			{
 				PCPP_LOG_ERROR("pcap_dispatch returned an error: " << pcap_geterr(m_PcapDescriptor));
 				pcapDispatchError = true;
@@ -528,7 +528,7 @@ int PcapLiveDevice::startCaptureBlockingMode(OnPacketArrivesStopBlocking onPacke
 		while (!m_StopThread && curTimeSec <= (startTimeSec + timeout))
 		{
 			long curTimeNSec = 0;
-			if (pcap_dispatch(m_PcapDescriptor, -1, onPacketArrivesBlockingMode, (uint8_t*)this) == -1)
+			if (pcap_dispatch(m_PcapDescriptor, -1, onPacketArrivesBlockingMode, reinterpret_cast<uint8_t*>(this)) == -1)
 			{
 				PCPP_LOG_ERROR("pcap_dispatch returned an error: " << pcap_geterr(m_PcapDescriptor));
 				pcapDispatchError = true;

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -176,12 +176,24 @@ void PcapLiveDevice::captureThreadMain()
 	if (m_CaptureCallbackMode)
 	{
 		while (!m_StopThread)
-			pcap_dispatch(m_PcapDescriptor, -1, onPacketArrives, (uint8_t*)this);
+		{
+			if (pcap_dispatch(m_PcapDescriptor, -1, onPacketArrives, (uint8_t*)this) == -1)
+			{
+				PCPP_LOG_ERROR(pcap_geterr(m_PcapDescriptor));
+				m_StopThread = true;
+			}
+		}
 	}
 	else
 	{
 		while (!m_StopThread)
-			pcap_dispatch(m_PcapDescriptor, 100, onPacketArrivesNoCallback, (uint8_t*)this);
+		{
+			if (pcap_dispatch(m_PcapDescriptor, 100, onPacketArrivesNoCallback, (uint8_t*)this) == -1)
+			{
+				PCPP_LOG_ERROR(pcap_geterr(m_PcapDescriptor));
+				m_StopThread = true;
+			}
+		}
 	}
 	PCPP_LOG_DEBUG("Ended capture thread for device '" << m_Name << "'");
 }
@@ -500,7 +512,11 @@ int PcapLiveDevice::startCaptureBlockingMode(OnPacketArrivesStopBlocking onPacke
 	{
 		while (!m_StopThread)
 		{
-			pcap_dispatch(m_PcapDescriptor, -1, onPacketArrivesBlockingMode, (uint8_t*)this);
+			if (pcap_dispatch(m_PcapDescriptor, -1, onPacketArrivesBlockingMode, (uint8_t*)this) == -1)
+			{
+				PCPP_LOG_ERROR(pcap_geterr(m_PcapDescriptor));
+				m_StopThread = true;
+			}
 		}
 		curTimeSec = startTimeSec + timeout;
 	}
@@ -509,7 +525,11 @@ int PcapLiveDevice::startCaptureBlockingMode(OnPacketArrivesStopBlocking onPacke
 		while (!m_StopThread && curTimeSec <= (startTimeSec + timeout))
 		{
 			long curTimeNSec = 0;
-			pcap_dispatch(m_PcapDescriptor, -1, onPacketArrivesBlockingMode, (uint8_t*)this);
+			if (pcap_dispatch(m_PcapDescriptor, -1, onPacketArrivesBlockingMode, (uint8_t*)this) == -1)
+			{
+				PCPP_LOG_ERROR(pcap_geterr(m_PcapDescriptor));
+				m_StopThread = true;
+			}
 			clockGetTime(curTimeSec, curTimeNSec);
 		}
 	}


### PR DESCRIPTION
We add this because:
1. Checking the return value is the right thing to do 😄 
2. Because the fuzzers build fails, here is an example: https://github.com/seladb/PcapPlusPlus/actions/runs/7092633076/job/19304338003

[According to the documentation ](https://linux.die.net/man/3/pcap_dispatch) only a return value of `-1` is considered an error, the rest of the values are not errors.