### PR TITLE
Remove redundant counters init in PcapFileWriterDevice constructor

### DIFF
--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -564,8 +564,6 @@ namespace pcpp
 	    : IFileWriterDevice(fileName)
 	{
 		m_PcapDumpHandler = nullptr;
-		m_NumOfPacketsNotWritten = 0;
-		m_NumOfPacketsWritten = 0;
 		m_PcapLinkLayerType = linkLayerType;
 		m_AppendMode = false;
 #if defined(PCAP_TSTAMP_PRECISION_NANO)


### PR DESCRIPTION
The constructor of the inherited IFileWriterDevice already initializes these values to zero:

```cpp
IFileWriterDevice::IFileWriterDevice(const std::string& fileName) : IFileDevice(fileName)
{
    m_NumOfPacketsNotWritten = 0;
    m_NumOfPacketsWritten = 0;
}
```

Therefore, there's no need to reinitialize them in the derived class.