### PR TITLE
Added overload to getAndDetach that accepts a constant reference.

### DIFF
--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -285,6 +285,18 @@ namespace pcpp
 		}
 
 		/**
+		 * Removes an element from the vector and transfers ownership to the returned unique pointer.
+		 * @param[in] position An iterator pointing to the element to detach.
+		 * @return An unique pointer that holds ownership of the detached element.
+		 */
+		std::unique_ptr<T> getAndDetach(VectorIterator const& position)
+		{
+			std::unique_ptr<T> result(*position);
+			m_Vector.erase(position);
+			return result;
+		}
+
+		/**
 		 * Return a pointer to the element in a certain index
 		 * @param[in] index The index to retrieve the element from
 		 * @return The element at the specified position in the vector


### PR DESCRIPTION
This PR addresses the issue of values being unable to be detached from an iterator temporary.

Example code: ```pVector.getAndDetach(pVector.begin())```