### PR TITLE
Port Pcap++ code to use override, part of #977

### DIFF
--- a/Pcap++/header/DpdkDevice.h
+++ b/Pcap++/header/DpdkDevice.h
@@ -754,12 +754,12 @@ namespace pcpp
 		 * @return True if the device was opened successfully, false if device is already opened, if RX/TX queues configuration failed or of DPDK port
 		 * configuration and startup failed
 		 */
-		bool open() { return openMultiQueues(1, 1); };
+		bool open() override { return openMultiQueues(1, 1); };
 
 		/**
 		 * Close the DpdkDevice. When device is closed it's not possible work with it
 		 */
-		void close();
+		void close() override;
 
 	private:
 

--- a/Pcap++/header/MBufRawPacket.h
+++ b/Pcap++/header/MBufRawPacket.h
@@ -143,7 +143,7 @@ namespace pcpp
 		/**
 		 * @return MBufRawPacket object type
 		 */
-		virtual inline uint8_t getObjectType() const { return MBUFRAWPACKET_OBJECT_TYPE; }
+		inline uint8_t getObjectType() const override { return MBUFRAWPACKET_OBJECT_TYPE; }
 
 		/**
 		 * An assignment operator for this class. Copies the data from the mbuf attached to the other MBufRawPacket to the mbuf

--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -461,7 +461,7 @@ namespace pcpp
 		 * Get statistics of packets written so far.
 		 * @param[out] stats The stats struct where stats are returned
 		 */
-		virtual void getStatistics(PcapStats& stats) const;
+		void getStatistics(PcapStats& stats) const override;
 	};
 
 

--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -414,7 +414,7 @@ namespace pcpp
 		 * or if the packet link layer type is different than the one defined for the file
 		 * (in all cases, an error will be printed to log)
 		 */
-		bool writePacket(RawPacket const& packet);
+		bool writePacket(RawPacket const& packet) override;
 
 		/**
 		 * Write multiple RawPacket to the file. Before using this method please verify the file is opened using open(). This method won't change
@@ -423,7 +423,7 @@ namespace pcpp
 		 * @return True if all packets were written successfully to the file. False will be returned if the file isn't opened (also, an error
 		 * log will be printed) or if at least one of the packets wasn't written successfully to the file
 		 */
-		bool writePackets(const RawPacketVector& packets);
+		bool writePackets(const RawPacketVector& packets) override;
 
 		//override methods
 
@@ -445,12 +445,12 @@ namespace pcpp
 		 * different from current file link type. In case appendMode is set to false, please refer to open() for return
 		 * values
 		 */
-		bool open(bool appendMode);
+		bool open(bool appendMode) override;
 
 		/**
 		 * Flush and close the pacp file
 		 */
-		virtual void close();
+		void close() override;
 
 		/**
 		 * Flush packets to disk.

--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -42,7 +42,7 @@ namespace pcpp
 		/**
 		 * Close the file
 		 */
-		virtual void close();
+		void close() override;
 	};
 
 
@@ -433,7 +433,7 @@ namespace pcpp
 		 * @return True if file was opened/created successfully or if file is already opened. False if opening the file failed for some reason
 		 * (an error will be printed to log)
 		 */
-		virtual bool open();
+		bool open() override;
 
 		/**
 		 * Same as open(), but enables to open the file in append mode in which packets will be appended to the file

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -257,7 +257,7 @@ namespace pcpp
 		/**
 		 * A destructor for this class
 		 */
-		virtual ~PcapLiveDevice();
+		~PcapLiveDevice() override;
 
 		/**
 		 * @return The type of the device (libPcap, WinPcap/Npcap or a remote device)
@@ -554,7 +554,7 @@ namespace pcpp
 		 * @return True if the device was opened successfully, false otherwise. When opening the device fails an error will be printed to log
 		 * as well
 		 */
-		bool open();
+		bool open() override;
 
 		/**
 		 * Enables to open a device in a non-default configuration. Configuration has parameters like packet buffer timeout & size, open in
@@ -564,7 +564,7 @@ namespace pcpp
 		 */
 		bool open(const DeviceConfiguration& config);
 
-		void close();
+		void close() override;
 
 		/**
 		 * Clones the current device class
@@ -572,7 +572,7 @@ namespace pcpp
 		 */
 		PcapLiveDevice* clone();
 
-		virtual void getStatistics(IPcapDevice::PcapStats& stats) const;
+		void getStatistics(IPcapDevice::PcapStats& stats) const override;
 
 	protected:
 		pcap_t* doOpen(const DeviceConfiguration& config);

--- a/Pcap++/header/RawSocketDevice.h
+++ b/Pcap++/header/RawSocketDevice.h
@@ -135,12 +135,12 @@ namespace pcpp
 		 * Open the device by creating a raw socket and binding it to the network interface specified in the c'tor
 		 * @return True if device was opened successfully, false otherwise with a corresponding error log message
 		 */
-		virtual bool open();
+		bool open() override;
 
 		/**
 		 * Close the raw socket
 		 */
-		virtual void close();
+		void close() override;
 
 	private:
 


### PR DESCRIPTION
This pull request updates Pcap++ to use override where applicable for readability, clarity and safety. It is a part of Issue #977 to change more parts of the code to C++11 for improved performance and readability. For testing, ensured that all existing tests still passed.