### PR TITLE
Fix argument dependent lookup for ostream operator on IPAddress and MacAddress.

### DIFF
--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -1082,40 +1082,41 @@ namespace pcpp
 		std::unique_ptr<IPv4Network> m_IPv4Network;
 		std::unique_ptr<IPv6Network> m_IPv6Network;
 	};
+
+	inline std::ostream& operator<<(std::ostream& os, const pcpp::IPv4Address& ipv4Address)
+	{
+		os << ipv4Address.toString();
+		return os;
+	}
+
+	inline std::ostream& operator<<(std::ostream& os, const pcpp::IPv6Address& ipv6Address)
+	{
+		os << ipv6Address.toString();
+		return os;
+	}
+
+	inline std::ostream& operator<<(std::ostream& os, const pcpp::IPAddress& ipAddress)
+	{
+		os << ipAddress.toString();
+		return os;
+	}
+
+	inline std::ostream& operator<<(std::ostream& os, const pcpp::IPv4Network& network)
+	{
+		os << network.toString();
+		return os;
+	}
+
+	inline std::ostream& operator<<(std::ostream& os, const pcpp::IPv6Network& network)
+	{
+		os << network.toString();
+		return os;
+	}
+
+	inline std::ostream& operator<<(std::ostream& os, const pcpp::IPNetwork& network)
+	{
+		os << network.toString();
+		return os;
+	}
+
 }  // namespace pcpp
-
-inline std::ostream& operator<<(std::ostream& os, const pcpp::IPv4Address& ipv4Address)
-{
-	os << ipv4Address.toString();
-	return os;
-}
-
-inline std::ostream& operator<<(std::ostream& os, const pcpp::IPv6Address& ipv6Address)
-{
-	os << ipv6Address.toString();
-	return os;
-}
-
-inline std::ostream& operator<<(std::ostream& os, const pcpp::IPAddress& ipAddress)
-{
-	os << ipAddress.toString();
-	return os;
-}
-
-inline std::ostream& operator<<(std::ostream& os, const pcpp::IPv4Network& network)
-{
-	os << network.toString();
-	return os;
-}
-
-inline std::ostream& operator<<(std::ostream& os, const pcpp::IPv6Network& network)
-{
-	os << network.toString();
-	return os;
-}
-
-inline std::ostream& operator<<(std::ostream& os, const pcpp::IPNetwork& network)
-{
-	os << network.toString();
-	return os;
-}

--- a/Common++/header/MacAddress.h
+++ b/Common++/header/MacAddress.h
@@ -173,10 +173,10 @@ namespace pcpp
 	private:
 		uint8_t m_Address[6] = { 0 };
 	};
-}  // namespace pcpp
 
-inline std::ostream& operator<<(std::ostream& os, const pcpp::MacAddress& macAddress)
-{
-	os << macAddress.toString();
-	return os;
-}
+	inline std::ostream& operator<<(std::ostream& os, const pcpp::MacAddress& macAddress)
+	{
+		os << macAddress.toString();
+		return os;
+	}
+}  // namespace pcpp


### PR DESCRIPTION
The PR moves std::ostream << operator overloads for `IPAddress`, `IPNetwork`, `MacAddress` inside the `pcpp` namespace to allow argument dependent lookup.