### PR TITLE
Port code to use `getAndDetach` and deprecate `getAndRemoveFromVector`.

### DIFF
--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -252,7 +252,7 @@ namespace pcpp
 		 */
 		T* getAndRemoveFromVector(VectorIterator& position)
 		{
-			T* result = (*position);
+			T* result = *position;
 			position = m_Vector.erase(position);
 			return result;
 		}

--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -253,9 +253,7 @@ namespace pcpp
 		T* getAndRemoveFromVector(VectorIterator& position)
 		{
 			T* result = (*position);
-			VectorIterator tempPos = position;
-			tempPos = m_Vector.erase(tempPos);
-			position = tempPos;
+			position = m_Vector.erase(position);
 			return result;
 		}
 

--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -6,6 +6,8 @@
 #include <vector>
 #include <memory>
 
+#include "DeprecationUtils.h"
+
 /// @file
 
 /**
@@ -249,7 +251,9 @@ namespace pcpp
 		 * The iterator is shifted to the following element after the removal is completed.
 		 * @return A pointer to the element which is no longer managed by the vector. It's user responsibility to free
 		 * it
+		 * @deprecated Deprecated in favor of 'getAndDetach' as that function provides memory safety.
 		 */
+		PCPP_DEPRECATED("Please use the memory safe 'getAndDetach' instead.")
 		T* getAndRemoveFromVector(VectorIterator& position)
 		{
 			T* result = *position;

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -503,7 +503,7 @@ void TcpReassembly::checkOutOfOrderFragments(TcpReassemblyData* tcpReassemblyDat
 				if ((*tcpFragIter)->sequence == curSideData.sequence)
 				{
 					// pop the fragment from fragment list
-					auto curTcpFrag = std::unique_ptr<TcpFragment>(curSideData.tcpFragmentList.getAndRemoveFromVector(tcpFragIter));
+					auto curTcpFrag = curSideData.tcpFragmentList.getAndDetach(tcpFragIter);
 					// update sequence
 					curSideData.sequence += curTcpFrag->dataLength;
 					if (curTcpFrag->data != nullptr)
@@ -528,7 +528,7 @@ void TcpReassembly::checkOutOfOrderFragments(TcpReassemblyData* tcpReassemblyDat
 				if (SEQ_LT((*tcpFragIter)->sequence, curSideData.sequence))
 				{
 					// pop the fragment from fragment list
-					auto curTcpFrag = std::unique_ptr<TcpFragment>(curSideData.tcpFragmentList.getAndRemoveFromVector(tcpFragIter));
+					auto curTcpFrag = curSideData.tcpFragmentList.getAndDetach(tcpFragIter);
 					// check if it still has new data
 					uint32_t newSequence = curTcpFrag->sequence + curTcpFrag->dataLength;
 
@@ -601,7 +601,7 @@ void TcpReassembly::checkOutOfOrderFragments(TcpReassemblyData* tcpReassemblyDat
 		if (closestSequenceFragIt != curSideData.tcpFragmentList.end())
 		{
 			// get the fragment with the closest sequence
-			auto curTcpFrag = std::unique_ptr<TcpFragment>(curSideData.tcpFragmentList.getAndRemoveFromVector(closestSequenceFragIt));
+			auto curTcpFrag = curSideData.tcpFragmentList.getAndDetach(closestSequenceFragIt);
 
 			// calculate number of missing bytes
 			uint32_t missingDataLen = curTcpFrag->sequence - curSideData.sequence;

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -992,7 +992,7 @@ PTF_TEST_CASE(TestRemoteCapture)
 	{
 		if ((*iter)->getRawDataLen() <= (int)remoteDevice->getMtu())
 		{
-			packetsToSend.pushBack(capturedPackets.getAndRemoveFromVector(iter));
+			packetsToSend.pushBack(capturedPackets.getAndDetach(iter));
 		}
 		else
 			++iter;

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -990,7 +990,7 @@ PTF_TEST_CASE(TestRemoteCapture)
 	size_t capturedPacketsSize = capturedPackets.size();
 	while (iter != capturedPackets.end())
 	{
-		if ((*iter)->getRawDataLen() <= (int)remoteDevice->getMtu())
+		if ((*iter)->getRawDataLen() <= static_cast<int>(remoteDevice->getMtu()))
 		{
 			packetsToSend.pushBack(capturedPackets.getAndDetach(iter));
 		}
@@ -998,12 +998,12 @@ PTF_TEST_CASE(TestRemoteCapture)
 			++iter;
 	}
 	int packetsSent = remoteDevice->sendPackets(packetsToSend);
-	PTF_ASSERT_EQUAL(packetsSent, (int)packetsToSend.size());
+	PTF_ASSERT_EQUAL(packetsSent, static_cast<int>(packetsToSend.size()));
 
 	//check statistics
 	pcpp::IPcapDevice::PcapStats stats;
 	remoteDevice->getStatistics(stats);
-	PTF_ASSERT_EQUAL((uint32_t)stats.packetsRecv, capturedPacketsSize);
+	PTF_ASSERT_EQUAL(static_cast<uint32_t>(stats.packetsRecv), capturedPacketsSize);
 
 	remoteDevice->close();
 


### PR DESCRIPTION
- Ports the current usages of `getAndRemoveFromVector` to use the memory safe `getAndDetach`.
- Deprecates `getAndRemoveFromVector` in favor of `getAndDetach`.