### PR TITLE
Do not check whether u8 value is greater than zero in LdapLayer.cpp

### DIFF
--- a/Packet++/src/LdapLayer.cpp
+++ b/Packet++/src/LdapLayer.cpp
@@ -671,7 +671,7 @@ namespace pcpp
 
 	LdapSearchRequestLayer::SearchRequestScope LdapSearchRequestLayer::SearchRequestScope::fromUintValue(uint8_t value)
 	{
-		if (value >= 0 && value <= 2)
+		if (value <= 2)
 		{
 			return static_cast<LdapSearchRequestLayer::SearchRequestScope::Value>(value);
 		}
@@ -686,7 +686,7 @@ namespace pcpp
 
 	LdapSearchRequestLayer::DerefAliases LdapSearchRequestLayer::DerefAliases::fromUintValue(uint8_t value)
 	{
-		if (value >= 0 && value <= 3)
+		if (value <= 3)
 		{
 			return static_cast<LdapSearchRequestLayer::DerefAliases::Value>(value);
 		}


### PR DESCRIPTION
This comparison is always true due to limited range of data type