### PR TITLE
Fixup TcpLayer deprecation macro cleanup.

### DIFF
--- a/Packet++/header/TcpLayer.h
+++ b/Packet++/header/TcpLayer.h
@@ -5,11 +5,8 @@
 #include "TLVData.h"
 #include <string.h>
 
-#ifndef PCPP_DEPRECATED_TCP_OPTION_TYPE
-#define PCPP_DEPRECATED_TCP_OPTION_TYPE__LOCAL_DEFINE
 #define PCPP_DEPRECATED_TCP_OPTION_TYPE PCPP_DEPRECATED("enum TcpOptionType is deprecated; " \
                                                         "Use enum class TcpOptionEnumType instead")
-#endif
 
 /// @file
 
@@ -677,7 +674,4 @@ namespace pcpp
 	}
 } // namespace pcpp
 
-#ifdef PCPP_DEPRECATED_TCP_OPTION_TYPE__LOCAL_DEFINE
 #undef PCPP_DEPRECATED_TCP_OPTION_TYPE
-#undef PCPP_DEPRECATED_TCP_OPTION_TYPE__LOCAL_DEFINE
-#endif // PCPP_DEPRECATED_TCP_OPTION_TYPE__LOCAL_DEFINE

--- a/Packet++/header/TcpLayer.h
+++ b/Packet++/header/TcpLayer.h
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #ifndef PCPP_DEPRECATED_TCP_OPTION_TYPE
+#define PCPP_DEPRECATED_TCP_OPTION_TYPE__LOCAL_DEFINE
 #define PCPP_DEPRECATED_TCP_OPTION_TYPE PCPP_DEPRECATED("enum TcpOptionType is deprecated; " \
                                                         "Use enum class TcpOptionEnumType instead")
 #endif
@@ -676,4 +677,7 @@ namespace pcpp
 	}
 } // namespace pcpp
 
+#ifdef PCPP_DEPRECATED_TCP_OPTION_TYPE__LOCAL_DEFINE
 #undef PCPP_DEPRECATED_TCP_OPTION_TYPE
+#undef PCPP_DEPRECATED_TCP_OPTION_TYPE__LOCAL_DEFINE
+#endif // PCPP_DEPRECATED_TCP_OPTION_TYPE__LOCAL_DEFINE


### PR DESCRIPTION
The macro `PCPP_DEPRECATED_TCP_OPTION_TYPE` was always being undefined at the end of `TcpLayey.h` even if it was externally defined.