### PR TITLE
Dependabot add "groups"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     target-branch: "dev"
     labels:
     - "automated-pr"
+    group:
+      name: "GitHub Actions"
+      package-ecosystem: "github-actions"
 
   - package-ecosystem: "pip"
     directories:
@@ -17,3 +20,6 @@ updates:
     target-branch: "dev"
     labels:
     - "automated-pr"
+    group:
+      name: "pip updates"
+      package-ecosystem: "pip"


### PR DESCRIPTION
To improve PR request efficiency, create groups for dependabot.