### PR TITLE
initialize timespec variable

### DIFF
--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -20,7 +20,7 @@ void RawPacket::init(bool deleteRawDataAtDestructor)
 
 RawPacket::RawPacket(const uint8_t* pRawData, int rawDataLen, timeval timestamp, bool deleteRawDataAtDestructor, LinkLayerType layerType)
 {
-	timespec nsec_time;
+	timespec nsec_time = {};
 	TIMEVAL_TO_TIMESPEC(&timestamp, &nsec_time);
 	init(deleteRawDataAtDestructor);
 	setRawData(pRawData, rawDataLen, nsec_time, layerType);


### PR DESCRIPTION
Fixes build warnings with GCC14

/mnt/b/yoe/master/build/tmp/work/core2-32-yoe-linux/pcapplusplus/23.09/git/Packet++/src/RawPacket.cpp: In constructor 'pcpp::RawPacket::RawPacket(const uint8_t*, int, timeval, bool, pcpp::LinkLayerType)': /mnt/b/yoe/master/build/tmp/work/core2-32-yoe-linux/pcapplusplus/23.09/git/Packet++/src/RawPacket.cpp:23:18: error: 'nsec_time.timespec::<anonymous>' is used uninitialized [-Werror=uninitialized]
   23 |         timespec nsec_time;
      |                  ^~~~~~~~~
cc1plus: all warnings being treated as errors