### PR TITLE
Refactor: Modernizing filters to Cpp11.

### DIFF
--- a/Pcap++/header/PcapFilter.h
+++ b/Pcap++/header/PcapFilter.h
@@ -178,7 +178,7 @@ namespace pcpp
 		 * @param[out] result An empty string that the parsing will be written into. If the string isn't empty, its content will be overridden
 		 * If the filter is not valid the result will be an empty string
 		 */
-		virtual void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		* Verify the filter is valid
@@ -279,7 +279,7 @@ namespace pcpp
 		 */
 		IPFilter(const std::string& ipAddress, Direction dir, int len) : IFilterWithDirection(dir), m_Address(ipAddress), m_IPv4Mask(""), m_Len(len) {}
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		 * Set the IPv4 address
@@ -321,7 +321,7 @@ namespace pcpp
 		 */
 		IPv4IDFilter(uint16_t ipID, FilterOperator op) : IFilterWithOperator(op), m_IpID(ipID) {}
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		 * Set the IP ID to filter
@@ -350,7 +350,7 @@ namespace pcpp
 		 */
 		IPv4TotalLengthFilter(uint16_t totalLength, FilterOperator op) : IFilterWithOperator(op), m_TotalLength(totalLength) {}
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		 * Set the total length value
@@ -379,7 +379,7 @@ namespace pcpp
 		 */
 		PortFilter(uint16_t port, Direction dir);
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		 * Set the port
@@ -410,7 +410,7 @@ namespace pcpp
 		 */
 		PortRangeFilter(uint16_t fromPort, uint16_t toPort, Direction dir) : IFilterWithDirection(dir), m_FromPort(fromPort), m_ToPort(toPort) {}
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		 * Set the lower end of the port range
@@ -444,7 +444,7 @@ namespace pcpp
 		 */
 		MacAddressFilter(MacAddress address, Direction dir) : IFilterWithDirection(dir), m_MacAddress(address) {}
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		 * Set the MAC address
@@ -472,7 +472,7 @@ namespace pcpp
 		 */
 		explicit EtherTypeFilter(uint16_t etherType) : m_EtherType(etherType) {}
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		 * Set the EtherType value
@@ -610,7 +610,7 @@ namespace pcpp
 		 */
 		explicit NotFilter(GeneralFilter* filterToInverse) { m_FilterToInverse = filterToInverse; }
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		 * Set a filter to create an inverse filter from
@@ -649,7 +649,7 @@ namespace pcpp
 		 */
 		explicit ProtoFilter(ProtocolTypeFamily protoFamily) : m_ProtoFamily(protoFamily) {}
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		 * Set the protocol to filter with
@@ -685,7 +685,7 @@ namespace pcpp
 		 */
 		explicit ArpFilter(ArpOpcode opCode) : m_OpCode(opCode) {}
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		 * Set the ARP opcode
@@ -713,7 +713,7 @@ namespace pcpp
 		 */
 		explicit VlanFilter(uint16_t vlanId) : m_VlanID(vlanId) {}
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		 * Set the VLAN ID of the filter
@@ -783,7 +783,7 @@ namespace pcpp
 		 */
 		void setTcpFlagsBitMask(uint8_t tcpFlagBitMask, MatchOptions matchOption) { m_TcpFlagsBitMask = tcpFlagBitMask; m_MatchOption = matchOption; }
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 	};
 
 
@@ -806,7 +806,7 @@ namespace pcpp
 		 */
 		TcpWindowSizeFilter(uint16_t windowSize, FilterOperator op) : IFilterWithOperator(op), m_WindowSize(windowSize) {}
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		 * Set window-size value
@@ -835,7 +835,7 @@ namespace pcpp
 		 */
 		UdpLengthFilter(uint16_t length, FilterOperator op) : IFilterWithOperator(op), m_Length(length) {}
 
-		void parseToString(std::string& result);
+		void parseToString(std::string& result) override;
 
 		/**
 		 * Set length value

--- a/Pcap++/src/PcapFilter.cpp
+++ b/Pcap++/src/PcapFilter.cpp
@@ -205,7 +205,7 @@ void IPFilter::convertToIPAddressWithLen(std::string& ipAddrmodified) const
 	if (ipAddr.getType() == IPAddress::IPv4AddressType)
 	{
 		uint32_t addrAsInt = ipAddr.getIPv4().toInt();
-		uint32_t mask = ((uint32_t) - 1) >> ((sizeof(uint32_t) * 8) - m_Len);
+		uint32_t mask = static_cast<uint32_t>(-1) >> ((sizeof(uint32_t) * 8) - m_Len);
 		addrAsInt &= mask;
 		ipAddrmodified = IPv4Address(addrAsInt).toString();
 	}
@@ -271,9 +271,9 @@ void PortRangeFilter::parseToString(std::string& result)
 	parseDirection(dir);
 
 	std::ostringstream fromPortStream;
-	fromPortStream << (int)m_FromPort;
+	fromPortStream << static_cast<int>(m_FromPort);
 	std::ostringstream toPortStream;
-	toPortStream << (int)m_ToPort;
+	toPortStream << static_cast<int>(m_ToPort);
 
 	result = dir + " portrange " + fromPortStream.str() + '-' + toPortStream.str();
 }
@@ -410,7 +410,7 @@ void TcpFlagsFilter::parseToString(std::string& result)
 	else //m_MatchOption == MatchAll
 	{
 		std::ostringstream stream;
-		stream << (int)m_TcpFlagsBitMask;
+		stream << static_cast<int>(m_TcpFlagsBitMask);
 		result += " = " + stream.str();
 	}
 }


### PR DESCRIPTION
Part of #977 

The change is mostly C-style casts to Cpp style casts.
Marked all `parseToString` overrides as `override`.

Additionally, some changes I think it might be beneficial, but I would like an opinion before starting on them:
1. `parseToString` being marked as `const`.
Reasoning: The conversion to string should not modify the filter internals under any circumstances. 
Potential issues: If someone has written custom filters inherited from `GenericFilter` or down the chain and implemented their own `parseToString` this will be a breaking change for the custom filter as `parseToString` and `parseToString const` are considered different functions by the compiler. 
No expected issues with plain usage of the function, if only one version exists, or the non-const version calls the const version as a default via some black magics like:
```
virtual void parseToString(std::string &result)
{
    static_cast<GeneralFilter const *>(this)->parseToString(result);
};
virtual void parseToString(std::string &result) const = 0;
```

2. `enum` -> `enum class` - Read some of the discussion in #1289, about potential solutions to that. Duplicated enums/ctors seem like the best solution for keeping the backwards compatibility in the intermediary period. Although I am debating on the naming. Simplest solution is to stick a `V2` or `Type` suffix or something? (example `Direction` -> `DirectionV2` or `DirectionType`).
Also I am wondering what to do with the functions that return an enum like `Direction getDir()`?

4. Implement C++11 move semantics for filter ctors that take `string const&`. Either by implementing 'perfect forwarding' or 'pass by value and move' as a simpler alternative.

5. Explicitly defaulting empty destructors. Should produce no compatibility issues in the current situation but can have some caveats in other situations explained [here](https://stackoverflow.com/a/34383632/11922936)