### PR TITLE
fix pre-commit clang-tidy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,6 @@ repos:
         name: Check clang-format version
         entry: python3 ./ci/check-clang-format-version.py
         language: system
-      - id: clang-format
-        name: Clang format
-        entry: clang-format
-        language: system
-        args: ["--style=file"]  # Use the .clang-format file for configuration
-        files: ^Common\+\+/.*\.(cpp|h)$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
@@ -28,6 +22,9 @@ repos:
   - repo: https://github.com/pocc/pre-commit-hooks
     rev: v1.3.5
     hooks:
+      - id: clang-format
+        args: ["--style=file"]  # Use the .clang-format file for configuration
+        files: ^Common\+\+/.*\.(cpp|h)$
       - id: cppcheck
         args: ["--std=c++11", "--language=c++", "--suppressions-list=cppcheckSuppressions.txt", "--inline-suppr", "--force"]
   - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
seems that I didn't do it correctly in https://github.com/seladb/PcapPlusPlus/pull/1457

according to the experiment, if we put clang-format in "repo: local", it doesn't function.
No matter how I add incorrect formats in the file, it doesn't throw errors.

Therefore revert the previous change.