### PR TITLE
Replace variable length arrays with std::vector

### DIFF
--- a/Examples/DpdkExample-FilterTraffic/main.cpp
+++ b/Examples/DpdkExample-FilterTraffic/main.cpp
@@ -162,7 +162,7 @@ void listDpdkPorts()
 void prepareCoreConfiguration(std::vector<pcpp::DpdkDevice*>& dpdkDevicesToUse,
                               std::vector<pcpp::SystemCore>& coresToUse, bool writePacketsToDisk,
                               const std::string& packetFilePath, pcpp::DpdkDevice* sendPacketsTo,
-                              AppWorkerConfig workerConfigArr[], int workerConfigArrLen, uint16_t rxQueues)
+                              std::vector<AppWorkerConfig>& workerConfigArr, int workerConfigArrLen, uint16_t rxQueues)
 {
 	// create a list of pairs of DpdkDevice and RX queues for all RX queues in all requested devices
 	int totalNumOfRxQueues = 0;
@@ -588,7 +588,7 @@ int main(int argc, char* argv[])
 	}
 
 	// prepare configuration for every core
-	AppWorkerConfig workerConfigArr[coresToUse.size()];
+	std::vector<AppWorkerConfig> workerConfigArr(coresToUse.size());
 	prepareCoreConfiguration(dpdkDevicesToUse, coresToUse, writePacketsToDisk, packetFilePath, sendPacketsTo,
 	                         workerConfigArr, coresToUse.size(), rxQueues);
 

--- a/Examples/PfRingExample-FilterTraffic/main.cpp
+++ b/Examples/PfRingExample-FilterTraffic/main.cpp
@@ -406,7 +406,7 @@ int main(int argc, char* argv[])
 	int threadCount = 0;
 
 	// create an array of packet stats with the size of all machine cores
-	PacketStats packetStatsArr[totalNumOfCores];
+	std::vector<PacketStats> packetStatsArr(totalNumOfCores);
 
 	// init each packet stats instance with an illegal core ID
 	for (int coreId = 0; coreId < totalNumOfCores; coreId++)
@@ -430,7 +430,7 @@ int main(int argc, char* argv[])
 	PacketMatchingEngine matchingEngine(srcIPToMatch, dstIPToMatch, srcPortToMatch, dstPortToMatch, protocolToMatch);
 
 	// create a flow table for each core
-	std::unordered_map<uint32_t, bool> flowTables[totalNumOfCores];
+	std::vector<std::unordered_map<uint32_t, bool>> flowTables(totalNumOfCores);
 
 	pcpp::PcapFileWriterDevice** pcapWriters = nullptr;
 
@@ -463,9 +463,9 @@ int main(int argc, char* argv[])
 
 	// prepare packet capture configuration
 	CaptureThreadArgs args;
-	args.packetStatArr = packetStatsArr;
+	args.packetStatArr = packetStatsArr.data();
 	args.matchingEngine = &matchingEngine;
-	args.flowTables = flowTables;
+	args.flowTables = flowTables.data();
 	args.sendPacketsTo = sendPacketsToIface;
 	args.pcapWriters = pcapWriters;
 

--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -929,8 +929,8 @@ namespace pcpp
 			return 0;
 		}
 
-		struct rte_mbuf* mBufArray[rawPacketArrLength];
-		uint16_t packetsReceived = rte_eth_rx_burst(m_Id, rxQueueId, mBufArray, rawPacketArrLength);
+		std::vector<struct rte_mbuf*> mBufArray(rawPacketArrLength);
+		uint16_t packetsReceived = rte_eth_rx_burst(m_Id, rxQueueId, mBufArray.data(), rawPacketArrLength);
 
 		if (unlikely(!packetsReceived))
 		{
@@ -972,8 +972,8 @@ namespace pcpp
 			return 0;
 		}
 
-		struct rte_mbuf* mBufArray[packetsArrLength];
-		uint16_t packetsReceived = rte_eth_rx_burst(m_Id, rxQueueId, mBufArray, packetsArrLength);
+		std::vector<struct rte_mbuf*> mBufArray(packetsArrLength);
+		uint16_t packetsReceived = rte_eth_rx_burst(m_Id, rxQueueId, mBufArray.data(), packetsArrLength);
 
 		if (unlikely(!packetsReceived))
 		{
@@ -1133,9 +1133,9 @@ namespace pcpp
 
 	uint16_t DpdkDevice::sendPackets(Packet** packetsArr, uint16_t arrLength, uint16_t txQueueId, bool useTxBuffer)
 	{
-		rte_mbuf* mBufArr[arrLength];
+		std::vector<rte_mbuf*> mBufArr(arrLength);
 		MBufRawPacketVector mBufVec;
-		MBufRawPacket* mBufRawPacketArr[arrLength];
+		std::vector<MBufRawPacket*> mBufRawPacketArr(arrLength);
 
 		for (size_t i = 0; i < arrLength; i++)
 		{
@@ -1162,7 +1162,7 @@ namespace pcpp
 		}
 
 		uint16_t packetsSent =
-		    sendPacketsInner(txQueueId, (void*)mBufArr, getNextPacketFromMBufArray, arrLength, useTxBuffer);
+		    sendPacketsInner(txQueueId, (void*)mBufArr.data(), getNextPacketFromMBufArray, arrLength, useTxBuffer);
 
 		bool needToFreeMbuf = (!useTxBuffer && (packetsSent != arrLength));
 		for (int index = 0; index < arrLength; index++)
@@ -1174,8 +1174,8 @@ namespace pcpp
 	uint16_t DpdkDevice::sendPackets(RawPacketVector& rawPacketsVec, uint16_t txQueueId, bool useTxBuffer)
 	{
 		size_t vecSize = rawPacketsVec.size();
-		rte_mbuf* mBufArr[vecSize];
-		MBufRawPacket* mBufRawPacketArr[vecSize];
+		std::vector<rte_mbuf*> mBufArr(vecSize);
+		std::vector<MBufRawPacket*> mBufRawPacketArr(vecSize);
 		MBufRawPacketVector mBufVec;
 		int mBufIndex = 0;
 
@@ -1204,7 +1204,7 @@ namespace pcpp
 		}
 
 		uint16_t packetsSent =
-		    sendPacketsInner(txQueueId, (void*)mBufArr, getNextPacketFromMBufArray, vecSize, useTxBuffer);
+		    sendPacketsInner(txQueueId, (void*)mBufArr.data(), getNextPacketFromMBufArray, vecSize, useTxBuffer);
 
 		bool needToFreeMbuf = (!useTxBuffer && (packetsSent != vecSize));
 		for (size_t index = 0; index < rawPacketsVec.size(); index++)

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -121,7 +121,7 @@ namespace pcpp
 
 		// Should be equal to the number of static params
 		initDpdkArgc += 7;
-		std::string dpdkParamsArray[initDpdkArgc];
+		std::vector<std::string> dpdkParamsArray(initDpdkArgc);
 		initDpdkArgvBuffer = new char*[initDpdkArgc];
 		i = 0;
 		while (dpdkParamsStream.good() && i < initDpdkArgc)


### PR DESCRIPTION
Variable Length Arrays, while widely supported as compiler extensions are not part of the C++ standard. Replaced them with std::vector.

This PR extends [Dimi1010](https://github.com/Dimi1010)'s #1661 