### PR TITLE
Fix cmake warning about future support removal

### DIFF
--- a/3rdParty/MemPlumber/MemPlumber/CMakeLists.txt
+++ b/3rdParty/MemPlumber/MemPlumber/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.0...3.5)
 project(memplumber CXX)
 
 add_library(memplumber memplumber.cpp)


### PR DESCRIPTION
Simple fix of CMake warning about version < 3.5 future support removal.