### PR TITLE
Support more protocol types

### DIFF
--- a/Packet++/header/Layer.h
+++ b/Packet++/header/Layer.h
@@ -90,6 +90,13 @@ namespace pcpp
 		ProtocolType getProtocol() const { return m_Protocol; }
 
 		/**
+		 * Check if the layer's protocol matches a protocol family
+		 * @param protocolTypeFamily The protocol family to check
+		 * @return True if the layer's protocol matches the protocol family, false otherwise
+		 */
+		bool isMemberOfProtocolFamily(ProtocolTypeFamily protocolTypeFamily) const;
+
+		/**
 		 * @return A pointer to the layer raw data. In most cases it'll be a pointer to the first byte of the header
 		 */
 		uint8_t* getData() const { return m_Data; }

--- a/Packet++/header/Packet.h
+++ b/Packet++/header/Packet.h
@@ -30,7 +30,6 @@ namespace pcpp
 		RawPacket* m_RawPacket;
 		Layer* m_FirstLayer;
 		Layer* m_LastLayer;
-		uint64_t m_ProtocolTypes;
 		size_t m_MaxPacketLen;
 		bool m_FreeRawPacket;
 		bool m_CanReallocateData;
@@ -77,10 +76,21 @@ namespace pcpp
 		 * are created and linked to each other in the right order. In this overload of the constructor the user can specify whether to free
 		 * the instance of raw packet when the Packet is free or not. This constructor should be used to parse the packet up to a certain layer
 		 * @param[in] rawPacket A pointer to the raw packet
-		 * @param[in] parseUntil Optional parameter. Parse the packet until you reach a certain protocol (inclusive). Can be useful for cases when you need to parse only up to a
+		 * @param[in] parseUntil Parse the packet until you reach a certain protocol (inclusive). Can be useful for cases when you need to parse only up to a
 		 * certain layer and want to avoid the performance impact and memory consumption of parsing the whole packet
 		 */
-		Packet(RawPacket* rawPacket, ProtocolType parseUntil);
+		explicit Packet(RawPacket* rawPacket, ProtocolType parseUntil);
+
+		/**
+		 * A constructor for creating a packet out of already allocated RawPacket. Very useful when parsing packets that came from the network.
+		 * When using this constructor a pointer to the RawPacket is saved (data isn't copied) and the RawPacket is parsed, meaning all layers
+		 * are created and linked to each other in the right order. In this overload of the constructor the user can specify whether to free
+		 * the instance of raw packet when the Packet is free or not. This constructor should be used to parse the packet up to a certain layer
+		 * @param[in] rawPacket A pointer to the raw packet
+		 * @param[in] parseUntilFamily Parse the packet until you reach a certain protocol family (inclusive). Can be useful for cases when you need to parse only up to a
+		 * certain layer and want to avoid the performance impact and memory consumption of parsing the whole packet
+		 */
+		explicit Packet(RawPacket* rawPacket, ProtocolTypeFamily parseUntilFamily);
 
 		/**
 		 * A constructor for creating a packet out of already allocated RawPacket. Very useful when parsing packets that came from the network.
@@ -91,7 +101,7 @@ namespace pcpp
 		 * @param[in] parseUntilLayer Optional parameter. Parse the packet until you reach a certain layer in the OSI model (inclusive). Can be useful for cases when you need to
 		 * parse only up to a certain OSI layer (for example transport layer) and want to avoid the performance impact and memory consumption of parsing the whole packet
 		 */
-		Packet(RawPacket* rawPacket, OsiModelLayer parseUntilLayer);
+		explicit Packet(RawPacket* rawPacket, OsiModelLayer parseUntilLayer);
 
 		/**
 		 * A destructor for this class. Frees all layers allocated by this instance (Notice: it doesn't free layers that weren't allocated by this
@@ -131,7 +141,7 @@ namespace pcpp
 		 * @param[in] parseUntilLayer Parse the packet until certain layer in OSI model. Can be useful for cases when you need to parse only up to a certain layer and want to avoid the
 		 * performance impact and memory consumption of parsing the whole packet. Default value is ::OsiModelLayerUnknown which means don't take this parameter into account
 		 */
-		void setRawPacket(RawPacket* rawPacket, bool freeRawPacket, ProtocolType parseUntil = UnknownProtocol, OsiModelLayer parseUntilLayer = OsiModelLayerUnknown);
+		void setRawPacket(RawPacket* rawPacket, bool freeRawPacket, ProtocolTypeFamily parseUntil = UnknownProtocol, OsiModelLayer parseUntilLayer = OsiModelLayerUnknown);
 
 		/**
 		 * Get a pointer to the Packet's RawPacket in a read-only manner
@@ -286,11 +296,18 @@ namespace pcpp
 		TLayer* getPrevLayerOfType(Layer* startLayer) const;
 
 		/**
-		 * Check whether the packet contains a certain protocol
+		 * Check whether the packet contains a layer of a certain protocol
 		 * @param[in] protocolType The protocol type to search
-		 * @return True if the packet contains the protocol, false otherwise
+		 * @return True if the packet contains a layer of a certain protocol, false otherwise
 		 */
-		bool isPacketOfType(ProtocolType protocolType) const { return m_ProtocolTypes & protocolType; }
+		bool isPacketOfType(ProtocolType protocolType) const;
+
+		/**
+		* Check whether the packet contains a layer of a certain protocol family
+		* @param[in] protocolTypeFamily The protocol type family to search
+		 * @return True if the packet contains a layer of a certain protocol family, false otherwise
+		 */
+		bool isPacketOfType(ProtocolTypeFamily protocolTypeFamily) const;
 
 		/**
 		 * Each layer can have fields that can be calculate automatically from other fields using Layer#computeCalculateFields(). This method forces all layers to calculate these

--- a/Packet++/header/ProtocolType.h
+++ b/Packet++/header/ProtocolType.h
@@ -15,322 +15,328 @@ namespace pcpp
 	 * @typedef ProtocolType
 	 * Representing all protocols supported by PcapPlusPlus
 	 */
-	typedef uint64_t ProtocolType;
+	typedef uint8_t ProtocolType;
+
+	/**
+	 * @typedef ProtocolTypeFamily
+	 * Representing a family of protocols
+	 */
+	typedef uint32_t ProtocolTypeFamily;
 
 	/**
 	 * Unknown protocol (or unsupported by PcapPlusPlus)
 	 */
-	const ProtocolType UnknownProtocol = 0x00;
+	const ProtocolType UnknownProtocol = 0;
 
 	/**
 	 * Ethernet protocol
 	 */
-	const ProtocolType Ethernet = 0x01;
+	const ProtocolType Ethernet = 1;
 
 	/**
 	 * IPv4 protocol
 	 */
-	const ProtocolType IPv4 = 0x02;
+	const ProtocolType IPv4 = 2;
 
 	/**
 	 * IPv6 protocol
 	 */
-	const ProtocolType IPv6 = 0x04;
+	const ProtocolType IPv6 = 3;
 
 	/**
-	 * IP protocol (aggregation bitmask of IPv4 and IPv6 protocols)
+	 * IP protocol family (IPv4 and IPv6 protocols)
 	 */
-	const ProtocolType IP = 0x06;
+	const ProtocolTypeFamily IP = 0x203;
 
 	/**
 	 * TCP protocol
 	 */
-	const ProtocolType TCP = 0x08;
+	const ProtocolType TCP = 4;
 
 	/**
 	 * UDP protocol
 	 */
-	const ProtocolType UDP = 0x10;
+	const ProtocolType UDP = 5;
 
 	/**
 	 * HTTP request protocol
 	 */
-	const ProtocolType HTTPRequest = 0x20;
+	const ProtocolType HTTPRequest = 6;
 
 	/**
 	 * HTTP response protocol
 	 */
-	const ProtocolType HTTPResponse = 0x40;
+	const ProtocolType HTTPResponse = 7;
 
 	/**
-	 * HTTP protocol (aggregation bitmask of HTTP request and HTTP response protocols)
+	 * HTTP protocol family (HTTP request and HTTP response protocols)
 	 */
-	const ProtocolType HTTP = 0x60;
+	const ProtocolTypeFamily HTTP = 0x607;
 
 	/**
 	 * ARP protocol
 	 */
-	const ProtocolType ARP = 0x80;
+	const ProtocolType ARP = 8;
 
 	/**
 	 * VLAN protocol
 	 */
-	const ProtocolType VLAN = 0x100;
+	const ProtocolType VLAN = 9;
 
 	/**
 	 * ICMP protocol
 	 */
-	const ProtocolType ICMP = 0x200;
+	const ProtocolType ICMP = 10;
 
 	/**
 	 * PPPoE session protocol
 	 */
-	const ProtocolType PPPoESession = 0x400;
+	const ProtocolType PPPoESession = 11;
 
 	/**
 	 * PPPoE discovery protocol
 	 */
-	const ProtocolType PPPoEDiscovery = 0x800;
+	const ProtocolType PPPoEDiscovery = 12;
 
 	/**
-	 * PPPoE protocol (aggregation bitmask of PPPoESession and PPPoEDiscovery protocols)
+	 * PPPoE protocol family (PPPoESession and PPPoEDiscovery protocols)
 	 */
-	const ProtocolType PPPoE = 0xc00;
+	const ProtocolTypeFamily PPPoE = 0xb0c;
 
 	/**
 	 * DNS protocol
 	 */
-	const ProtocolType DNS = 0x1000;
+	const ProtocolType DNS = 13;
 
 	/**
 	 * MPLS protocol
 	 */
-	const ProtocolType MPLS = 0x2000;
+	const ProtocolType MPLS = 14;
 
 	/**
 	 * GRE version 0 protocol
 	 */
-	const ProtocolType GREv0 = 0x4000;
+	const ProtocolType GREv0 = 15;
 
 	/**
 	 * GRE version 1 protocol
 	 */
-	const ProtocolType GREv1 = 0x8000;
+	const ProtocolType GREv1 = 16;
 
 	/**
-	 * GRE protocol (aggregation bitmask of GREv0 and GREv1 protocols)
+	 * GRE protocol family (GREv0 and GREv1 protocols)
 	 */
-	const ProtocolType GRE = 0xc000;
+	const ProtocolTypeFamily GRE = 0xf10;
 
 	/**
 	 * PPP for PPTP protocol
 	 */
-	const ProtocolType PPP_PPTP = 0x10000;
+	const ProtocolType PPP_PPTP = 17;
 
 	/**
 	 * SSL/TLS protocol
 	 */
-	const ProtocolType SSL = 0x20000;
+	const ProtocolType SSL = 18;
 
 	/**
 	 * SLL (Linux cooked capture) protocol
 	 */
-	const ProtocolType SLL = 0x40000;
+	const ProtocolType SLL = 19;
 
 	/**
 	 * DHCP/BOOTP protocol
 	 */
-	const ProtocolType DHCP = 0x80000;
+	const ProtocolType DHCP = 20;
 
 	/**
 	 * Null/Loopback protocol
 	 */
-	const ProtocolType NULL_LOOPBACK = 0x100000;
-
-	/**
-	 * IGMP protocol
-	 */
-	const ProtocolType IGMP = 0xE00000;
+	const ProtocolType NULL_LOOPBACK = 21;
 
 	/**
 	 * IGMPv1 protocol
 	 */
-	const ProtocolType IGMPv1 = 0x200000;
+	const ProtocolType IGMPv1 = 22;
 
 	/**
 	 * IGMPv2 protocol
 	 */
-	const ProtocolType IGMPv2 = 0x400000;
+	const ProtocolType IGMPv2 = 23;
 
 	/**
 	 * IGMPv3 protocol
 	 */
-	const ProtocolType IGMPv3 = 0x800000;
+	const ProtocolType IGMPv3 = 24;
+
+	/**
+	 * IGMP protocol family (IGMPv1, IGMPv2, IGMPv3)
+	 */
+	const ProtocolTypeFamily IGMP = 0x161718;
 
 	/**
 	 * Generic payload (no specific protocol)
 	 */
-	const ProtocolType GenericPayload = 0x1000000;
+	const ProtocolType GenericPayload = 25;
 
 	/**
 	 * VXLAN protocol
 	 */
-	const ProtocolType VXLAN = 0x2000000;
+	const ProtocolType VXLAN = 26;
 
 	/**
 	 * SIP request protocol
 	 */
-	const ProtocolType SIPRequest = 0x4000000;
+	const ProtocolType SIPRequest = 27;
 
 	/**
 	 * SIP response protocol
 	 */
-	const ProtocolType SIPResponse = 0x8000000;
+	const ProtocolType SIPResponse = 28;
 
 	/**
-	 * SIP protocol (aggregation bitmask of SIPRequest and SIPResponse protocols)
+	 * SIP protocol family (SIPRequest and SIPResponse protocols)
 	 */
-	const ProtocolType SIP = 0xc000000;
+	const ProtocolTypeFamily SIP = 0x1b1c;
 
 	/**
 	 * SDP protocol
 	 */
-	const ProtocolType SDP = 0x10000000;
+	const ProtocolType SDP = 29;
 
 	/**
 	 * Packet trailer
 	 */
-	const ProtocolType PacketTrailer = 0x20000000;
+	const ProtocolType PacketTrailer = 30;
 
 	/**
 	 * RADIUS protocol
 	 */
-	const ProtocolType Radius = 0x40000000;
+	const ProtocolType Radius = 31;
 
 	/**
 	 * GTPv1 protocol
 	 */
-	const ProtocolType GTPv1 = 0x80000000;
+	const ProtocolType GTPv1 = 32;
 
 	/**
-	 * GTP protocol (currently the same as GTPv1)
+	 * GTP protocol family (currently only GTPv1)
 	 */
-	const ProtocolType GTP = 0x80000000;
+	const ProtocolTypeFamily GTP = 0x20;
 
 	/**
 	 * IEEE 802.3 Ethernet protocol
 	 */
-	const ProtocolType EthernetDot3 = 0x100000000;
+	const ProtocolType EthernetDot3 = 33;
 
 	/**
 	 * Border Gateway Protocol (BGP) version 4 protocol
 	 */
-	const ProtocolType BGP = 0x200000000;
+	const ProtocolType BGP = 34;
 
 	/**
 	 * SSH version 2 protocol
 	 */
-	const ProtocolType SSH = 0x400000000;
+	const ProtocolType SSH = 35;
 
 	/**
 	 * IPSec Authentication Header (AH) protocol
 	 */
-	const ProtocolType AuthenticationHeader = 0x800000000;
+	const ProtocolType AuthenticationHeader = 36;
 
 	/**
 	 * IPSec Encapsulating Security Payload (ESP) protocol
 	 */
-	const ProtocolType ESP = 0x1000000000;
+	const ProtocolType ESP = 37;
 
 	/**
-	 * IPSec protocol (aggregation bitmask of AH and ESP protocols)
+	 * IPSec protocol family (AH and ESP protocols)
 	 */
-	const ProtocolType IPSec = 0x1800000000;
+	const ProtocolTypeFamily IPSec = 0x2425;
 
 	/**
 	 * Dynamic Host Configuration Protocol version 6 (DHCPv6) protocol
 	 */
-	const ProtocolType DHCPv6 = 0x2000000000;
+	const ProtocolType DHCPv6 = 38;
 
 	/**
 	 * Network Time (NTP) Protocol
 	 */
-	const ProtocolType NTP = 0x4000000000;
+	const ProtocolType NTP = 39;
 
 	/**
 	 * Telnet Protocol
 	 */
-	const ProtocolType Telnet = 0x8000000000;
+	const ProtocolType Telnet = 40;
 
   	/**
    	 * File Transfer (FTP) Protocol
 	 */
-	const ProtocolType FTP = 0x10000000000;
+	const ProtocolType FTP = 41;
 
 	/**
 	 * ICMPv6 protocol
 	 */
-	const ProtocolType ICMPv6 = 0x20000000000;
+	const ProtocolType ICMPv6 = 42;
 
 	/**
 	 * Spanning Tree Protocol
 	 */
-	const ProtocolType STP = 0x40000000000;
+	const ProtocolType STP = 43;
 
 	/**
 	 * Logical Link Control (LLC)
 	 */
-	const ProtocolType LLC = 0x80000000000;
+	const ProtocolType LLC = 44;
 
 	/**
 	 * SOME/IP Base protocol
 	 */
-	const ProtocolType SomeIP = 0x100000000000;
+	const ProtocolType SomeIP = 45;
 
 	/**
 	 * Wake On LAN (WOL) Protocol
 	 */
-	const ProtocolType WakeOnLan = 0x200000000000;
+	const ProtocolType WakeOnLan = 46;
 
 	/**
 	 * NFLOG (Linux Netfilter NFLOG) Protocol
 	 */
-	const ProtocolType NFLOG = 0x400000000000;
+	const ProtocolType NFLOG = 47;
 
 	/**
 	 * TPKT protocol
 	 */
-	const ProtocolType TPKT = 0x800000000000;
-
- 	/**
-	 * VRRP protocol
-	 */
-	const ProtocolType VRRP = 0x3000000000000;
+	const ProtocolType TPKT = 48;
 
 	/**
 	 * VRRP version 2 protocol
 	 */
-	const ProtocolType VRRPv2 = 0x1000000000000;
+	const ProtocolType VRRPv2 = 49;
 
 	/**
 	 * VRRP version 3 protocol
 	 */
-	const ProtocolType VRRPv3 = 0x2000000000000;
+	const ProtocolType VRRPv3 = 50;
+
+	/**
+	* VRRP protocol family (VRRPv2 and VRRPv3 protocols)
+	*/
+	const ProtocolTypeFamily VRRP = 0x3132;
 
 	/**
 	 * COTP protocol
 	 */
-	const ProtocolType COTP = 0x4000000000000;
+	const ProtocolType COTP = 51;
 
 	/**
 	 * SLL2 protocol
 	 */
-	const ProtocolType SLL2 = 0x8000000000000;
+	const ProtocolType SLL2 = 52;
 
 	/**
 	 * S7COMM protocol
 	 */
-	const ProtocolType S7COMM = 0x10000000000000;
+	const ProtocolType S7COMM = 53;
 
 	/**
 	 * An enum representing OSI model layers

--- a/Packet++/src/Layer.cpp
+++ b/Packet++/src/Layer.cpp
@@ -41,6 +41,17 @@ Layer& Layer::operator=(const Layer& other)
 	return *this;
 }
 
+bool Layer::isMemberOfProtocolFamily(ProtocolTypeFamily protocolTypeFamily) const
+{
+	auto protocolToFamily = static_cast<ProtocolTypeFamily>(m_Protocol);
+	return (m_Protocol != UnknownProtocol &&
+	       (protocolToFamily == (protocolTypeFamily & 0xff) ||
+	        protocolToFamily << 8 == (protocolTypeFamily & 0xff00) ||
+	        protocolToFamily << 16 == (protocolTypeFamily & 0xff0000) ||
+	        protocolToFamily << 24 == (protocolTypeFamily & 0xff000000)));
+}
+
+
 void Layer::copyData(uint8_t* toArr) const
 {
 	memcpy(toArr, m_Data, m_DataLen);

--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -30,7 +30,6 @@ Packet::Packet(size_t maxPacketLen) :
 	m_RawPacket(nullptr),
 	m_FirstLayer(nullptr),
 	m_LastLayer(nullptr),
-	m_ProtocolTypes(UnknownProtocol),
 	m_MaxPacketLen(maxPacketLen),
 	m_FreeRawPacket(true),
 	m_CanReallocateData(true)
@@ -46,7 +45,6 @@ Packet::Packet(uint8_t* buffer, size_t bufferSize) :
 	m_RawPacket(nullptr),
 	m_FirstLayer(nullptr),
 	m_LastLayer(nullptr),
-	m_ProtocolTypes(UnknownProtocol),
 	m_MaxPacketLen(bufferSize),
 	m_FreeRawPacket(true),
 	m_CanReallocateData(false)
@@ -57,13 +55,12 @@ Packet::Packet(uint8_t* buffer, size_t bufferSize) :
 	m_RawPacket = new RawPacket(buffer, 0, time, false, LINKTYPE_ETHERNET);
 }
 
-void Packet::setRawPacket(RawPacket* rawPacket, bool freeRawPacket, ProtocolType parseUntil, OsiModelLayer parseUntilLayer)
+void Packet::setRawPacket(RawPacket* rawPacket, bool freeRawPacket, ProtocolTypeFamily parseUntil, OsiModelLayer parseUntilLayer)
 {
 	destructPacketData();
 
 	m_FirstLayer = nullptr;
 	m_LastLayer = nullptr;
-	m_ProtocolTypes = UnknownProtocol;
 	m_MaxPacketLen = rawPacket->getRawDataLen();
 	m_FreeRawPacket = freeRawPacket;
 	m_RawPacket = rawPacket;
@@ -77,9 +74,8 @@ void Packet::setRawPacket(RawPacket* rawPacket, bool freeRawPacket, ProtocolType
 
 	m_LastLayer = m_FirstLayer;
 	Layer* curLayer = m_FirstLayer;
-	while (curLayer != nullptr && (curLayer->getProtocol() & parseUntil) == 0 && curLayer->getOsiModelLayer() <= parseUntilLayer)
+	while (curLayer != nullptr && (parseUntil == UnknownProtocol || !curLayer->isMemberOfProtocolFamily(parseUntil)) && curLayer->getOsiModelLayer() <= parseUntilLayer)
 	{
-		m_ProtocolTypes |= curLayer->getProtocol();
 		curLayer->parseNextLayer();
 		curLayer->m_IsAllocatedInPacket = true;
 		curLayer = curLayer->getNextLayer();
@@ -87,9 +83,8 @@ void Packet::setRawPacket(RawPacket* rawPacket, bool freeRawPacket, ProtocolType
 			m_LastLayer = curLayer;
 	}
 
-	if (curLayer != nullptr && (curLayer->getProtocol() & parseUntil) != 0)
+	if (curLayer != nullptr && curLayer->isMemberOfProtocolFamily(parseUntil))
 	{
-		m_ProtocolTypes |= curLayer->getProtocol();
 		curLayer->m_IsAllocatedInPacket = true;
 	}
 
@@ -116,7 +111,6 @@ void Packet::setRawPacket(RawPacket* rawPacket, bool freeRawPacket, ProtocolType
 			trailerLayer->m_IsAllocatedInPacket = true;
 			m_LastLayer->setNextLayer(trailerLayer);
 			m_LastLayer = trailerLayer;
-			m_ProtocolTypes |= trailerLayer->getProtocol();
 		}
 	}
 }
@@ -134,7 +128,16 @@ Packet::Packet(RawPacket* rawPacket, ProtocolType parseUntil)
 	m_FreeRawPacket = false;
 	m_RawPacket = nullptr;
 	m_FirstLayer = nullptr;
-	setRawPacket(rawPacket, false, parseUntil, OsiModelLayerUnknown);
+	auto parseUntilFamily = static_cast<ProtocolTypeFamily>(parseUntil);
+	setRawPacket(rawPacket, false, parseUntilFamily, OsiModelLayerUnknown);
+}
+
+Packet::Packet(RawPacket* rawPacket, ProtocolTypeFamily parseUntilFamily)
+{
+	m_FreeRawPacket = false;
+	m_RawPacket = nullptr;
+	m_FirstLayer = nullptr;
+	setRawPacket(rawPacket, false, parseUntilFamily, OsiModelLayerUnknown);
 }
 
 Packet::Packet(RawPacket* rawPacket, OsiModelLayer parseUntilLayer)
@@ -176,7 +179,6 @@ void Packet::copyDataFrom(const Packet& other)
 	m_RawPacket = new RawPacket(*(other.m_RawPacket));
 	m_FreeRawPacket = true;
 	m_MaxPacketLen = other.m_MaxPacketLen;
-	m_ProtocolTypes = other.m_ProtocolTypes;
 	m_FirstLayer = createFirstLayer(m_RawPacket->getLinkLayerType());
 	m_LastLayer = m_FirstLayer;
 	m_CanReallocateData = true;
@@ -323,8 +325,6 @@ bool Packet::insertLayer(Layer* prevLayer, Layer* newLayer, bool ownInPacket)
 		curLayer = curLayer->getNextLayer();
 	}
 
-	// add layer protocol to protocol collection
-	m_ProtocolTypes |= newLayer->getProtocol();
 	return true;
 }
 
@@ -484,10 +484,6 @@ bool Packet::removeLayer(Layer* layer, bool tryToDelete)
 		else
 			curLayer->m_DataLen = dataLen - packetTrailerLen;
 
-		// check if current layer's protocol is the same as removed layer protocol and set the flag accordingly
-		if (curLayer->getProtocol() == layer->getProtocol())
-			anotherLayerWithSameProtocolExists = true;
-
 		// advance data ptr and data length
 		dataPtr += curLayer->getHeaderLen();
 		dataLen -= curLayer->getHeaderLen();
@@ -495,10 +491,6 @@ bool Packet::removeLayer(Layer* layer, bool tryToDelete)
 		// move to next layer
 		curLayer = curLayer->getNextLayer();
 	}
-
-	// remove layer protocol from protocol list if necessary
-	if (!anotherLayerWithSameProtocolExists)
-		m_ProtocolTypes &= ~((uint64_t)layer->getProtocol());
 
 	// if layer was allocated by this packet and tryToDelete flag is set, delete it
 	if (tryToDelete && layer->m_IsAllocatedInPacket)
@@ -535,6 +527,36 @@ Layer* Packet::getLayerOfType(ProtocolType layerType, int index) const
 
 	return curLayer;
 }
+
+	bool Packet::isPacketOfType(ProtocolType protocolType) const
+	{
+		Layer* curLayer = getFirstLayer();
+		while (curLayer != nullptr)
+		{
+			if (curLayer->getProtocol() == protocolType)
+			{
+				return true;
+			}
+			curLayer = curLayer->getNextLayer();
+		}
+
+		return false;
+	}
+
+	bool Packet::isPacketOfType(ProtocolTypeFamily protocolTypeFamily) const
+	{
+		Layer* curLayer = getFirstLayer();
+		while (curLayer != nullptr)
+		{
+			if (curLayer->isMemberOfProtocolFamily(protocolTypeFamily))
+			{
+				return true;
+			}
+			curLayer = curLayer->getNextLayer();
+		}
+
+		return false;
+	}
 
 bool Packet::extendLayer(Layer* layer, int offsetInLayer, size_t numOfBytesToExtend)
 {

--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -467,9 +467,6 @@ bool Packet::removeLayer(Layer* layer, bool tryToDelete)
 
 	curLayer = m_FirstLayer;
 
-	// a flag to be set if there is another layer in this packet with the same protocol
-	bool anotherLayerWithSameProtocolExists = false;
-
 	// go over all layers from the first layer to the last layer and set the data ptr and data length for each one
 	while (curLayer != nullptr)
 	{

--- a/Packet++/src/SingleCommandTextProtocol.cpp
+++ b/Packet++/src/SingleCommandTextProtocol.cpp
@@ -2,6 +2,7 @@
 #include "Logger.h"
 
 #include <string.h>
+#include <algorithm>
 
 #define ASCII_HYPHEN 0x2d
 #define ASCII_SPACE 0x20

--- a/Pcap++/header/PcapFilter.h
+++ b/Pcap++/header/PcapFilter.h
@@ -591,31 +591,47 @@ namespace pcpp
 
 	/**
 	 * @class ProtoFilter
-	 * A class for filtering traffic by protocol. Notice not all protocols are supported, only the following are supported:
-	 * ::TCP, ::UDP, ::ICMP, ::VLAN, ::IPv4, ::IPv6, ::ARP, ::Ethernet, ::GRE (distinguish between ::GREv0 and ::GREv1 is not supported),
-	 * ::IGMP (distinguish between ::IGMPv1, ::IGMPv2 and ::IGMPv3 is not supported). <BR>
+	 * A class for filtering traffic by protocol. Notice not all protocols are supported, only the following protocol are supported:
+	 * ::TCP, ::UDP, ::ICMP, ::VLAN, ::IPv4, ::IPv6, ::ARP, ::Ethernet.
+	 * In addition, the following protocol families are supported: ::GRE (distinguish between ::GREv0 and ::GREv1 is not supported),
+	 * ::IGMP (distinguish between ::IGMPv1, ::IGMPv2 and ::IGMPv3 is not supported).
+	 *
 	 * For deeper understanding of the filter concept please refer to PcapFilter.h
 	 */
 	class ProtoFilter : public GeneralFilter
 	{
 	private:
-		ProtocolType m_Proto;
+		ProtocolTypeFamily m_ProtoFamily;
 	public:
 		/**
-		 * A constructor that gets the protocol and creates the filter
+		 * A constructor that gets a protocol and creates the filter
 		 * @param[in] proto The protocol to filter, only packets matching this protocol will be received. Please note not all protocols are
 		 * supported. List of supported protocols is found in the class description
 		 */
-		explicit ProtoFilter(ProtocolType proto) : m_Proto(proto) {}
+		explicit ProtoFilter(ProtocolType proto) : m_ProtoFamily(proto) {}
+
+		/**
+		 * A constructor that gets a protocol family and creates the filter
+		 * @param[in] protoFamily The protocol family to filter, only packets matching this protocol will be received. Please note not all protocols are
+		 * supported. List of supported protocols is found in the class description
+		 */
+		explicit ProtoFilter(ProtocolTypeFamily protoFamily) : m_ProtoFamily(protoFamily) {}
 
 		void parseToString(std::string& result);
 
 		/**
 		 * Set the protocol to filter with
-		 * @param[in] proto The protocol to filter, only packets matching this protocol will be received. Please note not all protocols are
+		 * @param[in] proto The protocol to filter, only packets matching this protocol will be received. Please note not all protocol families are
 		 * supported. List of supported protocols is found in the class description
 		 */
-		void setProto(ProtocolType proto) { m_Proto = proto; }
+		void setProto(ProtocolType proto) { m_ProtoFamily = proto; }
+
+		/**
+		 * Set the protocol family to filter with
+		 * @param[in] protoFamily The protocol family to filter, only packets matching this protocol will be received. Please note not all protocol families are
+		 * supported. List of supported protocols is found in the class description
+		 */
+		void setProto(ProtocolTypeFamily protoFamily) { m_ProtoFamily = protoFamily; }
 	};
 
 

--- a/Pcap++/src/PcapFilter.cpp
+++ b/Pcap++/src/PcapFilter.cpp
@@ -364,7 +364,7 @@ void ProtoFilter::parseToString(std::string& result)
 {
 	std::ostringstream stream;
 
-	switch (m_Proto)
+	switch (m_ProtoFamily)
 	{
 	case TCP:
 		result = "tcp";

--- a/Tests/Packet++Test/TestDefinition.h
+++ b/Tests/Packet++Test/TestDefinition.h
@@ -56,7 +56,8 @@ PTF_TEST_CASE(RawPacketTimeStampSetterTest);
 PTF_TEST_CASE(ParsePartialPacketTest);
 PTF_TEST_CASE(PacketTrailerTest);
 PTF_TEST_CASE(ResizeLayerTest);
-PTF_TEST_CASE(PrintPacketAndLayers);
+PTF_TEST_CASE(PrintPacketAndLayersTest);
+PTF_TEST_CASE(ProtocolFamilyMembershipTest);
 
 // Implemented in HttpTests.cpp
 PTF_TEST_CASE(HttpRequestParseMethodTest);

--- a/Tests/Packet++Test/Tests/HttpTests.cpp
+++ b/Tests/Packet++Test/Tests/HttpTests.cpp
@@ -53,6 +53,7 @@ PTF_TEST_CASE(HttpRequestLayerParsingTest)
 	pcpp::Packet httpPacket(&rawPacket1);
 
 	PTF_ASSERT_TRUE(httpPacket.isPacketOfType(pcpp::HTTPRequest));
+	PTF_ASSERT_TRUE(httpPacket.isPacketOfType(pcpp::HTTP));
 	pcpp::HttpRequestLayer* requestLayer = httpPacket.getLayerOfType<pcpp::HttpRequestLayer>();
 	PTF_ASSERT_NOT_NULL(requestLayer);
 
@@ -366,6 +367,7 @@ PTF_TEST_CASE(HttpResponseLayerParsingTest)
 	pcpp::Packet httpPacket(&rawPacket1);
 
 	PTF_ASSERT_TRUE(httpPacket.isPacketOfType(pcpp::HTTPResponse));
+	PTF_ASSERT_TRUE(httpPacket.isPacketOfType(pcpp::HTTP));
 	pcpp::HttpResponseLayer* responseLayer = httpPacket.getLayerOfType<pcpp::HttpResponseLayer>();
 	PTF_ASSERT_NOT_NULL(responseLayer);
 

--- a/Tests/Packet++Test/Tests/IPv4Tests.cpp
+++ b/Tests/Packet++Test/Tests/IPv4Tests.cpp
@@ -69,6 +69,7 @@ PTF_TEST_CASE(IPv4PacketParsing)
 	pcpp::Packet ip4Packet(&rawPacket1);
 	PTF_ASSERT_TRUE(ip4Packet.isPacketOfType(pcpp::Ethernet));
 	PTF_ASSERT_NOT_NULL(ip4Packet.getLayerOfType<pcpp::EthLayer>());
+	PTF_ASSERT_TRUE(ip4Packet.isPacketOfType(pcpp::IP));
 	PTF_ASSERT_TRUE(ip4Packet.isPacketOfType(pcpp::IPv4));
 	PTF_ASSERT_NOT_NULL(ip4Packet.getLayerOfType<pcpp::IPv4Layer>());
 

--- a/Tests/Packet++Test/Tests/IPv6Tests.cpp
+++ b/Tests/Packet++Test/Tests/IPv6Tests.cpp
@@ -19,6 +19,8 @@ PTF_TEST_CASE(IPv6UdpPacketParseAndCreate)
 	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/IPv6UdpPacket.dat");
 
 	pcpp::Packet ip6UdpPacket(&rawPacket1);
+	PTF_ASSERT_TRUE(ip6UdpPacket.isPacketOfType(pcpp::IPv6));
+	PTF_ASSERT_TRUE(ip6UdpPacket.isPacketOfType(pcpp::IP));
 	PTF_ASSERT_FALSE(ip6UdpPacket.isPacketOfType(pcpp::IPv4));
 	PTF_ASSERT_FALSE(ip6UdpPacket.isPacketOfType(pcpp::TCP));
 	pcpp::IPv6Layer* ipv6Layer = nullptr;

--- a/Tests/Packet++Test/Tests/PacketTests.cpp
+++ b/Tests/Packet++Test/Tests/PacketTests.cpp
@@ -973,7 +973,7 @@ PTF_TEST_CASE(ResizeLayerTest)
 } // ResizeLayerTest
 
 
-PTF_TEST_CASE(PrintPacketAndLayers)
+PTF_TEST_CASE(PrintPacketAndLayersTest)
 {
 	timeval time;
 	time.tv_sec = 1634026009;
@@ -1041,3 +1041,26 @@ PTF_TEST_CASE(PrintPacketAndLayers)
 	packet.toStringList(packetAsStringList);
 	PTF_ASSERT_TRUE(packetAsStringList == expectedLayerStrings);
 } // PrintPacketAndLayer
+
+
+PTF_TEST_CASE(ProtocolFamilyMembershipTest)
+{
+	timeval time;
+	gettimeofday(&time, nullptr);
+
+	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/TwoHttpRequests1.dat");
+
+	pcpp::Packet packet(&rawPacket1);
+
+	auto ipV4Layer = packet.getLayerOfType<pcpp::IPv4Layer>();
+	PTF_ASSERT_TRUE(ipV4Layer->isMemberOfProtocolFamily(pcpp::IP));
+	PTF_ASSERT_TRUE(ipV4Layer->isMemberOfProtocolFamily(pcpp::IPv4));
+	PTF_ASSERT_FALSE(ipV4Layer->isMemberOfProtocolFamily(pcpp::IPv6));
+	PTF_ASSERT_FALSE(ipV4Layer->isMemberOfProtocolFamily(pcpp::HTTP));
+
+	auto httpLayer = packet.getLayerOfType<pcpp::HttpRequestLayer>();
+	PTF_ASSERT_TRUE(httpLayer->isMemberOfProtocolFamily(pcpp::HTTP));
+	PTF_ASSERT_TRUE(httpLayer->isMemberOfProtocolFamily(pcpp::HTTPRequest));
+	PTF_ASSERT_FALSE(httpLayer->isMemberOfProtocolFamily(pcpp::HTTPResponse));
+	PTF_ASSERT_FALSE(httpLayer->isMemberOfProtocolFamily(pcpp::IP));
+}

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -157,7 +157,8 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(ParsePartialPacketTest, "packet;partial_packet");
 	PTF_RUN_TEST(PacketTrailerTest, "packet;packet_trailer");
 	PTF_RUN_TEST(ResizeLayerTest, "packet;resize");
-	PTF_RUN_TEST(PrintPacketAndLayers, "packet;print");
+	PTF_RUN_TEST(PrintPacketAndLayersTest, "packet;print");
+	PTF_RUN_TEST(ProtocolFamilyMembershipTest, "packet");
 
 	PTF_RUN_TEST(HttpRequestParseMethodTest, "http");
 	PTF_RUN_TEST(HttpRequestLayerParsingTest, "http");


### PR DESCRIPTION
Update the system of storing and calculating protocol types for layers. This should serve the following purposes:
- Support more than 64 protocol types (which is the limit we have today)
- Reduce the amount of memory stored per packet

The changes made in this PR are:
- Previously each protocol type was `uint64_t` with 1 bit set, and a `Packet` contained a bitmap of all protocols set on the layer (also with the size of `uint64_t`). This required 8 bytes on `Packet` + 8 bytes for each layer in the packet, and the only benefit was a faster calculation of `Packet::isPacketOfType()`. However, it also limited the number of possible values in `ProtocolType` to 64
- With the new design, `ProtocolType` is a number of type `uint8_t` (supporting up to 255 protocols, which should be good enough for a long time). We no longer store a bitmap on `Packet`, instead `Packet::isPacketOfType()` goes over the layers and tries to find the protocol. It's a bit slower but not too much really
- To support "protocol families", such as "IP" which includes IPv4 and IPv6, a new typedef was added: `ProtocolTypeFamily`, a 4-byte bitmap of its family members. A new `Layer::isMemberOfProtocolFamily()` method was added to check if a layer is a member of a protocol family: it goes over the bytes in the "protocol family" to check if one of those bytes matches the layer's protocol type
- Modify `ProtoFilter` to support both protocols and protocol families