### PR TITLE
Add NDK version to `app/build.gradle` in Android CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -649,7 +649,6 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # master
         with:
           repository: seladb/ToyVpn-PcapPlusPlus
-          ref: update-ndk
           path: ./ToyVpn-PcapPlusPlus
           submodules: true
 
@@ -670,6 +669,8 @@ jobs:
         working-directory: ./ToyVpn-PcapPlusPlus
         run: |
           sed -i.bak "s|abiFilters.*$|abiFilters '${{ matrix.target }}'|g" app/build.gradle
+          NDK_VERSION=$(echo "$ANDROID_NDK" | awk -F'/' '{print $NF}')
+          sed -i "/defaultConfig {/a \\n        ndkVersion \"$NDK_VERSION\"" app/build.gradle
           chmod +x gradlew
           ./gradlew assembleDebug
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -672,7 +672,8 @@ jobs:
           sed -i.bak "s|abiFilters.*$|abiFilters '${{ matrix.target }}'|g" app/build.gradle
           if [[ "${{ matrix.run-on-os }}" == "macos"* ]]; then
               sed -i.bak "/defaultConfig {/a\\
-                  ndkVersion \"$NDK_VERSION\"" app/build.gradle
+                  ndkVersion \"$NDK_VERSION\"
+              " app/build.gradle
           else
               sed -i "/defaultConfig {/a\\        ndkVersion \"$NDK_VERSION\"" app/build.gradle
           fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -670,7 +670,7 @@ jobs:
         run: |
           NDK_VERSION=$(echo "$ANDROID_NDK" | awk -F'/' '{print $NF}')
           sed -i.bak "s|abiFilters.*$|abiFilters '${{ matrix.target }}'|g" app/build.gradle
-          sed -i.bak "/defaultConfig {/a \        ndkVersion \"$NDK_VERSION\"" app/build.gradle
+          sed -i.bak "/defaultConfig {/a\        ndkVersion \"$NDK_VERSION\"" app/build.gradle
           chmod +x gradlew
           ./gradlew assembleDebug
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -670,7 +670,12 @@ jobs:
         run: |
           NDK_VERSION=$(echo "$ANDROID_NDK" | awk -F'/' '{print $NF}')
           sed -i.bak "s|abiFilters.*$|abiFilters '${{ matrix.target }}'|g" app/build.gradle
-          sed -i.bak "/defaultConfig {/a\        ndkVersion \"$NDK_VERSION\"" app/build.gradle
+          if [[ "${{ matrix.run-on-os }}" == "macos"* ]]; then
+              sed -i.bak "/defaultConfig {/a\\
+                  ndkVersion \"$NDK_VERSION\"" app/build.gradle
+          else
+              sed -i "/defaultConfig {/a\\        ndkVersion \"$NDK_VERSION\"" app/build.gradle
+          fi
           chmod +x gradlew
           ./gradlew assembleDebug
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -668,9 +668,9 @@ jobs:
       - name: Build ToyVpn-PcapPlusPlus
         working-directory: ./ToyVpn-PcapPlusPlus
         run: |
-          sed -i.bak "s|abiFilters.*$|abiFilters '${{ matrix.target }}'|g" app/build.gradle
           NDK_VERSION=$(echo "$ANDROID_NDK" | awk -F'/' '{print $NF}')
-          sed -i "/defaultConfig {/a \\n        ndkVersion \"$NDK_VERSION\"" app/build.gradle
+          sed -i.bak "s|abiFilters.*$|abiFilters '${{ matrix.target }}'|g" app/build.gradle
+          sed -i.bak "/defaultConfig {/a \        ndkVersion \"$NDK_VERSION\"" app/build.gradle
           chmod +x gradlew
           ./gradlew assembleDebug
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -649,6 +649,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # master
         with:
           repository: seladb/ToyVpn-PcapPlusPlus
+          ref: update-ndk
           path: ./ToyVpn-PcapPlusPlus
           submodules: true
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -378,16 +378,16 @@ jobs:
           python3 -m pip install gcovr
           gcovr -v -r . $GCOVR_FLAGS -o coverage.xml
 
-      - name: Upload Coverage Results
-        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
-        if: ${{ matrix.host-arch == matrix.arch }}
-        with:
-          files: ./coverage.xml
-          flags: ${{ matrix.os-version }},unittest
-          fail_ci_if_error: false
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      # - name: Upload Coverage Results
+      #   uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
+      #   if: ${{ matrix.host-arch == matrix.arch }}
+      #   with:
+      #     files: ./coverage.xml
+      #     flags: ${{ matrix.os-version }},unittest
+      #     fail_ci_if_error: false
+      #     verbose: true
+      #   env:
+      #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Save Ccache
         uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2


### PR DESCRIPTION
I think there was a change in GitHub Actions runners which upgraded the NDK version, and created some conflicts between different NDK versions installed on the runners.

This PR pins the default NDK version installed on the runner in `app/build.gradle` to avoid these conflicts.

It adds the following line to the file:
```groovy
android {
    compileSdkVersion 30
    buildToolsVersion "30.0.3"

    defaultConfig {
        ndkVersion "27.0.12077973" // <== this line is added
        applicationId "com.example.android.toyvpn"
        ...
    }
```

In addition this PR disables sending codecov reports on macOS because they started failing. Hopefully [this PR](https://github.com/seladb/PcapPlusPlus/pull/1524) should fix it.