### PR TITLE
WinPcapLiveDevice.h : explicit override

### DIFF
--- a/Pcap++/header/WinPcapLiveDevice.h
+++ b/Pcap++/header/WinPcapLiveDevice.h
@@ -32,7 +32,7 @@ namespace pcpp
 		WinPcapLiveDevice& operator=(const WinPcapLiveDevice& other);
 
 	public:
-		virtual LiveDeviceType getDeviceType() const override
+		LiveDeviceType getDeviceType() const override
 		{
 			return WinPcapDevice;
 		}

--- a/Pcap++/header/WinPcapLiveDevice.h
+++ b/Pcap++/header/WinPcapLiveDevice.h
@@ -32,17 +32,17 @@ namespace pcpp
 		WinPcapLiveDevice& operator=(const WinPcapLiveDevice& other);
 
 	public:
-		virtual LiveDeviceType getDeviceType() const
+		virtual LiveDeviceType getDeviceType() const override
 		{
 			return WinPcapDevice;
 		}
 
 		bool startCapture(OnPacketArrivesCallback onPacketArrives, void* onPacketArrivesUserCookie,
 		                  int intervalInSecondsToUpdateStats, OnStatsUpdateCallback onStatsUpdate,
-		                  void* onStatsUpdateUserCookie);
+		                  void* onStatsUpdateUserCookie) override;
 		bool startCapture(int intervalInSecondsToUpdateStats, OnStatsUpdateCallback onStatsUpdate,
-		                  void* onStatsUpdateUserCookie);
-		bool startCapture(RawPacketVector& capturedPacketsVector)
+		                  void* onStatsUpdateUserCookie) override;
+		bool startCapture(RawPacketVector& capturedPacketsVector) override
 		{
 			return PcapLiveDevice::startCapture(capturedPacketsVector);
 		}


### PR DESCRIPTION
fix `error: 'getDeviceType' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]` when compiling with `mingw-llvm 19.1.0`