### PR TITLE
Fix LightPcapNg timestamp calculation

### DIFF
--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
@@ -422,7 +422,7 @@ int light_get_next_packet(light_pcapng_t *pcapng, light_packet_header *packet_he
 			timestamp = timestamp << 32;
 			timestamp += epb->timestamp_low;
 			uint64_t ticks_per_sec = pcapng->file_info->timestamp_ticks_per_second[epb->interface_id];
-			uint64_t packet_secs = timestamp / ticks_per_sec;
+			uint64_t packet_secs = (ticks_per_sec != 0 ?  timestamp / ticks_per_sec : 0);
 			uint64_t ticks = timestamp % ticks_per_sec;
 			if (packet_secs <= MAXIMUM_PACKET_SECONDS_VALUE)
 			{

--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
@@ -423,9 +423,9 @@ int light_get_next_packet(light_pcapng_t *pcapng, light_packet_header *packet_he
 			timestamp += epb->timestamp_low;
 			uint64_t ticks_per_sec = pcapng->file_info->timestamp_ticks_per_second[epb->interface_id];
 			uint64_t packet_secs = (ticks_per_sec != 0 ?  timestamp / ticks_per_sec : 0);
-			uint64_t ticks = timestamp % ticks_per_sec;
-			if (packet_secs <= MAXIMUM_PACKET_SECONDS_VALUE)
+			if (packet_secs <= MAXIMUM_PACKET_SECONDS_VALUE && packet_secs != 0)
 			{
+				uint64_t ticks = timestamp % ticks_per_sec;
 				packet_header->timestamp.tv_sec = packet_secs;
 				packet_header->timestamp.tv_nsec = (1000000000ul * ticks) / ticks_per_sec;
 			}


### PR DESCRIPTION
The change introduced in this PR: https://github.com/seladb/PcapPlusPlus/pull/1514
Doesn't take into account cases where `ticks_per_sec` is zero. This PR fixes it