### PR TITLE
Fixed unhandled exceptions crashing the entire test suite.

### DIFF
--- a/Tests/PcppTestFramework/PcppTestFrameworkRun.h
+++ b/Tests/PcppTestFramework/PcppTestFrameworkRun.h
@@ -72,7 +72,16 @@ static bool __ptfCheckTags(const std::string &tagSet, const std::string &tagSetT
 			bool memAllocVerbose = __ptfCheckTags("mem_leak_check_verbose", configTagsToRun, false); \
 			MemPlumber::start(memAllocVerbose); \
 		} \
-		TestName(TestName##_result, verboseMode, showSkippedTests); \
+		try \
+		{ \
+			TestName(TestName##_result, verboseMode, showSkippedTests); \
+		} \
+		catch (std::exception const& e) \
+		{ \
+			TestName##_result = PTF_RESULT_FAILED; \
+			std::cout << std::left << std::setw(35) << #TestName << ": FAILED. Unhandled exception occurred! " \
+			<< "Exception: " << e.what() << std::endl; \
+		} \
 		if (runMemLeakCheck) \
 		{ \
 			if (TestName##_result != PTF_RESULT_PASSED) \


### PR DESCRIPTION
This PR wraps the individual tests into a `try-catch` block and automatically fails the test if an exception is propagated out of the test function. The previous implementation crashed the entire test suite without providing meaningful information.