### PR TITLE
DPDK filter traffic example app improvements

### DIFF
--- a/Examples/DpdkExample-FilterTraffic/AppWorkerThread.h
+++ b/Examples/DpdkExample-FilterTraffic/AppWorkerThread.h
@@ -46,7 +46,7 @@ public:
 	{
 		m_CoreId = coreId;
 		m_Stop = false;
-		m_Stats.WorkerId = coreId;
+		m_Stats.workerId = coreId;
 		pcpp::DpdkDevice* sendPacketsTo = m_WorkerConfig.SendPacketsTo;
 		pcpp::PcapFileWriterDevice* pcapWriter = NULL;
 
@@ -92,7 +92,7 @@ public:
 						// collect packet statistics
 						m_Stats.collectStats(parsedPacket);
 
-						bool packetMatched = false;
+						bool packetMatched;
 
 						// hash the packet by 5-tuple and look in the flow table to see whether this packet belongs to an existing or new flow
 						uint32_t hash = pcpp::hash5Tuple(&parsedPacket);
@@ -114,11 +114,11 @@ public:
 								//collect stats
 								if (parsedPacket.isPacketOfType(pcpp::TCP))
 								{
-									m_Stats.MatchedTcpFlows++;
+									m_Stats.matchedTcpFlows++;
 								}
 								else if (parsedPacket.isPacketOfType(pcpp::UDP))
 								{
-									m_Stats.MatchedUdpFlows++;
+									m_Stats.matchedUdpFlows++;
 								}
 
 							}
@@ -138,7 +138,7 @@ public:
 								pcapWriter->writePacket(*packetArr[i]);
 							}
 
-							m_Stats.MatchedPackets++;
+							m_Stats.matchedPackets++;
 						}
 					}
 				}

--- a/Examples/DpdkExample-FilterTraffic/AppWorkerThread.h
+++ b/Examples/DpdkExample-FilterTraffic/AppWorkerThread.h
@@ -47,13 +47,13 @@ public:
 		m_CoreId = coreId;
 		m_Stop = false;
 		m_Stats.workerId = coreId;
-		pcpp::DpdkDevice* sendPacketsTo = m_WorkerConfig.SendPacketsTo;
+		pcpp::DpdkDevice* sendPacketsTo = m_WorkerConfig.sendPacketsTo;
 		pcpp::PcapFileWriterDevice* pcapWriter = NULL;
 
 		// if needed, create the pcap file writer which all matched packets will be written into
-		if (m_WorkerConfig.WriteMatchedPacketsToFile)
+		if (m_WorkerConfig.writeMatchedPacketsToFile)
 		{
-			pcapWriter = new pcpp::PcapFileWriterDevice(m_WorkerConfig.PathToWritePackets.c_str());
+			pcapWriter = new pcpp::PcapFileWriterDevice(m_WorkerConfig.pathToWritePackets.c_str());
 			if (!pcapWriter->open())
 			{
 				EXIT_WITH_ERROR("Couldn't open pcap writer device");
@@ -61,7 +61,7 @@ public:
 		}
 
 		// if no DPDK devices were assigned to this worker/core don't enter the main loop and exit
-		if (m_WorkerConfig.InDataCfg.size() == 0)
+		if (m_WorkerConfig.inDataCfg.size() == 0)
 		{
 			return true;
 		}
@@ -74,7 +74,7 @@ public:
 		while (!m_Stop)
 		{
 			// go over all DPDK devices configured for this worker/core
-			for (const auto &iter : m_WorkerConfig.InDataCfg)
+			for (const auto &iter : m_WorkerConfig.inDataCfg)
 			{
 				// for each DPDK device go over all RX queues configured for this worker/core
 				for (const auto &iter2 : iter.second)

--- a/Examples/DpdkExample-FilterTraffic/Common.h
+++ b/Examples/DpdkExample-FilterTraffic/Common.h
@@ -40,15 +40,14 @@ typedef std::map<pcpp::DpdkDevice*, std::vector<int> > InputDataConfig;
  */
 struct AppWorkerConfig
 {
-	uint32_t CoreId;
-	InputDataConfig InDataCfg;
-	pcpp::DpdkDevice* SendPacketsTo;
-	bool WriteMatchedPacketsToFile;
-	std::string PathToWritePackets;
+	uint32_t coreId;
+	InputDataConfig inDataCfg;
+	pcpp::DpdkDevice* sendPacketsTo;
+	bool writeMatchedPacketsToFile;
+	std::string pathToWritePackets;
 
-	AppWorkerConfig() : CoreId(MAX_NUM_OF_CORES+1), SendPacketsTo(NULL), WriteMatchedPacketsToFile(false), PathToWritePackets("")
-	{
-	}
+	AppWorkerConfig() : coreId(MAX_NUM_OF_CORES+1), sendPacketsTo(nullptr),
+	                    writeMatchedPacketsToFile(false), pathToWritePackets("") {}
 };
 
 

--- a/Examples/DpdkExample-FilterTraffic/Common.h
+++ b/Examples/DpdkExample-FilterTraffic/Common.h
@@ -58,115 +58,84 @@ struct AppWorkerConfig
 struct PacketStats
 {
 public:
-	uint8_t WorkerId;
+	uint8_t workerId;
 
-	int PacketCount;
-	int EthCount;
-	int ArpCount;
-	int Ip4Count;
-	int Ip6Count;
-	int TcpCount;
-	int UdpCount;
-	int HttpCount;
+	int packetCount;
+	int ethCount;
+	int arpCount;
+	int ipv4Count;
+	int ipv6Count;
+	int tcpCount;
+	int udpCount;
+	int httpCount;
+	int dnsCount;
+	int tlsCount;
 
-	int MatchedTcpFlows;
-	int MatchedUdpFlows;
-	int MatchedPackets;
+	int matchedTcpFlows;
+	int matchedUdpFlows;
+	int matchedPackets;
 
-	PacketStats() : WorkerId(MAX_NUM_OF_CORES+1), PacketCount(0), EthCount(0), ArpCount(0), Ip4Count(0), Ip6Count(0), TcpCount(0), UdpCount(0), HttpCount(0), MatchedTcpFlows(0), MatchedUdpFlows(0), MatchedPackets(0) {}
+	PacketStats() : workerId(MAX_NUM_OF_CORES+1), packetCount(0), ethCount(0), arpCount(0), ipv4Count(0), ipv6Count(0),
+	                tcpCount(0), udpCount(0), httpCount(0), dnsCount(0), tlsCount(0),
+					matchedTcpFlows(0), matchedUdpFlows(0), matchedPackets(0) {}
 
 	void collectStats(pcpp::Packet& packet)
 	{
-		PacketCount++;
+		packetCount++;
 		if (packet.isPacketOfType(pcpp::Ethernet))
-			EthCount++;
+			ethCount++;
 		if (packet.isPacketOfType(pcpp::ARP))
-			ArpCount++;
+			arpCount++;
 		if (packet.isPacketOfType(pcpp::IPv4))
-			Ip4Count++;
+			ipv4Count++;
 		if (packet.isPacketOfType(pcpp::IPv6))
-			Ip6Count++;
+			ipv6Count++;
 		if (packet.isPacketOfType(pcpp::TCP))
-			TcpCount++;
+			tcpCount++;
 		if (packet.isPacketOfType(pcpp::UDP))
-			UdpCount++;
+			udpCount++;
 		if (packet.isPacketOfType(pcpp::HTTP))
-			HttpCount++;
+			httpCount++;
+		if (packet.isPacketOfType(pcpp::DNS))
+			dnsCount++;
+		if (packet.isPacketOfType(pcpp::SSL))
+			tlsCount++;
 	}
 
 	void collectStats(const PacketStats& stats)
 	{
-		PacketCount += stats.PacketCount;
-		EthCount += stats.EthCount;
-		ArpCount += stats.ArpCount;
-		Ip4Count += stats.Ip4Count;
-		Ip6Count += stats.Ip6Count;
-		TcpCount += stats.TcpCount;
-		UdpCount += stats.UdpCount;
-		HttpCount += stats.HttpCount;
+		packetCount += stats.packetCount;
+		ethCount += stats.ethCount;
+		arpCount += stats.arpCount;
+		ipv4Count += stats.ipv4Count;
+		ipv6Count += stats.ipv6Count;
+		tcpCount += stats.tcpCount;
+		udpCount += stats.udpCount;
+		httpCount += stats.httpCount;
+		dnsCount += stats.dnsCount;
+		tlsCount += stats.tlsCount;
 
-		MatchedTcpFlows += stats.MatchedTcpFlows;
-		MatchedUdpFlows += stats.MatchedUdpFlows;
-		MatchedPackets += stats.MatchedPackets;
+		matchedTcpFlows += stats.matchedTcpFlows;
+		matchedUdpFlows += stats.matchedUdpFlows;
+		matchedPackets += stats.matchedPackets;
 	}
 
-	void clear() { WorkerId = MAX_NUM_OF_CORES+1; PacketCount = 0; EthCount = 0; ArpCount = 0; Ip4Count = 0; Ip6Count = 0; TcpCount = 0; UdpCount = 0; HttpCount = 0; MatchedTcpFlows = 0; MatchedUdpFlows = 0; MatchedPackets = 0; }
-
-	std::string getStatValuesAsString(const std::string &delimiter)
+	void clear()
 	{
-		std::stringstream values;
-		if (WorkerId == MAX_NUM_OF_CORES+1)
-			values << "Total" << delimiter;
-		else
-			values << (int)WorkerId << delimiter;
-		values << PacketCount << delimiter;
-		values << EthCount << delimiter;
-		values << ArpCount << delimiter;
-		values << Ip4Count << delimiter;
-		values << Ip6Count << delimiter;
-		values << TcpCount << delimiter;
-		values << UdpCount << delimiter;
-		values << HttpCount << delimiter;
-		values << MatchedTcpFlows << delimiter;
-		values << MatchedUdpFlows << delimiter;
-		values << MatchedPackets;
+		workerId = MAX_NUM_OF_CORES+1;
+		packetCount = 0;
+		ethCount = 0;
+		arpCount = 0;
+		ipv4Count = 0;
+		ipv6Count = 0;
+		tcpCount = 0;
+		udpCount = 0;
+		httpCount = 0;
+		dnsCount = 0;
+		tlsCount = 0;
 
-		return values.str();
-	}
-
-	static void getStatsColumns(std::vector<std::string>& columnNames, std::vector<int>& columnWidths)
-	{
-		columnNames.clear();
-		columnWidths.clear();
-
-	    static const int narrowColumnWidth = 11;
-	    static const int wideColumnWidth = 18;
-
-		columnNames.push_back("Core ID");
-		columnNames.push_back("Packet Cnt");
-		columnNames.push_back("Eth Cnt");
-		columnNames.push_back("ARP Cnt");
-		columnNames.push_back("IPv4 Cnt");
-		columnNames.push_back("IPv6 Cnt");
-		columnNames.push_back("TCP Cnt");
-		columnNames.push_back("UDP Cnt");
-		columnNames.push_back("HTTP Cnt");
-		columnNames.push_back("Matched TCP Flows");
-		columnNames.push_back("Matched UDP Flows");
-		columnNames.push_back("Matched Packets");
-
-		columnWidths.push_back(7);
-		columnWidths.push_back(narrowColumnWidth);
-		columnWidths.push_back(narrowColumnWidth);
-		columnWidths.push_back(narrowColumnWidth);
-		columnWidths.push_back(narrowColumnWidth);
-		columnWidths.push_back(narrowColumnWidth);
-		columnWidths.push_back(narrowColumnWidth);
-		columnWidths.push_back(narrowColumnWidth);
-		columnWidths.push_back(narrowColumnWidth);
-		columnWidths.push_back(wideColumnWidth);
-		columnWidths.push_back(wideColumnWidth);
-		columnWidths.push_back(wideColumnWidth);
-
+		matchedTcpFlows = 0;
+		matchedUdpFlows = 0;
+		matchedPackets = 0;
 	}
 };

--- a/Examples/DpdkExample-FilterTraffic/main.cpp
+++ b/Examples/DpdkExample-FilterTraffic/main.cpp
@@ -175,31 +175,31 @@ void prepareCoreConfiguration(std::vector<pcpp::DpdkDevice*>& dpdkDevicesToUse, 
 	for (const auto &core : coresToUse)
 	{
 		std::cout << "Using core " << (int)core.Id << std::endl;
-		workerConfigArr[i].CoreId = core.Id;
-		workerConfigArr[i].WriteMatchedPacketsToFile = writePacketsToDisk;
+		workerConfigArr[i].coreId = core.Id;
+		workerConfigArr[i].writeMatchedPacketsToFile = writePacketsToDisk;
 
 		std::stringstream packetFileName;
-		packetFileName << packetFilePath << "Core" << workerConfigArr[i].CoreId << ".pcap";
-		workerConfigArr[i].PathToWritePackets = packetFileName.str();
+		packetFileName << packetFilePath << "Core" << workerConfigArr[i].coreId << ".pcap";
+		workerConfigArr[i].pathToWritePackets = packetFileName.str();
 
-		workerConfigArr[i].SendPacketsTo = sendPacketsTo;
+		workerConfigArr[i].sendPacketsTo = sendPacketsTo;
 		for (int rxQIndex = 0; rxQIndex < numOfRxQueuesPerCore; rxQIndex++)
 		{
 			if (pairVecIter == deviceAndRxQVec.end())
 				break;
-			workerConfigArr[i].InDataCfg[pairVecIter->first].push_back(pairVecIter->second);
+			workerConfigArr[i].inDataCfg[pairVecIter->first].push_back(pairVecIter->second);
 			++pairVecIter;
 		}
 		if (rxQueuesRemainder > 0 && (pairVecIter != deviceAndRxQVec.end()))
 		{
-			workerConfigArr[i].InDataCfg[pairVecIter->first].push_back(pairVecIter->second);
+			workerConfigArr[i].inDataCfg[pairVecIter->first].push_back(pairVecIter->second);
 			++pairVecIter;
 			rxQueuesRemainder--;
 		}
 
 		// print configuration for core
 		std::cout << "   Core configuration:" << std::endl;
-		for (const auto &iter2 : workerConfigArr[i].InDataCfg)
+		for (const auto &iter2 : workerConfigArr[i].inDataCfg)
 		{
 			std::cout << "      DPDK device#" << iter2.first->getDeviceId() << ": ";
 			for (const auto &iter3 : iter2.second)
@@ -208,7 +208,7 @@ void prepareCoreConfiguration(std::vector<pcpp::DpdkDevice*>& dpdkDevicesToUse, 
 			}
 			std::cout << std::endl;
 		}
-		if (workerConfigArr[i].InDataCfg.size() == 0)
+		if (workerConfigArr[i].inDataCfg.size() == 0)
 		{
 			std::cout << "      None" << std::endl;
 		}


### PR DESCRIPTION
- Modify stats printing (see below)
- Collect additional stats - DNS and TLS packets
- Standardize struct attribute names (should start with lowercase)
- Additional minor fixes

Stats before:
```
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| Core ID | Packet Cnt  | Eth Cnt     | ARP Cnt     | IPv4 Cnt    | IPv6 Cnt    | TCP Cnt     | UDP Cnt     | HTTP Cnt    | Matched TCP Flows  | Matched UDP Flows  | Matched Packets    |
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| 1       | 12          | 12          | 0           | 6           | 6           | 0           | 12          | 0           | 0                  | 3                  | 12                 |
| 2       | 0           | 0           | 0           | 0           | 0           | 0           | 0           | 0           | 0                  | 0                  | 0                  |
| 3       | 0           | 0           | 0           | 0           | 0           | 0           | 0           | 0           | 0                  | 0                  | 0                  |
| 4       | 0           | 0           | 0           | 0           | 0           | 0           | 0           | 0           | 0                  | 0                  | 0                  |
| 5       | 0           | 0           | 0           | 0           | 0           | 0           | 0           | 0           | 0                  | 0                  | 0                  |
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| Total   | 12          | 12          | 0           | 6           | 6           | 0           | 12          | 0           | 0                  | 3                  | 12                 |
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

If the window is small, stats get scrambled:
![image](https://github.com/seladb/PcapPlusPlus/assets/9059541/2facb4ed-6523-4fb0-bd95-5d7c9622a7e8)

Stats now:
```
--------------------------------------
| Core #1 Stat          | Count      |
-------------------------------------
| Eth count             | 1          |
| ARP count             | 1          |
| IPv4 count            | 0          |
| IPv6 count            | 0          |
| TCP count             | 0          |
| UDP count             | 0          |
| HTTP count            | 0          |
| DNS count             | 0          |
| TLS count             | 0          |
--------------------------------------
| Matched TCP flows     | 0          |
| Matched UDP flows     | 0          |
--------------------------------------
| Matched packet count  | 1          |
| Total packet count    | 1          |
--------------------------------------

Core #2 - no packets received
Core #3 - no packets received
Core #4 - no packets received
Core #5 - no packets received

--------------------------------------
| Aggregated Stats      | Count      |
--------------------------------------
| Eth count             | 1          |
| ARP count             | 1          |
| IPv4 count            | 0          |
| IPv6 count            | 0          |
| TCP count             | 0          |
| UDP count             | 0          |
| HTTP count            | 0          |
| DNS count             | 0          |
| TLS count             | 0          |
--------------------------------------
| Matched TCP flows     | 0          |
| Matched UDP flows     | 0          |
--------------------------------------
| Matched packet count  | 1          |
| Total packet count    | 1          |
--------------------------------------
```