### PR TITLE
Temp fix for XDP - run CI on Ubuntu 22.04 instead of `ubuntu-latest` which is Ubuntu 24.04

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -701,7 +701,7 @@ jobs:
           ./gradlew assembleDebug
 
   xdp:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
I need to figure out why it fails on Ubuntu 24.04, but until then we can unblock all existing PRs