### PR TITLE
Added ProtocolType to Layer constructor.

### DIFF
--- a/Packet++/header/ArpLayer.h
+++ b/Packet++/header/ArpLayer.h
@@ -67,9 +67,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		ArpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
+		    : Layer(data, dataLen, prevLayer, packet, ARP)
 		{
-			m_Protocol = ARP;
 			m_DataLen = sizeof(arphdr);
 		}
 

--- a/Packet++/header/BgpLayer.h
+++ b/Packet++/header/BgpLayer.h
@@ -127,10 +127,8 @@ namespace pcpp
 		BgpLayer()
 		{}
 		BgpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = BGP;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, BGP)
+		{}
 
 		bgp_common_header* getBasicHeader() const
 		{

--- a/Packet++/header/CotpLayer.h
+++ b/Packet++/header/CotpLayer.h
@@ -37,10 +37,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		CotpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = COTP;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, COTP)
+		{}
 
 		/**
 		 * A constructor that allocates a new COTP header

--- a/Packet++/header/EthDot3Layer.h
+++ b/Packet++/header/EthDot3Layer.h
@@ -41,10 +41,9 @@ namespace pcpp
 		 * @param[in] dataLen Size of the data in bytes
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
-		EthDot3Layer(uint8_t* data, size_t dataLen, Packet* packet) : Layer(data, dataLen, nullptr, packet)
-		{
-			m_Protocol = EthernetDot3;
-		}
+		EthDot3Layer(uint8_t* data, size_t dataLen, Packet* packet)
+		    : Layer(data, dataLen, nullptr, packet, EthernetDot3)
+		{}
 
 		/**
 		 * A constructor that creates the layer from an existing packet raw data
@@ -54,10 +53,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		EthDot3Layer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = EthernetDot3;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, EthernetDot3)
+		{}
 
 		/**
 		 * A constructor that creates a new IEEE 802.3 Ethernet header and allocates the data

--- a/Packet++/header/EthLayer.h
+++ b/Packet++/header/EthLayer.h
@@ -78,10 +78,8 @@ namespace pcpp
 		 * @param[in] dataLen Size of the data in bytes
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
-		EthLayer(uint8_t* data, size_t dataLen, Packet* packet) : Layer(data, dataLen, nullptr, packet)
-		{
-			m_Protocol = Ethernet;
-		}
+		EthLayer(uint8_t* data, size_t dataLen, Packet* packet) : Layer(data, dataLen, nullptr, packet, Ethernet)
+		{}
 
 		/**
 		 * A constructor that creates the layer from an existing packet raw data
@@ -91,10 +89,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		EthLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = Ethernet;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, Ethernet)
+		{}
 
 		/**
 		 * A constructor that creates a new Ethernet header and allocates the data

--- a/Packet++/header/FtpLayer.h
+++ b/Packet++/header/FtpLayer.h
@@ -19,14 +19,9 @@ namespace pcpp
 	{
 	protected:
 		FtpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : SingleCommandTextProtocol(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = FTP;
-		};
-		FtpLayer(const std::string& command, const std::string& option) : SingleCommandTextProtocol(command, option)
-		{
-			m_Protocol = FTP;
-		};
+		    : SingleCommandTextProtocol(data, dataLen, prevLayer, packet, FTP) {};
+		FtpLayer(const std::string& command, const std::string& option)
+		    : SingleCommandTextProtocol(command, option, FTP) {};
 
 	public:
 		/**

--- a/Packet++/header/GreLayer.h
+++ b/Packet++/header/GreLayer.h
@@ -160,8 +160,8 @@ namespace pcpp
 		}
 
 	protected:
-		GreLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
+		GreLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet, ProtocolType protocol)
+		    : Layer(data, dataLen, prevLayer, packet, protocol)
 		{}
 
 		GreLayer()
@@ -196,10 +196,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		GREv0Layer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : GreLayer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = GREv0;
-		}
+		    : GreLayer(data, dataLen, prevLayer, packet, GREv0)
+		{}
 
 		/**
 		 * A constructor that creates a new GREv0 header and allocates the data
@@ -322,10 +320,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		GREv1Layer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : GreLayer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = GREv1;
-		}
+		    : GreLayer(data, dataLen, prevLayer, packet, GREv1)
+		{}
 
 		/**
 		 * A constructor that creates a new GREv1 header and allocates the data
@@ -414,10 +410,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		PPP_PPTPLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = PPP_PPTP;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, PPP_PPTP)
+		{}
 
 		/**
 		 * A constructor that allocates a new PPP-PPTP header

--- a/Packet++/header/GtpLayer.h
+++ b/Packet++/header/GtpLayer.h
@@ -317,10 +317,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		GtpV1Layer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = GTPv1;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, GTPv1)
+		{}
 
 		/**
 		 * A constructor that creates a new GTPv1 layer and sets the message type and the TEID value

--- a/Packet++/header/HttpLayer.h
+++ b/Packet++/header/HttpLayer.h
@@ -100,8 +100,8 @@ namespace pcpp
 		}
 
 	protected:
-		HttpMessage(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : TextBasedProtocolMessage(data, dataLen, prevLayer, packet)
+		HttpMessage(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet, ProtocolType protocol)
+		    : TextBasedProtocolMessage(data, dataLen, prevLayer, packet, protocol)
 		{}
 		HttpMessage() : TextBasedProtocolMessage()
 		{}

--- a/Packet++/header/IPSecLayer.h
+++ b/Packet++/header/IPSecLayer.h
@@ -58,10 +58,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		AuthenticationHeaderLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = AuthenticationHeader;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, AuthenticationHeader)
+		{}
 
 		/**
 		 * Get a pointer to the raw AH header. Notice this points directly to the data, so every change will change the
@@ -155,14 +153,12 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		ESPLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = ESP;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, ESP)
+		{}
 
 		ipsec_esp* getESPHeader() const
 		{
-			return (ipsec_esp*)m_Data;
+			return reinterpret_cast<ipsec_esp*>(m_Data);
 		}
 
 		/**

--- a/Packet++/header/IcmpLayer.h
+++ b/Packet++/header/IcmpLayer.h
@@ -385,10 +385,8 @@ namespace pcpp
 		 */
 		// cppcheck-suppress uninitMemberVar
 		IcmpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = ICMP;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, ICMP)
+		{}
 
 		/**
 		 * An empty constructor that creates a new layer with an empty ICMP header without setting the ICMP type or ICMP

--- a/Packet++/header/IcmpV6Layer.h
+++ b/Packet++/header/IcmpV6Layer.h
@@ -140,10 +140,8 @@ namespace pcpp
 		 * @param packet A pointer to the Packet instance where layer will be stored in
 		 */
 		IcmpV6Layer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = ICMPv6;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, ICMPv6)
+		{}
 
 		/**
 		 * A constructor that allocates a new ICMPv6 layer with type, code and data

--- a/Packet++/header/IgmpLayer.h
+++ b/Packet++/header/IgmpLayer.h
@@ -162,10 +162,8 @@ namespace pcpp
 	{
 	protected:
 		IgmpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet, ProtocolType igmpVer)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = igmpVer;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, igmpVer)
+		{}
 
 		IgmpLayer(IgmpType type, const IPv4Address& groupAddr, uint8_t maxResponseTime, ProtocolType igmpVer);
 

--- a/Packet++/header/LLCLayer.h
+++ b/Packet++/header/LLCLayer.h
@@ -41,10 +41,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		LLCLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = LLC;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, LLC)
+		{}
 
 		/**
 		 * A constructor that creates the LLC layer from provided values

--- a/Packet++/header/Layer.h
+++ b/Packet++/header/Layer.h
@@ -211,8 +211,8 @@ namespace pcpp
 		      m_PrevLayer(nullptr), m_IsAllocatedInPacket(false)
 		{}
 
-		Layer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : m_Data(data), m_DataLen(dataLen), m_Packet(packet), m_Protocol(UnknownProtocol), m_NextLayer(nullptr),
+		Layer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet, ProtocolType protocol = UnknownProtocol)
+		    : m_Data(data), m_DataLen(dataLen), m_Packet(packet), m_Protocol(protocol), m_NextLayer(nullptr),
 		      m_PrevLayer(prevLayer), m_IsAllocatedInPacket(false)
 		{}
 

--- a/Packet++/header/MplsLayer.h
+++ b/Packet++/header/MplsLayer.h
@@ -40,10 +40,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		MplsLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = MPLS;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, MPLS)
+		{}
 
 		/**
 		 * A constructor that allocates a new MPLS header

--- a/Packet++/header/NflogLayer.h
+++ b/Packet++/header/NflogLayer.h
@@ -175,10 +175,8 @@ namespace pcpp
 		 * @param[in] dataLen Size of the data in bytes
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
-		NflogLayer(uint8_t* data, size_t dataLen, Packet* packet) : Layer(data, dataLen, nullptr, packet)
-		{
-			m_Protocol = NFLOG;
-		}
+		NflogLayer(uint8_t* data, size_t dataLen, Packet* packet) : Layer(data, dataLen, nullptr, packet, NFLOG)
+		{}
 
 		~NflogLayer()
 		{}

--- a/Packet++/header/NtpLayer.h
+++ b/Packet++/header/NtpLayer.h
@@ -326,10 +326,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		NtpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = NTP;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, NTP)
+		{}
 
 		/**
 		 * Empty c'tor

--- a/Packet++/header/NullLoopbackLayer.h
+++ b/Packet++/header/NullLoopbackLayer.h
@@ -36,10 +36,9 @@ namespace pcpp
 		 * @param[in] dataLen Size of the data in bytes
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
-		NullLoopbackLayer(uint8_t* data, size_t dataLen, Packet* packet) : Layer(data, dataLen, nullptr, packet)
-		{
-			m_Protocol = NULL_LOOPBACK;
-		}
+		NullLoopbackLayer(uint8_t* data, size_t dataLen, Packet* packet)
+		    : Layer(data, dataLen, nullptr, packet, NULL_LOOPBACK)
+		{}
 
 		/**
 		 * A constructor that allocates a new Null/Loopback header

--- a/Packet++/header/PPPoELayer.h
+++ b/Packet++/header/PPPoELayer.h
@@ -107,8 +107,8 @@ namespace pcpp
 
 	protected:
 		// protected c'tor as this class shouldn't be instantiated
-		PPPoELayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
+		PPPoELayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet, ProtocolType protocol)
+		    : Layer(data, dataLen, prevLayer, packet, protocol)
 		{}
 
 		// protected c'tor as this class shouldn't be instantiated
@@ -131,10 +131,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		PPPoESessionLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : PPPoELayer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = PPPoESession;
-		}
+		    : PPPoELayer(data, dataLen, prevLayer, packet, PPPoESession)
+		{}
 
 		/**
 		 * A constructor that allocates a new PPPoE Session header with version, type and session ID
@@ -340,9 +338,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		PPPoEDiscoveryLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : PPPoELayer(data, dataLen, prevLayer, packet)
+		    : PPPoELayer(data, dataLen, prevLayer, packet, PPPoEDiscovery)
 		{
-			m_Protocol = PPPoEDiscovery;
 			m_DataLen = getHeaderLen();
 		}
 

--- a/Packet++/header/PacketTrailerLayer.h
+++ b/Packet++/header/PacketTrailerLayer.h
@@ -38,10 +38,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		PacketTrailerLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = PacketTrailer;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, PacketTrailer)
+		{}
 
 		~PacketTrailerLayer()
 		{}

--- a/Packet++/header/PayloadLayer.h
+++ b/Packet++/header/PayloadLayer.h
@@ -25,10 +25,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		PayloadLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = GenericPayload;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, GenericPayload)
+		{}
 
 		/**
 		 * A constructor that allocates a new payload

--- a/Packet++/header/RadiusLayer.h
+++ b/Packet++/header/RadiusLayer.h
@@ -184,10 +184,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		RadiusLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = Radius;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, Radius)
+		{}
 
 		/**
 		 * A constructor that creates a new layer from scratch

--- a/Packet++/header/S7CommLayer.h
+++ b/Packet++/header/S7CommLayer.h
@@ -104,9 +104,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		S7CommLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
+		    : Layer(data, dataLen, prevLayer, packet, S7COMM)
 		{
-			m_Protocol = S7COMM;
 			m_Parameter = nullptr;
 		}
 

--- a/Packet++/header/SSHLayer.h
+++ b/Packet++/header/SSHLayer.h
@@ -120,10 +120,8 @@ namespace pcpp
 	protected:
 		// protected c'tor, this class cannot be instantiated
 		SSHLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = SSH;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, SSH)
+		{}
 
 	private:
 		// this layer supports only parsing

--- a/Packet++/header/SSLLayer.h
+++ b/Packet++/header/SSLLayer.h
@@ -263,10 +263,8 @@ namespace pcpp
 
 	protected:
 		SSLLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = SSL;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, SSL)
+		{}
 
 	};  // class SSLLayer
 

--- a/Packet++/header/SingleCommandTextProtocol.h
+++ b/Packet++/header/SingleCommandTextProtocol.h
@@ -23,10 +23,11 @@ namespace pcpp
 		bool hyphenRequired(const std::string& value);
 
 	protected:
-		SingleCommandTextProtocol(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet) {};
+		SingleCommandTextProtocol(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet,
+		                          ProtocolType protocol)
+		    : Layer(data, dataLen, prevLayer, packet, protocol) {};
 
-		SingleCommandTextProtocol(const std::string& command, const std::string& option);
+		SingleCommandTextProtocol(const std::string& command, const std::string& option, ProtocolType protocol);
 
 		bool setCommandInternal(std::string value);
 		bool setCommandOptionInternal(std::string value);

--- a/Packet++/header/SipLayer.h
+++ b/Packet++/header/SipLayer.h
@@ -128,8 +128,8 @@ namespace pcpp
 		}
 
 	protected:
-		SipLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : TextBasedProtocolMessage(data, dataLen, prevLayer, packet)
+		SipLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet, ProtocolType protocol)
+		    : TextBasedProtocolMessage(data, dataLen, prevLayer, packet, protocol)
 		{}
 		SipLayer() : TextBasedProtocolMessage()
 		{}

--- a/Packet++/header/Sll2Layer.h
+++ b/Packet++/header/Sll2Layer.h
@@ -55,10 +55,8 @@ namespace pcpp
 		 * @param[in] dataLen Size of the data in bytes
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
-		Sll2Layer(uint8_t* data, size_t dataLen, Packet* packet) : Layer(data, dataLen, nullptr, packet)
-		{
-			m_Protocol = SLL2;
-		}
+		Sll2Layer(uint8_t* data, size_t dataLen, Packet* packet) : Layer(data, dataLen, nullptr, packet, SLL2)
+		{}
 
 		/**
 		 * A constructor that creates a new SLL2 header and allocates the data

--- a/Packet++/header/SllLayer.h
+++ b/Packet++/header/SllLayer.h
@@ -50,10 +50,8 @@ namespace pcpp
 		 * @param[in] dataLen Size of the data in bytes
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
-		SllLayer(uint8_t* data, size_t dataLen, Packet* packet) : Layer(data, dataLen, nullptr, packet)
-		{
-			m_Protocol = SLL;
-		}
+		SllLayer(uint8_t* data, size_t dataLen, Packet* packet) : Layer(data, dataLen, nullptr, packet, SLL)
+		{}
 
 		/**
 		 * A constructor that creates a new SLL header and allocates the data

--- a/Packet++/header/SmtpLayer.h
+++ b/Packet++/header/SmtpLayer.h
@@ -19,15 +19,10 @@ namespace pcpp
 	{
 	protected:
 		SmtpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : SingleCommandTextProtocol(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = SMTP;
-		};
+		    : SingleCommandTextProtocol(data, dataLen, prevLayer, packet, SMTP) {};
 
-		SmtpLayer(const std::string& command, const std::string& option) : SingleCommandTextProtocol(command, option)
-		{
-			m_Protocol = SMTP;
-		};
+		SmtpLayer(const std::string& command, const std::string& option)
+		    : SingleCommandTextProtocol(command, option, SMTP) {};
 
 	public:
 		/**

--- a/Packet++/header/SomeIpLayer.h
+++ b/Packet++/header/SomeIpLayer.h
@@ -92,10 +92,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		SomeIpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = SomeIP;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, SomeIP)
+		{}
 
 		/**
 		 * Construct a new layer object

--- a/Packet++/header/StpLayer.h
+++ b/Packet++/header/StpLayer.h
@@ -127,10 +127,8 @@ namespace pcpp
 	{
 	protected:
 		StpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = STP;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, STP)
+		{}
 
 		explicit StpLayer(size_t dataLen)
 		{

--- a/Packet++/header/TelnetLayer.h
+++ b/Packet++/header/TelnetLayer.h
@@ -227,9 +227,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		TelnetLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
+		    : Layer(data, dataLen, prevLayer, packet, Telnet)
 		{
-			m_Protocol = Telnet;
 			lastPositionOffset = SIZE_MAX;
 		};
 

--- a/Packet++/header/TextBasedProtocol.h
+++ b/Packet++/header/TextBasedProtocol.h
@@ -260,7 +260,8 @@ namespace pcpp
 		virtual void computeCalculateFields();
 
 	protected:
-		TextBasedProtocolMessage(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet);
+		TextBasedProtocolMessage(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet,
+		                         ProtocolType protocol);
 		TextBasedProtocolMessage() : m_FieldList(nullptr), m_LastField(nullptr), m_FieldsOffset(0)
 		{}
 

--- a/Packet++/header/TpktLayer.h
+++ b/Packet++/header/TpktLayer.h
@@ -43,10 +43,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		TpktLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = TPKT;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, TPKT)
+		{}
 
 		/**
 		 * A constructor that allocates a new TPKT header

--- a/Packet++/header/UdpLayer.h
+++ b/Packet++/header/UdpLayer.h
@@ -44,10 +44,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		UdpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = UDP;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, UDP)
+		{}
 
 		/**
 		 * A constructor that allocates a new UDP header with source and destination ports

--- a/Packet++/header/VlanLayer.h
+++ b/Packet++/header/VlanLayer.h
@@ -48,10 +48,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		VlanLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = VLAN;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, VLAN)
+		{}
 
 		/**
 		 * A constructor that allocates a new VLAN header

--- a/Packet++/header/VrrpLayer.h
+++ b/Packet++/header/VrrpLayer.h
@@ -135,10 +135,8 @@ namespace pcpp
 	protected:
 		VrrpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet, ProtocolType vrrpVer,
 		          IPAddress::AddressType addressType)
-		    : Layer(data, dataLen, prevLayer, packet), m_AddressType(addressType)
-		{
-			m_Protocol = vrrpVer;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, vrrpVer), m_AddressType(addressType)
+		{}
 
 		explicit VrrpLayer(ProtocolType subProtocol, uint8_t virtualRouterId, uint8_t priority);
 

--- a/Packet++/header/VxlanLayer.h
+++ b/Packet++/header/VxlanLayer.h
@@ -78,10 +78,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		VxlanLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = VXLAN;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, VXLAN)
+		{}
 
 		/**
 		 * A constructor that creates a new VXLAN header and allocates the data. Note: the VNI present flag is set

--- a/Packet++/header/WakeOnLanLayer.h
+++ b/Packet++/header/WakeOnLanLayer.h
@@ -43,10 +43,8 @@ namespace pcpp
 		 * @param[in] packet A pointer to the Packet instance where layer will be stored in
 		 */
 		WakeOnLanLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-		    : Layer(data, dataLen, prevLayer, packet)
-		{
-			m_Protocol = WakeOnLan;
-		}
+		    : Layer(data, dataLen, prevLayer, packet, WakeOnLan)
+		{}
 
 		/**
 		 * Construct a new Wake On Lan Layer with provided values

--- a/Packet++/src/DhcpLayer.cpp
+++ b/Packet++/src/DhcpLayer.cpp
@@ -42,10 +42,8 @@ namespace pcpp
 	}
 
 	DhcpLayer::DhcpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-	    : Layer(data, dataLen, prevLayer, packet)
-	{
-		m_Protocol = DHCP;
-	}
+	    : Layer(data, dataLen, prevLayer, packet, DHCP)
+	{}
 
 	void DhcpLayer::initDhcpLayer(size_t numOfBytesToAllocate)
 	{

--- a/Packet++/src/DhcpV6Layer.cpp
+++ b/Packet++/src/DhcpV6Layer.cpp
@@ -68,10 +68,8 @@ namespace pcpp
 	}
 
 	DhcpV6Layer::DhcpV6Layer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-	    : Layer(data, dataLen, prevLayer, packet)
-	{
-		m_Protocol = DHCPv6;
-	}
+	    : Layer(data, dataLen, prevLayer, packet, DHCPv6)
+	{}
 
 	DhcpV6Layer::DhcpV6Layer(DhcpV6MessageType messageType, uint32_t transactionId)
 	{

--- a/Packet++/src/HttpLayer.cpp
+++ b/Packet++/src/HttpLayer.cpp
@@ -63,9 +63,8 @@ namespace pcpp
 	// -------- Class HttpRequestLayer -----------------
 
 	HttpRequestLayer::HttpRequestLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-	    : HttpMessage(data, dataLen, prevLayer, packet)
+	    : HttpMessage(data, dataLen, prevLayer, packet, HTTPRequest)
 	{
-		m_Protocol = HTTPRequest;
 		m_FirstLine = new HttpRequestFirstLine(this);
 		m_FieldsOffset = m_FirstLine->getSize();
 		parseFields();
@@ -669,9 +668,8 @@ namespace pcpp
 	}
 
 	HttpResponseLayer::HttpResponseLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-	    : HttpMessage(data, dataLen, prevLayer, packet)
+	    : HttpMessage(data, dataLen, prevLayer, packet, HTTPResponse)
 	{
-		m_Protocol = HTTPResponse;
 		m_FirstLine = new HttpResponseFirstLine(this);
 		m_FieldsOffset = m_FirstLine->getSize();
 		parseFields();

--- a/Packet++/src/IPv6Layer.cpp
+++ b/Packet++/src/IPv6Layer.cpp
@@ -29,9 +29,8 @@ namespace pcpp
 	}
 
 	IPv6Layer::IPv6Layer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-	    : Layer(data, dataLen, prevLayer, packet)
+	    : Layer(data, dataLen, prevLayer, packet, IPv6)
 	{
-		m_Protocol = IPv6;
 		m_FirstExtension = nullptr;
 		m_LastExtension = nullptr;
 		m_ExtensionsLen = 0;

--- a/Packet++/src/LdapLayer.cpp
+++ b/Packet++/src/LdapLayer.cpp
@@ -193,9 +193,8 @@ namespace pcpp
 
 	LdapLayer::LdapLayer(std::unique_ptr<Asn1Record> asn1Record, uint8_t* data, size_t dataLen, Layer* prevLayer,
 	                     Packet* packet)
-	    : Layer(data, dataLen, prevLayer, packet)
+	    : Layer(data, dataLen, prevLayer, packet, LDAP)
 	{
-		m_Protocol = LDAP;
 		m_Asn1Record = std::move(asn1Record);
 	}
 

--- a/Packet++/src/SdpLayer.cpp
+++ b/Packet++/src/SdpLayer.cpp
@@ -21,9 +21,8 @@ namespace pcpp
 	}
 
 	SdpLayer::SdpLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-	    : TextBasedProtocolMessage(data, dataLen, prevLayer, packet)
+	    : TextBasedProtocolMessage(data, dataLen, prevLayer, packet, SDP)
 	{
-		m_Protocol = SDP;
 		m_FieldsOffset = 0;
 		parseFields();
 	}

--- a/Packet++/src/SingleCommandTextProtocol.cpp
+++ b/Packet++/src/SingleCommandTextProtocol.cpp
@@ -59,8 +59,10 @@ namespace pcpp
 		return (firstPos != std::string::npos) && (lastPos != std::string::npos) && (firstPos != lastPos);
 	}
 
-	SingleCommandTextProtocol::SingleCommandTextProtocol(const std::string& command, const std::string& option)
+	SingleCommandTextProtocol::SingleCommandTextProtocol(const std::string& command, const std::string& option,
+	                                                     ProtocolType protocol)
 	{
+		m_Protocol = protocol;
 		m_Data = new uint8_t[MIN_PACKET_LENGTH];
 		m_DataLen = MIN_PACKET_LENGTH;
 		if (!command.empty())

--- a/Packet++/src/SipLayer.cpp
+++ b/Packet++/src/SipLayer.cpp
@@ -349,9 +349,8 @@ namespace pcpp
 	// -------- Class SipRequestLayer -----------------
 
 	SipRequestLayer::SipRequestLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-	    : SipLayer(data, dataLen, prevLayer, packet)
+	    : SipLayer(data, dataLen, prevLayer, packet, SIPRequest)
 	{
-		m_Protocol = SIPRequest;
 		m_FirstLine = new SipRequestFirstLine(this);
 		m_FieldsOffset = m_FirstLine->getSize();
 		parseFields();
@@ -586,9 +585,8 @@ namespace pcpp
 	};
 
 	SipResponseLayer::SipResponseLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-	    : SipLayer(data, dataLen, prevLayer, packet)
+	    : SipLayer(data, dataLen, prevLayer, packet, SIPResponse)
 	{
-		m_Protocol = SIPResponse;
 		m_FirstLine = new SipResponseFirstLine(this);
 		m_FieldsOffset = m_FirstLine->getSize();
 		parseFields();

--- a/Packet++/src/TcpLayer.cpp
+++ b/Packet++/src/TcpLayer.cpp
@@ -317,9 +317,8 @@ namespace pcpp
 	}
 
 	TcpLayer::TcpLayer(uint8_t* data, const size_t dataLen, Layer* prevLayer, Packet* packet)
-	    : Layer(data, dataLen, prevLayer, packet)
+	    : Layer(data, dataLen, prevLayer, packet, TCP)
 	{
-		m_Protocol = TCP;
 		m_NumOfTrailingBytes = 0;
 	}
 

--- a/Packet++/src/TextBasedProtocol.cpp
+++ b/Packet++/src/TextBasedProtocol.cpp
@@ -23,8 +23,10 @@ namespace pcpp
 
 	// -------- Class TextBasedProtocolMessage -----------------
 
-	TextBasedProtocolMessage::TextBasedProtocolMessage(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
-	    : Layer(data, dataLen, prevLayer, packet), m_FieldList(nullptr), m_LastField(nullptr), m_FieldsOffset(0)
+	TextBasedProtocolMessage::TextBasedProtocolMessage(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet,
+	                                                   ProtocolType protocol)
+	    : Layer(data, dataLen, prevLayer, packet, protocol), m_FieldList(nullptr), m_LastField(nullptr),
+	      m_FieldsOffset(0)
 	{}
 
 	TextBasedProtocolMessage::TextBasedProtocolMessage(const TextBasedProtocolMessage& other) : Layer(other)


### PR DESCRIPTION
Implements #1531.

This PR essentially replaces most of the duplicated `m_Protocol = <ProtocolTypeHere>;` with a new parameter `ProtocolType protocol` in Layer's constructor (default value: `UnknownProtocol`).

NB: This PR does not modify cases where the layer is constructed via internal `init` method.