### PR TITLE
Update Android CI macOS version to 12

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -619,11 +619,11 @@ jobs:
           - run-on-os: ubuntu-20.04
             target: x86
             api-version: 30
-          - run-on-os: macos-11
+          - run-on-os: macos-13
             target: arm64-v8a
             cmake_configure: "-DCMAKE_OSX_ARCHITECTURES=arm64"
             api-version: 30
-          - run-on-os: macos-11
+          - run-on-os: macos-13
             target: x86_64
             cmake_configure: "-DCMAKE_OSX_ARCHITECTURES=x86_64"
             api-version: 30

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -619,11 +619,11 @@ jobs:
           - run-on-os: ubuntu-20.04
             target: x86
             api-version: 30
-          - run-on-os: macos-13
+          - run-on-os: macos-12
             target: arm64-v8a
             cmake_configure: "-DCMAKE_OSX_ARCHITECTURES=arm64"
             api-version: 30
-          - run-on-os: macos-13
+          - run-on-os: macos-12
             target: x86_64
             cmake_configure: "-DCMAKE_OSX_ARCHITECTURES=x86_64"
             api-version: 30


### PR DESCRIPTION
Android builds that use `macos-11` [stopped working](https://github.com/seladb/PcapPlusPlus/actions/runs/9642089564/job/26589124568). Apparently this version is being deprecated:
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

> The `macos-11` label has been deprecated and will no longer be available after 28 June 2024. 

We only use it in Android builds.

I tried upgrading to macOS 13 but it failed: https://github.com/seladb/PcapPlusPlus/actions/runs/9642620294/job/26590863567

When I'll have more time I'll try to fix it, but for now let's upgrade to macOS 12?


