### PR TITLE
Fix: sockaddr2string() is only the debug function. Throwing an except…

### DIFF
--- a/Common++/src/IpUtils.cpp
+++ b/Common++/src/IpUtils.cpp
@@ -100,7 +100,7 @@ namespace pcpp
 				break;
 			}
 			default:
-				throw std::invalid_argument("Unsupported sockaddr family. Family is not AF_INET or AF_INET6.");
+				PCPP_LOG_ERROR("Unsupported sockaddr family. Family is not AF_INET or AF_INET6.");
 			}
 		}
 


### PR DESCRIPTION
Fix: sockaddr2string() is only the debug function. Throwing an exception will cause the guide program to break. So change it to print debugging information.
