### PR TITLE
cmake: fetch libPCAP version and display if found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ Examples/Tutorials/**/*.exe
 #venv
 .venv/**
 venv/**
+
+#MacOS system files
+**/.DS_Store

--- a/cmake/modules/FindPCAP.cmake
+++ b/cmake/modules/FindPCAP.cmake
@@ -100,7 +100,7 @@ if(HAVE_PCAP_LIB_VERSION AND NOT CMAKE_CROSSCOMPILING)
     if (strncmp(version, prefix, strlen(prefix)) == 0) {
         version += strlen(prefix);
     }
-    printf(\"%s\\n\", version);
+    printf(\"%s\", version);
     return 0;
   }
   ")


### PR DESCRIPTION
This can give information during the configuration step of the libpcap used

Example of the output on Macos
```
-- Performing Test PCAP_LINKS_SOLO
-- Performing Test PCAP_LINKS_SOLO - Success
-- Looking for pcap_set_immediate_mode
-- Looking for pcap_set_immediate_mode - found
-- Looking for pcap_setdirection
-- Looking for pcap_setdirection - found
-- Looking for pcap_lib_version
-- Looking for pcap_lib_version - found
-- Found PCAP: /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/lib/libpcap.tbd (found version "1.10.1
")
```