### PR TITLE
Dependabot "directory" to "directories"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "pip"
     directories:
       - "/Tests/ExamplesTest"
-      - "/ci/run_tests" 
+      - "/ci/run_tests"
     schedule:
       interval: "monthly"
     target-branch: "dev"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,15 +9,9 @@ updates:
     - "automated-pr"
 
   - package-ecosystem: "pip"
-    directory: "/Tests/ExamplesTest"
-    schedule:
-      interval: "monthly"
-    target-branch: "dev"
-    labels:
-    - "automated-pr"
-
-  - package-ecosystem: "pip"
-    directory: "/ci/run_tests"
+    directories:
+      - "/Tests/ExamplesTest"
+      - "/ci/run_tests" 
     schedule:
       interval: "monthly"
     target-branch: "dev"

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ We'd be more than happy to get feedback, please feel free to reach out to us in 
 - Post a message in PcapPlusPlus Google group: <https://groups.google.com/d/forum/pcapplusplus-support>
 - Ask a question on Stack Overflow: <https://stackoverflow.com/questions/tagged/pcapplusplus>
 - Send an email to: <pcapplusplus@gmail.com>
-- Follow us on Twitter: <https://twitter.com/seladb>
+- Follow us on X: <https://x.com/seladb>
 
 If you like this project please __Star us on GitHub — it helps!__ :star: :star:
 


### PR DESCRIPTION
Recently dependabot add a new way to define multiple files/patterns to be updated by dependabot. With "directories" we can define multiple directories for every section/package of the configuration file.

https://github.blog/changelog/2024-06-25-simplified-dependabot-yml-configuration-with-multi-directory-key-directories-and-wildcard-glob-support/