### PR TITLE
Add setters and tests for WireGuard protocol message fields

### DIFF
--- a/Packet++/header/WireGuardLayer.h
+++ b/Packet++/header/WireGuardLayer.h
@@ -118,6 +118,11 @@ namespace pcpp
 		uint32_t getReserved() const;
 
 		/**
+		 * @param reserved The reserved field to set as a An array containing the 3-byte.
+		 */
+		void setReserved(const std::array<uint8_t, 3>& reserved);
+
+		/**
 		 * Does nothing for this layer (WireGuard layer is always last)
 		 */
 		void parseNextLayer() override
@@ -247,6 +252,36 @@ namespace pcpp
 		 */
 		std::array<uint8_t, 16> getMac2() const;
 
+		/**
+		 * @param senderIndex A 32-bit integer representing the sender index.
+		 */
+		void setSenderIndex(uint32_t senderIndex);
+
+		/**
+		 * @param initiatorEphemeral An array containing the 32-byte initiator ephemeral public key.
+		 */
+		void setInitiatorEphemeral(const std::array<uint8_t, 32>& initiatorEphemeral);
+
+		/**
+		 * @param encryptedInitiatorStatic An array containing the 48-byte encrypted initiator's static key.
+		 */
+		void setEncryptedInitiatorStatic(const std::array<uint8_t, 48>& encryptedInitiatorStatic);
+
+		/**
+		 * @param encryptedTimestamp An array containing the 28-byte encrypted timestamp.
+		 */
+		void setEncryptedTimestamp(const std::array<uint8_t, 28>& encryptedTimestamp);
+
+		/**
+		 * @param mac1 An array containing the 16-byte MAC1 field.
+		 */
+		void setMac1(const std::array<uint8_t, 16>& mac1);
+
+		/**
+		 * @param mac2 An array containing the 16-byte MAC2 field.
+		 */
+		void setMac2(const std::array<uint8_t, 16>& mac2);
+
 		// implement abstract methods
 
 		/**
@@ -347,6 +382,36 @@ namespace pcpp
 		 */
 		std::array<uint8_t, 16> getMac2() const;
 
+		/**
+		 * @param senderIndex A 32-bit unsigned integer representing the sender index.
+		 */
+		void setSenderIndex(uint32_t senderIndex);
+
+		/**
+		 * @param receiverIndex A 32-bit unsigned integer representing the receiver index.
+		 */
+		void setReceiverIndex(uint32_t receiverIndex);
+
+		/**
+		 * @param responderEphemeral An array containing the 32-byte responder ephemeral public key.
+		 */
+		void setResponderEphemeral(const std::array<uint8_t, 32>& responderEphemeral);
+
+		/**
+		 * @param encryptedEmpty An array containing the 16-byte encrypted empty field.
+		 */
+		void setEncryptedEmpty(const std::array<uint8_t, 16>& encryptedEmpty);
+
+		/**
+		 * @param mac1 An array containing the 16-byte MAC1 field.
+		 */
+		void setMac1(const std::array<uint8_t, 16>& mac1);
+
+		/**
+		 * @param mac2 An array containing the 16-byte MAC2 field.
+		 */
+		void setMac2(const std::array<uint8_t, 16>& mac2);
+
 		// implement abstract methods
 
 		/**
@@ -420,6 +485,21 @@ namespace pcpp
 		 * @return The encrypted cookie as an array of 32 bytes.
 		 */
 		std::array<uint8_t, 32> getEncryptedCookie() const;
+
+		/**
+		 * @param receiverIndex A 32-bit unsigned integer representing the receiver index.
+		 */
+		void setReceiverIndex(uint32_t receiverIndex);
+
+		/**
+		 * @param nonce An array containing the 24-byte nonce field.
+		 */
+		void setNonce(const std::array<uint8_t, 24>& nonce);
+
+		/**
+		 * @param encryptedCookie An array containing the 32-byte encrypted cookie.
+		 */
+		void setEncryptedCookie(const std::array<uint8_t, 32>& encryptedCookie);
 
 		// implement abstract methods
 
@@ -496,6 +576,22 @@ namespace pcpp
 		 * @return A pointer to the encrypted data field.
 		 */
 		const uint8_t* getEncryptedData() const;
+
+		/**
+		 * @param receiverIndex A 32-bit unsigned integer representing the receiver index.
+		 */
+		void setReceiverIndex(uint32_t receiverIndex);
+
+		/**
+		 * @param counter A 64-bit unsigned integer representing the counter field.
+		 */
+		void setCounter(uint64_t counter);
+
+		/**
+		 * @param encryptedData A pointer to the encrypted data.
+		 * @param encryptedDataLen The length of the encrypted data.
+		 */
+		void setEncryptedData(const uint8_t* encryptedData, size_t encryptedDataLen);
 
 		// implement abstract methods
 

--- a/Packet++/src/WireGuardLayer.cpp
+++ b/Packet++/src/WireGuardLayer.cpp
@@ -69,6 +69,12 @@ namespace pcpp
 		return be32toh(reservedValue);
 	}
 
+	void WireGuardLayer::setReserved(const std::array<uint8_t, 3>& reserved)
+	{
+		wg_common_header* msg = reinterpret_cast<wg_common_header*>(m_Data);
+		memcpy(msg->reserved, reserved.data(), 3);
+	}
+
 	bool WireGuardLayer::isDataValid(const uint8_t* data, size_t dataLen)
 	{
 		if (dataLen < sizeof(WireGuardLayer::wg_common_header))
@@ -149,6 +155,43 @@ namespace pcpp
 		return mac2Array;
 	}
 
+	void WireGuardHandshakeInitiationLayer::setSenderIndex(uint32_t senderIndex)
+	{
+		wg_handshake_initiation* msg = reinterpret_cast<wg_handshake_initiation*>(m_Data);
+		msg->senderIndex = htobe32(senderIndex);
+	}
+
+	void WireGuardHandshakeInitiationLayer::setInitiatorEphemeral(const std::array<uint8_t, 32>& initiatorEphemeral)
+	{
+		wg_handshake_initiation* msg = reinterpret_cast<wg_handshake_initiation*>(m_Data);
+		memcpy(msg->initiatorEphemeral, initiatorEphemeral.data(), 32);
+	}
+
+	void WireGuardHandshakeInitiationLayer::setEncryptedInitiatorStatic(
+	    const std::array<uint8_t, 48>& encryptedInitiatorStatic)
+	{
+		wg_handshake_initiation* msg = reinterpret_cast<wg_handshake_initiation*>(m_Data);
+		memcpy(msg->encryptedInitiatorStatic, encryptedInitiatorStatic.data(), 48);
+	}
+
+	void WireGuardHandshakeInitiationLayer::setEncryptedTimestamp(const std::array<uint8_t, 28>& encryptedTimestamp)
+	{
+		wg_handshake_initiation* msg = reinterpret_cast<wg_handshake_initiation*>(m_Data);
+		memcpy(msg->encryptedTimestamp, encryptedTimestamp.data(), 28);
+	}
+
+	void WireGuardHandshakeInitiationLayer::setMac1(const std::array<uint8_t, 16>& mac1)
+	{
+		wg_handshake_initiation* msg = reinterpret_cast<wg_handshake_initiation*>(m_Data);
+		memcpy(msg->mac1, mac1.data(), 16);
+	}
+
+	void WireGuardHandshakeInitiationLayer::setMac2(const std::array<uint8_t, 16>& mac2)
+	{
+		wg_handshake_initiation* msg = reinterpret_cast<wg_handshake_initiation*>(m_Data);
+		memcpy(msg->mac2, mac2.data(), 16);
+	}
+
 	// ~~~~~~~~~~~~~~~~~~~~
 	// WireGuardHandshakeResponseLayer
 	// ~~~~~~~~~~~~~~~~~~~~
@@ -213,6 +256,43 @@ namespace pcpp
 		return mac2Array;
 	}
 
+	void WireGuardHandshakeResponseLayer::setSenderIndex(uint32_t senderIndex)
+	{
+
+		wg_handshake_response* msg = reinterpret_cast<wg_handshake_response*>(m_Data);
+		msg->senderIndex = htobe32(senderIndex);
+	}
+
+	void WireGuardHandshakeResponseLayer::setReceiverIndex(uint32_t receiverIndex)
+	{
+		wg_handshake_response* msg = reinterpret_cast<wg_handshake_response*>(m_Data);
+		msg->receiverIndex = htobe32(receiverIndex);
+	}
+
+	void WireGuardHandshakeResponseLayer::setResponderEphemeral(const std::array<uint8_t, 32>& responderEphemeral)
+	{
+		wg_handshake_response* msg = reinterpret_cast<wg_handshake_response*>(m_Data);
+		memcpy(msg->responderEphemeral, responderEphemeral.data(), 32);
+	}
+
+	void WireGuardHandshakeResponseLayer::setEncryptedEmpty(const std::array<uint8_t, 16>& encryptedEmpty)
+	{
+		wg_handshake_response* msg = reinterpret_cast<wg_handshake_response*>(m_Data);
+		memcpy(msg->encryptedEmpty, encryptedEmpty.data(), 16);
+	}
+
+	void WireGuardHandshakeResponseLayer::setMac1(const std::array<uint8_t, 16>& mac1)
+	{
+		wg_handshake_response* msg = reinterpret_cast<wg_handshake_response*>(m_Data);
+		memcpy(msg->mac1, mac1.data(), 16);
+	}
+
+	void WireGuardHandshakeResponseLayer::setMac2(const std::array<uint8_t, 16>& mac2)
+	{
+		wg_handshake_response* msg = reinterpret_cast<wg_handshake_response*>(m_Data);
+		memcpy(msg->mac2, mac2.data(), 16);
+	}
+
 	// ~~~~~~~~~~~~~~~~~~~~
 	// WireGuardCookieReplyLayer
 	// ~~~~~~~~~~~~~~~~~~~~
@@ -255,6 +335,24 @@ namespace pcpp
 		return encryptedCookieArray;
 	}
 
+	void WireGuardCookieReplyLayer::setReceiverIndex(uint32_t receiverIndex)
+	{
+		wg_cookie_reply* msg = reinterpret_cast<wg_cookie_reply*>(m_Data);
+		msg->receiverIndex = htobe32(receiverIndex);
+	}
+
+	void WireGuardCookieReplyLayer::setNonce(const std::array<uint8_t, 24>& nonce)
+	{
+		wg_cookie_reply* msg = reinterpret_cast<wg_cookie_reply*>(m_Data);
+		memcpy(msg->nonce, nonce.data(), 24);
+	}
+
+	void WireGuardCookieReplyLayer::setEncryptedCookie(const std::array<uint8_t, 32>& encryptedCookie)
+	{
+		wg_cookie_reply* msg = reinterpret_cast<wg_cookie_reply*>(m_Data);
+		memcpy(msg->encryptedCookie, encryptedCookie.data(), 32);
+	}
+
 	// ~~~~~~~~~~~~~~~~~~~~
 	// WireGuardTransportDataLayer
 	// ~~~~~~~~~~~~~~~~~~~~
@@ -291,6 +389,24 @@ namespace pcpp
 	const uint8_t* WireGuardTransportDataLayer::getEncryptedData() const
 	{
 		return getTransportHeader()->encryptedData;
+	}
+
+	void WireGuardTransportDataLayer::setReceiverIndex(uint32_t receiverIndex)
+	{
+		wg_transport_data* msg = reinterpret_cast<wg_transport_data*>(m_Data);
+		msg->receiverIndex = htobe32(receiverIndex);
+	}
+
+	void WireGuardTransportDataLayer::setCounter(uint64_t counter)
+	{
+		wg_transport_data* msg = reinterpret_cast<wg_transport_data*>(m_Data);
+		msg->counter = htobe64(counter);
+	}
+
+	void WireGuardTransportDataLayer::setEncryptedData(const uint8_t* encryptedData, size_t encryptedDataLen)
+	{
+		wg_transport_data* msg = reinterpret_cast<wg_transport_data*>(m_Data);
+		memcpy(msg->encryptedData, encryptedData, encryptedDataLen);
 	}
 
 }  // namespace pcpp

--- a/Tests/Packet++Test/TestDefinition.h
+++ b/Tests/Packet++Test/TestDefinition.h
@@ -270,3 +270,4 @@ PTF_TEST_CASE(WireGuardHandshakeRespParsingTest);
 PTF_TEST_CASE(WireGuardCookieReplyParsingTest);
 PTF_TEST_CASE(WireGuardTransportDataParsingTest);
 PTF_TEST_CASE(WireGuardCreationTest);
+PTF_TEST_CASE(WireGuardEditTest);

--- a/Tests/Packet++Test/Tests/WireGuardTests.cpp
+++ b/Tests/Packet++Test/Tests/WireGuardTests.cpp
@@ -362,4 +362,165 @@ PTF_TEST_CASE(WireGuardCreationTest)
 	                       origTransportDataMessage->getDataLen());
 
 	delete origTransportDataMessage;
-}
+}  // WireGuardCreationTest
+
+PTF_TEST_CASE(WireGuardEditTest)
+{
+	timeval time;
+	gettimeofday(&time, nullptr);
+
+	// edit WireGuard Handshake Initiation message
+	READ_FILE_AND_CREATE_PACKET(1, "PacketExamples/WireGuardHandshakeInitiation.dat");
+
+	pcpp::Packet wgHandShakeInitPacket(&rawPacket1);
+
+	PTF_ASSERT_TRUE(wgHandShakeInitPacket.isPacketOfType(pcpp::WireGuard));
+
+	auto wgLayer = wgHandShakeInitPacket.getLayerOfType<pcpp::WireGuardLayer>();
+	PTF_ASSERT_NOT_NULL(wgLayer);
+
+	auto wgHandShakeInitLayer = wgHandShakeInitPacket.getLayerOfType<pcpp::WireGuardHandshakeInitiationLayer>();
+	PTF_ASSERT_NOT_NULL(wgHandShakeInitLayer);
+
+	std::array<uint8_t, 3> expectedReservedInit = { 0x01, 0x01, 0x01 };
+
+	std::array<uint8_t, 32> expectedPublicKeyInit = { 0x5f, 0xce, 0xc7, 0xc8, 0xe5, 0xc8, 0xe2, 0xe3, 0xf7, 0x98, 0x9e,
+		                                              0xef, 0x60, 0xc2, 0x28, 0xd8, 0x23, 0x29, 0xd6, 0x02, 0xb6, 0xb1,
+		                                              0xe2, 0xbb, 0x9d, 0x06, 0x8f, 0x89, 0xcf, 0x9d, 0x4d, 0x45 };
+
+	std::array<uint8_t, 48> expectedStaticKeyInit = { 0x32, 0x78, 0x0f, 0x6d, 0x27, 0x26, 0x4f, 0x7b, 0x98, 0x70,
+		                                              0x1f, 0xdc, 0x27, 0xa4, 0xec, 0x00, 0xae, 0xb6, 0xbe, 0xcd,
+		                                              0xbe, 0xf2, 0x33, 0x2f, 0x1b, 0x40, 0x84, 0xca, 0xdb, 0x93,
+		                                              0x82, 0x39, 0x35, 0xc0, 0x12, 0xae, 0x25, 0x5e, 0x7b, 0x25,
+		                                              0xef, 0xf1, 0x39, 0x40, 0xc3, 0x21, 0xfa, 0x6b };
+	std::array<uint8_t, 28> expectedTimestampInit = { 0xd6, 0x6a, 0x2a, 0x87, 0xb0, 0x61, 0xdb, 0x14, 0x30, 0x17,
+		                                              0x3e, 0x93, 0x7f, 0x56, 0x93, 0x49, 0xde, 0x28, 0x56, 0xdc,
+		                                              0x5f, 0x26, 0x16, 0x76, 0x3e, 0xee, 0xaf, 0xc0 };
+	std::array<uint8_t, 16> expectedMac1Init = { 0x53, 0x3b, 0x01, 0xdd, 0x96, 0x5e, 0x7e, 0xc7,
+		                                         0x69, 0x76, 0xe2, 0x8f, 0x68, 0x3d, 0x67, 0x12 };
+	std::array<uint8_t, 16> expectedMac2Init = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		                                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+	wgHandShakeInitLayer->setReserved(expectedReservedInit);
+	wgHandShakeInitLayer->setSenderIndex(1);
+	wgHandShakeInitLayer->setInitiatorEphemeral(expectedPublicKeyInit);
+	wgHandShakeInitLayer->setEncryptedInitiatorStatic(expectedStaticKeyInit);
+	wgHandShakeInitLayer->setEncryptedTimestamp(expectedTimestampInit);
+	wgHandShakeInitLayer->setMac1(expectedMac1Init);
+	wgHandShakeInitLayer->setMac2(expectedMac2Init);
+	uint32_t reservedValueInit = 0;
+	memcpy(&reservedValueInit, expectedReservedInit.data(), 3);
+	PTF_ASSERT_EQUAL(wgHandShakeInitLayer->getReserved(), be32toh(reservedValueInit));
+	PTF_ASSERT_EQUAL(wgHandShakeInitLayer->getSenderIndex(), 1);
+	PTF_ASSERT_TRUE(wgHandShakeInitLayer->getInitiatorEphemeral() == expectedPublicKeyInit);
+	PTF_ASSERT_TRUE(wgHandShakeInitLayer->getEncryptedInitiatorStatic() == expectedStaticKeyInit);
+	PTF_ASSERT_TRUE(wgHandShakeInitLayer->getEncryptedTimestamp() == expectedTimestampInit);
+	PTF_ASSERT_TRUE(wgHandShakeInitLayer->getMac1() == expectedMac1Init);
+	PTF_ASSERT_TRUE(wgHandShakeInitLayer->getMac2() == expectedMac2Init);
+
+	// edit WireGuard Handshake Response message
+	READ_FILE_AND_CREATE_PACKET(2, "PacketExamples/WireGuardHandshakeResponse.dat");
+
+	pcpp::Packet wgHandShakeResponsePacket(&rawPacket2);
+
+	PTF_ASSERT_TRUE(wgHandShakeResponsePacket.isPacketOfType(pcpp::WireGuard));
+
+	auto wgHandShakeResponseLayer = wgHandShakeResponsePacket.getLayerOfType<pcpp::WireGuardHandshakeResponseLayer>();
+	PTF_ASSERT_NOT_NULL(wgHandShakeResponseLayer);
+
+	std::array<uint8_t, 3> expectedReservedResp = { 0x01, 0x01, 0x01 };
+
+	std::array<uint8_t, 32> expectedResponderEphemeralResp = { 0xb1, 0x8d, 0x55, 0x50, 0xbd, 0x40, 0x42, 0xa3,
+		                                                       0x7a, 0x46, 0x82, 0x3a, 0xc0, 0x8d, 0xb1, 0xec,
+		                                                       0x66, 0x83, 0x9b, 0xc0, 0xca, 0x2d, 0x64, 0xbc,
+		                                                       0x15, 0xcd, 0x80, 0x23, 0x2b, 0x66, 0x23, 0x2f };
+
+	std::array<uint8_t, 16> encryptedEmptyDataResp = { 0xae, 0xc2, 0x4a, 0xf8, 0x91, 0x8d, 0xe1, 0x06,
+		                                               0x0f, 0xf5, 0xc9, 0x8e, 0x86, 0x5d, 0x5f, 0x35 };
+
+	std::array<uint8_t, 16> expectedMac1Resp = { 0xf2, 0x72, 0x21, 0x4c, 0x52, 0x60, 0x11, 0x0d,
+		                                         0xc4, 0xc6, 0x1e, 0x32, 0xcd, 0xd8, 0x54, 0x21 };
+
+	std::array<uint8_t, 16> expectedMac2Resp = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		                                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+	wgHandShakeResponseLayer->setReserved(expectedReservedResp);
+	wgHandShakeResponseLayer->setSenderIndex(1);
+	wgHandShakeResponseLayer->setReceiverIndex(1);
+	wgHandShakeResponseLayer->setResponderEphemeral(expectedResponderEphemeralResp);
+	wgHandShakeResponseLayer->setEncryptedEmpty(encryptedEmptyDataResp);
+	wgHandShakeResponseLayer->setMac1(expectedMac1Resp);
+	wgHandShakeResponseLayer->setMac2(expectedMac2Resp);
+	uint32_t reservedValueResp = 0;
+	memcpy(&reservedValueResp, expectedReservedResp.data(), 3);
+
+	PTF_ASSERT_EQUAL(wgHandShakeResponseLayer->getSenderIndex(), 1);
+	PTF_ASSERT_EQUAL(wgHandShakeResponseLayer->getReceiverIndex(), 1);
+	PTF_ASSERT_TRUE(wgHandShakeResponseLayer->getResponderEphemeral() == expectedResponderEphemeralResp);
+	PTF_ASSERT_TRUE(wgHandShakeResponseLayer->getEncryptedEmpty() == encryptedEmptyDataResp);
+	PTF_ASSERT_TRUE(wgHandShakeResponseLayer->getMac1() == expectedMac1Resp);
+	PTF_ASSERT_TRUE(wgHandShakeResponseLayer->getMac2() == expectedMac2Resp);
+
+	// edit WireGuard Cookie Reply message
+	READ_FILE_AND_CREATE_PACKET(3, "PacketExamples/WireGuardCookieReply.dat");
+
+	pcpp::Packet wgCookieReplyPacket(&rawPacket3);
+
+	PTF_ASSERT_TRUE(wgCookieReplyPacket.isPacketOfType(pcpp::WireGuard));
+
+	auto wgCookieReplyaLayer = wgCookieReplyPacket.getLayerOfType<pcpp::WireGuardCookieReplyLayer>();
+	PTF_ASSERT_NOT_NULL(wgCookieReplyaLayer);
+
+	std::array<uint8_t, 3> expectedReservedCookie = { 0x01, 0x01, 0x01 };
+
+	std::array<uint8_t, 24> nonceCookie = { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+		                                    0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+	std::array<uint8_t, 32> encryptedCookie = { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+		                                        0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+		                                        0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+	wgCookieReplyaLayer->setReserved(expectedReservedCookie);
+	wgCookieReplyaLayer->setNonce(nonceCookie);
+	wgCookieReplyaLayer->setReceiverIndex(1);
+	wgCookieReplyaLayer->setEncryptedCookie(encryptedCookie);
+
+	uint32_t reservedValueCookie = 0;
+	memcpy(&reservedValueCookie, expectedReservedCookie.data(), 3);
+	PTF_ASSERT_EQUAL(wgCookieReplyaLayer->getReserved(), be32toh(reservedValueCookie));
+	PTF_ASSERT_EQUAL(wgCookieReplyaLayer->getReceiverIndex(), 1);
+	PTF_ASSERT_BUF_COMPARE(wgCookieReplyaLayer->getNonce().data(), nonceCookie.data(), 24);
+	PTF_ASSERT_BUF_COMPARE(wgCookieReplyaLayer->getEncryptedCookie().data(), encryptedCookie.data(), 32);
+
+	// edit WireGuard Transport Data message
+	READ_FILE_AND_CREATE_PACKET(4, "PacketExamples/WireGuardTransportData.dat");
+
+	pcpp::Packet wgTransportDataPacket(&rawPacket4);
+
+	PTF_ASSERT_TRUE(wgTransportDataPacket.isPacketOfType(pcpp::WireGuard));
+
+	auto wgTransportDataLayer = wgTransportDataPacket.getLayerOfType<pcpp::WireGuardTransportDataLayer>();
+	PTF_ASSERT_NOT_NULL(wgTransportDataLayer);
+
+	std::array<uint8_t, 3> expectedReservedTrans = { 0x01, 0x01, 0x01 };
+
+	uint8_t expectedEncryptedDataTrans[112] = {
+		0xa4, 0xeb, 0xc1, 0x2e, 0xe3, 0xf9, 0x90, 0xda, 0x18, 0x03, 0x3a, 0x07, 0x89, 0xc0, 0x4e, 0x27,
+		0x00, 0xf6, 0xf5, 0xc2, 0x71, 0xd4, 0x2a, 0xc4, 0xb4, 0xd6, 0x26, 0x2e, 0x66, 0x65, 0x49, 0xb4,
+		0x45, 0xa7, 0x43, 0x6e, 0x82, 0x9b, 0xff, 0xb6, 0xac, 0x65, 0xf0, 0x56, 0x48, 0xbc, 0x0c, 0x39,
+		0x1f, 0xe7, 0xc5, 0x88, 0x48, 0x74, 0x37, 0x61, 0x27, 0x16, 0x49, 0x40, 0x18, 0x8f, 0x03, 0xdb,
+		0xa6, 0x7a, 0xf8, 0x38, 0x8e, 0xaa, 0xb7, 0x6c, 0x59, 0x36, 0x28, 0xbf, 0x9d, 0xc7, 0xbe, 0x03,
+		0x34, 0x6d, 0x91, 0x2e, 0x91, 0x6d, 0xad, 0x86, 0x25, 0x45, 0x45, 0x47, 0x01, 0x36, 0x4f, 0x2d,
+		0x24, 0x86, 0xd7, 0xce, 0xd4, 0xc8, 0x64, 0x2c, 0xe5, 0x47, 0xdd, 0xb2, 0x6e, 0xf6, 0xa4, 0x6b
+	};
+	wgTransportDataLayer->setReserved(expectedReservedTrans);
+	wgTransportDataLayer->setCounter(1);
+	wgTransportDataLayer->setReceiverIndex(1);
+	wgTransportDataLayer->setEncryptedData(expectedEncryptedDataTrans, sizeof(expectedEncryptedDataTrans));
+
+	uint32_t reservedValue = 0;
+	memcpy(&reservedValue, expectedReservedTrans.data(), 3);
+	PTF_ASSERT_EQUAL(wgTransportDataLayer->getCounter(), 1);
+	PTF_ASSERT_EQUAL(wgTransportDataLayer->getReceiverIndex(), 1);
+
+	PTF_ASSERT_BUF_COMPARE(wgTransportDataLayer->getEncryptedData(), expectedEncryptedDataTrans,
+	                       sizeof(expectedEncryptedDataTrans));
+
+}  // WireGuardEditTest

--- a/Tests/Packet++Test/Tests/WireGuardTests.cpp
+++ b/Tests/Packet++Test/Tests/WireGuardTests.cpp
@@ -407,6 +407,8 @@ PTF_TEST_CASE(WireGuardEditTest)
 	wgHandShakeInitLayer->setEncryptedTimestamp(expectedTimestampInit);
 	wgHandShakeInitLayer->setMac1(expectedMac1Init);
 	wgHandShakeInitLayer->setMac2(expectedMac2Init);
+	wgHandShakeInitLayer = wgHandShakeInitPacket.getLayerOfType<pcpp::WireGuardHandshakeInitiationLayer>();
+
 	uint32_t reservedValueInit = 0;
 	memcpy(&reservedValueInit, expectedReservedInit.data(), 3);
 	PTF_ASSERT_EQUAL(wgHandShakeInitLayer->getReserved(), be32toh(reservedValueInit));
@@ -450,6 +452,8 @@ PTF_TEST_CASE(WireGuardEditTest)
 	wgHandShakeResponseLayer->setEncryptedEmpty(encryptedEmptyDataResp);
 	wgHandShakeResponseLayer->setMac1(expectedMac1Resp);
 	wgHandShakeResponseLayer->setMac2(expectedMac2Resp);
+	wgHandShakeResponseLayer = wgHandShakeResponsePacket.getLayerOfType<pcpp::WireGuardHandshakeResponseLayer>();
+
 	uint32_t reservedValueResp = 0;
 	memcpy(&reservedValueResp, expectedReservedResp.data(), 3);
 
@@ -481,6 +485,7 @@ PTF_TEST_CASE(WireGuardEditTest)
 	wgCookieReplyaLayer->setNonce(nonceCookie);
 	wgCookieReplyaLayer->setReceiverIndex(1);
 	wgCookieReplyaLayer->setEncryptedCookie(encryptedCookie);
+	wgCookieReplyaLayer = wgCookieReplyPacket.getLayerOfType<pcpp::WireGuardCookieReplyLayer>();
 
 	uint32_t reservedValueCookie = 0;
 	memcpy(&reservedValueCookie, expectedReservedCookie.data(), 3);
@@ -514,6 +519,7 @@ PTF_TEST_CASE(WireGuardEditTest)
 	wgTransportDataLayer->setCounter(1);
 	wgTransportDataLayer->setReceiverIndex(1);
 	wgTransportDataLayer->setEncryptedData(expectedEncryptedDataTrans, sizeof(expectedEncryptedDataTrans));
+	wgTransportDataLayer = wgTransportDataPacket.getLayerOfType<pcpp::WireGuardTransportDataLayer>();
 
 	uint32_t reservedValue = 0;
 	memcpy(&reservedValue, expectedReservedTrans.data(), 3);

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -339,6 +339,7 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(WireGuardCookieReplyParsingTest, "wg");
 	PTF_RUN_TEST(WireGuardTransportDataParsingTest, "wg");
 	PTF_RUN_TEST(WireGuardCreationTest, "wg");
+	PTF_RUN_TEST(WireGuardEditTest, "wg");
 
 	PTF_END_RUNNING_TESTS;
 }


### PR DESCRIPTION
#### Reference
- #1554
- #1557 
-  [WireGuard Protocol](https://www.wireguard.com/papers/wireguard.pdf)

## Summary:
This PR introduces setter methods and corresponding tests for WireGuard message fields. These changes allow for easier modification of message attributes such as the reserved field, sender index, and encrypted data.

## What's Changed:
Added setter methods for various fields in WireGuard message structures, including Handshake Initiation, Handshake Response, Cookie Reply, and Transport Data.
#### WireGuardLayer

```cpp
void setReserved(const std::array<uint8_t, 3>& reserved);
```

#### WireGuardHandshakeInitiationLayer

```cpp
void setSenderIndex(uint32_t senderIndex);
void setInitiatorEphemeral(const std::array<uint8_t, 32>& initiatorEphemeral);
void setEncryptedInitiatorStatic(const std::array<uint8_t, 48>& encryptedInitiatorStatic);
void setEncryptedTimestamp(const std::array<uint8_t, 28>& encryptedTimestamp);
void setMac1(const std::array<uint8_t, 16>& mac1);
void setMac2(const std::array<uint8_t, 16>& mac2);
```

#### WireGuardHandshakeResponseLayer

```cpp
void setSenderIndex(uint32_t senderIndex);
void setReceiverIndex(uint32_t receiverIndex);
void setResponderEphemeral(const std::array<uint8_t, 32>& responderEphemeral);
void setEncryptedEmpty(const std::array<uint8_t, 16>& encryptedEmpty);
void setMac1(const std::array<uint8_t, 16>& mac1);
void setMac2(const std::array<uint8_t, 16>& mac2);
```

#### WireGuardCookieReplyLayer

```cpp
void setReceiverIndex(uint32_t receiverIndex);
void setNonce(const std::array<uint8_t, 24>& nonce);
void setEncryptedCookie(const std::array<uint8_t, 32>& encryptedCookie);
```

#### WireGuardTransportDataLayer

```cpp
void setReceiverIndex(uint32_t receiverIndex);
void setCounter(uint64_t counter);
void setEncryptedData(const uint8_t* encryptedData, size_t encryptedDataLen);
```