### PR TITLE
Fix Comments on improving FuzzTargetNg #1258

### DIFF
--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
@@ -143,7 +143,7 @@ static void __append_interface_block_to_file_info(const light_pcapng interface_b
 	light_option ts_resolution_option = NULL;
 	uint32_t ticks_per_sec;
 
-	if (info->interface_block_count >= MAX_SUPPORTED_INTERFACE_BLOCKS)
+	if (info == NULL || info->interface_block_count >= MAX_SUPPORTED_INTERFACE_BLOCKS)
 		return;
 
 	light_get_block_info(interface_block, LIGHT_INFO_BODY, &interface_desc_block, NULL);


### PR DESCRIPTION
Fix #1258

This should fix the issue, but LightPcapNg should be fully updated for potential other nullptr dereferences