### PR TITLE
Update FreeBSD image to 13.3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,7 +6,7 @@ task:
   name: Test FreeBSD
   freebsd_instance:
     matrix:
-      image_family: freebsd-13-2
+      image_family: freebsd-13-3
       image_family: freebsd-14-0
   install_script:
     - pkg install -y bash cmake git gmake gsed libpcap tcpreplay


### PR DESCRIPTION
This is not mentioned in [CirrusCI documentation](https://cirrus-ci.org/guide/FreeBSD/) (yet), but FreeBSD 13.2 image no longer exists on Google Cloud. The minimum supported version is 13.3:

