### PR TITLE
Fixed live device clone method returning wrong device type on win32 machines.

### DIFF
--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -570,12 +570,14 @@ namespace pcpp
 		 * Clones the current device class
 		 * @return Pointer to the copied class
 		 */
-		virtual PcapLiveDevice* clone() const;
+		PcapLiveDevice* clone() const;
 
 		void getStatistics(IPcapDevice::PcapStats& stats) const override;
 
 	protected:
 		pcap_t* doOpen(const DeviceConfiguration& config);
+
+		virtual PcapLiveDevice* cloneInternal(pcap_if_t& devInterface) const;
 	};
 
 } // namespace pcpp

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -570,7 +570,7 @@ namespace pcpp
 		 * Clones the current device class
 		 * @return Pointer to the copied class
 		 */
-		PcapLiveDevice* clone();
+		virtual PcapLiveDevice* clone() const;
 
 		void getStatistics(IPcapDevice::PcapStats& stats) const override;
 

--- a/Pcap++/header/WinPcapLiveDevice.h
+++ b/Pcap++/header/WinPcapLiveDevice.h
@@ -56,11 +56,8 @@ namespace pcpp
 		 */
 		int getMinAmountOfDataToCopyFromKernelToApplication() const { return m_MinAmountOfDataToCopyFromKernelToApplication; }
 
-		/**
-		 * Clones the current device class
-		 * @return Pointer to the copied class
-		 */
-		PcapLiveDevice* clone() const override;
+	protected:
+		PcapLiveDevice* cloneInternal(pcap_if_t& devInterface) const override;
 	};
 
 } // namespace pcpp

--- a/Pcap++/header/WinPcapLiveDevice.h
+++ b/Pcap++/header/WinPcapLiveDevice.h
@@ -55,6 +55,12 @@ namespace pcpp
 		 * setMinAmountOfDataToCopyFromKernelToApplication())
 		 */
 		int getMinAmountOfDataToCopyFromKernelToApplication() const { return m_MinAmountOfDataToCopyFromKernelToApplication; }
+
+		/**
+		 * Clones the current device class
+		 * @return Pointer to the copied class
+		 */
+		PcapLiveDevice* clone() const override;
 	};
 
 } // namespace pcpp

--- a/Pcap++/header/WinPcapLiveDevice.h
+++ b/Pcap++/header/WinPcapLiveDevice.h
@@ -57,7 +57,7 @@ namespace pcpp
 		int getMinAmountOfDataToCopyFromKernelToApplication() const { return m_MinAmountOfDataToCopyFromKernelToApplication; }
 
 	protected:
-		PcapLiveDevice* cloneInternal(pcap_if_t& devInterface) const override;
+		WinPcapLiveDevice* cloneInternal(pcap_if_t& devInterface) const override;
 	};
 
 } // namespace pcpp

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -401,11 +401,11 @@ void PcapLiveDevice::close()
 	PCPP_LOG_DEBUG("Device '" << m_Name << "' closed");
 }
 
-PcapLiveDevice* PcapLiveDevice::clone()
+PcapLiveDevice* PcapLiveDevice::clone() const
 {
-	PcapLiveDevice *retval = nullptr;
+	PcapLiveDevice* retval = nullptr;
 
-	pcap_if_t *interfaceList;
+	pcap_if_t* interfaceList;
 	char errbuf[PCAP_ERRBUF_SIZE];
 	int err = pcap_findalldevs(&interfaceList, errbuf);
 	if (err < 0)

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -424,12 +424,17 @@ PcapLiveDevice* PcapLiveDevice::clone() const
 	}
 
 	if(currInterface)
-		retval = new PcapLiveDevice(currInterface, true, true, true);
+		retval = cloneInternal(*currInterface);
 	else
 		PCPP_LOG_ERROR("Can't find interface " << getName().c_str());
 
 	pcap_freealldevs(interfaceList);
 	return retval;
+}
+
+PcapLiveDevice* PcapLiveDevice::cloneInternal(pcap_if_t& devInterface) const
+{
+	return new PcapLiveDevice(&devInterface, true, true, true);
 }
 
 bool PcapLiveDevice::startCapture(OnPacketArrivesCallback onPacketArrives, void* onPacketArrivesUserCookie)

--- a/Pcap++/src/WinPcapLiveDevice.cpp
+++ b/Pcap++/src/WinPcapLiveDevice.cpp
@@ -126,34 +126,9 @@ bool WinPcapLiveDevice::setMinAmountOfDataToCopyFromKernelToApplication(int size
 	return true;
 }
 
-PcapLiveDevice* WinPcapLiveDevice::clone() const
+PcapLiveDevice *WinPcapLiveDevice::cloneInternal(pcap_if_t& devInterface) const
 {
-	WinPcapLiveDevice* retval = nullptr;
-
-	pcap_if_t* interfaceList;
-	char errbuf[PCAP_ERRBUF_SIZE];
-	int err = pcap_findalldevs(&interfaceList, errbuf);
-	if (err < 0)
-	{
-		PCPP_LOG_ERROR("Error searching for devices: " << errbuf);
-		return nullptr;
-	}
-
-	pcap_if_t* currInterface = interfaceList;
-	while (currInterface != nullptr)
-	{
-		if (!strcmp(currInterface->name, getName().c_str()))
-			break;
-		currInterface = currInterface->next;
-	}
-
-	if (currInterface)
-		retval = new WinPcapLiveDevice(currInterface, true, true, true);
-	else
-		PCPP_LOG_ERROR("Can't find interface " << getName().c_str());
-
-	pcap_freealldevs(interfaceList);
-	return retval;
+	return new WinPcapLiveDevice(&devInterface, true, true, true);
 }
 
 } // namespace pcpp

--- a/Pcap++/src/WinPcapLiveDevice.cpp
+++ b/Pcap++/src/WinPcapLiveDevice.cpp
@@ -126,6 +126,36 @@ bool WinPcapLiveDevice::setMinAmountOfDataToCopyFromKernelToApplication(int size
 	return true;
 }
 
+PcapLiveDevice* WinPcapLiveDevice::clone() const
+{
+	WinPcapLiveDevice* retval = nullptr;
+
+	pcap_if_t* interfaceList;
+	char errbuf[PCAP_ERRBUF_SIZE];
+	int err = pcap_findalldevs(&interfaceList, errbuf);
+	if (err < 0)
+	{
+		PCPP_LOG_ERROR("Error searching for devices: " << errbuf);
+		return nullptr;
+	}
+
+	pcap_if_t* currInterface = interfaceList;
+	while (currInterface != nullptr)
+	{
+		if (!strcmp(currInterface->name, getName().c_str()))
+			break;
+		currInterface = currInterface->next;
+	}
+
+	if (currInterface)
+		retval = new WinPcapLiveDevice(currInterface, true, true, true);
+	else
+		PCPP_LOG_ERROR("Can't find interface " << getName().c_str());
+
+	pcap_freealldevs(interfaceList);
+	return retval;
+}
+
 } // namespace pcpp
 
 #endif // _WIN32

--- a/Pcap++/src/WinPcapLiveDevice.cpp
+++ b/Pcap++/src/WinPcapLiveDevice.cpp
@@ -126,7 +126,7 @@ bool WinPcapLiveDevice::setMinAmountOfDataToCopyFromKernelToApplication(int size
 	return true;
 }
 
-PcapLiveDevice *WinPcapLiveDevice::cloneInternal(pcap_if_t& devInterface) const
+WinPcapLiveDevice* WinPcapLiveDevice::cloneInternal(pcap_if_t& devInterface) const
 {
 	return new WinPcapLiveDevice(&devInterface, true, true, true);
 }

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -265,7 +265,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceClone)
 	// Test of clone device should be same with original
 	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
-	
+
 	{
 		pcpp::PcapLiveDevice* originalDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
 		PTF_ASSERT_NOT_NULL(originalDev);

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -265,8 +265,26 @@ PTF_TEST_CASE(TestPcapLiveDeviceClone)
 	// Test of clone device should be same with original
 	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
-	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch)->clone();
+	
+	{
+		pcpp::PcapLiveDevice* originalDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
+		PTF_ASSERT_NOT_NULL(originalDev);
+
+#ifdef _WIN32
+		// Tests if device pointer points to a Windows Live Device on a Windows machine.
+		PTF_ASSERT_NOT_NULL(dynamic_cast<pcpp::WinPcapLiveDevice*>(originalDev));
+#endif // _WIN32
+
+		liveDev = originalDev->clone();
+	}
+
 	PTF_ASSERT_NOT_NULL(liveDev);
+
+#ifdef _WIN32
+	// Tests if the clone is correctly returns a Windows Live Device on Windows systems.
+	PTF_ASSERT_NOT_NULL(dynamic_cast<pcpp::WinPcapLiveDevice*>(liveDev));
+#endif // _WIN32
+
 	PTF_ASSERT_GREATER_THAN(liveDev->getMtu(), 0);
 	PTF_ASSERT_TRUE(liveDev->open());
 	DeviceTeardown devTeardown(liveDev, true);


### PR DESCRIPTION
Fixes `clone` behavior of `PcapLiveDevice` and `WinPcapLiveDevice` and adds unit tests checking device classes when cloning.

Originally as the `clone` method was not virtual when a pointer referencing a `WinPcapLiveDevice` was cloned a device of the base class `PcapLiveDevice` was returned, instead of the derived class.