### PR TITLE
Fix bugs in `hash5Tuple`

### DIFF
--- a/Packet++/src/PacketUtils.cpp
+++ b/Packet++/src/PacketUtils.cpp
@@ -181,7 +181,7 @@ uint32_t hash5Tuple(Packet* packet, bool const& directionUnique)
 	IPv4Layer* ipv4Layer = packet->getLayerOfType<IPv4Layer>();
 	if (ipv4Layer != nullptr)
 	{
-		if (portSrc == portDst && ipv4Layer->getIPv4Header()->ipDst < ipv4Layer->getIPv4Header()->ipSrc)
+		if (!directionUnique && portSrc == portDst && ipv4Layer->getIPv4Header()->ipDst < ipv4Layer->getIPv4Header()->ipSrc)
 			srcPosition = 1;
 
 		vec[2 + srcPosition].buffer = (uint8_t*)&ipv4Layer->getIPv4Header()->ipSrc;
@@ -194,7 +194,7 @@ uint32_t hash5Tuple(Packet* packet, bool const& directionUnique)
 	else
 	{
 		IPv6Layer* ipv6Layer = packet->getLayerOfType<IPv6Layer>();
-		if (portSrc == portDst && (uint64_t)ipv6Layer->getIPv6Header()->ipDst < (uint64_t)ipv6Layer->getIPv6Header()->ipSrc)
+		if (!directionUnique && portSrc == portDst && memcmp(ipv6Layer->getIPv6Header()->ipDst, ipv6Layer->getIPv6Header()->ipSrc, 16) < 0)
 			srcPosition = 1;
 
 		vec[2 + srcPosition].buffer = ipv6Layer->getIPv6Header()->ipSrc;
@@ -232,8 +232,7 @@ uint32_t hash2Tuple(Packet* packet)
 	{
 		IPv6Layer* ipv6Layer = packet->getLayerOfType<IPv6Layer>();
 		int srcPosition = 0;
-		if ((uint64_t)ipv6Layer->getIPv6Header()->ipDst < (uint64_t)ipv6Layer->getIPv6Header()->ipSrc
-				&& (uint64_t)(ipv6Layer->getIPv6Header()->ipDst+8) < (uint64_t)(ipv6Layer->getIPv6Header()->ipSrc+8))
+		if (memcmp(ipv6Layer->getIPv6Header()->ipDst, ipv6Layer->getIPv6Header()->ipSrc, 16) < 0)
 			srcPosition = 1;
 
 		vec[0 + srcPosition].buffer = ipv6Layer->getIPv6Header()->ipSrc;

--- a/Tests/Packet++Test/Tests/PacketUtilsTests.cpp
+++ b/Tests/Packet++Test/Tests/PacketUtilsTests.cpp
@@ -97,6 +97,15 @@ PTF_TEST_CASE(PacketUtilsHash5TupleTcp)
 	PTF_ASSERT_EQUAL(pcpp::hash5Tuple(&dstSrcPacket, false), 1576639238 );
 	PTF_ASSERT_EQUAL(pcpp::hash5Tuple(&dstSrcPacket, true), 1576639238 );
 
+	tcpLayer.getTcpHeader()->portDst = 80;
+	tcpLayer.getTcpHeader()->portSrc = 80;
+
+	tcpLayer2.getTcpHeader()->portDst = 80;
+	tcpLayer2.getTcpHeader()->portSrc = 80;
+
+	PTF_ASSERT_EQUAL(pcpp::hash5Tuple(&srcDstPacket), pcpp::hash5Tuple(&dstSrcPacket));
+	PTF_ASSERT_NOT_EQUAL(pcpp::hash5Tuple(&srcDstPacket,true), pcpp::hash5Tuple(&dstSrcPacket,true));
+
 } // PacketUtilsHash5TupleTcp
 
 
@@ -132,5 +141,14 @@ PTF_TEST_CASE(PacketUtilsHash5TupleIPv6)
 	PTF_ASSERT_EQUAL(pcpp::hash5Tuple(&srcDstPacket, true), 2229527039);
 	PTF_ASSERT_EQUAL(pcpp::hash5Tuple(&dstSrcPacket, false), 4288746927);
 	PTF_ASSERT_EQUAL(pcpp::hash5Tuple(&dstSrcPacket, true), 4288746927);
+
+	udpLayer.getUdpHeader()->portDst = 80;
+	udpLayer.getUdpHeader()->portSrc = 80;
+
+	udpLayer2.getUdpHeader()->portDst = 80;
+	udpLayer2.getUdpHeader()->portSrc = 80;
+
+	PTF_ASSERT_EQUAL(pcpp::hash5Tuple(&srcDstPacket), pcpp::hash5Tuple(&dstSrcPacket));
+	PTF_ASSERT_NOT_EQUAL(pcpp::hash5Tuple(&srcDstPacket, true), pcpp::hash5Tuple(&dstSrcPacket, true));
 
 } // PacketUtilsHash5TupleIPv6


### PR DESCRIPTION
Fixes #1447 

1. Add directionUnique condition.
2. Use `memcmp` function to compare source and destination IPv6 addresses.