### PR TITLE
Refactor of RpcapdServerInitializer

### DIFF
--- a/Packet++/header/TcpLayer.h
+++ b/Packet++/header/TcpLayer.h
@@ -5,10 +5,8 @@
 #include "TLVData.h"
 #include <string.h>
 
-#ifndef PCPP_DEPRECATED_TCP_OPTION_TYPE
 #define PCPP_DEPRECATED_TCP_OPTION_TYPE PCPP_DEPRECATED("enum TcpOptionType is deprecated; " \
                                                         "Use enum class TcpOptionEnumType instead")
-#endif
 
 /// @file
 

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -10,7 +10,6 @@
 #include "../Common/GlobalTestArgs.h"
 #include "../Common/TestUtils.h"
 #include "../Common/PcapFileNamesDef.h"
-#include <sstream>
 #if defined(_WIN32)
 #include "PcapRemoteDevice.h"
 #include "PcapRemoteDeviceList.h"

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -163,8 +163,8 @@ public:
 		ZeroMemory( &pi, sizeof(pi) );
 		if (!CreateProcess (
 				TEXT(cmd.c_str()),
-				// CreateProcessW (Unicode version) modifies the argument string inplace during internal processing. 
-				// This can potentially cause access violation, if used with a compile time constant string, 
+				// CreateProcessW (Unicode version) modifies the argument string inplace during internal processing.
+				// This can potentially cause access violation, if used with a compile time constant string,
 				// but since the current usage uses a heap allocated string, it should be fine.
 				const_cast<char*>(TEXT(args.c_str())),
 				nullptr, nullptr, false,

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -187,7 +187,22 @@ public:
 	}
 
 	RpcapdServerInitializer(const RpcapdServerInitializer&) = delete;
+	RpcapdServerInitializer(RpcapdServerInitializer&& other) noexcept 
+		: m_ProcessHandle(other.m_ProcessHandle), m_JobHandle(other.m_JobHandle)
+	{
+		other.m_ProcessHandle = nullptr;
+		other.m_JobHandle = nullptr;
+	}
 	RpcapdServerInitializer& operator=(const RpcapdServerInitializer&) = delete;
+	RpcapdServerInitializer& operator=(RpcapdServerInitializer&& other) noexcept
+	{
+		killProcessAndCloseHandles();
+		m_ProcessHandle = other.m_ProcessHandle;
+		m_JobHandle = other.m_JobHandle;
+		other.m_ProcessHandle = nullptr;
+		other.m_JobHandle = nullptr;
+		return *this;
+	}
 
 	~RpcapdServerInitializer() { killProcessAndCloseHandles(); }
 

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -145,8 +145,7 @@ public:
 		// Sets up the job limits so closing the job will automatically kill all processes assigned to the job.
 		// This will prevent the subprocess continuing to live if the current process is killed without unwinding the stack (i.e. std::terminate is called),
 		// as the OS itself will kill the subprocesses when the last job handle is closed.
-		JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobLimitInfo;
-		ZeroMemory(&jobLimitInfo, sizeof(jobLimitInfo));
+		JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobLimitInfo{};
 		jobLimitInfo.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
 		if (!SetInformationJobObject(m_JobHandle, JobObjectExtendedLimitInformation, &jobLimitInfo, sizeof(jobLimitInfo)))
 		{

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -127,8 +127,8 @@ public:
 		// Sizeof C-string includes the NULL terminator in the size.
 		// For the purposes of this calculation the NULL terminator's inclusion in the size is used to simulate the space delimiter after the argument.
 		args.reserve(
-			sizeof("rpcapd\\rpcapd.exe -b") + ip.size() + 
-			sizeof(" -p") + 5 /* The maximum digits a uint16_t can have is 5 */ + 
+			sizeof("rpcapd\\rpcapd.exe -b") + ip.size() +
+			sizeof(" -p") + 5 /* The maximum digits a uint16_t can have is 5 */ +
 			sizeof(" -n") - 1 /* Subtracts one as the last NULL terminator is not needed */
 		);
 		args += "rpcapd\\rpcapd.exe -b ";

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -124,7 +124,7 @@ public:
 
 		std::string cmd = "rpcapd\\rpcapd.exe";
 		std::array<char, 256> args;
-		int res = std::snprintf(args.data(), args.size(), "rpcapd\\rpcapd.exe -b %s -p %d -n", ip.c_str(), port);
+		int res = std::snprintf(args.data(), args.size(), "%s -b %s -p %d -n", cmd.c_str(), ip.c_str(), port);
 		if (res < 0)
 		{
 			throw std::runtime_error("Error during string formatting");

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -868,6 +868,7 @@ PTF_TEST_CASE(TestRemoteCapture)
 	PTF_ASSERT_EQUAL(remoteDevices->getRemoteMachinePort(), remoteDevicePort);
 
 	pcpp::PcapRemoteDevice* remoteDevice = remoteDevices->getRemoteDeviceByIP(remoteDeviceIPAddr);
+	PTF_ASSERT_NOT_NULL(remoteDevice);
 	PTF_ASSERT_EQUAL(remoteDevice->getDeviceType(), pcpp::PcapLiveDevice::RemoteDevice, enum);
 	PTF_ASSERT_EQUAL(remoteDevice->getMtu(), 0);
 	pcpp::Logger::getInstance().suppressLogs();

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -109,7 +109,7 @@ private:
 		}
 
 		if (m_JobHandle != nullptr)
-	{
+		{
 			CloseHandle(m_JobHandle);
 			m_JobHandle = nullptr;
 		}
@@ -127,13 +127,13 @@ public:
 		// Sizeof C-string includes the NULL terminator in the size.
 		// For the purposes of this calculation the NULL terminator's inclusion in the size is used to simulate the space delimiter after the argument.
 		args.reserve(
-			sizeof("-b") + ip.size() + 
+			sizeof("rpcapd\\rpcapd.exe -b") + ip.size() + 
 			sizeof(" -p") + 5 /* The maximum digits a uint16_t can have is 5 */ + 
 			sizeof(" -n") - 1 /* Subtracts one as the last NULL terminator is not needed */
 		);
-		args += "-b ";
+		args += "rpcapd\\rpcapd.exe -b ";
 		args += ip;
-		args += " -p";
+		args += " -p ";
 		args += std::to_string(port);
 		args += " -n";
 
@@ -171,17 +171,17 @@ public:
 				&si,
 				&pi
 		))
-			{
+		{
 			DWORD errCode = GetLastError();
 			CloseHandle(m_JobHandle);
 			throw std::runtime_error("Create process failed with error code: " + std::to_string(errCode));
-			}
+		}
 
 		m_ProcessHandle = pi.hProcess;
 		CloseHandle(pi.hThread); // We don't need the thread handle, so we can close it.
 
 		if (!AssignProcessToJobObject(m_JobHandle, m_ProcessHandle))
-	{
+		{
 			DWORD errCode = GetLastError();
 			killProcessAndCloseHandles();
 			throw std::runtime_error("Failed assigning process to job object with code: " + std::to_string(errCode));

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -148,7 +148,7 @@ public:
 		JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobLimitInfo;
 		ZeroMemory(&jobLimitInfo, sizeof(jobLimitInfo));
 		jobLimitInfo.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-		if (!SetInformationJobObject(m_JobHandle, JobObjectExtendedLimitInformation ,&jobLimitInfo, sizeof(jobLimitInfo)))
+		if (!SetInformationJobObject(m_JobHandle, JobObjectExtendedLimitInformation, &jobLimitInfo, sizeof(jobLimitInfo)))
 		{
 			DWORD errCode = GetLastError();
 			CloseHandle(m_JobHandle);

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -163,7 +163,10 @@ public:
 		ZeroMemory( &pi, sizeof(pi) );
 		if (!CreateProcess (
 				TEXT(cmd.c_str()),
-				const_cast<char*>(TEXT(args.c_str())), // TODO: This can potentially cause access violation if Unicode version CreateProcessW is chosen.
+				// CreateProcessW (Unicode version) modifies the argument string inplace during internal processing. 
+				// This can potentially cause access violation, if used with a compile time constant string, 
+				// but since the current usage uses a heap allocated string, it should be fine.
+				const_cast<char*>(TEXT(args.c_str())),
 				nullptr, nullptr, false,
 				CREATE_NEW_CONSOLE,
 				nullptr, nullptr,

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -187,7 +187,7 @@ public:
 	}
 
 	RpcapdServerInitializer(const RpcapdServerInitializer&) = delete;
-	RpcapdServerInitializer(RpcapdServerInitializer&& other) noexcept 
+	RpcapdServerInitializer(RpcapdServerInitializer&& other) noexcept
 		: m_ProcessHandle(other.m_ProcessHandle), m_JobHandle(other.m_JobHandle)
 	{
 		other.m_ProcessHandle = nullptr;


### PR DESCRIPTION
This PR refactors the `RpcapdServerInitializer` object and contains the following changes:
- Fixed leak of sub-process thread handle by the initializer.
- Fixed sub-process not terminating if the main process is killed without calling object destructors.
- `getHandle` method marked as `const`.
- Explicitly deleted copy constructor and copy assignment operator for `RpcapdServerInitializer`.
NB: Move constructor can be added at a later date if needed.
- Removed the usages of `ostringstream` in favor of straight `string` allocation with `reserve` + `append`.
- Added assert to remote device test that the device pointer is not null.