### PR TITLE
Fix doxygen push trigger

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -28,7 +28,7 @@ jobs:
           doxygen Doxyfile-ci
 
       - name: Prepare documentation
-        if: github.ref_name == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         run: |
           cd pcapplusplus.github.io/static/api-docs/
           find next/ -maxdepth 1 -type f -exec rm {} \;
@@ -36,7 +36,7 @@ jobs:
           mv next/html/* next/
 
       - name: Upload documentation
-        if: github.ref_name == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         uses: cpina/github-action-push-to-another-repository@main
         env:
           SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}


### PR DESCRIPTION
The current push trigger doesn't work: https://github.com/seladb/PcapPlusPlus/actions/runs/9632290984/job/26565276463

`github.ref_name == master`, we should change to `github.ref` which is `refs/heads/master`