### PR TITLE
Fix ~PcapFileWriterDevice() to close the pcap file.

### DIFF
--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -458,7 +458,9 @@ namespace pcpp
 		 * A destructor for this class
 		 */
 		~PcapFileWriterDevice()
-		{}
+		{
+			PcapFileWriterDevice::close();
+		}
 
 		/**
 		 * Write a RawPacket to the file. Before using this method please verify the file is opened using open(). This

--- a/Tests/Pcap++Test/Common/PcapFileNamesDef.h
+++ b/Tests/Pcap++Test/Common/PcapFileNamesDef.h
@@ -30,5 +30,7 @@
 #define SLL2_PCAP_PATH "PcapExamples/sll2.pcap"
 #define SLL2_PCAP_WRITE_PATH "PcapExamples/sll2_copy.pcap"
 #define EXAMPLE_PCAP_MICRO_PATH "PcapExamples/microsecs.pcap"
+#define EXAMPLE_PCAP_DESTRUCTOR1_PATH "PcapExamples/destructor1.pcap"
+#define EXAMPLE_PCAP_DESTRUCTOR2_PATH "PcapExamples/destructor2.pcap"
 #define EXAMPLE_PCAP_NANO_PATH "PcapExamples/nanosecs.pcap"
 #define EXAMPLE_PCAPNG_NANO_PATH "PcapExamples/nanosecs.pcapng"

--- a/Tests/Pcap++Test/TestDefinition.h
+++ b/Tests/Pcap++Test/TestDefinition.h
@@ -30,6 +30,7 @@ PTF_TEST_CASE(TestPcapFileReadLinkTypeIPv6);
 PTF_TEST_CASE(TestPcapFileReadLinkTypeIPv4);
 PTF_TEST_CASE(TestSolarisSnoopFileRead);
 PTF_TEST_CASE(TestPcapNgFilePrecision);
+PTF_TEST_CASE(TestPcapFileWriterDeviceDestructor);
 
 // Implemented in LiveDeviceTests.cpp
 PTF_TEST_CASE(TestPcapLiveDeviceList);

--- a/Tests/Pcap++Test/Tests/FileTests.cpp
+++ b/Tests/Pcap++Test/Tests/FileTests.cpp
@@ -974,3 +974,40 @@ PTF_TEST_CASE(TestSolarisSnoopFileRead)
 
 	readerDev.close();
 }  // TestSolarisSnoopFileRead
+
+PTF_TEST_CASE(TestPcapFileWriterDeviceDestructor)
+{
+	std::array<uint8_t, 16> testPayload = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+											0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F };
+	pcpp::RawPacket rawPacket1(testPayload.data(), testPayload.size(), timeval({ 1, 2 }), false);     // 1.000002000
+	pcpp::RawPacket rawPacket2(testPayload.data(), testPayload.size(), timespec({ 1, 1234 }), false);  // 1.000001234
+
+	// Create some pcaps in a nested scope to test cleanup on destruction.
+	{
+		pcpp::PcapFileWriterDevice writerDevDestructor1(EXAMPLE_PCAP_DESTRUCTOR1_PATH, pcpp::LINKTYPE_ETHERNET, false);
+		PTF_ASSERT_EQUAL(writerDevDestructor1.getTimestampPrecision(), pcpp::FileTimestampPrecision::Microseconds, enumclass);
+		PTF_ASSERT_TRUE(writerDevDestructor1.open());
+		PTF_ASSERT_EQUAL(writerDevDestructor1.getTimestampPrecision(), pcpp::FileTimestampPrecision::Microseconds, enumclass);
+		PTF_ASSERT_TRUE(writerDevDestructor1.writePacket(rawPacket1));
+		PTF_ASSERT_TRUE(writerDevDestructor1.writePacket(rawPacket2));
+
+		pcpp::PcapFileWriterDevice writerDevDestructor2(EXAMPLE_PCAP_DESTRUCTOR2_PATH, pcpp::LINKTYPE_ETHERNET, false);
+		PTF_ASSERT_EQUAL(writerDevDestructor2.getTimestampPrecision(), pcpp::FileTimestampPrecision::Microseconds, enumclass);
+		PTF_ASSERT_TRUE(writerDevDestructor2.open());
+		PTF_ASSERT_EQUAL(writerDevDestructor2.getTimestampPrecision(), pcpp::FileTimestampPrecision::Microseconds, enumclass);
+		PTF_ASSERT_TRUE(writerDevDestructor2.writePacket(rawPacket1));
+		PTF_ASSERT_TRUE(writerDevDestructor2.writePacket(rawPacket2));
+		writerDevDestructor2.close();
+	}
+
+	// Check that file sizes are equal.  This may fail if the pcpp::PcapFileWriterDevice destructor does not close
+	FILE* writerDevDestructor1 = fopen(EXAMPLE_PCAP_DESTRUCTOR1_PATH, "rb");
+	fseek(writerDevDestructor1, 0, SEEK_END);
+	long pos1 = ftell(writerDevDestructor1);
+	fclose(writerDevDestructor1);
+	FILE* writerDevDestructor2 = fopen(EXAMPLE_PCAP_DESTRUCTOR2_PATH, "rb");
+	fseek(writerDevDestructor2, 0, SEEK_END);
+	long pos2 = ftell(writerDevDestructor2);
+	fclose(writerDevDestructor2);
+	PTF_ASSERT_EQUAL(pos1, pos2);
+}

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -227,6 +227,7 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(TestPcapFileReadLinkTypeIPv6, "no_network;pcap");
 	PTF_RUN_TEST(TestPcapFileReadLinkTypeIPv4, "no_network;pcap");
 	PTF_RUN_TEST(TestSolarisSnoopFileRead, "no_network;pcap;snoop");
+	PTF_RUN_TEST(TestPcapFileWriterDeviceDestructor, "no_network;pcap");
 
 	PTF_RUN_TEST(TestPcapLiveDeviceList, "no_network;live_device;skip_mem_leak_check");
 	PTF_RUN_TEST(TestPcapLiveDeviceListSearch, "live_device");


### PR DESCRIPTION
Bug fix to close pcap file on destroy.