### PR TITLE
Remove deprecated TcpOptionType

### DIFF
--- a/Packet++/header/TcpLayer.h
+++ b/Packet++/header/TcpLayer.h
@@ -5,9 +5,6 @@
 #include "TLVData.h"
 #include <string.h>
 
-#define PCPP_DEPRECATED_TCP_OPTION_TYPE                                                                                \
-	PCPP_DEPRECATED("enum TcpOptionType is deprecated; Use enum class TcpOptionEnumType instead")
-
 /// @file
 
 /**
@@ -85,63 +82,6 @@ namespace pcpp
 		uint16_t urgentPointer;
 	};
 #pragma pack(pop)
-
-	/**
-	 * TCP options types
-	 */
-	enum TcpOptionType : uint8_t
-	{
-		/** Padding */
-		PCPP_TCPOPT_NOP = 1,
-		/** End of options */
-		PCPP_TCPOPT_EOL = 0,
-		/** Segment size negotiating */
-		TCPOPT_MSS = 2,
-		/** Window scaling */
-		PCPP_TCPOPT_WINDOW = 3,
-		/** SACK Permitted */
-		TCPOPT_SACK_PERM = 4,
-		/** SACK Block */
-		PCPP_TCPOPT_SACK = 5,
-		/** Echo (obsoleted by option TcpOptionType::PCPP_TCPOPT_TIMESTAMP) */
-		TCPOPT_ECHO = 6,
-		/** Echo Reply (obsoleted by option TcpOptionType::PCPP_TCPOPT_TIMESTAMP) */
-		TCPOPT_ECHOREPLY = 7,
-		/** TCP Timestamps */
-		PCPP_TCPOPT_TIMESTAMP = 8,
-		/** CC (obsolete) */
-		TCPOPT_CC = 11,
-		/** CC.NEW (obsolete) */
-		TCPOPT_CCNEW = 12,
-		/** CC.ECHO(obsolete) */
-		TCPOPT_CCECHO = 13,
-		/** MD5 Signature Option */
-		TCPOPT_MD5 = 19,
-		/** Multipath TCP */
-		TCPOPT_MPTCP = 0x1e,
-		/** SCPS Capabilities */
-		TCPOPT_SCPS = 20,
-		/** SCPS SNACK */
-		TCPOPT_SNACK = 21,
-		/** SCPS Record Boundary */
-		TCPOPT_RECBOUND = 22,
-		/** SCPS Corruption Experienced */
-		TCPOPT_CORREXP = 23,
-		/** Quick-Start Response */
-		TCPOPT_QS = 27,
-		/** User Timeout Option (also, other known unauthorized use) */
-		TCPOPT_USER_TO = 28,
-		/** RFC3692-style Experiment 1 (also improperly used for shipping products) */
-		TCPOPT_EXP_FD = 0xfd,
-		/** RFC3692-style Experiment 2 (also improperly used for shipping products) */
-		TCPOPT_EXP_FE = 0xfe,
-		/** Riverbed probe option, non IANA registered option number */
-		TCPOPT_RVBD_PROBE = 76,
-		/** Riverbed transparency option, non IANA registered option number */
-		TCPOPT_RVBD_TRPY = 78,
-		/** Unknown option */
-		TCPOPT_Unknown = 255
-	};
 
 	/**
 	 * TCP options types
@@ -270,15 +210,6 @@ namespace pcpp
 		~TcpOption() override = default;
 
 		/**
-		 * @deprecated This method is deprecated, please use getTcpOptionEnumType()
-		 */
-		PCPP_DEPRECATED("Use getTcpOptionEnumType instead")
-		TcpOptionType getTcpOptionType() const
-		{
-			return getTcpOptionType(m_Data);
-		}
-
-		/**
 		 * @return TCP option type casted as pcpp::TcpOptionEnumType enum. If the data is null a value
 		 * of TcpOptionEnumType::Unknown is returned
 		 */
@@ -336,14 +267,6 @@ namespace pcpp
 		}
 
 	private:
-		static TcpOptionType getTcpOptionType(const TLVRawData* optionRawData)
-		{
-			if (optionRawData == nullptr)
-				return TcpOptionType::TCPOPT_Unknown;
-
-			return static_cast<TcpOptionType>(optionRawData->recordType);
-		}
-
 		static TcpOptionEnumType getTcpOptionEnumType(const TLVRawData* optionRawData)
 		{
 			if (optionRawData == nullptr)
@@ -365,17 +288,6 @@ namespace pcpp
 		/**
 		 * An enum to describe NOP and EOL TCP options. Used in one of this class's c'tors
 		 */
-		enum NopEolOptionTypes : uint8_t
-		{
-			/** NOP TCP option */
-			NOP,
-			/** EOL TCP option */
-			EOL
-		};
-
-		/**
-		 * An enum to describe NOP and EOL TCP options. Used in one of this class's c'tors
-		 */
 		enum class NopEolOptionEnumType : uint8_t
 		{
 			/** NOP TCP option */
@@ -383,14 +295,6 @@ namespace pcpp
 			/** EOL TCP option */
 			Eol
 		};
-
-		/**
-		 * @deprecated This method is deprecated, please use constructor with TcpOptionEnumType
-		 */
-		PCPP_DEPRECATED_TCP_OPTION_TYPE
-		TcpOptionBuilder(TcpOptionType optionType, const uint8_t* optionValue, uint8_t optionValueLen)
-		    : TLVRecordBuilder(static_cast<uint8_t>(optionType), optionValue, optionValueLen)
-		{}
 
 		/**
 		 * A c'tor for building TCP options which their value is a byte array. The TcpOption object can be later
@@ -405,28 +309,12 @@ namespace pcpp
 		{}
 
 		/**
-		 * @deprecated This method is deprecated, please use constructor with TcpOptionEnumType
-		 */
-		PCPP_DEPRECATED_TCP_OPTION_TYPE
-		TcpOptionBuilder(TcpOptionType optionType, uint8_t optionValue)
-		    : TLVRecordBuilder(static_cast<uint8_t>(optionType), optionValue)
-		{}
-
-		/**
 		 * A c'tor for building TCP options which have a 1-byte value. The TcpOption object can be later retrieved
 		 * by calling build()
 		 * @param[in] optionType TCP option type
 		 * @param[in] optionValue A 1-byte option value
 		 */
 		TcpOptionBuilder(TcpOptionEnumType optionType, uint8_t optionValue)
-		    : TLVRecordBuilder(static_cast<uint8_t>(optionType), optionValue)
-		{}
-
-		/**
-		 * @deprecated This method is deprecated, please use constructor with TcpOptionEnumType
-		 */
-		PCPP_DEPRECATED_TCP_OPTION_TYPE
-		TcpOptionBuilder(TcpOptionType optionType, uint16_t optionValue)
 		    : TLVRecordBuilder(static_cast<uint8_t>(optionType), optionValue)
 		{}
 
@@ -441,14 +329,6 @@ namespace pcpp
 		{}
 
 		/**
-		 * @deprecated This method is deprecated, please use constructor with TcpOptionEnumType
-		 */
-		PCPP_DEPRECATED_TCP_OPTION_TYPE
-		TcpOptionBuilder(TcpOptionType optionType, uint32_t optionValue)
-		    : TLVRecordBuilder(static_cast<uint8_t>(optionType), optionValue)
-		{}
-
-		/**
 		 * A c'tor for building TCP options which have a 4-byte value. The TcpOption object can be later retrieved
 		 * by calling build()
 		 * @param[in] optionType TCP option type
@@ -457,12 +337,6 @@ namespace pcpp
 		TcpOptionBuilder(TcpOptionEnumType optionType, uint32_t optionValue)
 		    : TLVRecordBuilder(static_cast<uint8_t>(optionType), optionValue)
 		{}
-
-		/**
-		 * @deprecated This method is deprecated, please use constructor with NopEolOptionEnumType
-		 */
-		PCPP_DEPRECATED("enum NopEolOptionTypes is deprecated; Use enum class NopEolOptionEnumType instead")
-		explicit TcpOptionBuilder(NopEolOptionTypes optionType);
 
 		/**
 		 * A c'tor for building TCP NOP and EOL options. These option types are special in that they contain only 1 byte
@@ -541,12 +415,6 @@ namespace pcpp
 		uint16_t getDstPort() const;
 
 		/**
-		 * @deprecated This method is deprecated, please use getTcpOption(TcpOptionEnumType option)
-		 */
-		PCPP_DEPRECATED_TCP_OPTION_TYPE
-		TcpOption getTcpOption(TcpOptionType option) const;
-
-		/**
 		 * Get a TCP option by type
 		 * @param[in] option TCP option type to retrieve
 		 * @return An TcpOption object that contains the first option that matches this type, or logical null
@@ -584,14 +452,6 @@ namespace pcpp
 		TcpOption addTcpOption(const TcpOptionBuilder& optionBuilder);
 
 		/**
-		 * @deprecated This method is deprecated, please use insertTcpOptionAfter(const TcpOptionBuilder& optionBuilder,
-		 * TcpOptionEnumType prevOptionType = TcpOptionEnumType::Unknown)
-		 */
-		PCPP_DEPRECATED("Use insertTcpOptionAfter instead")
-		TcpOption addTcpOptionAfter(const TcpOptionBuilder& optionBuilder,
-		                            TcpOptionType prevOptionType = TcpOptionType::TCPOPT_Unknown);
-
-		/**
 		 * Insert a new TCP option after an existing one
 		 * @param[in] optionBuilder A TcpOptionBuilder object that contains the requested TCP option data to be inserted
 		 * @param[in] prevOptionType The TCP option which the newly inserted option should come after. This is an
@@ -603,12 +463,6 @@ namespace pcpp
 		 */
 		TcpOption insertTcpOptionAfter(const TcpOptionBuilder& optionBuilder,
 		                               TcpOptionEnumType prevOptionType = TcpOptionEnumType::Unknown);
-
-		/**
-		 * @deprecated This method is deprecated, please use removeTcpOption(TcpOptionEnumType)
-		 */
-		PCPP_DEPRECATED_TCP_OPTION_TYPE
-		bool removeTcpOption(TcpOptionType optionType);
 
 		/**
 		 * Remove an existing TCP option from the layer. TCP option is found by type
@@ -692,5 +546,3 @@ namespace pcpp
 		       && dataLen >= hdr->dataOffset * sizeof(uint32_t);
 	}
 }  // namespace pcpp
-
-#undef PCPP_DEPRECATED_TCP_OPTION_TYPE

--- a/Tests/Packet++Test/Tests/TcpTests.cpp
+++ b/Tests/Packet++Test/Tests/TcpTests.cpp
@@ -10,10 +10,6 @@
 #include "PacketUtils.h"
 #include "DeprecationUtils.h"
 
-// TODO: remove these macros, when deprecated code is gone
-DISABLE_WARNING_PUSH
-DISABLE_WARNING_DEPRECATED
-
 PTF_TEST_CASE(TcpPacketNoOptionsParsing)
 {
 	timeval time;
@@ -50,11 +46,6 @@ PTF_TEST_CASE(TcpPacketNoOptionsParsing)
 	// TCP options
 	PTF_ASSERT_EQUAL(tcpLayer->getTcpOptionCount(), 0);
 
-	// TODO: remove deprecated
-	PTF_ASSERT_TRUE(tcpLayer->getTcpOption(pcpp::PCPP_TCPOPT_NOP).isNull());
-	PTF_ASSERT_TRUE(tcpLayer->getTcpOption(pcpp::PCPP_TCPOPT_TIMESTAMP).isNull());
-	// end deprecated
-
 	PTF_ASSERT_TRUE(tcpLayer->getTcpOption(pcpp::TcpOptionEnumType::Nop).isNull());
 	PTF_ASSERT_TRUE(tcpLayer->getTcpOption(pcpp::TcpOptionEnumType::Timestamp).isNull());
 
@@ -87,17 +78,6 @@ PTF_TEST_CASE(TcpPacketWithOptionsParsing)
 	// TCP options
 	PTF_ASSERT_EQUAL(tcpLayer->getTcpOptionCount(), 3);
 
-	// TODO: remove deprecated
-	PTF_ASSERT_TRUE(!tcpLayer->getTcpOption(pcpp::PCPP_TCPOPT_NOP).isNull());
-	pcpp::TcpOption timestampOptionData = tcpLayer->getTcpOption(pcpp::PCPP_TCPOPT_TIMESTAMP);
-	PTF_ASSERT_TRUE(!timestampOptionData.isNull());
-	PTF_ASSERT_EQUAL(timestampOptionData.getTotalSize(), 10);
-	uint32_t tsValue = timestampOptionData.getValueAs<uint32_t>();
-	uint32_t tsEchoReply = timestampOptionData.getValueAs<uint32_t>(4);
-	PTF_ASSERT_EQUAL(tsValue, htobe32(195102));
-	PTF_ASSERT_EQUAL(tsEchoReply, htobe32(3555729271UL));
-	// end deprecated
-
 	PTF_ASSERT_TRUE(!tcpLayer->getTcpOption(pcpp::TcpOptionEnumType::Nop).isNull());
 	pcpp::TcpOption timestampOptionData2 = tcpLayer->getTcpOption(pcpp::TcpOptionEnumType::Timestamp);
 	PTF_ASSERT_TRUE(!timestampOptionData2.isNull());
@@ -122,29 +102,6 @@ PTF_TEST_CASE(TcpPacketWithOptionsParsing2)
 
 	PTF_ASSERT_EQUAL(tcpLayer->getTcpOptionCount(), 5);
 
-	// TODO: remove deprecated
-	pcpp::TcpOption mssOption = tcpLayer->getTcpOption(pcpp::TCPOPT_MSS);
-	pcpp::TcpOption sackPermOption = tcpLayer->getTcpOption(pcpp::TCPOPT_SACK_PERM);
-	pcpp::TcpOption windowScaleOption = tcpLayer->getTcpOption(pcpp::PCPP_TCPOPT_WINDOW);
-	PTF_ASSERT_TRUE(mssOption.isNotNull());
-	PTF_ASSERT_TRUE(sackPermOption.isNotNull());
-	PTF_ASSERT_TRUE(windowScaleOption.isNotNull());
-
-	PTF_ASSERT_EQUAL(mssOption.getTcpOptionType(), pcpp::TCPOPT_MSS, enum);
-	PTF_ASSERT_EQUAL(sackPermOption.getTcpOptionType(), pcpp::TCPOPT_SACK_PERM, enum);
-	PTF_ASSERT_EQUAL(windowScaleOption.getTcpOptionType(), pcpp::PCPP_TCPOPT_WINDOW, enum);
-
-	PTF_ASSERT_EQUAL(mssOption.getTotalSize(), 4);
-	PTF_ASSERT_EQUAL(sackPermOption.getTotalSize(), 2);
-	PTF_ASSERT_EQUAL(windowScaleOption.getTotalSize(), 3);
-
-	PTF_ASSERT_EQUAL(mssOption.getValueAs<uint16_t>(), htobe16(1460));
-	PTF_ASSERT_EQUAL(windowScaleOption.getValueAs<uint8_t>(), 4);
-	PTF_ASSERT_EQUAL(sackPermOption.getValueAs<uint32_t>(), 0);
-	PTF_ASSERT_EQUAL(mssOption.getValueAs<uint32_t>(), 0);
-	PTF_ASSERT_EQUAL(mssOption.getValueAs<uint16_t>(1), 0);
-	// end deprecated
-
 	pcpp::TcpOption mssOption2 = tcpLayer->getTcpOption(pcpp::TcpOptionEnumType::Mss);
 	pcpp::TcpOption sackPermOption2 = tcpLayer->getTcpOption(pcpp::TcpOptionEnumType::SackPerm);
 	pcpp::TcpOption windowScaleOption2 = tcpLayer->getTcpOption(pcpp::TcpOptionEnumType::Window);
@@ -166,20 +123,7 @@ PTF_TEST_CASE(TcpPacketWithOptionsParsing2)
 	PTF_ASSERT_EQUAL(mssOption2.getValueAs<uint32_t>(), 0);
 	PTF_ASSERT_EQUAL(mssOption2.getValueAs<uint16_t>(1), 0);
 
-	// TODO: remove deprecated
 	pcpp::TcpOption curOpt = tcpLayer->getFirstTcpOption();
-	PTF_ASSERT_TRUE(curOpt.isNotNull() && curOpt.getTcpOptionType() == pcpp::TCPOPT_MSS);
-	curOpt = tcpLayer->getNextTcpOption(curOpt);
-	PTF_ASSERT_TRUE(curOpt.isNotNull() && curOpt.getTcpOptionType() == pcpp::TCPOPT_SACK_PERM);
-	curOpt = tcpLayer->getNextTcpOption(curOpt);
-	PTF_ASSERT_TRUE(curOpt.isNotNull() && curOpt.getTcpOptionType() == pcpp::PCPP_TCPOPT_TIMESTAMP);
-	curOpt = tcpLayer->getNextTcpOption(curOpt);
-	PTF_ASSERT_TRUE(curOpt.isNotNull() && curOpt.getTcpOptionType() == pcpp::PCPP_TCPOPT_NOP);
-	curOpt = tcpLayer->getNextTcpOption(curOpt);
-	PTF_ASSERT_TRUE(curOpt.isNotNull() && curOpt.getTcpOptionType() == pcpp::PCPP_TCPOPT_WINDOW);
-	// end deprecated
-
-	curOpt = tcpLayer->getFirstTcpOption();
 	PTF_ASSERT_TRUE(curOpt.isNotNull() && curOpt.getTcpOptionEnumType() == pcpp::TcpOptionEnumType::Mss);
 	curOpt = tcpLayer->getNextTcpOption(curOpt);
 	PTF_ASSERT_TRUE(curOpt.isNotNull() && curOpt.getTcpOptionEnumType() == pcpp::TcpOptionEnumType::SackPerm);
@@ -223,13 +167,16 @@ PTF_TEST_CASE(TcpPacketCreation)
 	tcpLayer.getTcpHeader()->ackFlag = 1;
 	tcpLayer.getTcpHeader()->pshFlag = 1;
 	tcpLayer.getTcpHeader()->windowSize = htobe16(20178);
-	PTF_ASSERT_TRUE(tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TcpOptionBuilder::NOP)).isNotNull());
-	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 24);
-	PTF_ASSERT_TRUE(tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TcpOptionBuilder::NOP)).isNotNull());
+	PTF_ASSERT_TRUE(
+	    tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TcpOptionBuilder::NopEolOptionEnumType::Nop)).isNotNull());
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 24);
 	PTF_ASSERT_TRUE(
-	    tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::PCPP_TCPOPT_TIMESTAMP, nullptr, PCPP_TCPOLEN_TIMESTAMP - 2))
-	        .isNotNull());
+	    tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TcpOptionBuilder::NopEolOptionEnumType::Nop)).isNotNull());
+	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 24);
+	PTF_ASSERT_TRUE(tcpLayer
+	                    .addTcpOption(pcpp::TcpOptionBuilder(pcpp::TcpOptionEnumType::Timestamp, nullptr,
+	                                                         PCPP_TCPOLEN_TIMESTAMP - 2))
+	                    .isNotNull());
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 32);
 
 	PTF_ASSERT_TRUE(
@@ -251,7 +198,7 @@ PTF_TEST_CASE(TcpPacketCreation)
 
 	uint32_t tsEchoReply = htobe32(196757);
 	uint32_t tsValue = htobe32(3555735960UL);
-	pcpp::TcpOption tsOption = tcpLayer.getTcpOption(pcpp::PCPP_TCPOPT_TIMESTAMP);
+	pcpp::TcpOption tsOption = tcpLayer.getTcpOption(pcpp::TcpOptionEnumType::Timestamp);
 	PTF_ASSERT_TRUE(tsOption.isNotNull());
 	tsOption.setValue<uint32_t>(tsValue);
 	tsOption.setValue<uint32_t>(tsEchoReply, 4);
@@ -289,27 +236,31 @@ PTF_TEST_CASE(TcpPacketCreation2)
 	tcpLayer.getTcpHeader()->synFlag = 1;
 	tcpLayer.getTcpHeader()->windowSize = htobe16(14600);
 
-	PTF_ASSERT_TRUE(tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TcpOptionBuilder::NOP)).isNotNull());
+	PTF_ASSERT_TRUE(
+	    tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TcpOptionBuilder::NopEolOptionEnumType::Nop)).isNotNull());
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 24);
 
-	PTF_ASSERT_TRUE(tcpLayer.addTcpOptionAfter(pcpp::TcpOptionBuilder(pcpp::TCPOPT_MSS, (uint16_t)1460)).isNotNull());
+	PTF_ASSERT_TRUE(tcpLayer.insertTcpOptionAfter(pcpp::TcpOptionBuilder(pcpp::TcpOptionEnumType::Mss, (uint16_t)1460))
+	                    .isNotNull());
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 28);
 
-	pcpp::TcpOption tsOption = tcpLayer.addTcpOptionAfter(
-	    pcpp::TcpOptionBuilder(pcpp::PCPP_TCPOPT_TIMESTAMP, nullptr, PCPP_TCPOLEN_TIMESTAMP - 2), pcpp::TCPOPT_MSS);
+	pcpp::TcpOption tsOption = tcpLayer.insertTcpOptionAfter(
+	    pcpp::TcpOptionBuilder(pcpp::TcpOptionEnumType::Timestamp, nullptr, PCPP_TCPOLEN_TIMESTAMP - 2),
+	    pcpp::TcpOptionEnumType::Mss);
 	PTF_ASSERT_TRUE(tsOption.isNotNull());
 	tsOption.setValue<uint32_t>(htobe32(197364));
 	tsOption.setValue<uint32_t>(0, 4);
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 36);
 
 	pcpp::TcpOption winScaleOption =
-	    tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::PCPP_TCPOPT_WINDOW, (uint8_t)4));
+	    tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TcpOptionEnumType::Window, (uint8_t)4));
 	PTF_ASSERT_TRUE(winScaleOption.isNotNull());
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 40);
 
-	PTF_ASSERT_TRUE(
-	    tcpLayer.addTcpOptionAfter(pcpp::TcpOptionBuilder(pcpp::TCPOPT_SACK_PERM, nullptr, 0), pcpp::TCPOPT_MSS)
-	        .isNotNull());
+	PTF_ASSERT_TRUE(tcpLayer
+	                    .insertTcpOptionAfter(pcpp::TcpOptionBuilder(pcpp::TcpOptionEnumType::SackPerm, nullptr, 0),
+	                                          pcpp::TcpOptionEnumType::Mss)
+	                    .isNotNull());
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 40);
 
 	PTF_ASSERT_EQUAL(tcpLayer.getTcpOptionCount(), 5);
@@ -327,8 +278,8 @@ PTF_TEST_CASE(TcpPacketCreation2)
 
 	PTF_ASSERT_BUF_COMPARE(tcpPacket.getRawPacket()->getRawData(), buffer1, bufferLength1);
 
-	pcpp::TcpOption qsOption =
-	    tcpLayer.addTcpOptionAfter(pcpp::TcpOptionBuilder(pcpp::TCPOPT_QS, nullptr, PCPP_TCPOLEN_QS), pcpp::TCPOPT_MSS);
+	pcpp::TcpOption qsOption = tcpLayer.insertTcpOptionAfter(
+	    pcpp::TcpOptionBuilder(pcpp::TcpOptionEnumType::Qs, nullptr, PCPP_TCPOLEN_QS), pcpp::TcpOptionEnumType::Mss);
 	PTF_ASSERT_TRUE(qsOption.isNotNull());
 	PTF_ASSERT_TRUE(qsOption.setValue(htobe32(9999)));
 	PTF_ASSERT_TRUE(
@@ -344,7 +295,7 @@ PTF_TEST_CASE(TcpPacketCreation2)
 
 	PTF_ASSERT_TRUE(tcpLayer.removeTcpOption(pcpp::TcpOptionEnumType::Qs));
 	PTF_ASSERT_EQUAL(tcpLayer.getTcpOptionCount(), 7);
-	PTF_ASSERT_TRUE(tcpLayer.removeTcpOption(pcpp::TCPOPT_SNACK));
+	PTF_ASSERT_TRUE(tcpLayer.removeTcpOption(pcpp::TcpOptionEnumType::Snack));
 	PTF_ASSERT_TRUE(tcpLayer.removeTcpOption(pcpp::TcpOptionEnumType::Nop));
 	PTF_ASSERT_EQUAL(tcpLayer.getTcpOptionCount(), 5);
 
@@ -356,10 +307,10 @@ PTF_TEST_CASE(TcpPacketCreation2)
 	PTF_ASSERT_EQUAL(tcpLayer.getTcpOptionCount(), 0);
 	PTF_ASSERT_TRUE(tcpLayer.getFirstTcpOption().isNull());
 	PTF_ASSERT_EQUAL(tcpLayer.getHeaderLen(), 20);
-	PTF_ASSERT_TRUE(tcpLayer.getTcpOption(pcpp::PCPP_TCPOPT_TIMESTAMP).isNull());
+	PTF_ASSERT_TRUE(tcpLayer.getTcpOption(pcpp::TcpOptionEnumType::Timestamp).isNull());
 
 	pcpp::TcpOption tcpSnackOption =
-	    tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TCPOPT_SNACK, nullptr, PCPP_TCPOLEN_SNACK));
+	    tcpLayer.addTcpOption(pcpp::TcpOptionBuilder(pcpp::TcpOptionEnumType::Snack, nullptr, PCPP_TCPOLEN_SNACK));
 	PTF_ASSERT_TRUE(tcpSnackOption.isNotNull());
 	PTF_ASSERT_TRUE(tcpSnackOption.setValue(htobe32(1000)));
 }  // TcpPacketCreation2
@@ -407,4 +358,3 @@ PTF_TEST_CASE(TcpChecksumMultiBuffer)
 	c = pcpp::computeChecksum(vec, 4);
 	PTF_ASSERT_EQUAL(c, 0);
 }  // TcpChecksumInvalidRead
-DISABLE_WARNING_POP


### PR DESCRIPTION
This is a continuation of https://github.com/seladb/PcapPlusPlus/pull/1289

Please let me know if you think it's okay to remove the deprecated feature, now that it was already released :)