### PR TITLE
Parse ASN.1 root record in x509 certificates

### DIFF
--- a/Packet++/header/SSLHandshake.h
+++ b/Packet++/header/SSLHandshake.h
@@ -3,6 +3,7 @@
 #include <utility>
 #include "SSLCommon.h"
 #include "PointerVector.h"
+#include "Asn1Codec.h"
 
 /**
  * @file
@@ -302,6 +303,12 @@ namespace pcpp
 		}
 
 		/**
+		 * @return The root ASN.1 record of the certificate data. All of the certificate data will be under this record.
+		 * If the Root ASN.1 record is malformed, an exception is thrown
+		 */
+		Asn1SequenceRecord* getRootAsn1Record();
+
+		/**
 		 * Certificate messages usually spread on more than 1 packet. So a certificate is likely to split between 2
 		 * packets or more. This method provides an indication whether all certificate data exists or only part of it
 		 * @return True if this data contains all certificate data, false otherwise
@@ -312,6 +319,7 @@ namespace pcpp
 		}
 
 	private:
+		std::unique_ptr<Asn1Record> m_Asn1Record;
 		uint8_t* m_Data;
 		size_t m_DataLen;
 		bool m_AllDataExists;

--- a/Packet++/src/SSLHandshake.cpp
+++ b/Packet++/src/SSLHandshake.cpp
@@ -1216,6 +1216,20 @@ namespace pcpp
 		return result;
 	}
 
+	// --------------------------
+	// SSLx509Certificate methods
+	// --------------------------
+
+	Asn1SequenceRecord* SSLx509Certificate::getRootAsn1Record()
+	{
+		if (m_Asn1Record == nullptr)
+		{
+			m_Asn1Record = Asn1Record::decode(m_Data, m_DataLen);
+		}
+
+		return m_Asn1Record->castAs<Asn1SequenceRecord>();
+	}
+
 	// ---------------------------
 	// SSLHandshakeMessage methods
 	// ---------------------------

--- a/Tests/Packet++Test/Tests/SSLTests.cpp
+++ b/Tests/Packet++Test/Tests/SSLTests.cpp
@@ -353,6 +353,10 @@ PTF_TEST_CASE(SSLMultipleRecordParsing3Test)
 	PTF_ASSERT_TRUE(pos != std::string::npos);
 	pos = certBuffer.find("Internal Development CA");
 	PTF_ASSERT_EQUAL(pos, std::string::npos, ptr);
+	auto asn1Record = cert->getRootAsn1Record();
+	PTF_ASSERT_NOT_NULL(asn1Record);
+	PTF_ASSERT_EQUAL(asn1Record->getSubRecords().size(), 3);
+
 	cert = certMsg->getCertificate(1);
 	PTF_ASSERT_NOT_NULL(cert);
 	PTF_ASSERT_TRUE(cert->allDataExists());
@@ -360,6 +364,7 @@ PTF_TEST_CASE(SSLMultipleRecordParsing3Test)
 	certBuffer = std::string(cert->getData(), cert->getData() + cert->getDataLength());
 	pos = certBuffer.find("Internal Development CA");
 	PTF_ASSERT_TRUE(pos != std::string::npos);
+
 	cert = certMsg->getCertificate(2);
 	PTF_ASSERT_NOT_NULL(cert);
 	PTF_ASSERT_TRUE(cert->allDataExists());


### PR DESCRIPTION
In the future we might add code to parse the entire certificate data, but for now we only parse the root record, which allows access to all the sub-records to get the (raw) data