### PR TITLE
Replaced raw arrays with std::array in IPv4 and IPv6 address classes.

### DIFF
--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -64,32 +64,27 @@ namespace pcpp
 		IPv4Address(const std::string& addrAsString);
 
 		/**
-		 * Converts the IPv4 address into a 4B integer
-		 * @return a 4B integer in network byte order representing the IPv4 address
+		 * @return A 4-byte integer in network byte order representing the IPv4 address
 		 */
 		inline uint32_t toInt() const;
 
 		/**
-		 * Returns a view of the IPv4 address as a 4-byte raw C-style array
-		 * @return A non-owning pointer to 4-byte array representing the IPv4 address
+		 * @return A non-owning pointer to 4-byte C-style array representing the IPv4 address
 		 */
 		const uint8_t* toBytes() const { return m_Bytes.data(); }
 
 		/**
-		 * Returns a view of the IPv4 address as a std::array of bytes
 		 * @return A reference to a 4-byte standard array representing the IPv4 address
 		 */
 		const std::array<uint8_t, 4>& toByteArray() const { return m_Bytes; }
 
 		/**
-		 * Returns a std::string representation of the address
 		 * @return A string representation of the address
 		 */
 		std::string toString() const;
 
 		/**
-		 * Determine whether the address is a multicast address
-		 * @return True if an address is multicast
+		 * @return True if an address is multicast, false otherwise.
 		 */
 		bool isMulticast() const;
 

--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -172,7 +172,7 @@ namespace pcpp
 	uint32_t IPv4Address::toInt() const
 	{
 		uint32_t addr;
-		memcpy(&addr, m_Bytes.data(), m_Bytes.size() /* * sizeof(uint8_t) = 1 byte */);
+		memcpy(&addr, m_Bytes.data(), m_Bytes.size() * sizeof(uint8_t));
 		return addr;
 	}
 

--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <algorithm>
 #include <ostream>
+#include <array>
 #include <memory>
 
 /// @file
@@ -40,13 +41,13 @@ namespace pcpp
 		 * A constructor that creates an instance of the class out of 4-byte integer value.
 		 * @param[in] addrAsInt The address as 4-byte integer in network byte order
 		 */
-		IPv4Address(const uint32_t addrAsInt) { memcpy(m_Bytes, &addrAsInt, sizeof(m_Bytes)); }
+		IPv4Address(const uint32_t addrAsInt) { memcpy_s(m_Bytes.data(), m_Bytes.size(), &addrAsInt, sizeof(addrAsInt)); }
 
 		/**
 		 * A constructor that creates an instance of the class out of 4-byte array.
 		 * @param[in] bytes The address as 4-byte array in network byte order
 		 */
-		IPv4Address(const uint8_t bytes[4]) { memcpy(m_Bytes, bytes, sizeof(m_Bytes)); }
+		IPv4Address(const uint8_t bytes[4]) { memcpy_s(m_Bytes.data(), m_Bytes.size(), bytes, 4 * sizeof(uint8_t)); }
 
 		/**
 		 * A constructor that creates an instance of the class out of std::string value.
@@ -65,7 +66,7 @@ namespace pcpp
 		/**
 		 * Returns a pointer to 4-byte array representing the IPv4 address
 		 */
-		const uint8_t* toBytes() const { return m_Bytes; }
+		const uint8_t* toBytes() const { return m_Bytes.data(); }
 
 		/**
 		 * Returns a std::string representation of the address
@@ -151,7 +152,7 @@ namespace pcpp
 		static const IPv4Address MulticastRangeUpperBound;
 
 	private:
-		uint8_t m_Bytes[4] = {0};
+		std::array<uint8_t, 4> m_Bytes = {0};
 	}; // class IPv4Address
 
 
@@ -160,7 +161,7 @@ namespace pcpp
 	uint32_t IPv4Address::toInt() const
 	{
 		uint32_t addr;
-		memcpy(&addr, m_Bytes, sizeof(m_Bytes));
+		memcpy_s(&addr, sizeof(addr), m_Bytes.data(), m_Bytes.size() /* * sizeof(uint8_t) = 1 byte */);
 		return addr;
 	}
 

--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -192,7 +192,13 @@ namespace pcpp
 		 * A constructor that creates an instance of the class out of 16-byte array.
 		 * @param[in] bytes The address as 16-byte array in network byte order
 		 */
-		IPv6Address(const uint8_t bytes[16]) { memcpy(m_Bytes, bytes, sizeof(m_Bytes)); }
+		IPv6Address(const uint8_t bytes[16]) { memcpy_s(m_Bytes.data(), m_Bytes.size(), bytes, 16 * sizeof(uint8_t)); }
+
+		/**
+		 * A constructor that creates an instance of the class out of a 16-byte standard array.
+		 * @param[in] bytes The address as 16-byte standard array in network byte order
+		 */
+		IPv6Address(const std::array<uint8_t, 16>& bytes) : m_Bytes(bytes) {}
 
 		/**
 		 * A constructor that creates an instance of the class out of std::string value.
@@ -205,7 +211,12 @@ namespace pcpp
 		/**
 		 * Returns a pointer to 16-byte array representing the IPv6 address
 		 */
-		const uint8_t* toBytes() const { return m_Bytes; }
+		const uint8_t* toBytes() const { return m_Bytes.data(); }
+
+		/**
+		 * Returns a reference to a 16-byte standard array representing the IPv6 address
+		 */
+		const std::array<uint8_t, 16>& toBytesArray() const { return m_Bytes; }
 
 		/**
 		 * Returns a std::string representation of the address
@@ -253,7 +264,7 @@ namespace pcpp
 		 * This method assumes array allocated size is at least 16 (the size of an IPv6 address)
 		 * @param[in] arr A pointer to the array which address will be copied to
 		 */
-		void copyTo(uint8_t* arr) const { memcpy(arr, m_Bytes, sizeof(m_Bytes)); }
+		void copyTo(uint8_t* arr) const { memcpy_s(arr, 16 * sizeof(uint8_t), m_Bytes.data(), m_Bytes.size() * sizeof(uint8_t)); }
 
 		/**
 		 * Checks whether the address matches a network.
@@ -297,7 +308,7 @@ namespace pcpp
 		static const IPv6Address MulticastRangeLowerBound;
 
 	private:
-		uint8_t m_Bytes[16] = {0};
+		std::array<uint8_t, 16> m_Bytes = {0};
 	}; // class IPv6Address
 
 

--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -50,6 +50,12 @@ namespace pcpp
 		IPv4Address(const uint8_t bytes[4]) { memcpy_s(m_Bytes.data(), m_Bytes.size(), bytes, 4 * sizeof(uint8_t)); }
 
 		/**
+		 * A constructor that creates an instance of the class out of a 4-byte standard array.
+		 * @param[in] bytes The address as 4-byte standard array in network byte order
+		 */
+		IPv4Address(const std::array<uint8_t, 4>& bytes) : m_Bytes(bytes) {}
+
+		/**
 		 * A constructor that creates an instance of the class out of std::string value.
 		 *
 		 * @param[in] addrAsString The std::string representation of the address
@@ -67,6 +73,11 @@ namespace pcpp
 		 * Returns a pointer to 4-byte array representing the IPv4 address
 		 */
 		const uint8_t* toBytes() const { return m_Bytes.data(); }
+
+		/**
+		 * Returns a reference to a 4-byte standard array representing the IPv4 address
+		 */
+		const std::array<uint8_t, 4>& toBytesArray() const { return m_Bytes; }
 
 		/**
 		 * Returns a std::string representation of the address

--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -41,13 +41,13 @@ namespace pcpp
 		 * A constructor that creates an instance of the class out of 4-byte integer value.
 		 * @param[in] addrAsInt The address as 4-byte integer in network byte order
 		 */
-		IPv4Address(const uint32_t addrAsInt) { memcpy_s(m_Bytes.data(), m_Bytes.size(), &addrAsInt, sizeof(addrAsInt)); }
+		IPv4Address(const uint32_t addrAsInt) { memcpy(m_Bytes.data(), &addrAsInt, sizeof(addrAsInt)); }
 
 		/**
 		 * A constructor that creates an instance of the class out of 4-byte array.
 		 * @param[in] bytes The address as 4-byte array in network byte order
 		 */
-		IPv4Address(const uint8_t bytes[4]) { memcpy_s(m_Bytes.data(), m_Bytes.size(), bytes, 4 * sizeof(uint8_t)); }
+		IPv4Address(const uint8_t bytes[4]) { memcpy(m_Bytes.data(), bytes, 4 * sizeof(uint8_t)); }
 
 		/**
 		 * A constructor that creates an instance of the class out of a 4-byte standard array.
@@ -172,7 +172,7 @@ namespace pcpp
 	uint32_t IPv4Address::toInt() const
 	{
 		uint32_t addr;
-		memcpy_s(&addr, sizeof(addr), m_Bytes.data(), m_Bytes.size() /* * sizeof(uint8_t) = 1 byte */);
+		memcpy(&addr, m_Bytes.data(), m_Bytes.size() /* * sizeof(uint8_t) = 1 byte */);
 		return addr;
 	}
 
@@ -192,7 +192,7 @@ namespace pcpp
 		 * A constructor that creates an instance of the class out of 16-byte array.
 		 * @param[in] bytes The address as 16-byte array in network byte order
 		 */
-		IPv6Address(const uint8_t bytes[16]) { memcpy_s(m_Bytes.data(), m_Bytes.size(), bytes, 16 * sizeof(uint8_t)); }
+		IPv6Address(const uint8_t bytes[16]) { memcpy(m_Bytes.data(), bytes, 16 * sizeof(uint8_t)); }
 
 		/**
 		 * A constructor that creates an instance of the class out of a 16-byte standard array.
@@ -264,7 +264,7 @@ namespace pcpp
 		 * This method assumes array allocated size is at least 16 (the size of an IPv6 address)
 		 * @param[in] arr A pointer to the array which address will be copied to
 		 */
-		void copyTo(uint8_t* arr) const { memcpy_s(arr, 16 * sizeof(uint8_t), m_Bytes.data(), m_Bytes.size() * sizeof(uint8_t)); }
+		void copyTo(uint8_t* arr) const { memcpy(arr, m_Bytes.data(), m_Bytes.size() * sizeof(uint8_t)); }
 
 		/**
 		 * Checks whether the address matches a network.

--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -70,12 +70,14 @@ namespace pcpp
 		inline uint32_t toInt() const;
 
 		/**
-		 * Returns a pointer to 4-byte array representing the IPv4 address
+		 * Returns a view of the IPv4 address as a 4-byte raw C-style array
+		 * @return A non-owning pointer to 4-byte array representing the IPv4 address
 		 */
 		const uint8_t* toBytes() const { return m_Bytes.data(); }
 
 		/**
-		 * Returns a reference to a 4-byte standard array representing the IPv4 address
+		 * Returns a view of the IPv4 address as a std::array of bytes
+		 * @return A reference to a 4-byte standard array representing the IPv4 address
 		 */
 		const std::array<uint8_t, 4>& toBytesArray() const { return m_Bytes; }
 
@@ -209,12 +211,14 @@ namespace pcpp
 		IPv6Address(const std::string& addrAsString);
 
 		/**
-		 * Returns a pointer to 16-byte array representing the IPv6 address
+		 * Returns a view of the IPv6 address as a 16-byte raw C-style array
+		 * @return A non-owning pointer to 16-byte array representing the IPv6 address
 		 */
 		const uint8_t* toBytes() const { return m_Bytes.data(); }
 
 		/**
-		 * Returns a reference to a 16-byte standard array representing the IPv6 address
+		 * Returns a view of the IPv6 address as a std::array of bytes
+		 * @return A reference to a 16-byte standard array representing the IPv6 address
 		 */
 		const std::array<uint8_t, 16>& toBytesArray() const { return m_Bytes; }
 

--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -79,7 +79,7 @@ namespace pcpp
 		 * Returns a view of the IPv4 address as a std::array of bytes
 		 * @return A reference to a 4-byte standard array representing the IPv4 address
 		 */
-		const std::array<uint8_t, 4>& toBytesArray() const { return m_Bytes; }
+		const std::array<uint8_t, 4>& toByteArray() const { return m_Bytes; }
 
 		/**
 		 * Returns a std::string representation of the address
@@ -220,7 +220,7 @@ namespace pcpp
 		 * Returns a view of the IPv6 address as a std::array of bytes
 		 * @return A reference to a 16-byte standard array representing the IPv6 address
 		 */
-		const std::array<uint8_t, 16>& toBytesArray() const { return m_Bytes; }
+		const std::array<uint8_t, 16>& toByteArray() const { return m_Bytes; }
 
 		/**
 		 * Returns a std::string representation of the address

--- a/Common++/src/IpAddress.cpp
+++ b/Common++/src/IpAddress.cpp
@@ -51,7 +51,7 @@ namespace pcpp
 
 	IPv4Address::IPv4Address(const std::string& addrAsString)
 	{
-		if (inet_pton(AF_INET, addrAsString.data(), m_Bytes) <= 0)
+		if (inet_pton(AF_INET, addrAsString.data(), m_Bytes.data()) <= 0)
 		{
 			throw std::invalid_argument("Not a valid IPv4 address: " + addrAsString);
 		}

--- a/Common++/src/IpAddress.cpp
+++ b/Common++/src/IpAddress.cpp
@@ -109,7 +109,7 @@ namespace pcpp
 
 	IPv6Address::IPv6Address(const std::string& addrAsString)
 	{
-		if(inet_pton(AF_INET6, addrAsString.data(), m_Bytes) <= 0)
+		if(inet_pton(AF_INET6, addrAsString.data(), m_Bytes.data()) <= 0)
 		{
 			throw std::invalid_argument("Not a valid IPv6 address: " + addrAsString);
 		}
@@ -118,10 +118,10 @@ namespace pcpp
 
 	void IPv6Address::copyTo(uint8_t** arr, size_t& length) const
 	{
-		const size_t addrLen = sizeof(m_Bytes);
+		const size_t addrLen = m_Bytes.size() * sizeof(uint8_t);
 		length = addrLen;
 		*arr = new uint8_t[addrLen];
-		memcpy(*arr, m_Bytes, addrLen);
+		memcpy(*arr, m_Bytes.data(), addrLen);
 	}
 
 


### PR DESCRIPTION
Overview of changes:
- Replaced raw array usages with `std::array` in internal implementation of `IPv4Address` and `IPv6Address`.

Overview of new additions:
- Added new constructors to `IPv4Address` and `IPv6Address` that take `std::array<uint8_t, 4>` and `std::array<uint8_t, 16>` respectively.
- Added new getter method `toByteArray()` to to `IPv4Address` and `IPv6Address` that return `std::array<uint8_t, 4>` and `std::array<uint8_t, 16>` respectively.