### PR TITLE
Disable jobs of old pushes to speed up PR runners

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,6 +15,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   doxygen:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+I am a tiny little change
 <div align="center">
 
 [![PcapPlusPlus Logo](https://pcapplusplus.github.io/img/logo/logo_color.png)](https://pcapplusplus.github.io)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-I am a tiny little change
+
 <div align="center">
 
 [![PcapPlusPlus Logo](https://pcapplusplus.github.io/img/logo/logo_color.png)](https://pcapplusplus.github.io)


### PR DESCRIPTION
With this change, runners from old commits will be automatically cancelled if there is a newer commit to release CI resources