### PR TITLE
Cleaned up Layer destructors.

### DIFF
--- a/Packet++/header/ArpLayer.h
+++ b/Packet++/header/ArpLayer.h
@@ -84,9 +84,6 @@ namespace pcpp
 		ArpLayer(ArpOpcode opCode, const MacAddress& senderMacAddr, const MacAddress& targetMacAddr,
 		         const IPv4Address& senderIpAddr, const IPv4Address& targetIpAddr);
 
-		~ArpLayer()
-		{}
-
 		/**
 		 * Get a pointer to the ARP header. Notice this points directly to the data, so every change will change the
 		 * actual packet data

--- a/Packet++/header/CotpLayer.h
+++ b/Packet++/header/CotpLayer.h
@@ -48,9 +48,6 @@ namespace pcpp
 		 */
 		explicit CotpLayer(uint8_t tpduNumber);
 
-		virtual ~CotpLayer()
-		{}
-
 		/**
 		 * @return COTP length
 		 */

--- a/Packet++/header/DhcpLayer.h
+++ b/Packet++/header/DhcpLayer.h
@@ -638,12 +638,6 @@ namespace pcpp
 		DhcpLayer();
 
 		/**
-		 * A destructor for this layer
-		 */
-		virtual ~DhcpLayer()
-		{}
-
-		/**
 		 * Get a pointer to the DHCP header. Notice this points directly to the data, so every change will change the
 		 * actual packet data
 		 * @return A pointer to the @ref dhcp_header

--- a/Packet++/header/DnsLayer.h
+++ b/Packet++/header/DnsLayer.h
@@ -125,7 +125,7 @@ namespace pcpp
 		 */
 		DnsLayer& operator=(const DnsLayer& other);
 
-		virtual ~DnsLayer();
+		~DnsLayer() override;
 
 		/**
 		 * Get a pointer to the DNS header (as opposed to the DNS data which is the queries, answers, etc. Data can be

--- a/Packet++/header/EthDot3Layer.h
+++ b/Packet++/header/EthDot3Layer.h
@@ -67,9 +67,6 @@ namespace pcpp
 		 */
 		EthDot3Layer(const MacAddress& sourceMac, const MacAddress& destMac, uint16_t length);
 
-		~EthDot3Layer()
-		{}
-
 		/**
 		 * Get a pointer to the Ethernet header. Notice this points directly to the data, so every change will change
 		 * the actual packet data

--- a/Packet++/header/EthLayer.h
+++ b/Packet++/header/EthLayer.h
@@ -105,9 +105,6 @@ namespace pcpp
 		 */
 		EthLayer(const MacAddress& sourceMac, const MacAddress& destMac, uint16_t etherType = 0);
 
-		~EthLayer()
-		{}
-
 		/**
 		 * Get a pointer to the Ethernet header. Notice this points directly to the data, so every change will change
 		 * the actual packet data

--- a/Packet++/header/GreLayer.h
+++ b/Packet++/header/GreLayer.h
@@ -104,9 +104,6 @@ namespace pcpp
 	class GreLayer : public Layer
 	{
 	public:
-		virtual ~GreLayer()
-		{}
-
 		/**
 		 * A static method that determines the GRE version of GRE layer raw data by looking at the
 		 * gre_basic_header#version field
@@ -425,9 +422,6 @@ namespace pcpp
 		 * @param[in] control Control field
 		 */
 		PPP_PPTPLayer(uint8_t address, uint8_t control);
-
-		~PPP_PPTPLayer()
-		{}
 
 		/**
 		 * Get a pointer to the PPP-PPTP header. Notice this points directly to the data, so every change will change

--- a/Packet++/header/GtpLayer.h
+++ b/Packet++/header/GtpLayer.h
@@ -307,9 +307,6 @@ namespace pcpp
 			GtpExtension getNextExtension() const;
 		};  // GtpExtension
 
-		virtual ~GtpV1Layer()
-		{}
-
 		/** A constructor that creates the layer from an existing packet raw data
 		 * @param[in] data A pointer to the raw data
 		 * @param[in] dataLen Size of the data in bytes

--- a/Packet++/header/IPv6Layer.h
+++ b/Packet++/header/IPv6Layer.h
@@ -83,7 +83,7 @@ namespace pcpp
 		/**
 		 * A destructor for this layer
 		 */
-		~IPv6Layer();
+		~IPv6Layer() override;
 
 		/**
 		 * An assignment operator that first delete all data from current layer and then copy the entire header from the

--- a/Packet++/header/IcmpLayer.h
+++ b/Packet++/header/IcmpLayer.h
@@ -396,9 +396,6 @@ namespace pcpp
 		 */
 		IcmpLayer();
 
-		virtual ~IcmpLayer()
-		{}
-
 		/**
 		 * Get a pointer to the basic ICMP header. Notice this points directly to the data, so every change will change
 		 * the actual packet data

--- a/Packet++/header/IcmpV6Layer.h
+++ b/Packet++/header/IcmpV6Layer.h
@@ -154,9 +154,6 @@ namespace pcpp
 		 */
 		IcmpV6Layer(ICMPv6MessageType msgType, uint8_t code, const uint8_t* data, size_t dataLen);
 
-		virtual ~IcmpV6Layer()
-		{}
-
 		/**
 		 * A static method that creates an ICMPv6 layer from packet raw data
 		 * @param[in] data A pointer to the raw data

--- a/Packet++/header/IgmpLayer.h
+++ b/Packet++/header/IgmpLayer.h
@@ -174,9 +174,6 @@ namespace pcpp
 		size_t getHeaderSizeByVerAndType(ProtocolType igmpVer, IgmpType igmpType) const;
 
 	public:
-		virtual ~IgmpLayer()
-		{}
-
 		/**
 		 * Get a pointer to the raw IGMPv1/IGMPv2 header. Notice this points directly to the data, so every change will
 		 * change the actual packet data
@@ -275,12 +272,6 @@ namespace pcpp
 		    : IgmpLayer(type, groupAddr, 0, IGMPv1)
 		{}
 
-		/**
-		 * A destructor for this layer (does nothing)
-		 */
-		~IgmpV1Layer()
-		{}
-
 		// implement abstract methods
 
 		/**
@@ -317,12 +308,6 @@ namespace pcpp
 		 */
 		explicit IgmpV2Layer(IgmpType type, const IPv4Address& groupAddr = IPv4Address(), uint8_t maxResponseTime = 0)
 		    : IgmpLayer(type, groupAddr, maxResponseTime, IGMPv2)
-		{}
-
-		/**
-		 * A destructor for this layer (does nothing)
-		 */
-		~IgmpV2Layer()
 		{}
 
 		// implement abstract methods

--- a/Packet++/header/Layer.h
+++ b/Packet++/header/Layer.h
@@ -29,8 +29,7 @@ namespace pcpp
 		 */
 		virtual uint8_t* getDataPtr(size_t offset = 0) const = 0;
 
-		virtual ~IDataContainer()
-		{}
+		virtual ~IDataContainer() = default;
 	};
 
 	class Packet;
@@ -232,6 +231,7 @@ namespace pcpp
 		virtual bool extendLayer(int offsetInLayer, size_t numOfBytesToExtend);
 		virtual bool shortenLayer(int offsetInLayer, size_t numOfBytesToShorten);
 	};
+	static_assert(std::has_virtual_destructor<Layer>::value, "Layer must have a virtual destructor");
 
 }  // namespace pcpp
 

--- a/Packet++/header/LdapLayer.h
+++ b/Packet++/header/LdapLayer.h
@@ -410,9 +410,6 @@ namespace pcpp
 		LdapLayer(uint16_t messageId, LdapOperationType operationType, const std::vector<Asn1Record*>& messageRecords,
 		          const std::vector<LdapControl>& controls = std::vector<LdapControl>());
 
-		~LdapLayer()
-		{}
-
 		/**
 		 * @return The root ASN.1 record of the LDAP message. All of the message data will be under this record.
 		 * If the Root ASN.1 record is malformed, an exception is thrown

--- a/Packet++/header/MplsLayer.h
+++ b/Packet++/header/MplsLayer.h
@@ -55,9 +55,6 @@ namespace pcpp
 		 */
 		MplsLayer(uint32_t mplsLabel, uint8_t ttl, uint8_t experimentalUseValue, bool bottomOfStack);
 
-		virtual ~MplsLayer()
-		{}
-
 		/**
 		 * @return TTL value of the MPLS header
 		 */

--- a/Packet++/header/NflogLayer.h
+++ b/Packet++/header/NflogLayer.h
@@ -180,9 +180,6 @@ namespace pcpp
 			m_Protocol = NFLOG;
 		}
 
-		~NflogLayer()
-		{}
-
 		/**
 		 * Get a pointer to the Nflog header.
 		 * @return A pointer to the nflog_header

--- a/Packet++/header/NullLoopbackLayer.h
+++ b/Packet++/header/NullLoopbackLayer.h
@@ -48,12 +48,6 @@ namespace pcpp
 		explicit NullLoopbackLayer(uint32_t family);
 
 		/**
-		 * A destructor for this layer (does nothing)
-		 */
-		~NullLoopbackLayer()
-		{}
-
-		/**
 		 * @return The protocol family in this layer
 		 */
 		uint32_t getFamily() const;

--- a/Packet++/header/PPPoELayer.h
+++ b/Packet++/header/PPPoELayer.h
@@ -80,9 +80,6 @@ namespace pcpp
 			PPPOE_CODE_PADN = 0xd4
 		};
 
-		~PPPoELayer()
-		{}
-
 		/**
 		 * Get a pointer to the PPPoE header. Notice this points directly to the data, so every change will change the
 		 * actual packet data

--- a/Packet++/header/PacketTrailerLayer.h
+++ b/Packet++/header/PacketTrailerLayer.h
@@ -43,9 +43,6 @@ namespace pcpp
 			m_Protocol = PacketTrailer;
 		}
 
-		~PacketTrailerLayer()
-		{}
-
 		/**
 		 * Get a pointer to the trailer data
 		 * @return A pointer to the trailer data

--- a/Packet++/header/PayloadLayer.h
+++ b/Packet++/header/PayloadLayer.h
@@ -47,9 +47,6 @@ namespace pcpp
 		 */
 		explicit PayloadLayer(const std::string& payloadAsHexStream);
 
-		~PayloadLayer()
-		{}
-
 		/**
 		 * Get a pointer to the payload data
 		 * @return A pointer to the payload data

--- a/Packet++/header/RadiusLayer.h
+++ b/Packet++/header/RadiusLayer.h
@@ -213,12 +213,6 @@ namespace pcpp
 		RadiusLayer(uint8_t code, uint8_t id, const std::string& authenticator);
 
 		/**
-		 * A d'tor for this layer, currently does nothing
-		 */
-		~RadiusLayer()
-		{}
-
-		/**
 		 * Get a pointer to the RADIUS header. Notice this points directly to the data, so every change will change the
 		 * actual packet data
 		 * @return A pointer to the radius_header object

--- a/Packet++/header/S7CommLayer.h
+++ b/Packet++/header/S7CommLayer.h
@@ -110,7 +110,7 @@ namespace pcpp
 			m_Parameter = nullptr;
 		}
 
-		virtual ~S7CommLayer()
+		~S7CommLayer() override
 		{
 			if (m_Parameter)
 				delete m_Parameter;

--- a/Packet++/header/SdpLayer.h
+++ b/Packet++/header/SdpLayer.h
@@ -95,9 +95,6 @@ namespace pcpp
 		SdpLayer(const std::string& username, long sessionID, long sessionVersion, IPv4Address ipAddress,
 		         const std::string& sessionName, long startTime, long stopTime);
 
-		~SdpLayer()
-		{}
-
 		/**
 		 * A copy constructor for this layer. Inherits the base copy constructor and doesn't add
 		 * anything else

--- a/Packet++/header/Sll2Layer.h
+++ b/Packet++/header/Sll2Layer.h
@@ -68,9 +68,6 @@ namespace pcpp
 		 */
 		Sll2Layer(uint32_t interfaceIndex, uint16_t ARPHRDType, uint8_t packetType);
 
-		~Sll2Layer()
-		{}
-
 		/**
 		 * Get a pointer to the Sll header. Notice this points directly to the data, so every change will change the
 		 * actual packet data

--- a/Packet++/header/SllLayer.h
+++ b/Packet++/header/SllLayer.h
@@ -62,9 +62,6 @@ namespace pcpp
 		 */
 		SllLayer(uint16_t packetType, uint16_t ARPHRDType);
 
-		~SllLayer()
-		{}
-
 		/**
 		 * Get a pointer to the Sll header. Notice this points directly to the data, so every change will change the
 		 * actual packet data

--- a/Packet++/header/TcpLayer.h
+++ b/Packet++/header/TcpLayer.h
@@ -507,8 +507,6 @@ namespace pcpp
 		 */
 		TcpLayer(uint16_t portSrc, uint16_t portDst);
 
-		~TcpLayer() = default;
-
 		/**
 		 * A copy constructor that copy the entire header from the other TcpLayer (including TCP options)
 		 */

--- a/Packet++/header/TextBasedProtocol.h
+++ b/Packet++/header/TextBasedProtocol.h
@@ -124,7 +124,7 @@ namespace pcpp
 		friend class HeaderField;
 
 	public:
-		~TextBasedProtocolMessage();
+		~TextBasedProtocolMessage() override;
 
 		/**
 		 * Get a pointer to a header field by name. The search is case insensitive, meaning if a field with name "Host"

--- a/Packet++/header/TpktLayer.h
+++ b/Packet++/header/TpktLayer.h
@@ -55,9 +55,6 @@ namespace pcpp
 		 */
 		TpktLayer(uint8_t version, uint16_t length);
 
-		virtual ~TpktLayer()
-		{}
-
 		/**
 		 * @return TPKT reserved
 		 */

--- a/Packet++/header/VlanLayer.h
+++ b/Packet++/header/VlanLayer.h
@@ -63,9 +63,6 @@ namespace pcpp
 		 */
 		VlanLayer(const uint16_t vlanID, bool cfi, uint8_t priority, uint16_t etherType = 0);
 
-		~VlanLayer()
-		{}
-
 		/**
 		 * Get a pointer to the VLAN header. Notice this points directly to the data, so every change will change the
 		 * actual packet data

--- a/Packet++/header/VrrpLayer.h
+++ b/Packet++/header/VrrpLayer.h
@@ -177,9 +177,6 @@ namespace pcpp
 			Other
 		};
 
-		virtual ~VrrpLayer()
-		{}
-
 		/**
 		 * @return The VRRP IP Address type
 		 */

--- a/Packet++/header/VxlanLayer.h
+++ b/Packet++/header/VxlanLayer.h
@@ -95,9 +95,6 @@ namespace pcpp
 		explicit VxlanLayer(uint32_t vni = 0, uint16_t groupPolicyID = 0, bool setGbpFlag = false,
 		                    bool setPolicyAppliedFlag = false, bool setDontLearnFlag = false);
 
-		~VxlanLayer()
-		{}
-
 		/**
 		 * Get a pointer to the VXLAN header. Notice this points directly to the data, so every change will change the
 		 * actual packet data


### PR DESCRIPTION
- Removed empty body destructors on layer classes as the destructors were defined inconsistently across classes. Also complier generated default destructors (implicit or via '=default') are considered trivial while empty body destructors are not, allowing for better optimizations.
- Marked non-empty destructors with 'override' keyword.
- Added static_assert to ensure Layer has a virtual destructor.
- Replaced IDataContainer's empty body destructor with an explicitly defaulted destructor.