### PR TITLE
Cpp11 refactor of remote device.

### DIFF
--- a/Pcap++/header/PcapRemoteDevice.h
+++ b/Pcap++/header/PcapRemoteDevice.h
@@ -97,7 +97,7 @@ namespace pcpp
 		ThreadStart getCaptureThreadStart();
 
 	public:
-		virtual ~PcapRemoteDevice() {}
+		~PcapRemoteDevice() override {}
 
 		/**
 		 * @return The IP address of the remote machine where packets are transmitted from the remote machine to the client machine
@@ -109,21 +109,22 @@ namespace pcpp
 		 */
 		uint16_t getRemoteMachinePort() const { return m_RemoteMachinePort; }
 
-		//overridden methods
-
-		virtual LiveDeviceType getDeviceType() const { return RemoteDevice; }
+		/**
+		 * @return The type of the device (libPcap, WinPcap/Npcap or a remote device)
+		 */
+		LiveDeviceType getDeviceType() const override { return RemoteDevice; }
 
 		/**
 		 * MTU isn't supported for remote devices
 		 * @return 0
 		 */
-		virtual uint32_t getMtu() const;
+		uint32_t getMtu() const override;
 
 		/**
 		 * MAC address isn't supported for remote devices
 		 * @return MacAddress#Zero
 		 */
-		virtual MacAddress getMacAddress() const;
+		MacAddress getMacAddress() const override;
 
 		/**
 		 * Open the device using pcap_open. Opening the device makes the connection to the remote daemon (including authentication if needed
@@ -134,9 +135,9 @@ namespace pcpp
 		 * @return True if the device was opened successfully, false otherwise. When opening the device fails an error will be printed to log
 		 * as well, including the WinPcap/Npcap error if exists
 		 */
-		virtual bool open();
+		bool open() override;
 
-		virtual void getStatistics(IPcapDevice::PcapStats& stats) const;
+		void getStatistics(IPcapDevice::PcapStats& stats) const override;
 	};
 
 } // namespace pcpp

--- a/Pcap++/header/PcapRemoteDevice.h
+++ b/Pcap++/header/PcapRemoteDevice.h
@@ -86,17 +86,17 @@ namespace pcpp
 		// c'tor is private, as only PcapRemoteDeviceList should create instances of it, and it'll create only one for every remote interface
 		PcapRemoteDevice(pcap_if_t* iface, PcapRemoteAuthentication* remoteAuthentication, const IPAddress& remoteMachineIP, uint16_t remoteMachinePort);
 
-		// private copy c'tor
-		PcapRemoteDevice( const PcapRemoteDevice& other );
-		// private assignment operator
-		PcapRemoteDevice& operator=(const PcapRemoteDevice& other);
-
 		static void* remoteDeviceCaptureThreadMain(void *ptr);
 
 		//overridden methods
 		ThreadStart getCaptureThreadStart();
 
 	public:
+		PcapRemoteDevice(const PcapRemoteDevice&) = delete;
+		PcapRemoteDevice(PcapRemoteDevice&&) noexcept = delete;
+		PcapRemoteDevice& operator=(const PcapRemoteDevice&) = delete;
+		PcapRemoteDevice& operator=(PcapRemoteDevice&&) noexcept = delete;
+
 		~PcapRemoteDevice() override {}
 
 		/**

--- a/Pcap++/src/PcapRemoteDevice.cpp
+++ b/Pcap++/src/PcapRemoteDevice.cpp
@@ -14,8 +14,8 @@ pcap_rmtauth PcapRemoteAuthentication::getPcapRmAuth() const
 {
 	pcap_rmtauth result;
 	result.type = RPCAP_RMTAUTH_PWD;
-	result.username = (char*)userName.c_str();
-	result.password = (char*)password.c_str();
+	result.username = const_cast<char*>(userName.c_str());
+	result.password = const_cast<char*>(password.c_str());
 	return result;
 }
 
@@ -70,10 +70,10 @@ bool PcapRemoteDevice::open()
 	return true;
 }
 
-void* PcapRemoteDevice::remoteDeviceCaptureThreadMain(void *ptr)
+void* PcapRemoteDevice::remoteDeviceCaptureThreadMain(void* ptr)
 {
-	PcapRemoteDevice* pThis = (PcapRemoteDevice*)ptr;
-	if (pThis == NULL)
+	PcapRemoteDevice* pThis = reinterpret_cast<PcapRemoteDevice*>(ptr);
+	if (pThis == nullptr)
 	{
 		PCPP_LOG_ERROR("Capture thread: Unable to extract PcapLiveDevice instance");
 		return 0;
@@ -89,7 +89,7 @@ void* PcapRemoteDevice::remoteDeviceCaptureThreadMain(void *ptr)
 		while (!pThis->m_StopThread)
 		{
 			if (pcap_next_ex(pThis->m_PcapDescriptor, &pkthdr, &pktData) > 0)
-				onPacketArrives((uint8_t*)pThis, pkthdr, pktData);
+				onPacketArrives(reinterpret_cast<uint8_t*>(pThis), pkthdr, pktData);
 		}
 	}
 	else
@@ -97,7 +97,7 @@ void* PcapRemoteDevice::remoteDeviceCaptureThreadMain(void *ptr)
 		while (!pThis->m_StopThread)
 		{
 			if (pcap_next_ex(pThis->m_PcapDescriptor, &pkthdr, &pktData) > 0)
-				onPacketArrivesNoCallback((uint8_t*)pThis, pkthdr, pktData);
+				onPacketArrivesNoCallback(reinterpret_cast<uint8_t*>(pThis), pkthdr, pktData);
 		}
 	}
 	PCPP_LOG_DEBUG("Ended capture thread for device '" << pThis->m_Name << "'");
@@ -113,7 +113,7 @@ void PcapRemoteDevice::getStatistics(PcapStats& stats) const
 {
 	int allocatedMemory;
 	pcap_stat* tempStats = pcap_stats_ex(m_PcapDescriptor, &allocatedMemory);
-	if (allocatedMemory < (int)sizeof(pcap_stat))
+	if (allocatedMemory < static_cast<int>(sizeof(pcap_stat)))
 	{
 		PCPP_LOG_ERROR("Error getting statistics from live device '" << m_Name << "': WinPcap did not allocate the entire struct");
 		return;

--- a/Pcap++/src/PcapRemoteDevice.cpp
+++ b/Pcap++/src/PcapRemoteDevice.cpp
@@ -72,7 +72,7 @@ bool PcapRemoteDevice::open()
 
 void* PcapRemoteDevice::remoteDeviceCaptureThreadMain(void* ptr)
 {
-	PcapRemoteDevice* pThis = reinterpret_cast<PcapRemoteDevice*>(ptr);
+	PcapRemoteDevice* pThis = static_cast<PcapRemoteDevice*>(ptr);
 	if (pThis == nullptr)
 	{
 		PCPP_LOG_ERROR("Capture thread: Unable to extract PcapLiveDevice instance");


### PR DESCRIPTION
- Marked overridden functions as `override`
- Marked copy/move ctors as deleted.
- Changed casts to Cpp style.