### PR TITLE
Use std::unordered_map instead of std::map

### DIFF
--- a/Common++/header/LRUList.h
+++ b/Common++/header/LRUList.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <map>
+#include <unordered_map>
 #include <list>
 
 #if __cplusplus > 199711L || _MSC_VER >= 1800
@@ -29,7 +29,7 @@ namespace pcpp
 	public:
 
 		typedef typename std::list<T>::iterator ListIterator;
-		typedef typename std::map<T, ListIterator>::iterator MapIterator;
+		typedef typename std::unordered_map<T, ListIterator>::iterator MapIterator;
 
 		/**
 		 * A c'tor for this class
@@ -125,7 +125,7 @@ namespace pcpp
 
 	private:
 		std::list<T> m_CacheItemsList;
-		std::map<T, ListIterator> m_CacheItemsMap;
+		std::unordered_map<T, ListIterator> m_CacheItemsMap;
 		size_t m_MaxSize;
 	};
 

--- a/Examples/DnsSpoofing/main.cpp
+++ b/Examples/DnsSpoofing/main.cpp
@@ -11,7 +11,7 @@
 #include <algorithm>
 #include <sstream>
 #include <utility>
-#include <map>
+#include <unordered_map>
 #if !defined(_WIN32)
 #include <errno.h>
 #endif
@@ -59,7 +59,7 @@ static struct option DnsSpoofingOptions[] =
 struct DnsSpoofStats
 {
 	int numOfSpoofedDnsRequests;
-	std::map<std::string, int> spoofedHosts;
+	std::unordered_map<std::string, int> spoofedHosts;
 
 	DnsSpoofStats() : numOfSpoofedDnsRequests(0) {}
 };
@@ -283,7 +283,7 @@ void onApplicationInterrupted(void* cookie)
 		pcpp::TablePrinter printer(columnNames, columnsWidths);
 
 		// sort the spoofed hosts map so the most spoofed hosts will be first
-		// since it's not possible to sort a std::map you must copy it to a std::vector and sort it then
+		// since it's not possible to sort a std::unordered_map you must copy it to a std::vector and sort it then
 		std::vector<std::pair<std::string, int> > map2vec(args->stats.spoofedHosts.begin(), args->stats.spoofedHosts.end());
 		std::sort(map2vec.begin(),map2vec.end(), &stringCountComparer);
 

--- a/Examples/DpdkBridge/Common.h
+++ b/Examples/DpdkBridge/Common.h
@@ -6,7 +6,7 @@
 #include <SystemUtils.h>
 
 #include <string>
-#include <map>
+#include <unordered_map>
 #include <vector>
 #include <iomanip>
 #include <iostream>

--- a/Examples/DpdkExample-FilterTraffic/AppWorkerThread.h
+++ b/Examples/DpdkExample-FilterTraffic/AppWorkerThread.h
@@ -21,7 +21,7 @@ private:
 	uint32_t m_CoreId;
 	PacketStats m_Stats;
 	PacketMatchingEngine& m_PacketMatchingEngine;
-	std::map<uint32_t, bool> m_FlowTable;
+	std::unordered_map<uint32_t, bool> m_FlowTable;
 
 public:
 	AppWorkerThread(AppWorkerConfig& workerConfig, PacketMatchingEngine& matchingEngine) :

--- a/Examples/DpdkExample-FilterTraffic/Common.h
+++ b/Examples/DpdkExample-FilterTraffic/Common.h
@@ -6,7 +6,7 @@
 #include <SystemUtils.h>
 
 #include <string>
-#include <map>
+#include <unordered_map>
 #include <vector>
 #include <iomanip>
 #include <iostream>
@@ -30,7 +30,7 @@
 	exit(1); \
 	} while(0)
 
-typedef std::map<pcpp::DpdkDevice*, std::vector<int> > InputDataConfig;
+typedef std::unordered_map<pcpp::DpdkDevice*, std::vector<int> > InputDataConfig;
 
 
 /**

--- a/Examples/HttpAnalyzer/main.cpp
+++ b/Examples/HttpAnalyzer/main.cpp
@@ -239,7 +239,7 @@ void printHostnames(HttpRequestStats& reqStatscollector)
 	pcpp::TablePrinter printer(columnNames, columnsWidths);
 
 	// sort the hostname count map so the most popular hostnames will be first
-	// since it's not possible to sort a std::map you must copy it to a std::vector and sort it then
+	// since it's not possible to sort a std::unordered_map you must copy it to a std::vector and sort it then
 	std::vector<std::pair<std::string, int> > map2vec(reqStatscollector.hostnameCount.begin(), reqStatscollector.hostnameCount.end());
 	std::sort(map2vec.begin(), map2vec.end(), &hostnameComparer);
 

--- a/Examples/IPDefragUtil/main.cpp
+++ b/Examples/IPDefragUtil/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <map>
+#include <unordered_map>
 #include <sstream>
 #include <stdlib.h>
 #include <string.h>
@@ -96,7 +96,7 @@ void printAppVersion()
  */
 void processPackets(pcpp::IFileReaderDevice* reader, pcpp::IFileWriterDevice* writer,
 		bool filterByBpf, const std::string& bpfFilter,
-		bool filterByIpID, std::map<uint32_t, bool> fragIDs,
+		bool filterByIpID, std::unordered_map<uint32_t, bool> fragIDs,
 		bool copyAllPacketsToOutputFile,
 		DefragStats& stats)
 {
@@ -282,7 +282,7 @@ int main(int argc, char* argv[])
 	bool filterByBpfFilter = false;
 	std::string bpfFilter = "";
 	bool filterByFragID = false;
-	std::map<uint32_t, bool> fragIDMap;
+	std::unordered_map<uint32_t, bool> fragIDMap;
 	bool copyAllPacketsToOutputFile = false;
 
 

--- a/Examples/IPFragUtil/main.cpp
+++ b/Examples/IPFragUtil/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <map>
+#include <unordered_map>
 #include <sstream>
 #include <stdlib.h>
 #include <string.h>
@@ -234,7 +234,7 @@ void splitIPPacketToFragmentsBySize(pcpp::RawPacket* rawPacket, size_t fragmentS
 void processPackets(pcpp::IFileReaderDevice* reader, pcpp::IFileWriterDevice* writer,
 		int fragSize,
 		bool filterByBpf, const std::string& bpfFilter,
-		bool filterByIpID, std::map<uint16_t, bool> ipIDs,
+		bool filterByIpID, std::unordered_map<uint16_t, bool> ipIDs,
 		bool copyAllPacketsToOutputFile,
 		FragStats& stats)
 {
@@ -380,7 +380,7 @@ int main(int argc, char* argv[])
 	bool filterByBpfFilter = false;
 	std::string bpfFilter = "";
 	bool filterByIpID = false;
-	std::map<uint16_t, bool> ipIDMap;
+	std::unordered_map<uint16_t, bool> ipIDMap;
 	bool copyAllPacketsToOutputFile = false;
 
 	while((opt = getopt_long(argc, argv, "o:s:d:f:ahv", FragUtilOptions, &optionIndex)) != -1)

--- a/Examples/PcapSearch/main.cpp
+++ b/Examples/PcapSearch/main.cpp
@@ -30,7 +30,7 @@
 #include <dirent.h>
 #include <utility>
 #include <vector>
-#include <map>
+#include <unordered_map>
 #include <Logger.h>
 #include <PcapPlusPlusVersion.h>
 #include <SystemUtils.h>
@@ -201,7 +201,7 @@ int searchPcap(const std::string& pcapFilePath, std::string searchCriteria, std:
  * search criteria. This method outputs how many directories were searched, how many files were searched and how many packets were matched
  */
 void searchDirectories(const std::string &directory, bool includeSubDirectories, const std::string &searchCriteria, std::ofstream* detailedReportFile,
-		std::map<std::string, bool> extensionsToSearch,
+		std::unordered_map<std::string, bool> extensionsToSearch,
 		int& totalDirSearched, int& totalFilesSearched, int& totalPacketsFound)
 {
 	// open the directory
@@ -302,7 +302,7 @@ int main(int argc, char* argv[])
 
 	std::string detailedReportFileName = "";
 
-	std::map<std::string, bool> extensionsToSearch;
+	std::unordered_map<std::string, bool> extensionsToSearch;
 
 	// the default (unless set otherwise) is to search in '.pcap' and '.pcapng' extensions
 	extensionsToSearch["pcap"] = true;

--- a/Examples/PcapSplitter/ConnectionSplitters.h
+++ b/Examples/PcapSplitter/ConnectionSplitters.h
@@ -58,7 +58,7 @@ private:
 
 	// a flow table for saving TCP state per flow. Currently the only data that is saved is whether
 	// the last packet seen on the flow was a TCP SYN packet
-	std::map<uint32_t, bool> m_TcpFlowTable;
+	std::unordered_map<uint32_t, bool> m_TcpFlowTable;
 
 	/**
 	 * A utility method that takes a packet and returns true if it's a TCP SYN packet

--- a/Examples/PcapSplitter/Splitters.h
+++ b/Examples/PcapSplitter/Splitters.h
@@ -9,7 +9,7 @@
 #include "UdpLayer.h"
 #include "DnsLayer.h"
 #include "PacketUtils.h"
-#include <map>
+#include <unordered_map>
 #include <algorithm>
 #include <iomanip>
 #include <sstream>
@@ -166,9 +166,9 @@ class ValueBasedSplitter : public SplitterWithMaxFiles
 {
 protected:
 	// A flow table that keeps track of all flows (a flow is usually identified by 5-tuple)
-	std::map<uint32_t, int> m_FlowTable;
+	std::unordered_map<uint32_t, int> m_FlowTable;
 	// a map between the relevant packet value (e.g client-ip) and the file to write the packet to
-	std::map<uint32_t, int> m_ValueToFileTable;
+	std::unordered_map<uint32_t, int> m_ValueToFileTable;
 
 	/**
 	 * A protected c'tor for this class that only propagate the maxFiles to its ancestor

--- a/Examples/PcapSplitter/main.cpp
+++ b/Examples/PcapSplitter/main.cpp
@@ -49,7 +49,7 @@
 #include <sstream>
 #include <string>
 #include <iomanip>
-#include <map>
+#include <unordered_map>
 #include <RawPacket.h>
 #include <Packet.h>
 #include <PcapFileDevice.h>
@@ -380,7 +380,7 @@ int main(int argc, char* argv[])
 	pcpp::RawPacket rawPacket;
 
 	// prepare a map of file number to IFileWriterDevice
-	std::map<int, pcpp::IFileWriterDevice*> outputFiles;
+	std::unordered_map<int, pcpp::IFileWriterDevice*> outputFiles;
 
 	// read all packets from input file, for each packet do:
 	while (reader->getNextPacket(rawPacket))

--- a/Examples/PfRingExample-FilterTraffic/main.cpp
+++ b/Examples/PfRingExample-FilterTraffic/main.cpp
@@ -40,7 +40,7 @@
 #include <stdlib.h>
 #include <vector>
 #include <getopt.h>
-#include <map>
+#include <unordered_map>
 #include <sstream>
 #include <unistd.h>
 
@@ -70,7 +70,7 @@ struct CaptureThreadArgs
 {
 	PacketStats* packetStatArr;
 	PacketMatchingEngine* matchingEngine;
-	std::map<uint32_t, bool>* flowTables;
+	std::unordered_map<uint32_t, bool>* flowTables;
 	pcpp::PfRingDevice* sendPacketsTo;
 	pcpp::PcapFileWriterDevice** pcapWriters;
 
@@ -181,7 +181,7 @@ void packetArrived(pcpp::RawPacket* packets, uint32_t numOfPackets, uint8_t thre
 
 		// hash the packet by 5-tuple and look in the flow table to see whether this packet belongs to an existing or new flow
 		uint32_t hash = pcpp::hash5Tuple(&packet);
-		std::map<uint32_t, bool>::const_iterator iter = args->flowTables[threadId].find(hash);
+		std::unordered_map<uint32_t, bool>::const_iterator iter = args->flowTables[threadId].find(hash);
 
 		// if packet belongs to an already existing flow
 		if (iter !=args->flowTables[threadId].end() && iter->second)
@@ -419,7 +419,7 @@ int main(int argc, char* argv[])
 	PacketMatchingEngine matchingEngine(srcIPToMatch, dstIPToMatch, srcPortToMatch, dstPortToMatch, protocolToMatch);
 
 	// create a flow table for each core
-	std::map<uint32_t, bool> flowTables[totalNumOfCores];
+	std::unordered_map<uint32_t, bool> flowTables[totalNumOfCores];
 
 	pcpp::PcapFileWriterDevice** pcapWriters = NULL;
 

--- a/Examples/SSLAnalyzer/SSLStatsCollector.h
+++ b/Examples/SSLAnalyzer/SSLStatsCollector.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <map>
+#include <unordered_map>
 #include <sstream>
 #include "TcpLayer.h"
 #include "IPv4Layer.h"
@@ -35,8 +35,8 @@ struct SSLGeneralStats
 	double sampleTime; // total stats collection time
 	int numOfHandshakeCompleteFlows; // number of flows which handshake was complete
 	int numOfFlowsWithAlerts; // number of flows that were terminated because of SSL/TLS alert
-	std::map<uint16_t, int> sslVersionCount; // number of flows per SSL/TLS version
-	std::map<uint16_t, int> sslPortCount; // number of flows per TCP port
+	std::unordered_map<uint16_t, int> sslVersionCount; // number of flows per SSL/TLS version
+	std::unordered_map<uint16_t, int> sslPortCount; // number of flows per TCP port
 
 	void clear()
 	{
@@ -67,7 +67,7 @@ struct ClientHelloStats
 {
 	int numOfMessages; // total number of client-hello messages
 	Rate messageRate; // rate of client-hello messages
-	std::map<std::string, int> serverNameCount; // a map for counting the server names seen in traffic
+	std::unordered_map<std::string, int> serverNameCount; // a map for counting the server names seen in traffic
 
 	virtual ~ClientHelloStats() {}
 
@@ -87,7 +87,7 @@ struct ServerHelloStats
 {
 	int numOfMessages; // total number of server-hello messages
 	Rate messageRate; // rate of server-hello messages
-	std::map<std::string, int> cipherSuiteCount; // count of the different chosen cipher-suites
+	std::unordered_map<std::string, int> cipherSuiteCount; // count of the different chosen cipher-suites
 
 	virtual ~ServerHelloStats() {}
 
@@ -378,7 +378,7 @@ private:
 	ServerHelloStats m_ServerHelloStats;
 	ServerHelloStats m_PrevServerHelloStats;
 
-	std::map<uint32_t, SSLFlowData> m_FlowTable;
+	std::unordered_map<uint32_t, SSLFlowData> m_FlowTable;
 
 	double m_LastCalcRateTime;
 	double m_StartTime;

--- a/Examples/SSLAnalyzer/main.cpp
+++ b/Examples/SSLAnalyzer/main.cpp
@@ -206,7 +206,7 @@ void printServerNames(ClientHelloStats& clientHelloStatsCollector)
 	pcpp::TablePrinter printer(columnNames, columnsWidths);
 
 	// sort the server-name count map so the most popular names will be first
-	// since it's not possible to sort a std::map you must copy it to a std::vector and sort it then
+	// since it's not possible to sort a std::unordered_map you must copy it to a std::vector and sort it then
 	std::vector<std::pair<std::string, int> > map2vec(clientHelloStatsCollector.serverNameCount.begin(), clientHelloStatsCollector.serverNameCount.end());
 	std::sort(map2vec.begin(),map2vec.end(), &stringCountComparer);
 
@@ -223,7 +223,7 @@ void printServerNames(ClientHelloStats& clientHelloStatsCollector)
 /**
  * Print SSL record version map
  */
-void printVersions(std::map<uint16_t, int>& versionMap, const std::string& headline)
+void printVersions(std::unordered_map<uint16_t, int>& versionMap, const std::string& headline)
 {
 	// create the table
 	std::vector<std::string> columnNames;
@@ -235,7 +235,7 @@ void printVersions(std::map<uint16_t, int>& versionMap, const std::string& headl
 	pcpp::TablePrinter printer(columnNames, columnsWidths);
 
 	// sort the version map so the most popular version will be first
-	// since it's not possible to sort a std::map you must copy it to a std::vector and sort it then
+	// since it's not possible to sort a std::unordered_map you must copy it to a std::vector and sort it then
 	std::vector<std::pair<uint16_t, int> > map2vec(versionMap.begin(), versionMap.end());
 	std::sort(map2vec.begin(),map2vec.end(), &uint16CountComparer);
 
@@ -264,7 +264,7 @@ void printCipherSuites(ServerHelloStats& serverHelloStats)
 	pcpp::TablePrinter printer(columnNames, columnsWidths);
 
 	// sort the cipher-suite count map so the most popular names will be first
-	// since it's not possible to sort a std::map you must copy it to a std::vector and sort it then
+	// since it's not possible to sort a std::unordered_map you must copy it to a std::vector and sort it then
 	std::vector<std::pair<std::string, int> > map2vec(serverHelloStats.cipherSuiteCount.begin(), serverHelloStats.cipherSuiteCount.end());
 	std::sort(map2vec.begin(),map2vec.end(), &stringCountComparer);
 
@@ -290,7 +290,7 @@ void printPorts(SSLGeneralStats& stats)
 	pcpp::TablePrinter printer(columnNames, columnsWidths);
 
 	// sort the port count map so the most popular names will be first
-	// since it's not possible to sort a std::map you must copy it to a std::vector and sort it then
+	// since it's not possible to sort a std::unordered_map you must copy it to a std::vector and sort it then
 	std::vector<std::pair<uint16_t, int> > map2vec(stats.sslPortCount.begin(), stats.sslPortCount.end());
 	std::sort(map2vec.begin(),map2vec.end(), &uint16CountComparer);
 

--- a/Examples/TLSFingerprinting/main.cpp
+++ b/Examples/TLSFingerprinting/main.cpp
@@ -8,7 +8,7 @@
  * You can also run `TLSFingerprinting -h` for modes of operation and parameters.
  */
 
-#include <map>
+#include <unordered_map>
 #include <vector>
 #include <algorithm>
 #include <iostream>
@@ -222,8 +222,8 @@ struct TLSFingerprintingStats
 	uint64_t numOfPacketsTotal;
 	uint64_t numOfCHPackets;
 	uint64_t numOfSHPackets;
-	std::map<std::string, uint64_t> chFingerprints;
-	std::map<std::string, uint64_t> shFingerprints;
+	std::unordered_map<std::string, uint64_t> chFingerprints;
+	std::unordered_map<std::string, uint64_t> shFingerprints;
 };
 
 struct HandlePacketData
@@ -239,7 +239,7 @@ struct HandlePacketData
 /**
  * Print cipher-suite map in a table sorted by number of occurrences (most common cipher-suite will be first)
  */
-void printCommonTLSFingerprints(const std::map<std::string, uint64_t>& tlsFingerprintMap, int printCountItems)
+void printCommonTLSFingerprints(const std::unordered_map<std::string, uint64_t>& tlsFingerprintMap, int printCountItems)
 {
 	// create the table
 	std::vector<std::string> columnNames;
@@ -251,7 +251,7 @@ void printCommonTLSFingerprints(const std::map<std::string, uint64_t>& tlsFinger
 	pcpp::TablePrinter printer(columnNames, columnsWidths);
 
 	// sort the TLS fingerprint map so the most popular will be first
-	// since it's not possible to sort a std::map you must copy it to a std::vector and sort it then
+	// since it's not possible to sort a std::unordered_map you must copy it to a std::vector and sort it then
 	std::vector<std::pair<std::string, int> > map2vec(tlsFingerprintMap.begin(), tlsFingerprintMap.end());
 	std::sort(map2vec.begin(),map2vec.end(), &stringCountComparer);
 

--- a/Packet++/header/IPReassembly.h
+++ b/Packet++/header/IPReassembly.h
@@ -4,7 +4,7 @@
 #include "LRUList.h"
 #include "IpAddress.h"
 #include "PointerVector.h"
-#include <map>
+#include <unordered_map>
 
 /**
  * @file
@@ -448,7 +448,7 @@ namespace pcpp
 		};
 
 		LRUList<uint32_t> m_PacketLRU;
-		std::map<uint32_t, IPFragmentData*> m_FragmentMap;
+		std::unordered_map<uint32_t, IPFragmentData*> m_FragmentMap;
 		OnFragmentsClean m_OnFragmentsCleanCallback;
 		void* m_CallbackUserCookie;
 

--- a/Packet++/header/SomeIpSdLayer.h
+++ b/Packet++/header/SomeIpSdLayer.h
@@ -6,7 +6,7 @@
 #include "SomeIpLayer.h"
 #include <cstring>
 #include <iterator>
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <stdexcept>
 #include <vector>

--- a/Packet++/header/TcpReassembly.h
+++ b/Packet++/header/TcpReassembly.h
@@ -3,6 +3,7 @@
 #include "Packet.h"
 #include "IpAddress.h"
 #include "PointerVector.h"
+#include <unordered_map>
 #include <map>
 #include <list>
 #include <time.h>
@@ -307,7 +308,7 @@ public:
 	/**
 	 * The type for storing the connection information
 	 */
-	typedef std::map<uint32_t, ConnectionData> ConnectionInfoList;
+	typedef std::unordered_map<uint32_t, ConnectionData> ConnectionInfoList;
 
 	/**
 	 * @typedef OnTcpMessageReady
@@ -428,7 +429,7 @@ private:
 		TcpReassemblyData() : closed(false), numOfSides(0), prevSide(-1) {}
 	};
 
-	typedef std::map<uint32_t, TcpReassemblyData> ConnectionList;
+	typedef std::unordered_map<uint32_t, TcpReassemblyData> ConnectionList;
 	typedef std::map<time_t, std::list<uint32_t> > CleanupList;
 
 	OnTcpMessageReady m_OnMessageReadyCallback;

--- a/Packet++/src/GtpLayer.cpp
+++ b/Packet++/src/GtpLayer.cpp
@@ -1,6 +1,6 @@
 #define LOG_MODULE PacketLogModuleGtpLayer
 
-#include <map>
+#include <unordered_map>
 #include <sstream>
 #include "Logger.h"
 #include "GtpLayer.h"
@@ -441,9 +441,9 @@ GtpV1MessageType GtpV1Layer::getMessageType() const
 	return (GtpV1MessageType)header->messageType;
 }
 
-std::map<uint8_t, std::string> createGtpV1MessageTypeToStringMap()
+std::unordered_map<uint8_t, std::string> createGtpV1MessageTypeToStringMap()
 {
-	std::map<uint8_t, std::string> tempMap;
+	std::unordered_map<uint8_t, std::string> tempMap;
 
 	tempMap[0] = "GTPv1 Message Type Unknown";
 	tempMap[1] = "Echo Request";
@@ -518,7 +518,7 @@ std::map<uint8_t, std::string> createGtpV1MessageTypeToStringMap()
 	return tempMap;
 }
 
-const std::map<uint8_t, std::string> GTPv1MsgTypeToStringMap = createGtpV1MessageTypeToStringMap();
+const std::unordered_map<uint8_t, std::string> GTPv1MsgTypeToStringMap = createGtpV1MessageTypeToStringMap();
 
 std::string GtpV1Layer::getMessageTypeAsString() const
 {
@@ -529,7 +529,7 @@ std::string GtpV1Layer::getMessageTypeAsString() const
 		return GTPv1MsgTypeToStringMap.find(0)->second;
 	}
 
-	std::map<uint8_t, std::string>::const_iterator iter = GTPv1MsgTypeToStringMap.find(header->messageType);
+	std::unordered_map<uint8_t, std::string>::const_iterator iter = GTPv1MsgTypeToStringMap.find(header->messageType);
 	if (iter != GTPv1MsgTypeToStringMap.end())
 	{
 		return iter->second;

--- a/Packet++/src/IPReassembly.cpp
+++ b/Packet++/src/IPReassembly.cpp
@@ -310,7 +310,7 @@ Packet* IPReassembly::processPacket(Packet* fragment, ReassemblyStatus& status, 
 	IPFragmentData* fragData = nullptr;
 
 	// check whether this packet already exists in the map
-	std::map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(hash);
+	std::unordered_map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(hash);
 
 	// this is the first fragment seen for this packet
 	if (iter == m_FragmentMap.end())
@@ -499,7 +499,7 @@ Packet* IPReassembly::getCurrentPacket(const PacketKey& key)
 	uint32_t hash = key.getHashValue();
 
 	// look for this hash value in the map
-	std::map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(hash);
+	std::unordered_map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(hash);
 
 	// hash was found
 	if (iter != m_FragmentMap.end())
@@ -556,7 +556,7 @@ void IPReassembly::removePacket(const PacketKey& key)
 	uint32_t hash = key.getHashValue();
 
 	// look for this hash value in the map
-	std::map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(hash);
+	std::unordered_map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(hash);
 
 	// hash was found
 	if (iter != m_FragmentMap.end())
@@ -578,7 +578,7 @@ void IPReassembly::addNewFragment(uint32_t hash, IPFragmentData* fragData)
 	if (m_PacketLRU.put(hash, &packetRemoved) == 1) // this means LRU list was full and the least recently used item was removed
 	{
 		// remove this item from the fragment map
-		std::map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(packetRemoved);
+		std::unordered_map<uint32_t, IPFragmentData*>::iterator iter = m_FragmentMap.find(packetRemoved);
 		IPFragmentData* dataRemoved = iter->second;
 
 		PacketKey* key = nullptr;

--- a/Packet++/src/PPPoELayer.cpp
+++ b/Packet++/src/PPPoELayer.cpp
@@ -5,7 +5,7 @@
 #include "IPv6Layer.h"
 #include "PayloadLayer.h"
 #include "Logger.h"
-#include <map>
+#include <unordered_map>
 #include <sstream>
 #include "EndianPortable.h"
 
@@ -94,9 +94,9 @@ void PPPoESessionLayer::setPPPNextProtocol(uint16_t nextProtocol)
 	*pppProto = htobe16(nextProtocol);
 }
 
-std::map<uint16_t, std::string> createPPPNextProtoToStringMap()
+std::unordered_map<uint16_t, std::string> createPPPNextProtoToStringMap()
 {
-	std::map<uint16_t, std::string> tempMap;
+	std::unordered_map<uint16_t, std::string> tempMap;
 	tempMap[PCPP_PPP_PADDING] =     "Padding Protocol";
 	tempMap[PCPP_PPP_ROHC_SCID] =   "ROHC small-CID";
 	tempMap[PCPP_PPP_ROHC_LCID] =   "ROHC large-CID";
@@ -233,11 +233,11 @@ std::map<uint16_t, std::string> createPPPNextProtoToStringMap()
 	return tempMap;
 }
 
-const std::map<uint16_t, std::string> PPPNextProtoToString = createPPPNextProtoToStringMap();
+const std::unordered_map<uint16_t, std::string> PPPNextProtoToString = createPPPNextProtoToStringMap();
 
 std::string PPPoESessionLayer::toString() const
 {
-	std::map<uint16_t, std::string>::const_iterator iter = PPPNextProtoToString.find(getPPPNextProtocol());
+	std::unordered_map<uint16_t, std::string>::const_iterator iter = PPPNextProtoToString.find(getPPPNextProtocol());
 	std::string nextProtocol;
 	if (iter != PPPNextProtoToString.end())
 		nextProtocol = iter->second;

--- a/Packet++/src/SSLHandshake.cpp
+++ b/Packet++/src/SSLHandshake.cpp
@@ -4,7 +4,7 @@
 #include "md5.h"
 #include <string.h>
 #include <sstream>
-#include <map>
+#include <unordered_map>
 #include <set>
 #include <utility>
 #include "Logger.h"
@@ -349,9 +349,9 @@ static const SSLCipherSuite Cipher328 = SSLCipherSuite(0x1304, SSL_KEYX_NULL, SS
 static const SSLCipherSuite Cipher329 = SSLCipherSuite(0x1305, SSL_KEYX_NULL, SSL_AUTH_NULL, SSL_SYM_AES_128_CCM_8, SSL_HASH_SHA256, "TLS_AES_128_CCM_8_SHA256");
 
 
-static std::map<uint16_t, SSLCipherSuite*> createCipherSuiteIdToObjectMap()
+static std::unordered_map<uint16_t, SSLCipherSuite*> createCipherSuiteIdToObjectMap()
 {
-	std::map<uint16_t, SSLCipherSuite*> result;
+	std::unordered_map<uint16_t, SSLCipherSuite*> result;
 
 	result[0x0000] = (SSLCipherSuite*)&Cipher1;
 	result[0x0001] = (SSLCipherSuite*)&Cipher2;
@@ -699,9 +699,9 @@ static uint32_t hashString(std::string str)
 	return h;
 }
 
-static std::map<uint32_t, SSLCipherSuite*> createCipherSuiteStringToObjectMap()
+static std::unordered_map<uint32_t, SSLCipherSuite*> createCipherSuiteStringToObjectMap()
 {
-	std::map<uint32_t, SSLCipherSuite*> result;
+	std::unordered_map<uint32_t, SSLCipherSuite*> result;
 
 	result[0x9F180F43] = (SSLCipherSuite*)&Cipher1;
 	result[0x97D9341F] = (SSLCipherSuite*)&Cipher2;
@@ -1042,15 +1042,15 @@ std::set<uint16_t> createGreaseSet()
 	return std::set<uint16_t>(greaseExtensions, greaseExtensions + 16);
 }
 
-static const std::map<uint16_t, SSLCipherSuite*> CipherSuiteIdToObjectMap = createCipherSuiteIdToObjectMap();
+static const std::unordered_map<uint16_t, SSLCipherSuite*> CipherSuiteIdToObjectMap = createCipherSuiteIdToObjectMap();
 
-static const std::map<uint32_t, SSLCipherSuite*> CipherSuiteStringToObjectMap = createCipherSuiteStringToObjectMap();
+static const std::unordered_map<uint32_t, SSLCipherSuite*> CipherSuiteStringToObjectMap = createCipherSuiteStringToObjectMap();
 
 static const std::set<uint16_t> GreaseSet = createGreaseSet();
 
 SSLCipherSuite* SSLCipherSuite::getCipherSuiteByID(uint16_t id)
 {
-	std::map<uint16_t, SSLCipherSuite*>::const_iterator pos = CipherSuiteIdToObjectMap.find(id);
+	std::unordered_map<uint16_t, SSLCipherSuite*>::const_iterator pos = CipherSuiteIdToObjectMap.find(id);
 	if (pos == CipherSuiteIdToObjectMap.end())
 		return nullptr;
 	else
@@ -1060,7 +1060,7 @@ SSLCipherSuite* SSLCipherSuite::getCipherSuiteByID(uint16_t id)
 SSLCipherSuite* SSLCipherSuite::getCipherSuiteByName(std::string name)
 {
 	uint32_t nameHash = hashString(std::move(name));
-	std::map<uint32_t, SSLCipherSuite*>::const_iterator pos = CipherSuiteStringToObjectMap.find(nameHash);
+	std::unordered_map<uint32_t, SSLCipherSuite*>::const_iterator pos = CipherSuiteStringToObjectMap.find(nameHash);
 	if (pos == CipherSuiteStringToObjectMap.end())
 		return nullptr;
 	else

--- a/Tests/Pcap++Test/Common/TestUtils.h
+++ b/Tests/Pcap++Test/Common/TestUtils.h
@@ -2,7 +2,7 @@
 
 #include <string>
 #include <vector>
-#include <map>
+#include <unordered_map>
 #include "RawPacket.h"
 #include "Device.h"
 
@@ -46,12 +46,12 @@ uint8_t* readFileIntoBuffer(const std::string &filename, int& bufferLength);
 
 template<typename KeyType, typename LeftValue, typename RightValue>
 void intersectMaps(
-	const std::map<KeyType, LeftValue> & left,
-	const std::map<KeyType, RightValue> & right,
-	std::map<KeyType, std::pair<LeftValue, RightValue> >& result)
+	const std::unordered_map<KeyType, LeftValue> & left,
+	const std::unordered_map<KeyType, RightValue> & right,
+	std::unordered_map<KeyType, std::pair<LeftValue, RightValue> >& result)
 {
-	typename std::map<KeyType, LeftValue>::const_iterator il = left.begin();
-	typename std::map<KeyType, RightValue>::const_iterator ir = right.begin();
+	typename std::unordered_map<KeyType, LeftValue>::const_iterator il = left.begin();
+	typename std::unordered_map<KeyType, RightValue>::const_iterator ir = right.begin();
 	while (il != left.end() && ir != right.end())
 	{
 			if (il->first < ir->first)

--- a/Tests/Pcap++Test/Tests/DpdkTests.cpp
+++ b/Tests/Pcap++Test/Tests/DpdkTests.cpp
@@ -2,7 +2,7 @@
 #include "../Common/GlobalTestArgs.h"
 #include "../Common/TestUtils.h"
 #include "../Common/PcapFileNamesDef.h"
-#include <map>
+#include <unordered_map>
 #include <stdlib.h>
 #include <sstream>
 
@@ -33,7 +33,7 @@ struct DpdkPacketData
 	int UdpCount;
 	int HttpCount;
 
-	std::map<uint32_t, pcpp::RawPacketVector> FlowKeys;
+	std::unordered_map<uint32_t, pcpp::RawPacketVector> FlowKeys;
 
 	DpdkPacketData() : ThreadId(-1), PacketCount(0), EthCount(0), ArpCount(0), Ip4Count(0), Ip6Count(0), TcpCount(0), UdpCount(0), HttpCount(0) {}
 	void clear() { ThreadId = -1; PacketCount = 0; EthCount = 0; ArpCount = 0; Ip4Count = 0; Ip6Count = 0; TcpCount = 0; UdpCount = 0; HttpCount = 0; FlowKeys.clear(); }
@@ -480,7 +480,7 @@ PTF_TEST_CASE(TestDpdkMultiThread)
 			if ((pcpp::SystemCores::IdToSystemCore[secondCoreId].Mask & coreMask) == 0)
 				continue;
 
-			std::map<uint32_t, std::pair<pcpp::RawPacketVector, pcpp::RawPacketVector> > res;
+			std::unordered_map<uint32_t, std::pair<pcpp::RawPacketVector, pcpp::RawPacketVector> > res;
 			intersectMaps<uint32_t, pcpp::RawPacketVector, pcpp::RawPacketVector>(packetDataMultiThread[firstCoreId].FlowKeys, packetDataMultiThread[secondCoreId].FlowKeys, res);
 			PTF_ASSERT_EQUAL(res.size(), 0);
 			if (PTF_IS_VERBOSE_MODE)

--- a/Tests/Pcap++Test/Tests/PfRingTests.cpp
+++ b/Tests/Pcap++Test/Tests/PfRingTests.cpp
@@ -25,7 +25,7 @@ struct PfRingPacketData
 	int IpCount;
 	int TcpCount;
 	int UdpCount;
-	std::map<uint32_t, pcpp::RawPacketVector> FlowKeys;
+	std::unordered_map<uint32_t, pcpp::RawPacketVector> FlowKeys;
 
 	PfRingPacketData() : ThreadId(-1), PacketCount(0), EthCount(0), IpCount(0), TcpCount(0), UdpCount(0) {}
 	void clear() { ThreadId = -1; PacketCount = 0; EthCount = 0; IpCount = 0; TcpCount = 0; UdpCount = 0; FlowKeys.clear(); }
@@ -363,7 +363,7 @@ PTF_TEST_CASE(TestPfRingDeviceMultiThread)
 	{
 		for (int secondCoreId = firstCoreId+1; secondCoreId < totalnumOfCores; secondCoreId++)
 		{
-			std::map<uint32_t, std::pair<pcpp::RawPacketVector, pcpp::RawPacketVector> > res;
+			std::unordered_map<uint32_t, std::pair<pcpp::RawPacketVector, pcpp::RawPacketVector> > res;
 			intersectMaps<uint32_t, pcpp::RawPacketVector, pcpp::RawPacketVector>(packetDataMultiThread[firstCoreId].FlowKeys, packetDataMultiThread[secondCoreId].FlowKeys, res);
 			PTF_ASSERT_EQUAL(res.size(), 0);
 		}

--- a/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
+++ b/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
@@ -41,7 +41,7 @@ struct TcpReassemblyStats
 struct TcpReassemblyMultipleConnStats
 {
 	typedef std::vector<uint32_t> FlowKeysList;
-	typedef std::map<uint32_t, TcpReassemblyStats> Stats;
+	typedef std::unordered_map<uint32_t, TcpReassemblyStats> Stats;
 
 	Stats stats;
 	FlowKeysList flowKeysList;

--- a/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
+++ b/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
@@ -41,7 +41,7 @@ struct TcpReassemblyStats
 struct TcpReassemblyMultipleConnStats
 {
 	typedef std::vector<uint32_t> FlowKeysList;
-	typedef std::unordered_map<uint32_t, TcpReassemblyStats> Stats;
+	typedef std::map<uint32_t, TcpReassemblyStats> Stats;
 
 	Stats stats;
 	FlowKeysList flowKeysList;


### PR DESCRIPTION
part of #977

changed `std::map` to `std::unordered_map`

there are a few cases that still keep using `std::map` due to the original intention usage of the `std::map` properties.