### PR TITLE
Fixed a potential memory leak during PointerVector deep copy.

### DIFF
--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -67,6 +67,7 @@ namespace pcpp
 					catch (const std::exception&)
 					{
 						delete objCopy;
+						throw;
 					}
 				}
 			}
@@ -76,6 +77,7 @@ namespace pcpp
 				{
 					delete obj;
 				}
+				throw;
 			}
 		}
 

--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -58,7 +58,14 @@ namespace pcpp
 			for (const auto iter : other)
 			{
 				T* objCopy = new T(*iter);
-				m_Vector.push_back(objCopy);
+				try
+				{
+					m_Vector.push_back(objCopy);
+				}
+				catch (const std::exception&)
+				{
+					delete objCopy;
+				}
 			}
 		}
 

--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -55,16 +55,26 @@ namespace pcpp
 		 */
 		PointerVector(const PointerVector& other)
 		{
-			for (const auto iter : other)
+			try
 			{
-				T* objCopy = new T(*iter);
-				try
+				for (const auto iter : other)
 				{
-					m_Vector.push_back(objCopy);
+					T* objCopy = new T(*iter);
+					try
+					{
+						m_Vector.push_back(objCopy);
+					}
+					catch (const std::exception&)
+					{
+						delete objCopy;
+					}
 				}
-				catch (const std::exception&)
+			}
+			catch (const std::exception&) 
+			{
+				for (auto obj : m_Vector)
 				{
-					delete objCopy;
+					delete obj;
 				}
 			}
 		}

--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -71,7 +71,7 @@ namespace pcpp
 					}
 				}
 			}
-			catch (const std::exception&) 
+			catch (const std::exception&)
 			{
 				for (auto obj : m_Vector)
 				{


### PR DESCRIPTION
Closes #1326 for the most part. Full change to unique_ptr has issues with the iterators and keeping backwards compat.