### PR TITLE
using std::function for callback

### DIFF
--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -30,19 +30,17 @@ namespace pcpp
 	class PcapLiveDevice;
 
 	/**
-	 * @typedef OnPacketArrivesCallback
 	 * A callback that is called when a packet is captured by PcapLiveDevice
-	 * @param[in] pPacket A pointer to the raw packet
-	 * @param[in] pDevice A pointer to the PcapLiveDevice instance
+	 * @param[in] packet A pointer to the raw packet
+	 * @param[in] device A pointer to the PcapLiveDevice instance
 	 * @param[in] userCookie A pointer to the object put by the user when packet capturing stared
 	 */
 	using OnPacketArrivesCallback = std::function<void(RawPacket*, PcapLiveDevice*, void*)>;
 
 	/**
-	 * @typedef OnPacketArrivesStopBlocking
 	 * A callback that is called when a packet is captured by PcapLiveDevice
-	 * @param[in] pPacket A pointer to the raw packet
-	 * @param[in] pDevice A pointer to the PcapLiveDevice instance
+	 * @param[in] packet A pointer to the raw packet
+	 * @param[in] device A pointer to the PcapLiveDevice instance
 	 * @param[in] userCookie A pointer to the object put by the user when packet capturing stared
 	 * @return True when main thread should stop blocking or false otherwise
 	 */
@@ -50,7 +48,6 @@ namespace pcpp
 
 
 	/**
-	 * @typedef OnStatsUpdateCallback
 	 * A callback that is called periodically for stats collection if user asked to start packet capturing with periodic stats collection
 	 * @param[in] stats A reference to the most updated stats
 	 * @param[in] userCookie A pointer to the object put by the user when packet capturing stared

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <string.h>
 #include <thread>
+#include <functional>
 
 #include "IpAddress.h"
 #include "Packet.h"
@@ -35,7 +36,7 @@ namespace pcpp
 	 * @param[in] pDevice A pointer to the PcapLiveDevice instance
 	 * @param[in] userCookie A pointer to the object put by the user when packet capturing stared
 	 */
-	typedef void (*OnPacketArrivesCallback)(RawPacket* pPacket, PcapLiveDevice* pDevice, void* userCookie);
+	using OnPacketArrivesCallback = std::function<void(RawPacket*, PcapLiveDevice*, void*)>;
 
 	/**
 	 * @typedef OnPacketArrivesStopBlocking
@@ -45,7 +46,7 @@ namespace pcpp
 	 * @param[in] userCookie A pointer to the object put by the user when packet capturing stared
 	 * @return True when main thread should stop blocking or false otherwise
 	 */
-	typedef bool (*OnPacketArrivesStopBlocking)(RawPacket* pPacket, PcapLiveDevice* pDevice, void* userCookie);
+	using OnPacketArrivesStopBlocking = std::function<bool(RawPacket*, PcapLiveDevice*, void*)>;
 
 
 	/**
@@ -54,7 +55,7 @@ namespace pcpp
 	 * @param[in] stats A reference to the most updated stats
 	 * @param[in] userCookie A pointer to the object put by the user when packet capturing stared
 	 */
-	typedef void (*OnStatsUpdateCallback)(IPcapDevice::PcapStats& stats, void* userCookie);
+	using OnStatsUpdateCallback = std::function<void(IPcapDevice::PcapStats&, void*)>;
 
 	// for internal use only
 	typedef void* (*ThreadStart)(void*);

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -426,12 +426,12 @@ PcapLiveDevice* PcapLiveDevice::clone()
 
 bool PcapLiveDevice::startCapture(OnPacketArrivesCallback onPacketArrives, void* onPacketArrivesUserCookie)
 {
-	return startCapture(onPacketArrives, onPacketArrivesUserCookie, 0, nullptr, nullptr);
+	return startCapture(std::move(onPacketArrives), onPacketArrivesUserCookie, 0, nullptr, nullptr);
 }
 
 bool PcapLiveDevice::startCapture(int intervalInSecondsToUpdateStats, OnStatsUpdateCallback onStatsUpdate, void* onStatsUpdateUserCookie)
 {
-	return startCapture(nullptr, nullptr, intervalInSecondsToUpdateStats, onStatsUpdate, onStatsUpdateUserCookie);
+	return startCapture(nullptr, nullptr, intervalInSecondsToUpdateStats, std::move(onStatsUpdate), onStatsUpdateUserCookie);
 }
 
 bool PcapLiveDevice::startCapture(OnPacketArrivesCallback onPacketArrives, void* onPacketArrivesUserCookie, int intervalInSecondsToUpdateStats, OnStatsUpdateCallback onStatsUpdate, void* onStatsUpdateUserCookie)
@@ -451,7 +451,7 @@ bool PcapLiveDevice::startCapture(OnPacketArrivesCallback onPacketArrives, void*
 	m_IntervalToUpdateStats = intervalInSecondsToUpdateStats;
 
 	m_CaptureCallbackMode = true;
-	m_cbOnPacketArrives = onPacketArrives;
+	m_cbOnPacketArrives = std::move(onPacketArrives);
 	m_cbOnPacketArrivesUserCookie = onPacketArrivesUserCookie;
 
 	m_CaptureThread = std::thread(&pcpp::PcapLiveDevice::captureThreadMain, this);
@@ -460,7 +460,7 @@ bool PcapLiveDevice::startCapture(OnPacketArrivesCallback onPacketArrives, void*
 
 	if (onStatsUpdate != nullptr && intervalInSecondsToUpdateStats > 0)
 	{
-		m_cbOnStatsUpdate = onStatsUpdate;
+		m_cbOnStatsUpdate = std::move(onStatsUpdate);
 		m_cbOnStatsUpdateUserCookie = onStatsUpdateUserCookie;
 		m_StatsThread = std::thread(&pcpp::PcapLiveDevice::statsThreadMain, this);
 		m_StatsThreadStarted = true;
@@ -515,7 +515,7 @@ int PcapLiveDevice::startCaptureBlockingMode(OnPacketArrivesStopBlocking onPacke
 	m_cbOnPacketArrivesUserCookie = nullptr;
 	m_cbOnStatsUpdateUserCookie = nullptr;
 
-	m_cbOnPacketArrivesBlockingMode = onPacketArrives;
+	m_cbOnPacketArrivesBlockingMode = std::move(onPacketArrives);
 	m_cbOnPacketArrivesBlockingModeUserCookie = userCookie;
 
 	m_CaptureThreadStarted = true;

--- a/Tests/Pcap++Test/TestDefinition.h
+++ b/Tests/Pcap++Test/TestDefinition.h
@@ -36,6 +36,8 @@ PTF_TEST_CASE(TestPcapLiveDeviceClone);
 PTF_TEST_CASE(TestPcapLiveDeviceNoNetworking);
 PTF_TEST_CASE(TestPcapLiveDeviceStatsMode);
 PTF_TEST_CASE(TestPcapLiveDeviceBlockingMode);
+PTF_TEST_CASE(TestPcapLiveDeviceWithLambda);
+PTF_TEST_CASE(TestPcapLiveDeviceBlockingModeWithLambda);
 PTF_TEST_CASE(TestPcapLiveDeviceSpecialCfg);
 PTF_TEST_CASE(TestWinPcapLiveDevice);
 PTF_TEST_CASE(TestSendPacket);

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -517,19 +517,9 @@ PTF_TEST_CASE(TestPcapLiveDeviceWithLambda)
 } // TestPcapLiveDeviceWithLambda
 
 
+
 PTF_TEST_CASE(TestPcapLiveDeviceBlockingModeWithLambda)
 {
-	std::vector<pcpp::PcapLiveDevice::DeviceConfiguration> configs;
-	configs.emplace_back(); // the default config
-
-#if !defined(_WIN32)
-	configs.emplace_back(); // the config used poll
-	configs[1].usePoll = true;
-#endif
-
-	auto packetArrivesBlockingModeTimeoutLambda = [](
-		pcpp::RawPacket *rawPacket, pcpp::PcapLiveDevice *dev,void *userCookie) { return false; };
-
 	auto packetArrivesBlockingModeNoTimeoutLambda = [](
 		pcpp::RawPacket *rawPacket, pcpp::PcapLiveDevice *dev, void *userCookie)
 	{
@@ -541,128 +531,22 @@ PTF_TEST_CASE(TestPcapLiveDeviceBlockingModeWithLambda)
 		return false;
 	};
 
-	auto packetArrivesBlockingModeStartCaptureLambda = [](pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev, void* userCookie)
-	{
-		pcpp::Logger::getInstance().suppressLogs();
-		if (dev->startCaptureBlockingMode(packetArrivesBlockingModeTimeout, nullptr, 5) != 0)
-			return false;
+	// open device
+	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	PTF_ASSERT_NOT_NULL(liveDev);
+	PTF_ASSERT_TRUE(liveDev->open());
+	DeviceTeardown devTeardown(liveDev);
 
-		int temp = 0;
-		if (dev->startCapture(packetArrives, &temp) != 0)
-			return false;
+	int packetCount = 0;
+	PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeNoTimeoutLambda, &packetCount, 30), 1);
+	PTF_ASSERT_EQUAL(packetCount, 5);
 
-		pcpp::Logger::getInstance().enableLogs();
+	liveDev->close();
 
-		int* packetCount = (int*)userCookie;
-		if ((*packetCount) == 5)
-			return true;
-
-		(*packetCount)++;
-		return false;
-	};
-
-	auto packetArrivesBlockingModeStopCaptureLambda = [](pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev, void* userCookie)
-	{
-		// shouldn't do anything
-		dev->stopCapture();
-
-		int* packetCount = (int*)userCookie;
-		if ((*packetCount) == 5)
-			return true;
-
-		(*packetCount)++;
-		return false;
-	};
-
-
-	// test the common behaviour for all configs
-	for(const auto & config: configs)
-	{
-		// open device
-		pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
-		PTF_ASSERT_NOT_NULL(liveDev);
-		PTF_ASSERT_TRUE(liveDev->open(config));
-		DeviceTeardown devTeardown(liveDev);
-
-		// sanity - test blocking mode returns with timeout
-		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeTimeoutLambda, nullptr, 5), -1);
-
-		// sanity - test blocking mode returns before timeout
-		int packetCount = 0;
-		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeNoTimeoutLambda, &packetCount, 30), 1);
-		PTF_ASSERT_EQUAL(packetCount, 5);
-
-		// verify stop capture doesn't do any effect on blocking mode
-		liveDev->stopCapture();
-		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeTimeoutLambda, nullptr, 1), -1);
-		packetCount = 0;
-		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeNoTimeoutLambda, &packetCount, 30), 1);
-		PTF_ASSERT_EQUAL(packetCount, 5);
-
-		// verify it's possible to capture non-blocking mode after blocking mode
-		packetCount = 0;
-		PTF_ASSERT_TRUE(liveDev->startCapture(packetArrives, &packetCount));
-
-		int totalSleepTime = 0;
-		while (totalSleepTime <= 5)
-		{
-			pcpp::multiPlatformSleep(1);
-			totalSleepTime += 1;
-			if (packetCount > 0)
-				break;
-		}
-
-		liveDev->stopCapture();
-
-		PTF_PRINT_VERBOSE("Total sleep time: " << totalSleepTime << " secs");
-
-		PTF_ASSERT_GREATER_THAN(packetCount, 0);
-
-		// verify it's possible to capture blocking mode after non-blocking mode
-		packetCount = 0;
-		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeNoTimeoutLambda, &packetCount, 30), 1);
-		PTF_ASSERT_EQUAL(packetCount, 5);
-
-		// try to start capture from within the callback, verify no error
-		packetCount = 0;
-		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeStartCaptureLambda, &packetCount, 30), 1);
-		PTF_ASSERT_EQUAL(packetCount, 5);
-
-		// try to stop capture from within the callback, verify no impact on capturing
-		packetCount = 0;
-		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeStopCaptureLambda, &packetCount, 10), 1);
-		PTF_ASSERT_EQUAL(packetCount, 5);
-
-		// verify it's possible to capture non-blocking after the mess done in previous lines
-		packetCount = 0;
-		PTF_ASSERT_TRUE(liveDev->startCapture(packetArrives, &packetCount));
-
-		// verify an error returns if trying capture blocking while non-blocking is running
-		pcpp::Logger::getInstance().suppressLogs();
-		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeTimeoutLambda, nullptr, 1), 0);
-		pcpp::Logger::getInstance().enableLogs();
-
-		totalSleepTime = 0;
-		while (totalSleepTime <= 5)
-		{
-			pcpp::multiPlatformSleep(1);
-			totalSleepTime += 1;
-			if (packetCount > 0)
-				break;
-		}
-
-		PTF_PRINT_VERBOSE("Total sleep time: " << totalSleepTime << " secs");
-
-		liveDev->stopCapture();
-		PTF_ASSERT_GREATER_THAN(packetCount, 0);
-
-		liveDev->close();
-
-		// a negative test
-		pcpp::Logger::getInstance().suppressLogs();
-		PTF_ASSERT_FALSE(liveDev->startCapture(packetArrives, &packetCount));
-		pcpp::Logger::getInstance().enableLogs();
-	}
+	// a negative test
+	pcpp::Logger::getInstance().suppressLogs();
+	PTF_ASSERT_FALSE(liveDev->startCapture(packetArrives, &packetCount));
+	pcpp::Logger::getInstance().enableLogs();
 } // TestPcapLiveDeviceBlockingModeWithLambda
 
 

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -65,31 +65,6 @@ static bool packetArrivesBlockingModeStartCapture(pcpp::RawPacket* rawPacket, pc
 	return false;
 }
 
-static bool packetArrivesBlockingModeStartCaptureUsingLambda(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev, void* userCookie)
-{
-	pcpp::Logger::getInstance().suppressLogs();
-	if (dev->startCaptureBlockingMode(packetArrivesBlockingModeTimeout, nullptr, 5) != 0)
-		return false;
-
-	auto packetArrivesLambda = [](pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* pDevice, void* userCookie)
-	{
-		(*(int*)userCookie)++;
-	};
-
-	int temp = 0;
-	if (dev->startCapture(packetArrivesLambda, &temp) != 0)
-		return false;
-
-	pcpp::Logger::getInstance().enableLogs();
-
-	int* packetCount = (int*)userCookie;
-	if ((*packetCount) == 5)
-		return true;
-
-	(*packetCount)++;
-	return false;
-}
-
 static bool packetArrivesBlockingModeStopCapture(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev, void* userCookie)
 {
 	// shouldn't do anything
@@ -464,11 +439,6 @@ PTF_TEST_CASE(TestPcapLiveDeviceBlockingMode)
 		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeStartCapture, &packetCount, 30), 1);
 		PTF_ASSERT_EQUAL(packetCount, 5);
 
-		// try to start capture from within the callback, verify no error
-		packetCount = 0;
-		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeStartCaptureUsingLambda, &packetCount, 30), 1);
-		PTF_ASSERT_EQUAL(packetCount, 5);
-
 		// try to stop capture from within the callback, verify no impact on capturing
 		packetCount = 0;
 		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeStopCapture, &packetCount, 10), 1);
@@ -506,6 +476,194 @@ PTF_TEST_CASE(TestPcapLiveDeviceBlockingMode)
 	}
 } // TestPcapLiveDeviceBlockingMode
 
+
+PTF_TEST_CASE(TestPcapLiveDeviceWithLambda)
+{
+	pcpp::PcapLiveDevice* liveDev = nullptr;
+	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
+	PTF_ASSERT_NOT_NULL(liveDev);
+	PTF_ASSERT_GREATER_THAN(liveDev->getMtu(), 0);
+	PTF_ASSERT_TRUE(liveDev->open());
+	DeviceTeardown devTeardown(liveDev);
+	int packetCount = 0;
+	int numOfTimeStatsWereInvoked = 0;
+
+	auto packetArrivesLambda = [](pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* pDevice, void* userCookie)
+	{
+		(*(int*)userCookie)++;
+	};
+
+	auto statsUpdateLambda = [](pcpp::IPcapDevice::PcapStats& stats, void* userCookie)
+	{
+		(*(int*)userCookie)++;
+	};
+
+	PTF_ASSERT_TRUE(liveDev->startCapture(packetArrivesLambda , (void*)&packetCount, 1, statsUpdateLambda, (void*)&numOfTimeStatsWereInvoked));
+	int totalSleepTime = 0;
+	while (totalSleepTime <= 20)
+	{
+		pcpp::multiPlatformSleep(2);
+		totalSleepTime += 2;
+		if (packetCount > 0)
+			break;
+	}
+
+	PTF_PRINT_VERBOSE("Total sleep time: " << totalSleepTime << " secs");
+
+	liveDev->stopCapture();
+	PTF_ASSERT_GREATER_THAN(packetCount, 0);
+	PTF_ASSERT_GREATER_OR_EQUAL_THAN(numOfTimeStatsWereInvoked, totalSleepTime-2);
+} // TestPcapLiveDeviceWithLambda
+
+
+PTF_TEST_CASE(TestPcapLiveDeviceBlockingModeWithLambda)
+{
+	std::vector<pcpp::PcapLiveDevice::DeviceConfiguration> configs;
+	configs.emplace_back(); // the default config
+
+#if !defined(_WIN32)
+	configs.emplace_back(); // the config used poll
+	configs[1].usePoll = true;
+#endif
+
+	auto packetArrivesBlockingModeTimeoutLambda = [](
+		pcpp::RawPacket *rawPacket, pcpp::PcapLiveDevice *dev,void *userCookie) { return false; };
+
+	auto packetArrivesBlockingModeNoTimeoutLambda = [](
+		pcpp::RawPacket *rawPacket, pcpp::PcapLiveDevice *dev, void *userCookie)
+	{
+		int *packetCount = (int *)userCookie;
+		if ((*packetCount) == 5)
+			return true;
+
+		(*packetCount)++;
+		return false;
+	};
+
+	auto packetArrivesBlockingModeStartCaptureLambda = [](pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev, void* userCookie)
+	{
+		pcpp::Logger::getInstance().suppressLogs();
+		if (dev->startCaptureBlockingMode(packetArrivesBlockingModeTimeout, nullptr, 5) != 0)
+			return false;
+
+		int temp = 0;
+		if (dev->startCapture(packetArrives, &temp) != 0)
+			return false;
+
+		pcpp::Logger::getInstance().enableLogs();
+
+		int* packetCount = (int*)userCookie;
+		if ((*packetCount) == 5)
+			return true;
+
+		(*packetCount)++;
+		return false;
+	};
+
+	auto packetArrivesBlockingModeStopCaptureLambda = [](pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev, void* userCookie)
+	{
+		// shouldn't do anything
+		dev->stopCapture();
+
+		int* packetCount = (int*)userCookie;
+		if ((*packetCount) == 5)
+			return true;
+
+		(*packetCount)++;
+		return false;
+	};
+
+
+	// test the common behaviour for all configs
+	for(const auto & config: configs)
+	{
+		// open device
+		pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+		PTF_ASSERT_NOT_NULL(liveDev);
+		PTF_ASSERT_TRUE(liveDev->open(config));
+		DeviceTeardown devTeardown(liveDev);
+
+		// sanity - test blocking mode returns with timeout
+		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeTimeoutLambda, nullptr, 5), -1);
+
+		// sanity - test blocking mode returns before timeout
+		int packetCount = 0;
+		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeNoTimeoutLambda, &packetCount, 30), 1);
+		PTF_ASSERT_EQUAL(packetCount, 5);
+
+		// verify stop capture doesn't do any effect on blocking mode
+		liveDev->stopCapture();
+		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeTimeoutLambda, nullptr, 1), -1);
+		packetCount = 0;
+		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeNoTimeoutLambda, &packetCount, 30), 1);
+		PTF_ASSERT_EQUAL(packetCount, 5);
+
+		// verify it's possible to capture non-blocking mode after blocking mode
+		packetCount = 0;
+		PTF_ASSERT_TRUE(liveDev->startCapture(packetArrives, &packetCount));
+
+		int totalSleepTime = 0;
+		while (totalSleepTime <= 5)
+		{
+			pcpp::multiPlatformSleep(1);
+			totalSleepTime += 1;
+			if (packetCount > 0)
+				break;
+		}
+
+		liveDev->stopCapture();
+
+		PTF_PRINT_VERBOSE("Total sleep time: " << totalSleepTime << " secs");
+
+		PTF_ASSERT_GREATER_THAN(packetCount, 0);
+
+		// verify it's possible to capture blocking mode after non-blocking mode
+		packetCount = 0;
+		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeNoTimeoutLambda, &packetCount, 30), 1);
+		PTF_ASSERT_EQUAL(packetCount, 5);
+
+		// try to start capture from within the callback, verify no error
+		packetCount = 0;
+		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeStartCaptureLambda, &packetCount, 30), 1);
+		PTF_ASSERT_EQUAL(packetCount, 5);
+
+		// try to stop capture from within the callback, verify no impact on capturing
+		packetCount = 0;
+		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeStopCaptureLambda, &packetCount, 10), 1);
+		PTF_ASSERT_EQUAL(packetCount, 5);
+
+		// verify it's possible to capture non-blocking after the mess done in previous lines
+		packetCount = 0;
+		PTF_ASSERT_TRUE(liveDev->startCapture(packetArrives, &packetCount));
+
+		// verify an error returns if trying capture blocking while non-blocking is running
+		pcpp::Logger::getInstance().suppressLogs();
+		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeTimeoutLambda, nullptr, 1), 0);
+		pcpp::Logger::getInstance().enableLogs();
+
+		totalSleepTime = 0;
+		while (totalSleepTime <= 5)
+		{
+			pcpp::multiPlatformSleep(1);
+			totalSleepTime += 1;
+			if (packetCount > 0)
+				break;
+		}
+
+		PTF_PRINT_VERBOSE("Total sleep time: " << totalSleepTime << " secs");
+
+		liveDev->stopCapture();
+		PTF_ASSERT_GREATER_THAN(packetCount, 0);
+
+		liveDev->close();
+
+		// a negative test
+		pcpp::Logger::getInstance().suppressLogs();
+		PTF_ASSERT_FALSE(liveDev->startCapture(packetArrives, &packetCount));
+		pcpp::Logger::getInstance().enableLogs();
+	}
+} // TestPcapLiveDeviceBlockingModeWithLambda
 
 
 

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -65,6 +65,31 @@ static bool packetArrivesBlockingModeStartCapture(pcpp::RawPacket* rawPacket, pc
 	return false;
 }
 
+static bool packetArrivesBlockingModeStartCaptureUsingLambda(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev, void* userCookie)
+{
+	pcpp::Logger::getInstance().suppressLogs();
+	if (dev->startCaptureBlockingMode(packetArrivesBlockingModeTimeout, nullptr, 5) != 0)
+		return false;
+
+	auto packetArrivesLambda = [](pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* pDevice, void* userCookie)
+	{
+		(*(int*)userCookie)++;
+	};
+
+	int temp = 0;
+	if (dev->startCapture(packetArrivesLambda, &temp) != 0)
+		return false;
+
+	pcpp::Logger::getInstance().enableLogs();
+
+	int* packetCount = (int*)userCookie;
+	if ((*packetCount) == 5)
+		return true;
+
+	(*packetCount)++;
+	return false;
+}
+
 static bool packetArrivesBlockingModeStopCapture(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev, void* userCookie)
 {
 	// shouldn't do anything

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -464,6 +464,11 @@ PTF_TEST_CASE(TestPcapLiveDeviceBlockingMode)
 		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeStartCapture, &packetCount, 30), 1);
 		PTF_ASSERT_EQUAL(packetCount, 5);
 
+		// try to start capture from within the callback, verify no error
+		packetCount = 0;
+		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeStartCaptureUsingLambda, &packetCount, 30), 1);
+		PTF_ASSERT_EQUAL(packetCount, 5);
+
 		// try to stop capture from within the callback, verify no impact on capturing
 		packetCount = 0;
 		PTF_ASSERT_EQUAL(liveDev->startCaptureBlockingMode(packetArrivesBlockingModeStopCapture, &packetCount, 10), 1);

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -229,6 +229,8 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(TestPcapLiveDeviceNoNetworking, "no_network;live_device");
 	PTF_RUN_TEST(TestPcapLiveDeviceStatsMode, "live_device");
 	PTF_RUN_TEST(TestPcapLiveDeviceBlockingMode, "live_device");
+	PTF_RUN_TEST(TestPcapLiveDeviceWithLambda, "live_device");
+	PTF_RUN_TEST(TestPcapLiveDeviceBlockingModeWithLambda, "live_device");
 	PTF_RUN_TEST(TestPcapLiveDeviceSpecialCfg, "live_device");
 	PTF_RUN_TEST(TestWinPcapLiveDevice, "live_device;winpcap");
 	PTF_RUN_TEST(TestSendPacket, "live_device;send");


### PR DESCRIPTION
fixed #1261

using `std::fucntion` for `startCapture` related APIs.

`std::function` itself supports lamba and c-style functions, so no need to worry about backward compatibility.