### PR TITLE
remove unused `dummy` argument in `PayloadLayer`

### DIFF
--- a/Examples/IPFragUtil/main.cpp
+++ b/Examples/IPFragUtil/main.cpp
@@ -205,7 +205,7 @@ void splitIPPacketToFragmentsBySize(pcpp::RawPacket* rawPacket, size_t fragmentS
 		newFrag.removeAllLayersAfter(fragIpLayer);
 
 		// create a new PayloadLayer with the fragmented data and add it to the new fragment packet
-		pcpp::PayloadLayer newPayload(ipLayer->getLayerPayload() + curOffset, curFragSize, false);
+		pcpp::PayloadLayer newPayload(ipLayer->getLayerPayload() + curOffset, curFragSize);
 		newFrag.addLayer(&newPayload);
 
 		// set fragment parameters in IPv4/6 layer

--- a/Packet++/header/PayloadLayer.h
+++ b/Packet++/header/PayloadLayer.h
@@ -30,10 +30,8 @@ namespace pcpp
 		 * A constructor that allocates a new payload
 		 * @param[in] data A raw buffer that will be used as a payload. This data will be copied to the layer
 		 * @param[in] dataLen The raw buffer length
-		 * @param[in] dummy A dummy parameter to separate the constructor signature from the other constructor. Its value isn't used anywhere
-		 * @todo dummy is probably not necessary anymore. Remove it
 		 */
-		PayloadLayer(const uint8_t* data, size_t dataLen, bool dummy);
+		PayloadLayer(const uint8_t* data, size_t dataLen);
 
 		/**
 		 * A constructor that allocates a new payload from an hex stream

--- a/Packet++/src/PayloadLayer.cpp
+++ b/Packet++/src/PayloadLayer.cpp
@@ -8,7 +8,7 @@
 namespace pcpp
 {
 
-PayloadLayer::PayloadLayer(const uint8_t* data, size_t dataLen, bool) : Layer()
+PayloadLayer::PayloadLayer(const uint8_t* data, size_t dataLen) : Layer()
 {
 	m_Data = new uint8_t[dataLen];
 	memcpy(m_Data, data, dataLen);

--- a/Tests/Packet++Test/Tests/EthAndArpTests.cpp
+++ b/Tests/Packet++Test/Tests/EthAndArpTests.cpp
@@ -33,7 +33,7 @@ PTF_TEST_CASE(EthPacketCreation)
 	pcpp::EthLayer ethLayer(srcMac, dstMac, PCPP_ETHERTYPE_IP);
 
 	uint8_t payload[] = { 0x01, 0x02, 0x03, 0x04 };
-	pcpp::PayloadLayer payloadLayer(payload, 4, true);
+	pcpp::PayloadLayer payloadLayer(payload, 4);
 
 	pcpp::Packet ethPacket(1);
 	PTF_ASSERT_TRUE(ethPacket.addLayer(&ethLayer));
@@ -61,7 +61,7 @@ PTF_TEST_CASE(EthPacketPointerCreation)
 	pcpp::EthLayer* ethLayer = new pcpp::EthLayer(srcMac, dstMac, PCPP_ETHERTYPE_IP);
 
 	uint8_t payload[] = { 0x01, 0x02, 0x03, 0x04 };
-	pcpp::PayloadLayer* payloadLayer = new pcpp::PayloadLayer(payload, 4, true);
+	pcpp::PayloadLayer* payloadLayer = new pcpp::PayloadLayer(payload, 4);
 
 	pcpp::Packet* ethPacket = new pcpp::Packet(1);
 	PTF_ASSERT_TRUE(ethPacket->addLayer(ethLayer, true));

--- a/Tests/Packet++Test/Tests/GreTests.cpp
+++ b/Tests/Packet++Test/Tests/GreTests.cpp
@@ -177,7 +177,7 @@ PTF_TEST_CASE(GreCreationTest)
 	pppLayer.getPPP_PPTPHeader()->protocol = htobe16(PCPP_PPP_CCP);
 
 	uint8_t data[4] = { 0x06, 0x04, 0x00, 0x04 };
-	pcpp::PayloadLayer payloadLayer(data, 4, true);
+	pcpp::PayloadLayer payloadLayer(data, 4);
 
 	pcpp::Packet grev1Packet(1);
 	PTF_ASSERT_TRUE(grev1Packet.addLayer(&ethLayer));

--- a/Tests/Packet++Test/Tests/IPv4Tests.cpp
+++ b/Tests/Packet++Test/Tests/IPv4Tests.cpp
@@ -25,7 +25,7 @@ PTF_TEST_CASE(IPv4PacketCreation)
 
 
 	uint8_t payload[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0xa };
-	pcpp::PayloadLayer payloadLayer(payload, 10, true);
+	pcpp::PayloadLayer payloadLayer(payload, 10);
 
 
 	pcpp::Packet ip4Packet(1);

--- a/Tests/Packet++Test/Tests/IPv6Tests.cpp
+++ b/Tests/Packet++Test/Tests/IPv6Tests.cpp
@@ -52,7 +52,7 @@ PTF_TEST_CASE(IPv6UdpPacketParseAndCreate)
 	pcpp::Layer* afterIpv6Layer = pUdpLayer->getNextLayer();
 	uint8_t* payloadData = new uint8_t[afterIpv6Layer->getDataLen()];
 	afterIpv6Layer->copyData(payloadData);
-	pcpp::PayloadLayer payloadLayer(payloadData, afterIpv6Layer->getDataLen(), true);
+	pcpp::PayloadLayer payloadLayer(payloadData, afterIpv6Layer->getDataLen());
 
 	pcpp::Packet ip6UdpPacketNew(1);
 	PTF_ASSERT_TRUE(ip6UdpPacketNew.addLayer(&ethLayer));

--- a/Tests/Packet++Test/Tests/PacketTests.cpp
+++ b/Tests/Packet++Test/Tests/PacketTests.cpp
@@ -36,7 +36,7 @@ PTF_TEST_CASE(InsertDataToPacket)
 	ip4Layer.getIPv4Header()->protocol = pcpp::PACKETPP_IPPROTO_TCP;
 
 	uint8_t payload[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0xa };
-	pcpp::PayloadLayer payloadLayer(payload, 10, true);
+	pcpp::PayloadLayer payloadLayer(payload, 10);
 
 	// create the packet
 	pcpp::Packet ip4Packet(1);
@@ -119,7 +119,7 @@ PTF_TEST_CASE(CreatePacketFromBuffer)
 	PTF_ASSERT_TRUE(newPacket->addLayer(&ip4Layer));
 
 	uint8_t payload[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0xa };
-	pcpp::PayloadLayer payloadLayer(payload, 10, true);
+	pcpp::PayloadLayer payloadLayer(payload, 10);
 	PTF_ASSERT_TRUE(newPacket->addLayer(&payloadLayer));
 
 	pcpp::Logger::getInstance().suppressLogs();
@@ -256,7 +256,7 @@ PTF_TEST_CASE(RemoveLayerTest)
 	PTF_ASSERT_TRUE(testPacket.addLayer(&ip4Layer));
 
 	uint8_t payload[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0xa };
-	pcpp::PayloadLayer payloadLayer(payload, 10, true);
+	pcpp::PayloadLayer payloadLayer(payload, 10);
 	PTF_ASSERT_TRUE(testPacket.addLayer(&payloadLayer));
 
 
@@ -819,7 +819,7 @@ PTF_TEST_CASE(PacketTrailerTest)
 
 	// add layer after trailer (result with an error)
 	uint8_t payload[4] = { 0x1, 0x2, 0x3, 0x4 };
-	std::unique_ptr<pcpp::PayloadLayer> newPayloadLayer(new pcpp::PayloadLayer(payload, 4, false));
+	std::unique_ptr<pcpp::PayloadLayer> newPayloadLayer(new pcpp::PayloadLayer(payload, 4));
 	pcpp::Logger::getInstance().suppressLogs();
 	PTF_ASSERT_FALSE(trailerIPv4Packet.addLayer(newPayloadLayer.get(), true));
 	pcpp::Logger::getInstance().enableLogs();
@@ -923,7 +923,7 @@ PTF_TEST_CASE(PacketTrailerTest)
 PTF_TEST_CASE(ResizeLayerTest)
 {
 	uint8_t payload[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0xa };
-	pcpp::PayloadLayer payloadLayer(payload, 10, true);
+	pcpp::PayloadLayer payloadLayer(payload, 10);
 
     // Creating a packet
     pcpp::Packet packet(1500);

--- a/Tests/Packet++Test/Tests/SipSdpTests.cpp
+++ b/Tests/Packet++Test/Tests/SipSdpTests.cpp
@@ -201,7 +201,7 @@ PTF_TEST_CASE(SipRequestLayerCreationTest)
 	PTF_ASSERT_TRUE(newSipPacket.addLayer(&sipReqLayer));
 
 	pcpp::SipRequestLayer* samplePacketSipLayer = sipReqSamplePacket.getLayerOfType<pcpp::SipRequestLayer>();
-	auto payloadLayer = new pcpp::PayloadLayer(samplePacketSipLayer->getLayerPayload(), samplePacketSipLayer->getLayerPayloadSize(), true);
+	auto payloadLayer = new pcpp::PayloadLayer(samplePacketSipLayer->getLayerPayload(), samplePacketSipLayer->getLayerPayloadSize());
 	PTF_ASSERT_TRUE(newSipPacket.addLayer(payloadLayer, true));
 
 	newSipPacket.computeCalculateFields();

--- a/Tests/Packet++Test/Tests/SllNullLoopbackTests.cpp
+++ b/Tests/Packet++Test/Tests/SllNullLoopbackTests.cpp
@@ -133,7 +133,7 @@ PTF_TEST_CASE(NullLoopbackTest)
 	pcpp::UdpLayer newUdpLayer(55369, 8612);
 
 	uint8_t payload[] = { 0x42, 0x4a, 0x4e, 0x42, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-	pcpp::PayloadLayer newPayloadLayer(payload, 16, false);
+	pcpp::PayloadLayer newPayloadLayer(payload, 16);
 
 	pcpp::Packet newNullPacket(1);
 	PTF_ASSERT_TRUE(newNullPacket.addLayer(&newNullLoopbackLayer));

--- a/Tests/Packet++Test/Tests/TcpTests.cpp
+++ b/Tests/Packet++Test/Tests/TcpTests.cpp
@@ -180,7 +180,7 @@ PTF_TEST_CASE(TcpPacketCreation)
 	PTF_ASSERT_EQUAL(tcpLayer.getTcpOptionCount(), 3);
 
 	uint8_t payloadData[9] = { 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82 };
-	pcpp::PayloadLayer payloadLayer(payloadData, 9, true);
+	pcpp::PayloadLayer payloadLayer(payloadData, 9);
 
 	pcpp::Packet tcpPacket(1);
 	tcpPacket.addLayer(&ethLayer);

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -780,7 +780,7 @@ PTF_TEST_CASE(TestMtuSize)
 	size_t smallDataLen = liveDev->getMtu() - (smallIPLayer.getDataLen());
 	uint8_t* smallData = new uint8_t[smallDataLen];
 	memset(smallData, 0xFF, smallDataLen);
-	pcpp::PayloadLayer smallPayload(smallData, smallDataLen, false);
+	pcpp::PayloadLayer smallPayload(smallData, smallDataLen);
 	smallPacket.addLayer(&smallPayload);
 
 	// Check the size of the small Packet
@@ -812,7 +812,7 @@ PTF_TEST_CASE(TestMtuSize)
 	size_t largeDataLen = liveDev->getMtu() - largeIPLayer.getDataLen() + 1;
 	uint8_t* largeData = new uint8_t[largeDataLen];
 	memset(largeData, 0xFF, largeDataLen);
-	pcpp::PayloadLayer largePayload(largeData, largeDataLen, false);
+	pcpp::PayloadLayer largePayload(largeData, largeDataLen);
 	largePacket.addLayer(&largePayload);
 
 	// Check the size of the large Packet

--- a/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
+++ b/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
@@ -254,7 +254,7 @@ static pcpp::RawPacket tcpReassemblyAddRetransmissions(pcpp::RawPacket rawPacket
 
 	tcpLayer->getTcpHeader()->sequenceNumber = htobe32(be32toh(tcpLayer->getTcpHeader()->sequenceNumber) + beginning);
 
-	pcpp::PayloadLayer newPayloadLayer(newPayload, numOfBytes, false);
+	pcpp::PayloadLayer newPayloadLayer(newPayload, numOfBytes);
 	packet.addLayer(&newPayloadLayer);
 
 	packet.computeCalculateFields();


### PR DESCRIPTION
We don't need `dummy` anymore.