### PR TITLE
Fixed leaked win32 handle during testing.

### DIFF
--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -128,7 +128,7 @@ public:
 				)
 			{
 				m_ProcessHandle = NULL;
-				PCPP_LOG_ERROR("Create process failed " << (int)GetLastError());
+				PCPP_LOG_ERROR("Create process failed " << static_cast<int>(GetLastError()));
 				return;
 			}
 

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -140,6 +140,7 @@ public:
 		if (m_ProcessHandle != NULL)
 		{
 			TerminateProcess(m_ProcessHandle, 0);
+			CloseHandle(m_ProcessHandle);
 		}
 	}
 


### PR DESCRIPTION
Fixed `RpcapdServerInitializer` leaking the `rpcapd.exe` process handle after calling `TerminateProcess` on destruction, therefor keeping the process kernel object alive until the main test process ends.