### PR TITLE
Refactor of IP utils to use exceptions on invalid input.

### DIFF
--- a/Common++/header/IpUtils.h
+++ b/Common++/header/IpUtils.h
@@ -67,12 +67,26 @@ namespace pcpp
 		in_addr* sockaddr2in_addr(struct sockaddr *sa);
 
 		/**
+		 * Attempt to extract IPv4 address from sockaddr.
+		 * @param[in] sa - input sockaddr
+		 * @return Pointer to address in in_addr format or nullptr if extraction fails.
+		 */
+		in_addr* try_sockaddr2in_addr(struct sockaddr* sa);
+
+		/**
 		 * Extract IPv6 address from sockaddr
 		 * @param[in] sa - input sockaddr
 		 * @return Address in in6_addr format
 		 * @throws std::invalid_argument Sockaddr family is not AF_INET6 or sockaddr is nullptr. 
 		 */
 		in6_addr* sockaddr2in6_addr(struct sockaddr *sa);
+
+		/**
+		 * Attempt to extract IPv6 address from sockaddr.
+		 * @param[in] sa - input sockaddr
+		 * @return Pointer to address in in6_addr format or nullptr if extraction fails.
+		 */
+		in6_addr* try_sockaddr2in6_addr(struct sockaddr* sa);
 
 		/**
 		 * Converts a sockaddr format address to its string representation

--- a/Common++/header/IpUtils.h
+++ b/Common++/header/IpUtils.h
@@ -62,7 +62,7 @@ namespace pcpp
 		 * Extract IPv4 address from sockaddr
 		 * @param[in] sa - input sockaddr
 		 * @return Address in in_addr format
-		 * @throws std::invalid_argument Sockaddr family is not AF_INET or sockaddr is nullptr. 
+		 * @throws std::invalid_argument Sockaddr family is not AF_INET or sockaddr is nullptr.
 		 */
 		in_addr* sockaddr2in_addr(struct sockaddr *sa);
 
@@ -77,9 +77,9 @@ namespace pcpp
 		 * Extract IPv6 address from sockaddr
 		 * @param[in] sa - input sockaddr
 		 * @return Address in in6_addr format
-		 * @throws std::invalid_argument Sockaddr family is not AF_INET6 or sockaddr is nullptr. 
+		 * @throws std::invalid_argument Sockaddr family is not AF_INET6 or sockaddr is nullptr.
 		 */
-		in6_addr* sockaddr2in6_addr(struct sockaddr *sa);
+		in6_addr* sockaddr2in6_addr(struct sockaddr* sa);
 
 		/**
 		 * Attempt to extract IPv6 address from sockaddr.
@@ -91,10 +91,10 @@ namespace pcpp
 		/**
 		 * Converts a sockaddr format address to its string representation
 		 * @param[in] sa Address in sockaddr format
-		 * @param[out]  resultString String representation of the address
-		 * @throws std::invalid_argument Sockaddr family is not AF_INET or AF_INET6, or sockaddr is nullptr. 
+		 * @param[out] resultString String representation of the address
+		 * @throws std::invalid_argument Sockaddr family is not AF_INET or AF_INET6, or sockaddr is nullptr.
 		 */
-		void sockaddr2string(struct sockaddr *sa, char* resultString);
+		void sockaddr2string(struct sockaddr* sa, char* resultString);
 
 		/**
 		 * Convert a in_addr format address to 32bit representation

--- a/Common++/header/IpUtils.h
+++ b/Common++/header/IpUtils.h
@@ -62,6 +62,7 @@ namespace pcpp
 		 * Extract IPv4 address from sockaddr
 		 * @param[in] sa - input sockaddr
 		 * @return Address in in_addr format
+		 * @throws std::invalid_argument Sockaddr family is not AF_INET or sockaddr is nullptr. 
 		 */
 		in_addr* sockaddr2in_addr(struct sockaddr *sa);
 
@@ -69,6 +70,7 @@ namespace pcpp
 		 * Extract IPv6 address from sockaddr
 		 * @param[in] sa - input sockaddr
 		 * @return Address in in6_addr format
+		 * @throws std::invalid_argument Sockaddr family is not AF_INET6 or sockaddr is nullptr. 
 		 */
 		in6_addr* sockaddr2in6_addr(struct sockaddr *sa);
 
@@ -76,6 +78,7 @@ namespace pcpp
 		 * Converts a sockaddr format address to its string representation
 		 * @param[in] sa Address in sockaddr format
 		 * @param[out]  resultString String representation of the address
+		 * @throws std::invalid_argument Sockaddr family is not AF_INET or AF_INET6, or sockaddr is nullptr. 
 		 */
 		void sockaddr2string(struct sockaddr *sa, char* resultString);
 

--- a/Common++/header/IpUtils.h
+++ b/Common++/header/IpUtils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <string>
 #ifdef __linux__
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -67,7 +68,7 @@ namespace pcpp
 		in_addr* sockaddr2in_addr(struct sockaddr *sa);
 
 		/**
-		 * Attempt to extract IPv4 address from sockaddr.
+		 * Attempt to extract IPv4 address from sockaddr
 		 * @param[in] sa - input sockaddr
 		 * @return Pointer to address in in_addr format or nullptr if extraction fails.
 		 */
@@ -82,7 +83,7 @@ namespace pcpp
 		in6_addr* sockaddr2in6_addr(struct sockaddr* sa);
 
 		/**
-		 * Attempt to extract IPv6 address from sockaddr.
+		 * Attempt to extract IPv6 address from sockaddr
 		 * @param[in] sa - input sockaddr
 		 * @return Pointer to address in in6_addr format or nullptr if extraction fails.
 		 */
@@ -95,6 +96,14 @@ namespace pcpp
 		 * @throws std::invalid_argument Sockaddr family is not AF_INET or AF_INET6, or sockaddr is nullptr.
 		 */
 		void sockaddr2string(struct sockaddr* sa, char* resultString);
+
+		/**
+		 * Converts a spckaddr format address to its string representation
+		 * @param[in] sa Address in sockaddr format
+		 * @return String representation of the address
+		 * @throws std::invalid_argument Sockaddr family is not AF_INET or AF_INET6, or sockaddr is nullptr.
+		 */
+		std::string sockaddr2string(struct sockaddr& sa);
 
 		/**
 		 * Convert a in_addr format address to 32bit representation

--- a/Common++/src/IpUtils.cpp
+++ b/Common++/src/IpUtils.cpp
@@ -33,6 +33,18 @@ namespace pcpp
 			}
 		}
 
+		in_addr* try_sockaddr2in_addr(struct sockaddr* sa)
+		{
+			try
+			{
+				return sockaddr2in_addr(sa);
+			}
+			catch (const std::invalid_argument&)
+			{
+				return nullptr;
+			}
+		}
+
 		in6_addr* sockaddr2in6_addr(struct sockaddr* sa)
 		{
 			if (sa == nullptr)
@@ -44,6 +56,18 @@ namespace pcpp
 				return &(((struct sockaddr_in6*)sa)->sin6_addr);
 			default:
 				throw std::invalid_argument("sockaddr family is not AF_INET6.");
+			}
+		}
+
+		in6_addr* try_sockaddr2in6_addr(struct sockaddr* sa)
+		{
+			try
+			{
+				return sockaddr2in6_addr(sa);
+			}
+			catch (const std::invalid_argument&)
+			{
+				return nullptr;
 			}
 		}
 

--- a/Common++/src/IpUtils.cpp
+++ b/Common++/src/IpUtils.cpp
@@ -39,8 +39,9 @@ namespace pcpp
 			{
 				return sockaddr2in_addr(sa);
 			}
-			catch (const std::invalid_argument&)
+			catch (const std::invalid_argument& e)
 			{
+				PCPP_LOG_DEBUG("Extraction failed: " << e.what() << " Returning nullptr.");
 				return nullptr;
 			}
 		}
@@ -65,8 +66,9 @@ namespace pcpp
 			{
 				return sockaddr2in6_addr(sa);
 			}
-			catch (const std::invalid_argument&)
+			catch (const std::invalid_argument& e)
 			{
+				PCPP_LOG_DEBUG("Extraction failed: " << e.what() << " Returning nullptr.");
 				return nullptr;
 			}
 		}

--- a/Common++/src/IpUtils.cpp
+++ b/Common++/src/IpUtils.cpp
@@ -86,13 +86,33 @@ namespace pcpp
 			}
 			case AF_INET6:
 			{
-				PCPP_LOG_DEBUG("Not IPv4 packet address. Assuming IPv6 packet");
+				PCPP_LOG_DEBUG("IPv6 packet address");
 				inet_ntop(AF_INET6, &(((sockaddr_in6*)sa)->sin6_addr), resultString, INET6_ADDRSTRLEN);
 				break;
 			}
 			default:
 				throw std::invalid_argument("Unsupported sockaddr family. Family is not AF_INET or AF_INET6.");
 			}
+		}
+
+		std::string sockaddr2string(struct sockaddr& sa)
+		{
+			std::string resultString;
+			switch (sa.sa_family)
+			{
+			case AF_INET:
+				resultString.resize(INET_ADDRSTRLEN);
+				break;
+			case AF_INET6:
+				resultString.resize(INET6_ADDRSTRLEN);
+				break;
+			default:
+				throw std::invalid_argument("Unsupported sockaddr family. Family is not AF_INET or AF_INET6.");
+			}
+
+			// Pre cpp-17 does not have a non-const version of data().
+			sockaddr2string(&sa, const_cast<char*>(resultString.data()));
+			return resultString;
 		}
 
 		uint32_t in_addr2int(in_addr inAddr)

--- a/Common++/src/IpUtils.cpp
+++ b/Common++/src/IpUtils.cpp
@@ -4,6 +4,7 @@
 #include "Logger.h"
 #include <string.h>
 #include <stdio.h>
+#include <stdexcept>
 #ifndef NS_INADDRSZ
 #define NS_INADDRSZ	4
 #endif
@@ -21,33 +22,52 @@ namespace pcpp
 		in_addr* sockaddr2in_addr(struct sockaddr* sa)
 		{
 			if (sa == nullptr)
-				return nullptr;
-			if (sa->sa_family == AF_INET)
+				throw std::invalid_argument("sockaddr is nullptr");
+
+			switch (sa->sa_family)
+			{
+			case AF_INET:
 				return &(((struct sockaddr_in*)sa)->sin_addr);
-			PCPP_LOG_DEBUG("sockaddr family is not AF_INET. Returning NULL");
-			return nullptr;
+			default:
+				throw std::invalid_argument("sockaddr family is not AF_INET.");
+			}
 		}
 
 		in6_addr* sockaddr2in6_addr(struct sockaddr* sa)
 		{
-			if (sa->sa_family == AF_INET6)
+			if (sa == nullptr)
+				throw std::invalid_argument("sockaddr is nullptr");
+
+			switch (sa->sa_family)
+			{
+			case AF_INET6:
 				return &(((struct sockaddr_in6*)sa)->sin6_addr);
-			PCPP_LOG_DEBUG("sockaddr family is not AF_INET6. Returning NULL");
-			return nullptr;
+			default:
+				throw std::invalid_argument("sockaddr family is not AF_INET6.");
+			}
 		}
 
 		void sockaddr2string(struct sockaddr* sa, char* resultString)
 		{
-			in_addr* ipv4Addr = sockaddr2in_addr(sa);
-			if (ipv4Addr != nullptr)
+			if (sa == nullptr)
+				throw std::invalid_argument("sockaddr is nullptr");
+
+			switch (sa->sa_family)
+			{
+			case AF_INET:
 			{
 				PCPP_LOG_DEBUG("IPv4 packet address");
 				inet_ntop(AF_INET, &(((sockaddr_in*)sa)->sin_addr), resultString, INET_ADDRSTRLEN);
+				break;
 			}
-			else
+			case AF_INET6:
 			{
 				PCPP_LOG_DEBUG("Not IPv4 packet address. Assuming IPv6 packet");
 				inet_ntop(AF_INET6, &(((sockaddr_in6*)sa)->sin6_addr), resultString, INET6_ADDRSTRLEN);
+				break;
+			}
+			default:
+				throw std::invalid_argument("Unsupported sockaddr family. Family is not AF_INET or AF_INET6.");
 			}
 		}
 

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -1099,7 +1099,7 @@ IPv4Address PcapLiveDevice::getIPv4Address() const
 			PCPP_LOG_DEBUG("Searching address " << addrAsString);
 		}
 
-		in_addr* currAddr = internal::sockaddr2in_addr(addrIter.addr);
+		in_addr* currAddr = internal::try_sockaddr2in_addr(addrIter.addr);
 		if (currAddr == nullptr)
 		{
 			PCPP_LOG_DEBUG("Address is NULL");
@@ -1129,7 +1129,7 @@ IPv6Address PcapLiveDevice::getIPv6Address() const
 			internal::sockaddr2string(addrIter.addr, addrAsString);
 			PCPP_LOG_DEBUG("Searching address " << addrAsString);
 		}
-		in6_addr *currAddr = internal::sockaddr2in6_addr(addrIter.addr);
+		in6_addr *currAddr = internal::try_sockaddr2in6_addr(addrIter.addr);
 		if (currAddr == nullptr)
 		{
 			PCPP_LOG_DEBUG("Address is NULL");

--- a/Pcap++/src/PcapLiveDeviceList.cpp
+++ b/Pcap++/src/PcapLiveDeviceList.cpp
@@ -236,7 +236,7 @@ void PcapLiveDeviceList::setDnsServers()
 		sockaddr* saddr = (sockaddr*)&_res.nsaddr_list[i];
 		if (saddr == nullptr)
 			continue;
-		in_addr* inaddr = internal::sockaddr2in_addr(saddr);
+		in_addr* inaddr = internal::try_sockaddr2in_addr(saddr);
 		if (inaddr == nullptr)
 			continue;
 
@@ -280,7 +280,7 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const IPv4Address& ipA
 				PCPP_LOG_DEBUG("Searching address " << addrAsString);
 			}
 
-			in_addr* currAddr = internal::sockaddr2in_addr(addrIter.addr);
+			in_addr* currAddr = internal::try_sockaddr2in_addr(addrIter.addr);
 			if (currAddr == nullptr)
 			{
 				PCPP_LOG_DEBUG("Address is nullptr");
@@ -313,7 +313,7 @@ PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const IPv6Address& ip6
 				PCPP_LOG_DEBUG("Searching address " << addrAsString);
 			}
 
-			in6_addr* currAddr = internal::sockaddr2in6_addr(addrIter.addr);
+			in6_addr* currAddr = internal::try_sockaddr2in6_addr(addrIter.addr);
 			if (currAddr == nullptr)
 			{
 				PCPP_LOG_DEBUG("Address is nullptr");

--- a/Pcap++/src/PcapRemoteDeviceList.cpp
+++ b/Pcap++/src/PcapRemoteDeviceList.cpp
@@ -113,7 +113,7 @@ PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(const IPv4Address& i
 				PCPP_LOG_DEBUG("Searching address " << addrAsString);
 			}
 
-			in_addr* currAddr = internal::sockaddr2in_addr(addrIter.addr);
+			in_addr* currAddr = internal::try_sockaddr2in_addr(addrIter.addr);
 			if (currAddr == NULL)
 			{
 				PCPP_LOG_DEBUG("Address is NULL");
@@ -147,7 +147,7 @@ PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(const IPv6Address& i
 				PCPP_LOG_DEBUG("Searching address " << addrAsString);
 			}
 
-			in6_addr* currAddr = internal::sockaddr2in6_addr(addrIter.addr);
+			in6_addr* currAddr = internal::try_sockaddr2in6_addr(addrIter.addr);
 			if (currAddr == NULL)
 			{
 				PCPP_LOG_DEBUG("Address is NULL");


### PR DESCRIPTION
- Refactors `sockaddr2in*` functions to throw exceptions when invalid `sockaddr` is provided.
- Adds `try_sockaddr2in*` functions that mirror the old functionality to return `nullptr` on failed extractions.
- Adds overload for `sockaddr2string` that takes only `sockaddr` as parameter and returns a `string`.