### PR TITLE
cmake: use Ccache if it's available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,16 @@ pcapp_detect_compiler(PCAPPP_TARGET)
 # Get architecture
 target_architecture(PCAPP_TARGET_ARCHITECTURE)
 
+# Use Ccache if available
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  message(STATUS "Ccache found!")
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${CCACHE_PROGRAM}")
+else()
+  message(STATUS "Ccache not found!")
+endif()
+
 # LINUX is set Only since 3.25 see: https://cmake.org/cmake/help/latest/variable/LINUX.html
 if(UNIX
    AND NOT APPLE


### PR DESCRIPTION
If ccache tool is available use it for both compiling and linking

I will introduce in another MR the save/restore of the ccache database for github ci runners