### PR TITLE
Removed dead code from PcapRemoteDevice.

### DIFF
--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -52,9 +52,6 @@ namespace pcpp
 	 */
 	using OnStatsUpdateCallback = std::function<void(IPcapDevice::PcapStats&, void*)>;
 
-	// for internal use only
-	typedef void* (*ThreadStart)(void*);
-
 	/**
 	 * @class PcapLiveDevice
 	 * A class that wraps a network interface (each of the interfaces listed in ifconfig/ipconfig).

--- a/Pcap++/header/PcapRemoteDevice.h
+++ b/Pcap++/header/PcapRemoteDevice.h
@@ -97,11 +97,6 @@ namespace pcpp
 		PcapRemoteDevice(pcap_if_t* iface, std::shared_ptr<PcapRemoteAuthentication> remoteAuthentication,
 		                 const IPAddress& remoteMachineIP, uint16_t remoteMachinePort);
 
-		static void* remoteDeviceCaptureThreadMain(void* ptr);
-
-		// overridden methods
-		ThreadStart getCaptureThreadStart();
-
 	public:
 		PcapRemoteDevice(const PcapRemoteDevice&) = delete;
 		PcapRemoteDevice(PcapRemoteDevice&&) noexcept = delete;

--- a/Pcap++/src/PcapRemoteDevice.cpp
+++ b/Pcap++/src/PcapRemoteDevice.cpp
@@ -70,45 +70,6 @@ namespace pcpp
 		return true;
 	}
 
-	void* PcapRemoteDevice::remoteDeviceCaptureThreadMain(void* ptr)
-	{
-		PcapRemoteDevice* pThis = static_cast<PcapRemoteDevice*>(ptr);
-		if (pThis == nullptr)
-		{
-			PCPP_LOG_ERROR("Capture thread: Unable to extract PcapLiveDevice instance");
-			return 0;
-		}
-
-		PCPP_LOG_DEBUG("Started capture thread for device '" << pThis->m_Name << "'");
-
-		pcap_pkthdr* pkthdr;
-		const uint8_t* pktData;
-
-		if (pThis->m_CaptureCallbackMode)
-		{
-			while (!pThis->m_StopThread)
-			{
-				if (pcap_next_ex(pThis->m_PcapDescriptor, &pkthdr, &pktData) > 0)
-					onPacketArrives(reinterpret_cast<uint8_t*>(pThis), pkthdr, pktData);
-			}
-		}
-		else
-		{
-			while (!pThis->m_StopThread)
-			{
-				if (pcap_next_ex(pThis->m_PcapDescriptor, &pkthdr, &pktData) > 0)
-					onPacketArrivesNoCallback(reinterpret_cast<uint8_t*>(pThis), pkthdr, pktData);
-			}
-		}
-		PCPP_LOG_DEBUG("Ended capture thread for device '" << pThis->m_Name << "'");
-		return 0;
-	}
-
-	ThreadStart PcapRemoteDevice::getCaptureThreadStart()
-	{
-		return &remoteDeviceCaptureThreadMain;
-	}
-
 	void PcapRemoteDevice::getStatistics(PcapStats& stats) const
 	{
 		int allocatedMemory;


### PR DESCRIPTION
`ThreadStart`, `remoteDeviceCaptureThreadMain` and `getCaptureThreadStart` are artifacts left over from previous refactor.

`PcapLiveDevice` currently handles all capture through `pcap_dispatch` in `PcapLiveDevice::captureThreadMain`.