### PR TITLE
Fix the target branch in the upload documentation step

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -46,3 +46,4 @@ jobs:
           destination-repository-name: "pcapplusplus.github.io"
           user-email: noreply@github.com
           commit-message: Update API documentation for commit ORIGIN_COMMIT
+          target-branch: master


### PR DESCRIPTION
Build doxygen failed on `master`: https://github.com/seladb/PcapPlusPlus/actions/runs/9637853555/job/26577683049

This is because the default target branch in the target repo (`PcapPlusPlus/pcapplusplus.github.io`) is `main` and our docs repo still has `master` as its root branch. This PR specifies the target branch which should fix the issue