### PR TITLE
Fix memory management in RawPacket

### DIFF
--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -332,9 +332,8 @@ namespace pcpp
 
 		/**
 		 * Assignment operator overload for this class. When using this operator on an already initialized RawPacket
-		 * instance, the original raw data is freed first. Then the other instance is copied to this instance, the same
-		 * way the copy constructor works
-		 * @todo free raw data only if deleteRawDataAtDestructor was set to 'true'
+		 * instance, the original raw data is freed first if deleteRawDataAtDestructor was set to 'true'.
+		 * Then the other instance is copied to this instance, the same way the copy constructor works
 		 * @param[in] other The instance to copy from
 		 */
 		RawPacket& operator=(const RawPacket& other);
@@ -474,7 +473,7 @@ namespace pcpp
 
 		/**
 		 * Clears all members of this instance, meaning setting raw data to nullptr, raw data length to 0, etc.
-		 * Currently raw data is always freed, even if deleteRawDataAtDestructor was set to 'false'
+		 * Frees the raw data if deleteRawDataAtDestructor was set to 'true'
 		 * @todo deleteRawDataAtDestructor was set to 'true', don't free the raw data
 		 * @todo set timestamp to a default value as well
 		 */

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -41,10 +41,7 @@ namespace pcpp
 
 	RawPacket::~RawPacket()
 	{
-		if (m_DeleteRawDataAtDestructor)
-		{
-			delete[] m_RawData;
-		}
+		clear();
 	}
 
 	RawPacket::RawPacket(const RawPacket& other)
@@ -57,10 +54,7 @@ namespace pcpp
 	{
 		if (this != &other)
 		{
-			if (m_RawData != nullptr)
-				delete[] m_RawData;
-
-			m_RawPacketSet = false;
+			clear();
 
 			copyDataFrom(other, true);
 		}
@@ -104,14 +98,9 @@ namespace pcpp
 	bool RawPacket::setRawData(const uint8_t* pRawData, int rawDataLen, timespec timestamp, LinkLayerType layerType,
 	                           int frameLength)
 	{
-		if (frameLength == -1)
-			frameLength = rawDataLen;
-		m_FrameLength = frameLength;
-		if (m_RawData != nullptr && m_DeleteRawDataAtDestructor)
-		{
-			delete[] m_RawData;
-		}
+		clear();
 
+		m_FrameLength = (frameLength == -1) ? rawDataLen : frameLength;
 		m_RawData = (uint8_t*)pRawData;
 		m_RawDataLen = rawDataLen;
 		m_TimeStamp = timestamp;
@@ -129,7 +118,7 @@ namespace pcpp
 
 	void RawPacket::clear()
 	{
-		if (m_RawData != nullptr)
+		if (m_RawData != nullptr && m_DeleteRawDataAtDestructor)
 			delete[] m_RawData;
 
 		m_RawData = nullptr;


### PR DESCRIPTION
Ensure that the destructor and assignment operator correctly handle the deletion of raw data based on the m_DeleteRawDataAtDestructor flag by using the updated clear() method.

Update comments to reflect these changes.

Closes #1626