### PR TITLE
Support jumbo frames in DPDK devices

### DIFF
--- a/Pcap++/header/DpdkDevice.h
+++ b/Pcap++/header/DpdkDevice.h
@@ -773,13 +773,7 @@ namespace pcpp
 			DpdkCoreConfiguration() : RxQueueId(-1), IsCoreInUse(false) {}
 		};
 
-		/**
-		 * Initialize DPDK device
-		 * @param[in] port RSS hash functions mask to check. This mask should be built from values in DpdkRssHashFunction enum
-		 * @param[in] mBufPoolSize The number of elements in the mbuf pool. The optimum size (in terms of memory usage) for a mempool is when n is a power of two minus one: n = (2^q - 1).
-		 * @param[in] mMbufDataSize Size of data buffer in each mbuf. When the default value is -1, we will take the value RTE_MBUF_DEFAULT_BUF_SIZE
-		 */
-		DpdkDevice(int port, uint32_t mBufPoolSize, int32_t mMbufDataSize = -1);
+		DpdkDevice(int port, uint32_t mBufPoolSize, uint16_t mMbufDataSize);
 		bool initMemPool(struct rte_mempool*& memPool, const char* mempoolName, uint32_t mBufPoolSize);
 
 		bool configurePort(uint8_t numOfRxQueues, uint8_t numOfTxQueues);
@@ -810,7 +804,7 @@ namespace pcpp
 		int m_Id;
 		MacAddress m_MacAddress;
 		uint16_t m_DeviceMtu;
-		int32_t m_MbufDataSize;
+		uint16_t m_MbufDataSize;
 		struct rte_mempool* m_MBufMempool;
 		struct rte_eth_dev_tx_buffer** m_TxBuffers;
 		uint64_t m_TxBufferDrainTsc;

--- a/Pcap++/header/DpdkDevice.h
+++ b/Pcap++/header/DpdkDevice.h
@@ -804,7 +804,7 @@ namespace pcpp
 		int m_Id;
 		MacAddress m_MacAddress;
 		uint16_t m_DeviceMtu;
-		uint16_t m_MbufDataSize;
+		uint16_t m_MBufDataSize;
 		struct rte_mempool* m_MBufMempool;
 		struct rte_eth_dev_tx_buffer** m_TxBuffers;
 		uint64_t m_TxBufferDrainTsc;

--- a/Pcap++/header/DpdkDevice.h
+++ b/Pcap++/header/DpdkDevice.h
@@ -773,7 +773,13 @@ namespace pcpp
 			DpdkCoreConfiguration() : RxQueueId(-1), IsCoreInUse(false) {}
 		};
 
-		DpdkDevice(int port, uint32_t mBufPoolSize);
+		/**
+		 * Initialize DPDK device
+		 * @param[in] port RSS hash functions mask to check. This mask should be built from values in DpdkRssHashFunction enum
+		 * @param[in] mBufPoolSize The number of elements in the mbuf pool. The optimum size (in terms of memory usage) for a mempool is when n is a power of two minus one: n = (2^q - 1).
+		 * @param[in] mMbufDataSize Size of data buffer in each mbuf. When the default value is -1, we will take the value RTE_MBUF_DEFAULT_BUF_SIZE
+		 */
+		DpdkDevice(int port, uint32_t mBufPoolSize, int32_t mMbufDataSize = -1);
 		bool initMemPool(struct rte_mempool*& memPool, const char* mempoolName, uint32_t mBufPoolSize);
 
 		bool configurePort(uint8_t numOfRxQueues, uint8_t numOfTxQueues);
@@ -804,6 +810,7 @@ namespace pcpp
 		int m_Id;
 		MacAddress m_MacAddress;
 		uint16_t m_DeviceMtu;
+		int32_t m_MbufDataSize;
 		struct rte_mempool* m_MBufMempool;
 		struct rte_eth_dev_tx_buffer** m_TxBuffers;
 		uint64_t m_TxBufferDrainTsc;

--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -101,7 +101,7 @@ namespace pcpp
 		{
 			static DpdkDeviceList instance;
 			if (!instance.isInitialized())
-				instance.initDpdkDevices(DpdkDeviceList::m_MBufPoolSizePerDevice,DpdkDeviceList::m_MBufDataSize);
+				instance.initDpdkDevices(DpdkDeviceList::m_MBufPoolSizePerDevice, DpdkDeviceList::m_MBufDataSize);
 
 			return instance;
 		}

--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -120,6 +120,7 @@ namespace pcpp
 		 * minus 1, for example: 1023 (= 2^10-1) or 4,294,967,295 (= 2^32-1), etc. This is a DPDK limitation, not PcapPlusPlus.
 		 * The size of the mbuf pool size dictates how many packets can be handled by the application at the same time. For example: if
 		 * pool size is 1023 it means that no more than 1023 packets can be handled or stored in application memory at every point in time
+		 * @param[in] mMBufDataSize The size of data buffer in each mbuf. If this value is less than 1, we will use RTE_MBUF_DEFAULT_BUF_SIZE.
 		 * @param[in] masterCore The core DPDK will use as master to control all worker thread. The default, unless set otherwise, is 0
 		 * @param[in] initDpdkArgc Number of optional arguments
 		 * @param[in] initDpdkArgv Optional arguments

--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -76,6 +76,7 @@ namespace pcpp
 		bool m_IsInitialized;
 		static bool m_IsDpdkInitialized;
 		static uint32_t m_MBufPoolSizePerDevice;
+		static uint16_t m_MBufDataSize;
 		static CoreMask m_CoreMask;
 		std::vector<DpdkDevice*> m_DpdkDeviceList;
 		std::vector<DpdkWorkerThread*> m_WorkerThreads;
@@ -83,7 +84,7 @@ namespace pcpp
 		DpdkDeviceList();
 
 		bool isInitialized() const { return (m_IsInitialized && m_IsDpdkInitialized); }
-		bool initDpdkDevices(uint32_t mBufPoolSizePerDevice);
+		bool initDpdkDevices(uint32_t mBufPoolSizePerDevice, uint16_t mMbufDataSize);
 		static bool verifyHugePagesAndDpdkDriver();
 
 		static int dpdkWorkerThreadStart(void* ptr);
@@ -100,7 +101,7 @@ namespace pcpp
 		{
 			static DpdkDeviceList instance;
 			if (!instance.isInitialized())
-				instance.initDpdkDevices(DpdkDeviceList::m_MBufPoolSizePerDevice);
+				instance.initDpdkDevices(DpdkDeviceList::m_MBufPoolSizePerDevice,DpdkDeviceList::m_MBufDataSize);
 
 			return instance;
 		}
@@ -128,7 +129,7 @@ namespace pcpp
 		 * returned false it's impossible to use DPDK with PcapPlusPlus. You can get some more details about mbufs and pools in
 		 * DpdkDevice.h file description or in DPDK web site
 		 */
-		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore = 0, uint32_t initDpdkArgc = 0, char **initDpdkArgv = NULL, const std::string& appName = "pcapplusplusapp");
+		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint16_t mMbufDataSize = 0, uint8_t masterCore = 0, uint32_t initDpdkArgc = 0, char **initDpdkArgv = NULL, const std::string& appName = "pcapplusplusapp");
 
 		/**
 		 * Get a DpdkDevice by port ID

--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -120,7 +120,7 @@ namespace pcpp
 		 * minus 1, for example: 1023 (= 2^10-1) or 4,294,967,295 (= 2^32-1), etc. This is a DPDK limitation, not PcapPlusPlus.
 		 * The size of the mbuf pool size dictates how many packets can be handled by the application at the same time. For example: if
 		 * pool size is 1023 it means that no more than 1023 packets can be handled or stored in application memory at every point in time
-		 * @param[in] mMBufDataSize The size of data buffer in each mbuf. If this value is less than 1, we will use RTE_MBUF_DEFAULT_BUF_SIZE.
+		 * @param[in] mBufDataSize The size of data buffer in each mbuf. If this value is less than 1, we will use RTE_MBUF_DEFAULT_BUF_SIZE.
 		 * @param[in] masterCore The core DPDK will use as master to control all worker thread. The default, unless set otherwise, is 0
 		 * @param[in] initDpdkArgc Number of optional arguments
 		 * @param[in] initDpdkArgv Optional arguments
@@ -130,7 +130,7 @@ namespace pcpp
 		 * returned false it's impossible to use DPDK with PcapPlusPlus. You can get some more details about mbufs and pools in
 		 * DpdkDevice.h file description or in DPDK web site
 		 */
-		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint16_t mMbufDataSize = 0, uint8_t masterCore = 0, uint32_t initDpdkArgc = 0, char **initDpdkArgv = NULL, const std::string& appName = "pcapplusplusapp");
+		static bool initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint16_t mBufDataSize = 0, uint8_t masterCore = 0, uint32_t initDpdkArgc = 0, char **initDpdkArgv = NULL, const std::string& appName = "pcapplusplusapp");
 
 		/**
 		 * Get a DpdkDevice by port ID

--- a/Pcap++/header/MBufRawPacket.h
+++ b/Pcap++/header/MBufRawPacket.h
@@ -53,7 +53,7 @@ namespace pcpp
 	protected:
 		struct rte_mbuf* m_MBuf;
 		struct rte_mempool* m_Mempool;
-		int m_MbufDataSize;
+		uint16_t m_MbufDataSize;
 		bool m_FreeMbuf;
 
 		void setMBuf(struct rte_mbuf* mBuf, timespec timestamp);

--- a/Pcap++/header/MBufRawPacket.h
+++ b/Pcap++/header/MBufRawPacket.h
@@ -49,11 +49,11 @@ namespace pcpp
 #ifdef USE_DPDK_KNI
 		friend class KniDevice;
 #endif
-		static const int MBUF_DATA_SIZE;
 
 	protected:
 		struct rte_mbuf* m_MBuf;
 		struct rte_mempool* m_Mempool;
+		int m_MbufDataSize;
 		bool m_FreeMbuf;
 
 		void setMBuf(struct rte_mbuf* mBuf, timespec timestamp);

--- a/Pcap++/header/MBufRawPacket.h
+++ b/Pcap++/header/MBufRawPacket.h
@@ -66,7 +66,7 @@ namespace pcpp
 		 * an mbuf the user should call the init() method. Without calling init() the instance of this class is not usable.
 		 * This c'tor can be used for initializing an array of MBufRawPacket (which requires an empty c'tor)
 		 */
-		MBufRawPacket() : RawPacket(), m_MBuf(NULL), m_Mempool(NULL), m_FreeMbuf(true) { m_DeleteRawDataAtDestructor = false; }
+		MBufRawPacket() : RawPacket(), m_MBuf(NULL), m_Mempool(NULL), m_MbufDataSize(0), m_FreeMbuf(true) { m_DeleteRawDataAtDestructor = false; }
 
 		/**
 		 * A d'tor for this class. Once called it frees the mbuf attached to it (returning it back to the mbuf pool it was allocated from)

--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -113,8 +113,8 @@ uint8_t DpdkDevice::m_RSSKey[40] = {
 		0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A,
 	};
 
-DpdkDevice::DpdkDevice(int port, uint32_t mBufPoolSize, int32_t mMbufDataSize)
-	: m_Id(port), m_MacAddress(MacAddress::Zero), m_MbufDataSize(mMbufDataSize == -1 ? RTE_MBUF_DEFAULT_BUF_SIZE : mMbufDataSize)
+DpdkDevice::DpdkDevice(int port, uint32_t mBufPoolSize, uint16_t mMbufDataSize)
+	: m_Id(port), m_MacAddress(MacAddress::Zero), m_MbufDataSize(mMbufDataSize < 1 ? RTE_MBUF_DEFAULT_BUF_SIZE : mMbufDataSize)
 {
 	std::ostringstream deviceNameStream;
 	deviceNameStream << "DPDK_" << m_Id;

--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -113,8 +113,8 @@ uint8_t DpdkDevice::m_RSSKey[40] = {
 		0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A,
 	};
 
-DpdkDevice::DpdkDevice(int port, uint32_t mBufPoolSize)
-	: m_Id(port), m_MacAddress(MacAddress::Zero)
+DpdkDevice::DpdkDevice(int port, uint32_t mBufPoolSize, int32_t mMbufDataSize)
+	: m_Id(port), m_MacAddress(MacAddress::Zero), m_MbufDataSize(mMbufDataSize == -1 ? RTE_MBUF_DEFAULT_BUF_SIZE : mMbufDataSize)
 {
 	std::ostringstream deviceNameStream;
 	deviceNameStream << "DPDK_" << m_Id;
@@ -422,7 +422,7 @@ bool DpdkDevice::initMemPool(struct rte_mempool*& memPool, const char* mempoolNa
 	bool ret = false;
 
 	// create mbuf pool
-	memPool = rte_pktmbuf_pool_create(mempoolName, mBufPoolSize, MEMPOOL_CACHE_SIZE, 0, RTE_MBUF_DEFAULT_BUF_SIZE, rte_socket_id());
+	memPool = rte_pktmbuf_pool_create(mempoolName, mBufPoolSize, MEMPOOL_CACHE_SIZE, 0, m_MbufDataSize, rte_socket_id());
 	if (memPool == NULL)
 	{
 		PCPP_LOG_ERROR("Failed to create packets memory pool for port " << m_Id << ", pool name: " << mempoolName << ". Error was: '" << rte_strerror(rte_errno) << "' [Error code: " << rte_errno << "]");

--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -113,8 +113,8 @@ uint8_t DpdkDevice::m_RSSKey[40] = {
 		0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A,
 	};
 
-DpdkDevice::DpdkDevice(int port, uint32_t mBufPoolSize, uint16_t mMbufDataSize)
-	: m_Id(port), m_MacAddress(MacAddress::Zero), m_MbufDataSize(mMbufDataSize < 1 ? RTE_MBUF_DEFAULT_BUF_SIZE : mMbufDataSize)
+DpdkDevice::DpdkDevice(int port, uint32_t mBufPoolSize, uint16_t mBufDataSize)
+	: m_Id(port), m_MacAddress(MacAddress::Zero), m_MBufDataSize(mBufDataSize < 1 ? RTE_MBUF_DEFAULT_BUF_SIZE : mBufDataSize)
 {
 	std::ostringstream deviceNameStream;
 	deviceNameStream << "DPDK_" << m_Id;
@@ -422,7 +422,7 @@ bool DpdkDevice::initMemPool(struct rte_mempool*& memPool, const char* mempoolNa
 	bool ret = false;
 
 	// create mbuf pool
-	memPool = rte_pktmbuf_pool_create(mempoolName, mBufPoolSize, MEMPOOL_CACHE_SIZE, 0, m_MbufDataSize, rte_socket_id());
+	memPool = rte_pktmbuf_pool_create(mempoolName, mBufPoolSize, MEMPOOL_CACHE_SIZE, 0, m_MBufDataSize, rte_socket_id());
 	if (memPool == NULL)
 	{
 		PCPP_LOG_ERROR("Failed to create packets memory pool for port " << m_Id << ", pool name: " << mempoolName << ". Error was: '" << rte_strerror(rte_errno) << "' [Error code: " << rte_errno << "]");

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -56,6 +56,7 @@ namespace pcpp
 bool DpdkDeviceList::m_IsDpdkInitialized = false;
 CoreMask DpdkDeviceList::m_CoreMask = 0;
 uint32_t DpdkDeviceList::m_MBufPoolSizePerDevice = 0;
+uint16_t DpdkDeviceList::m_MBufDataSize = 0;
 
 DpdkDeviceList::DpdkDeviceList()
 {
@@ -72,7 +73,7 @@ DpdkDeviceList::~DpdkDeviceList()
 	m_DpdkDeviceList.clear();
 }
 
-bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint8_t masterCore, uint32_t initDpdkArgc, char **initDpdkArgv, const std::string& appName)
+bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint16_t mMbufDataSize, uint8_t masterCore, uint32_t initDpdkArgc, char **initDpdkArgv, const std::string& appName)
 {
 	char **initDpdkArgvBuffer;
 
@@ -158,11 +159,12 @@ bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice,
 	m_IsDpdkInitialized = true;
 
 	m_MBufPoolSizePerDevice = mBufPoolSizePerDevice;
+	m_MBufDataSize = mMbufDataSize;
 	DpdkDeviceList::getInstance().setDpdkLogLevel(Logger::Info);
-	return DpdkDeviceList::getInstance().initDpdkDevices(m_MBufPoolSizePerDevice);
+	return DpdkDeviceList::getInstance().initDpdkDevices(m_MBufPoolSizePerDevice, m_MBufDataSize);
 }
 
-bool DpdkDeviceList::initDpdkDevices(uint32_t mBufPoolSizePerDevice)
+bool DpdkDeviceList::initDpdkDevices(uint32_t mBufPoolSizePerDevice, uint16_t mMbufDataSize)
 {
 	if (!m_IsDpdkInitialized)
 	{
@@ -190,7 +192,7 @@ bool DpdkDeviceList::initDpdkDevices(uint32_t mBufPoolSizePerDevice)
 	// Initialize a DpdkDevice per port
 	for (int i = 0; i < numOfPorts; i++)
 	{
-		DpdkDevice* newDevice = new DpdkDevice(i, mBufPoolSizePerDevice);
+		DpdkDevice* newDevice = new DpdkDevice(i, mBufPoolSizePerDevice, mMbufDataSize);
 		PCPP_LOG_DEBUG("DpdkDevice #" << i << ": Name='" << newDevice->getDeviceName() << "', PCI-slot='" << newDevice->getPciAddress() << "', PMD='" << newDevice->getPMDName() << "', MAC Addr='" << newDevice->getMacAddress() << "'");
 		m_DpdkDeviceList.push_back(newDevice);
 	}

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -73,7 +73,7 @@ DpdkDeviceList::~DpdkDeviceList()
 	m_DpdkDeviceList.clear();
 }
 
-bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint16_t mMbufDataSize, uint8_t masterCore, uint32_t initDpdkArgc, char **initDpdkArgv, const std::string& appName)
+bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint16_t mBufDataSize, uint8_t masterCore, uint32_t initDpdkArgc, char **initDpdkArgv, const std::string& appName)
 {
 	char **initDpdkArgvBuffer;
 
@@ -159,12 +159,12 @@ bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice,
 	m_IsDpdkInitialized = true;
 
 	m_MBufPoolSizePerDevice = mBufPoolSizePerDevice;
-	m_MBufDataSize = mMbufDataSize;
+	m_MBufDataSize = mBufDataSize;
 	DpdkDeviceList::getInstance().setDpdkLogLevel(Logger::Info);
 	return DpdkDeviceList::getInstance().initDpdkDevices(m_MBufPoolSizePerDevice, m_MBufDataSize);
 }
 
-bool DpdkDeviceList::initDpdkDevices(uint32_t mBufPoolSizePerDevice, uint16_t mMbufDataSize)
+bool DpdkDeviceList::initDpdkDevices(uint32_t mBufPoolSizePerDevice, uint16_t mBufDataSize)
 {
 	if (!m_IsDpdkInitialized)
 	{
@@ -192,7 +192,7 @@ bool DpdkDeviceList::initDpdkDevices(uint32_t mBufPoolSizePerDevice, uint16_t mM
 	// Initialize a DpdkDevice per port
 	for (int i = 0; i < numOfPorts; i++)
 	{
-		DpdkDevice* newDevice = new DpdkDevice(i, mBufPoolSizePerDevice, mMbufDataSize);
+		DpdkDevice* newDevice = new DpdkDevice(i, mBufPoolSizePerDevice, mBufDataSize);
 		PCPP_LOG_DEBUG("DpdkDevice #" << i << ": Name='" << newDevice->getDeviceName() << "', PCI-slot='" << newDevice->getPciAddress() << "', PMD='" << newDevice->getPMDName() << "', MAC Addr='" << newDevice->getMacAddress() << "'");
 		m_DpdkDeviceList.push_back(newDevice);
 	}

--- a/Pcap++/src/KniDevice.cpp
+++ b/Pcap++/src/KniDevice.cpp
@@ -185,7 +185,7 @@ KniDevice::KniDevice(const KniDeviceConfiguration& conf, size_t mempoolSize, int
 	std::memset(&kniConf, 0, sizeof(kniConf));
 	snprintf(kniConf.name, RTE_KNI_NAMESIZE, "%s", conf.name.c_str());
 	kniConf.core_id = conf.kthreadCoreId;
-	kniConf.mbuf_size = MBufRawPacket::MBUF_DATA_SIZE;
+	kniConf.mbuf_size = RTE_MBUF_DEFAULT_BUF_SIZE;
 	kniConf.force_bind = conf.bindKthread ? 1 : 0;
 	#if RTE_VERSION >= RTE_VERSION_NUM(18, 2, 0, 0)
 		if (conf.mac != MacAddress::Zero)

--- a/Pcap++/src/MBufRawPacket.cpp
+++ b/Pcap++/src/MBufRawPacket.cpp
@@ -22,10 +22,6 @@
 #include <stdint.h>
 #include <unistd.h>
 
-#ifndef MBUF_DATA_SIZE_DEFINE
-#	define MBUF_DATA_SIZE_DEFINE RTE_MBUF_DEFAULT_DATAROOM
-#endif
-
 namespace pcpp
 {
 
@@ -34,8 +30,6 @@ namespace pcpp
  * Class MBufRawPacket
  * ===================
  */
-
-const int MBufRawPacket::MBUF_DATA_SIZE = MBUF_DATA_SIZE_DEFINE;
 
 MBufRawPacket::~MBufRawPacket()
 {
@@ -72,6 +66,7 @@ bool MBufRawPacket::init(struct rte_mempool* mempool)
 
 bool MBufRawPacket::init(DpdkDevice* device)
 {
+	m_MbufDataSize = device->m_MbufDataSize;
 	return init(device->m_MBufMempool);
 }
 
@@ -124,6 +119,7 @@ MBufRawPacket::MBufRawPacket(const MBufRawPacket& other)
 	m_RawPacketSet = false;
 	m_RawData = NULL;
 	m_Mempool = other.m_Mempool;
+	m_MbufDataSize = other.m_MbufDataSize;
 
 	rte_mbuf* newMbuf = rte_pktmbuf_alloc(m_Mempool);
 	if (newMbuf == NULL)
@@ -181,9 +177,9 @@ MBufRawPacket& MBufRawPacket::operator=(const MBufRawPacket& other)
 
 bool MBufRawPacket::setRawData(const uint8_t* pRawData, int rawDataLen, timespec timestamp, LinkLayerType layerType, int frameLength)
 {
-	if (rawDataLen > MBUF_DATA_SIZE)
+	if (rawDataLen > m_MbufDataSize)
 	{
-		PCPP_LOG_ERROR("Cannot set raw data which length is larger than mBuf max size. mBuf max length: " << MBUF_DATA_SIZE << "; requested length: " << rawDataLen);
+		PCPP_LOG_ERROR("Cannot set raw data which length is larger than mBuf max size. mBuf max length: " << m_MbufDataSize << "; requested length: " << rawDataLen);
 		return false;
 	}
 
@@ -310,9 +306,9 @@ bool MBufRawPacket::reallocateData(size_t newBufferLength)
 		return false;
 	}
 
-	if (newBufferLength > MBUF_DATA_SIZE)
+	if ((int)newBufferLength > m_MbufDataSize)
 	{
-		PCPP_LOG_ERROR("Cannot reallocate mBuf raw packet to a size larger than mBuf data. mBuf max length: " << MBUF_DATA_SIZE << "; requested length: " << newBufferLength);
+		PCPP_LOG_ERROR("Cannot reallocate mBuf raw packet to a size larger than mBuf data. mBuf max length: " << m_MbufDataSize << "; requested length: " << newBufferLength);
 		return false;
 	}
 

--- a/Pcap++/src/MBufRawPacket.cpp
+++ b/Pcap++/src/MBufRawPacket.cpp
@@ -66,7 +66,7 @@ bool MBufRawPacket::init(struct rte_mempool* mempool)
 
 bool MBufRawPacket::init(DpdkDevice* device)
 {
-	m_MbufDataSize = device->m_MbufDataSize;
+	m_MbufDataSize = device->m_MBufDataSize;
 	return init(device->m_MBufMempool);
 }
 


### PR DESCRIPTION
When using a DPDK device, support customization size of data buffer in each mbuf. To support jumbo frames in DPDK devices #1339 