### PR TITLE
Fix android package

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -283,16 +283,16 @@ jobs:
           find . -name example-app -type d -exec rm -r {} +
           find . -name cmake -type d -exec rm -r {} +
           find . -name pkgconfig -type d -exec rm -r {} +
-          mv ${COMBINED_PACKAGE_DIR}/include/pcapplusplus/* ${COMBINED_PACKAGE_DIR}/include/
-          rmdir ${COMBINED_PACKAGE_DIR}/include/pcapplusplus/
-          mkdir -p android-package
-          mv ${COMBINED_PACKAGE_DIR} android-package
+          mv ${COMBINED_PACKAGE_DIR}/include/pcapplusplus/* "${COMBINED_PACKAGE_DIR}/include/"
+          rmdir "${COMBINED_PACKAGE_DIR}/include/pcapplusplus/"
+          mkdir -p "android-package"
+          mv "${COMBINED_PACKAGE_DIR}" "android-package"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: android-package
-          if-no-files-found: error
           path: android-package
+          name: android-package-${{ matrix.target }}-${{ matrix.api-version }}
+          if-no-files-found: error
 
   android-package:
     needs: android-build
@@ -301,7 +301,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: android-package
+          pattern: android-package-*
+          merge-multiple: true
 
       - name: Package into archive
         run: |


### PR DESCRIPTION
With the bump to upload-artifact@v4 we don't support merging artifact with the same name and we should explicit it during the download artifact process.