### PR TITLE
Refactor of `PcapRemoteDeviceList`'s factory functions.

### DIFF
--- a/Pcap++/header/PcapRemoteDeviceList.h
+++ b/Pcap++/header/PcapRemoteDeviceList.h
@@ -34,7 +34,9 @@ namespace pcpp
 		std::shared_ptr<PcapRemoteAuthentication> m_RemoteAuthentication;
 
 		// private c'tor. User should create the list via static methods PcapRemoteDeviceList::getRemoteDeviceList()
-		PcapRemoteDeviceList() : m_RemoteMachinePort(0), m_RemoteAuthentication(nullptr) {}
+		PcapRemoteDeviceList(const IPAddress& ipAddress, uint16_t port,
+		                     std::shared_ptr<PcapRemoteAuthentication> remoteAuth,
+		                     std::vector<PcapRemoteDevice*> deviceList);
 
 		void setRemoteMachineIpAddress(const IPAddress& ipAddress);
 		void setRemoteMachinePort(uint16_t port);
@@ -76,11 +78,11 @@ namespace pcpp
 		/**
 		 * A static method for creating a PcapRemoteDeviceList instance for a specific remote machine.
 		 * This methods creates the instance and populates it with PcapRemoteDevice instances.
-		 * Each PcapRemoteDevice instance correspons to a network interface on the remote machine.
-		 * 
-		 * This method overload is for remote daemons which don't require authentication for accessing them. 
+		 * Each PcapRemoteDevice instance corresponds to a network interface on the remote machine.
+		 *
+		 * This method overload is for remote daemons which don't require authentication for accessing them.
 		 * For daemons which do require authentication use the other method overload.
-		 * 
+		 *
 		 * @param[in] ipAddress The IP address of the remote machine through which clients can connect to the rpcapd
 		 * daemon
 		 * @param[in] port The port of the remote machine through which clients can connect to the rpcapd daemon
@@ -109,11 +111,11 @@ namespace pcpp
 		/**
 		 * A static method for creating a PcapRemoteDeviceList instance for a specific remote machine.
 		 * This methods creates the instance and populates it with PcapRemoteDevice instances.
-		 * Each PcapRemoteDevice instance correspons to a network interface on the remote machine.
-		 * 
+		 * Each PcapRemoteDevice instance corresponds to a network interface on the remote machine.
+		 *
 		 * This method overload is for remote daemons which require authentication for accessing them.
 		 * If no authentication is required, use the other method overload.
-		 * 
+		 *
 		 * @param[in] ipAddress The IP address of the remote machine through which clients can connect to the rpcapd
 		 * daemon
 		 * @param[in] port The port of the remote machine through which clients can connect to the rpcapd daemon
@@ -125,7 +127,7 @@ namespace pcpp
 		 * - WinPcap/Npcap encountered an error connecting to the rpcapd daemon on the remote machine or retrieving
 		 * devices on the remote machine
 		 */
-		static std::unique_ptr<PcapRemoteDeviceList> createRemoteDeviceList(const IPAddress& ipAddress, uint16_t port, PcapRemoteAuthentication* remoteAuth);
+		static std::unique_ptr<PcapRemoteDeviceList> createRemoteDeviceList(const IPAddress& ipAddress, uint16_t port, PcapRemoteAuthentication const* remoteAuth);
 
 		/**
 		 * @return The IP address of the remote machine

--- a/Pcap++/header/PcapRemoteDeviceList.h
+++ b/Pcap++/header/PcapRemoteDeviceList.h
@@ -38,10 +38,6 @@ namespace pcpp
 		                     std::shared_ptr<PcapRemoteAuthentication> remoteAuth,
 		                     std::vector<PcapRemoteDevice*> deviceList);
 
-		void setRemoteMachineIpAddress(const IPAddress& ipAddress);
-		void setRemoteMachinePort(uint16_t port);
-		void setRemoteAuthentication(const PcapRemoteAuthentication* remoteAuth);
-
 	public:
 		/**
 		 * Iterator object that can be used for iterating all PcapRemoteDevice in list

--- a/Pcap++/header/PcapRemoteDeviceList.h
+++ b/Pcap++/header/PcapRemoteDeviceList.h
@@ -74,6 +74,25 @@ namespace pcpp
 		static PcapRemoteDeviceList* getRemoteDeviceList(const IPAddress& ipAddress, uint16_t port);
 
 		/**
+		 * A static method for creating a PcapRemoteDeviceList instance for a specific remote machine.
+		 * This methods creates the instance and populates it with PcapRemoteDevice instances.
+		 * Each PcapRemoteDevice instance correspons to a network interface on the remote machine.
+		 * 
+		 * This method overload is for remote daemons which don't require authentication for accessing them. 
+		 * For daemons which do require authentication use the other method overload.
+		 * 
+		 * @param[in] ipAddress The IP address of the remote machine through which clients can connect to the rpcapd
+		 * daemon
+		 * @param[in] port The port of the remote machine through which clients can connect to the rpcapd daemon
+		 * @return A smart pointer to the newly created PcapRemoteDeviceList, or nullptr if (an appropriate error will be printed
+		 * to log in each case):
+		 * - WinPcap/Npcap encountered an error in creating the remote connection string
+		 * - WinPcap/Npcap encountered an error connecting to the rpcapd daemon on the remote machine or retrieving
+		 * devices on the remote machine
+		 */
+		static std::unique_ptr<PcapRemoteDeviceList> createRemoteDeviceList(const IPAddress& ipAddress, uint16_t port);
+
+		/**
 		 * An overload of the previous getRemoteDeviceList() method but with authentication support. This method is suitable for connecting to
 		 * remote daemons which require authentication for accessing them
 		 * @param[in] ipAddress The IP address of the remote machine through which clients can connect to the rpcapd daemon
@@ -86,6 +105,27 @@ namespace pcpp
 		 * - WinPcap/Npcap encountered an error connecting to the rpcapd daemon on the remote machine or retrieving devices on the remote machine
 		 */
 		static PcapRemoteDeviceList* getRemoteDeviceList(const IPAddress& ipAddress, uint16_t port, PcapRemoteAuthentication* remoteAuth);
+
+		/**
+		 * A static method for creating a PcapRemoteDeviceList instance for a specific remote machine.
+		 * This methods creates the instance and populates it with PcapRemoteDevice instances.
+		 * Each PcapRemoteDevice instance correspons to a network interface on the remote machine.
+		 * 
+		 * This method overload is for remote daemons which require authentication for accessing them.
+		 * If no authentication is required, use the other method overload.
+		 * 
+		 * @param[in] ipAddress The IP address of the remote machine through which clients can connect to the rpcapd
+		 * daemon
+		 * @param[in] port The port of the remote machine through which clients can connect to the rpcapd daemon
+		 * @param[in] remoteAuth A pointer to the authentication object which contains the username and password for
+		 * connecting to the remote daemon
+		 * @return A smart pointer to the newly created PcapRemoteDeviceList, or nullptr if (an appropriate error will be printed
+		 * to log in each case):
+		 * - WinPcap/Npcap encountered an error in creating the remote connection string
+		 * - WinPcap/Npcap encountered an error connecting to the rpcapd daemon on the remote machine or retrieving
+		 * devices on the remote machine
+		 */
+		static std::unique_ptr<PcapRemoteDeviceList> createRemoteDeviceList(const IPAddress& ipAddress, uint16_t port, PcapRemoteAuthentication* remoteAuth);
 
 		/**
 		 * @return The IP address of the remote machine

--- a/Pcap++/header/PcapRemoteDeviceList.h
+++ b/Pcap++/header/PcapRemoteDeviceList.h
@@ -44,12 +44,12 @@ namespace pcpp
 		/**
 		 * Iterator object that can be used for iterating all PcapRemoteDevice in list
 		 */
-		typedef typename std::vector<PcapRemoteDevice*>::iterator RemoteDeviceListIterator;
+		using RemoteDeviceListIterator = typename std::vector<PcapRemoteDevice*>::iterator;
 
 		/**
 		 * Const iterator object that can be used for iterating all PcapRemoteDevice in a constant list
 		 */
-		typedef typename std::vector<PcapRemoteDevice*>::const_iterator ConstRemoteDeviceListIterator;
+		using ConstRemoteDeviceListIterator = typename std::vector<PcapRemoteDevice*>::const_iterator;
 
 		PcapRemoteDeviceList(const PcapRemoteDeviceList&) = delete;
 		PcapRemoteDeviceList(PcapRemoteDeviceList&&) noexcept = delete;

--- a/Pcap++/header/PcapRemoteDeviceList.h
+++ b/Pcap++/header/PcapRemoteDeviceList.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include "IpAddress.h"
 #include "PcapRemoteDevice.h"
+#include "DeprecationUtils.h"
 
 /// @file
 
@@ -33,7 +34,7 @@ namespace pcpp
 		uint16_t m_RemoteMachinePort;
 		std::shared_ptr<PcapRemoteAuthentication> m_RemoteAuthentication;
 
-		// private c'tor. User should create the list via static methods PcapRemoteDeviceList::getRemoteDeviceList()
+		// private c'tor. User should create the list via static methods PcapRemoteDeviceList::createRemoteDeviceList()
 		PcapRemoteDeviceList(const IPAddress& ipAddress, uint16_t port,
 		                     std::shared_ptr<PcapRemoteAuthentication> remoteAuth,
 		                     std::vector<PcapRemoteDevice*> deviceList);
@@ -68,7 +69,9 @@ namespace pcpp
 		 * - IP address provided is NULL or not valid
 		 * - WinPcap/Npcap encountered an error in creating the remote connection string
 		 * - WinPcap/Npcap encountered an error connecting to the rpcapd daemon on the remote machine or retrieving devices on the remote machine
+		 * @deprecated This factory function has been deprecated in favor of 'createRemoteDeviceList' factory for better memory safety.
 		 */
+		PCPP_DEPRECATED("Please use 'createRemoteDeviceList' factory method instead.")
 		static PcapRemoteDeviceList* getRemoteDeviceList(const IPAddress& ipAddress, uint16_t port);
 
 		/**
@@ -101,7 +104,9 @@ namespace pcpp
 		 * - IP address provided is NULL or not valid
 		 * - WinPcap/Npcap encountered an error in creating the remote connection string
 		 * - WinPcap/Npcap encountered an error connecting to the rpcapd daemon on the remote machine or retrieving devices on the remote machine
+		 * @deprecated This factory function has been deprecated in favor of 'createRemoteDeviceList' factory for better memory safety.
 		 */
+		PCPP_DEPRECATED("Please use 'createRemoteDeviceList' factory method instead.")
 		static PcapRemoteDeviceList* getRemoteDeviceList(const IPAddress& ipAddress, uint16_t port, PcapRemoteAuthentication* remoteAuth);
 
 		/**

--- a/Pcap++/src/PcapRemoteDeviceList.cpp
+++ b/Pcap++/src/PcapRemoteDeviceList.cpp
@@ -74,14 +74,14 @@ PcapRemoteDeviceList* PcapRemoteDeviceList::getRemoteDeviceList(const IPAddress&
 
 std::unique_ptr<PcapRemoteDeviceList> PcapRemoteDeviceList::createRemoteDeviceList(const IPAddress& ipAddress, uint16_t port, PcapRemoteAuthentication const* remoteAuth)
 {
-	std::shared_ptr<PcapRemoteAuthentication> remoteAuthCopy;
+	std::shared_ptr<PcapRemoteAuthentication> pRemoteAuthCopy;
 	pcap_rmtauth* pRmAuth = nullptr;
 	pcap_rmtauth rmAuth;
 	if (remoteAuth != nullptr)
 	{
 		PCPP_LOG_DEBUG("Authentication requested. Username: " << remoteAuth->userName << ", Password: " << remoteAuth->password);
-		remoteAuthCopy = std::make_shared<PcapRemoteAuthentication>(*remoteAuth);
-		rmAuth = remoteAuthCopy->getPcapRmAuth();
+		pRemoteAuthCopy = std::make_shared<PcapRemoteAuthentication>(*remoteAuth);
+		rmAuth = pRemoteAuthCopy->getPcapRmAuth();
 		pRmAuth = &rmAuth;
 	}
 
@@ -101,7 +101,7 @@ std::unique_ptr<PcapRemoteDeviceList> PcapRemoteDeviceList::createRemoteDeviceLi
 	{
 		for (pcap_if_t* currInterface = interfaceList.get(); currInterface != nullptr; currInterface = currInterface->next)
 		{
-			auto pNewRemoteDevice = std::unique_ptr<PcapRemoteDevice>(new PcapRemoteDevice(currInterface, remoteAuthCopy, ipAddress, port));
+			auto pNewRemoteDevice = std::unique_ptr<PcapRemoteDevice>(new PcapRemoteDevice(currInterface, pRemoteAuthCopy, ipAddress, port));
 			// Release is called after pushback to prevent memory leaks if vector reallocation fails.
 			// cppcheck-suppress danglingLifetime
 			devices.push_back(pNewRemoteDevice.get());
@@ -118,7 +118,7 @@ std::unique_ptr<PcapRemoteDeviceList> PcapRemoteDeviceList::createRemoteDeviceLi
 		return nullptr;
 	}
 
-	return std::unique_ptr<PcapRemoteDeviceList>(new PcapRemoteDeviceList(ipAddress, port, remoteAuthCopy, devices));
+	return std::unique_ptr<PcapRemoteDeviceList>(new PcapRemoteDeviceList(ipAddress, port, pRemoteAuthCopy, devices));
 }
 
 PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(const std::string& ipAddrAsString) const

--- a/Pcap++/src/PcapRemoteDeviceList.cpp
+++ b/Pcap++/src/PcapRemoteDeviceList.cpp
@@ -110,9 +110,9 @@ std::unique_ptr<PcapRemoteDeviceList> PcapRemoteDeviceList::createRemoteDeviceLi
 	}
 	catch (const std::exception& e)
 	{
-		for (auto dev : devices)
+		for (auto device : devices)
 		{
-			delete dev;
+			delete device;
 		}
 		PCPP_LOG_ERROR("Error creating remote devices: " << e.what());
 		return nullptr;

--- a/Pcap++/src/PcapRemoteDeviceList.cpp
+++ b/Pcap++/src/PcapRemoteDeviceList.cpp
@@ -220,26 +220,6 @@ PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(const IPv6Address& i
 
 }
 
-void PcapRemoteDeviceList::setRemoteMachineIpAddress(const IPAddress& ipAddress)
-{
-	m_RemoteMachineIpAddress = ipAddress;
-}
-
-void PcapRemoteDeviceList::setRemoteMachinePort(uint16_t port)
-{
-	m_RemoteMachinePort = port;
-}
-
-void PcapRemoteDeviceList::setRemoteAuthentication(const PcapRemoteAuthentication* remoteAuth)
-{
-	if (remoteAuth != nullptr)
-		m_RemoteAuthentication = std::shared_ptr<PcapRemoteAuthentication>(new PcapRemoteAuthentication(*remoteAuth));
-	else
-	{
-		m_RemoteAuthentication = nullptr;
-	}
-}
-
 PcapRemoteDeviceList::~PcapRemoteDeviceList()
 {
 	while (m_RemoteDeviceList.size() > 0)

--- a/Pcap++/src/PcapRemoteDeviceList.cpp
+++ b/Pcap++/src/PcapRemoteDeviceList.cpp
@@ -50,10 +50,22 @@ namespace pcpp
 
 PcapRemoteDeviceList* PcapRemoteDeviceList::getRemoteDeviceList(const IPAddress& ipAddress, uint16_t port)
 {
-	return PcapRemoteDeviceList::getRemoteDeviceList(ipAddress, port, NULL);
+	auto result = PcapRemoteDeviceList::createRemoteDeviceList(ipAddress, port);
+	return result.release();
+}
+
+std::unique_ptr<PcapRemoteDeviceList> PcapRemoteDeviceList::createRemoteDeviceList(const IPAddress& ipAddress, uint16_t port)
+{
+	return PcapRemoteDeviceList::createRemoteDeviceList(ipAddress, port, nullptr);
 }
 
 PcapRemoteDeviceList* PcapRemoteDeviceList::getRemoteDeviceList(const IPAddress& ipAddress, uint16_t port, PcapRemoteAuthentication* remoteAuth)
+{
+	auto result = PcapRemoteDeviceList::createRemoteDeviceList(ipAddress, port, remoteAuth);
+	return result.release();
+}
+
+std::unique_ptr<PcapRemoteDeviceList> PcapRemoteDeviceList::createRemoteDeviceList(const IPAddress& ipAddress, uint16_t port, PcapRemoteAuthentication* remoteAuth)
 {
 	pcap_rmtauth* pRmAuth = nullptr;
 	pcap_rmtauth rmAuth;
@@ -75,7 +87,7 @@ PcapRemoteDeviceList* PcapRemoteDeviceList::getRemoteDeviceList(const IPAddress&
 		return nullptr;
 	}
 
-	PcapRemoteDeviceList* resultList = new PcapRemoteDeviceList();
+	std::unique_ptr<PcapRemoteDeviceList> resultList = std::unique_ptr<PcapRemoteDeviceList>(new PcapRemoteDeviceList());
 	resultList->setRemoteMachineIpAddress(ipAddress);
 	resultList->setRemoteMachinePort(port);
 	resultList->setRemoteAuthentication(remoteAuth);

--- a/Pcap++/src/PcapRemoteDeviceList.cpp
+++ b/Pcap++/src/PcapRemoteDeviceList.cpp
@@ -48,6 +48,13 @@ namespace pcpp
 		}
 	}
 
+PcapRemoteDeviceList::PcapRemoteDeviceList(const IPAddress& ipAddress, uint16_t port, std::shared_ptr<PcapRemoteAuthentication> remoteAuth, std::vector<PcapRemoteDevice*> deviceList)
+	: m_RemoteDeviceList(std::move(deviceList))
+	, m_RemoteMachineIpAddress(ipAddress)
+	, m_RemoteMachinePort(port)
+	, m_RemoteAuthentication(std::move(remoteAuth))
+{}
+
 PcapRemoteDeviceList* PcapRemoteDeviceList::getRemoteDeviceList(const IPAddress& ipAddress, uint16_t port)
 {
 	auto result = PcapRemoteDeviceList::createRemoteDeviceList(ipAddress, port);
@@ -65,14 +72,16 @@ PcapRemoteDeviceList* PcapRemoteDeviceList::getRemoteDeviceList(const IPAddress&
 	return result.release();
 }
 
-std::unique_ptr<PcapRemoteDeviceList> PcapRemoteDeviceList::createRemoteDeviceList(const IPAddress& ipAddress, uint16_t port, PcapRemoteAuthentication* remoteAuth)
+std::unique_ptr<PcapRemoteDeviceList> PcapRemoteDeviceList::createRemoteDeviceList(const IPAddress& ipAddress, uint16_t port, PcapRemoteAuthentication const* remoteAuth)
 {
+	std::shared_ptr<PcapRemoteAuthentication> sRemoteAuth;
 	pcap_rmtauth* pRmAuth = nullptr;
 	pcap_rmtauth rmAuth;
 	if (remoteAuth != nullptr)
 	{
 		PCPP_LOG_DEBUG("Authentication requested. Username: " << remoteAuth->userName << ", Password: " << remoteAuth->password);
-		rmAuth = remoteAuth->getPcapRmAuth();
+		sRemoteAuth = std::make_shared<PcapRemoteAuthentication>(*remoteAuth);
+		rmAuth = sRemoteAuth->getPcapRmAuth();
 		pRmAuth = &rmAuth;
 	}
 
@@ -87,20 +96,29 @@ std::unique_ptr<PcapRemoteDeviceList> PcapRemoteDeviceList::createRemoteDeviceLi
 		return nullptr;
 	}
 
-	std::unique_ptr<PcapRemoteDeviceList> resultList = std::unique_ptr<PcapRemoteDeviceList>(new PcapRemoteDeviceList());
-	resultList->setRemoteMachineIpAddress(ipAddress);
-	resultList->setRemoteMachinePort(port);
-	resultList->setRemoteAuthentication(remoteAuth);
-
-
-	for (pcap_if_t* currInterface = interfaceList.get(); currInterface != nullptr; currInterface = currInterface->next)
+	std::vector<PcapRemoteDevice*> devices;
+	try
 	{
-		PcapRemoteDevice* pNewRemoteDevice = new PcapRemoteDevice(currInterface, resultList->m_RemoteAuthentication,
-				resultList->getRemoteMachineIpAddress(), resultList->getRemoteMachinePort());
-		resultList->m_RemoteDeviceList.push_back(pNewRemoteDevice);
+		for (pcap_if_t* currInterface = interfaceList.get(); currInterface != nullptr; currInterface = currInterface->next)
+		{
+			auto pNewRemoteDevice = std::unique_ptr<PcapRemoteDevice>(new PcapRemoteDevice(currInterface, sRemoteAuth, ipAddress, port));
+			// Release is called after pushback to prevent memory leaks if vector reallocation fails.
+			// cppcheck-suppress danglingLifetime
+			devices.push_back(pNewRemoteDevice.get());
+			pNewRemoteDevice.release();
+		}
+	}
+	catch (const std::exception& e)
+	{
+		for (auto dev : devices)
+		{
+			delete dev;
+		}
+		PCPP_LOG_ERROR("Error creating remote devices: " << e.what());
+		return nullptr;
 	}
 
-	return resultList;
+	return std::unique_ptr<PcapRemoteDeviceList>(new PcapRemoteDeviceList(ipAddress, port, sRemoteAuth, devices));
 }
 
 PcapRemoteDevice* PcapRemoteDeviceList::getRemoteDeviceByIP(const std::string& ipAddrAsString) const


### PR DESCRIPTION
Part of #1431. implements point 6.

- Added a new factory function `createRemoteDeviceList` with overloads with/without authentication returning `unique_ptr`.
- Deprecated the old `getRemoteDeviceList` due to the functions returning raw pointers.
- Removed default constructor of `PcapRemoteDeviceList`
- Added parameterized constructor to `PcapRemoteDeviceList` for detailed initialization.
- Removed unused private methods:
  - `setRemoteMachineIpAddress`
  - `setRemoteMachinePort`
  - `setRemoteAuthentication`
- Changed typedefs to Cpp11 standard.
- Typo fixes