### PR TITLE
Added static asserts to fixed length header structures.

### DIFF
--- a/Packet++/header/BgpLayer.h
+++ b/Packet++/header/BgpLayer.h
@@ -59,6 +59,7 @@ namespace pcpp
 			uint8_t messageType;
 		};
 #pragma pack(pop)
+		static_assert(sizeof(bgp_common_header) == 19, "bgp_common_header size is not 19 bytes");
 
 		/**
 		 * @return BGP message type

--- a/Packet++/header/CotpLayer.h
+++ b/Packet++/header/CotpLayer.h
@@ -11,7 +11,7 @@ namespace pcpp
  * Represents a COTP protocol header
  */
 #pragma pack(push, 1)
-	typedef struct
+	struct cotphdr
 	{
 		/** length */
 		uint8_t length;
@@ -19,8 +19,9 @@ namespace pcpp
 		uint8_t pduType;
 		/** TPDU number sequence*/
 		uint8_t tpduNumber;
-	} cotphdr;
+	};
 #pragma pack(pop)
+	static_assert(sizeof(cotphdr) == 3, "cotphdr size is not 3 bytes");
 
 	/**
 	 * @class CotpLayer

--- a/Packet++/header/DhcpLayer.h
+++ b/Packet++/header/DhcpLayer.h
@@ -54,6 +54,7 @@ namespace pcpp
 		uint32_t magicNumber;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(dhcp_header) == 240, "dhcp_header size is not 240 bytes");
 
 	/**
 	 * BootP opcodes

--- a/Packet++/header/DhcpV6Layer.h
+++ b/Packet++/header/DhcpV6Layer.h
@@ -275,6 +275,7 @@ namespace pcpp
 		/** DHCPv6 transaction ID (last byte) */
 		uint8_t transactionId3;
 	};
+	static_assert(sizeof(dhcpv6_header) == 4, "dhcpv6_header size is not 4 bytes");
 
 	/**
 	 * @class DhcpV6Layer

--- a/Packet++/header/DnsLayer.h
+++ b/Packet++/header/DnsLayer.h
@@ -79,6 +79,7 @@ namespace pcpp
 		uint16_t numberOfAdditional;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(dnshdr) == 12, "dnshdr size is not 12 bytes");
 
 	// forward declarations
 	class DnsQuery;

--- a/Packet++/header/EthDot3Layer.h
+++ b/Packet++/header/EthDot3Layer.h
@@ -27,6 +27,7 @@ namespace pcpp
 		uint16_t length;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(ether_dot3_header) == 14, "ether_dot3_header size is not 14 bytes");
 
 	/**
 	 * @class EthDot3Layer

--- a/Packet++/header/EthLayer.h
+++ b/Packet++/header/EthLayer.h
@@ -27,6 +27,7 @@ namespace pcpp
 		uint16_t etherType;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(ether_header) == 14, "ether_header size is not 14 bytes");
 
 	/* Ethernet protocol ID's */
 

--- a/Packet++/header/GreLayer.h
+++ b/Packet++/header/GreLayer.h
@@ -65,6 +65,7 @@ namespace pcpp
 		uint16_t protocol;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(gre_basic_header) == 4, "gre_basic_header size is not 4 bytes");
 
 	/**
 	 * @struct gre1_header
@@ -79,6 +80,7 @@ namespace pcpp
 		uint16_t callID;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(gre1_header) == 8, "gre1_header size is not 8 bytes");
 
 	/**
 	 * @struct ppp_pptp_header
@@ -95,6 +97,7 @@ namespace pcpp
 		uint16_t protocol;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(ppp_pptp_header) == 4, "ppp_pptp_header size is not 4 bytes");
 
 	/**
 	 * @class GreLayer

--- a/Packet++/header/GtpLayer.h
+++ b/Packet++/header/GtpLayer.h
@@ -59,8 +59,8 @@ namespace pcpp
 		 * tunnel */
 		uint32_t teid;
 	};
-
 #pragma pack(pop)
+	static_assert(sizeof(gtpv1_header) == 8, "gtpv1_header size is not 8 bytes");
 
 	/**
 	 * An enum representing the possible GTP v1 message types.

--- a/Packet++/header/IPSecLayer.h
+++ b/Packet++/header/IPSecLayer.h
@@ -29,6 +29,7 @@ namespace pcpp
 		uint32_t sequenceNumber;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(ipsec_authentication_header) == 12, "ipsec_authentication_header size is not 12 bytes");
 
 	/**
 	 * @struct ipsec_esp
@@ -43,6 +44,7 @@ namespace pcpp
 		uint32_t sequenceNumber;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(ipsec_esp) == 8, "ipsec_esp size is not 8 bytes");
 
 	/**
 	 * @class AuthenticationHeaderLayer

--- a/Packet++/header/IPv4Layer.h
+++ b/Packet++/header/IPv4Layer.h
@@ -57,6 +57,7 @@ namespace pcpp
 		/*The options start here. */
 	};
 #pragma pack(pop)
+	static_assert(sizeof(iphdr) == 20, "iphdr size is not 20 bytes");
 
 	/**
 	 * An enum for all possible IPv4 and IPv6 protocol types

--- a/Packet++/header/IPv6Layer.h
+++ b/Packet++/header/IPv6Layer.h
@@ -46,6 +46,7 @@ namespace pcpp
 		uint8_t ipDst[16];
 	};
 #pragma pack(pop)
+	static_assert(sizeof(ip6_hdr) == 40, "ip6_hdr size is not 40 bytes");
 
 	/**
 	 * @class IPv6Layer

--- a/Packet++/header/IcmpLayer.h
+++ b/Packet++/header/IcmpLayer.h
@@ -33,6 +33,7 @@ namespace pcpp
 		uint16_t checksum;
 	} icmphdr;
 #pragma pack(pop)
+	static_assert(sizeof(icmphdr) == 4, "icmphdr size is not 4 bytes");
 
 	/**
 	 * An enum of all supported ICMP message types
@@ -134,6 +135,7 @@ namespace pcpp
 		uint64_t timestamp;
 	} icmp_echo_hdr;
 #pragma pack(pop)
+	static_assert(sizeof(icmp_echo_hdr) == 16, "icmp_echo_hdr size is not 16 bytes");
 
 	/**
 	 * @struct icmp_echo_request
@@ -174,12 +176,14 @@ namespace pcpp
 		uint32_t transmitTimestamp;
 	} icmp_timestamp_request;
 #pragma pack(pop)
+	static_assert(sizeof(icmp_timestamp_request) == 20, "icmp_timestamp_request size is not 20 bytes");
 
 	/**
 	 * @typedef icmp_timestamp_reply
 	 * ICMP timestamp reply message structure, same as icmp_timestamp_request
 	 */
 	typedef icmp_timestamp_request icmp_timestamp_reply;
+	static_assert(sizeof(icmp_timestamp_reply) == 20, "icmp_timestamp_reply size is not 20 bytes");
 
 	/**
 	 * @struct icmp_destination_unreachable
@@ -194,6 +198,7 @@ namespace pcpp
 		uint16_t nextHopMTU;
 	} icmp_destination_unreachable;
 #pragma pack(pop)
+	static_assert(sizeof(icmp_destination_unreachable) == 8, "icmp_destination_unreachable size is not 8 bytes");
 
 	/**
 	 * @struct icmp_time_exceeded
@@ -206,12 +211,14 @@ namespace pcpp
 		uint32_t unused;
 	} icmp_time_exceeded;
 #pragma pack(pop)
+	static_assert(sizeof(icmp_time_exceeded) == 8, "icmp_time_exceeded size is not 8 bytes");
 
 	/**
 	 * @typedef icmp_source_quench
 	 * ICMP source quence message structure, same as icmp_time_exceeded
 	 */
 	typedef icmp_time_exceeded icmp_source_quench;
+	static_assert(sizeof(icmp_source_quench) == 8, "icmp_source_quench size is not 8 bytes");
 
 	/**
 	 * @struct icmp_param_problem
@@ -229,12 +236,14 @@ namespace pcpp
 		uint16_t unused2;
 	} icmp_param_problem;
 #pragma pack(pop)
+	static_assert(sizeof(icmp_param_problem) == 8, "icmp_param_problem size is not 8 bytes");
 
 	/**
 	 * @typedef icmp_router_solicitation
 	 * ICMP router solicitation message structure, same as icmphdr
 	 */
 	typedef icmphdr icmp_router_solicitation;
+	static_assert(sizeof(icmp_router_solicitation) == 4, "icmp_router_solicitation size is not 4 bytes");
 
 	/**
 	 * @struct icmp_redirect
@@ -247,6 +256,7 @@ namespace pcpp
 		uint32_t gatewayAddress;
 	} icmp_redirect;
 #pragma pack(pop)
+	static_assert(sizeof(icmp_redirect) == 8, "icmp_redirect size is not 8 bytes");
 
 	/**
 	 * @struct icmp_router_address_structure
@@ -278,6 +288,7 @@ namespace pcpp
 		}
 	};
 #pragma pack(pop)
+	static_assert(sizeof(icmp_router_address_structure) == 8, "icmp_router_address_structure size is not 8 bytes");
 
 	/**
 	 * @struct icmp_router_advertisement_hdr
@@ -296,6 +307,7 @@ namespace pcpp
 		uint16_t lifetime;
 	} icmp_router_advertisement_hdr;
 #pragma pack(pop)
+	static_assert(sizeof(icmp_router_advertisement_hdr) == 8, "icmp_router_advertisement_hdr size is not 8 bytes");
 
 	/**
 	 * @struct icmp_router_advertisement
@@ -331,6 +343,7 @@ namespace pcpp
 		uint32_t addressMask;
 	} icmp_address_mask_request;
 #pragma pack(pop)
+	static_assert(sizeof(icmp_address_mask_request) == 12, "icmp_address_mask_request size is not 12 bytes");
 
 	/**
 	 * @typedef icmp_address_mask_reply
@@ -351,12 +364,14 @@ namespace pcpp
 		uint16_t sequence;
 	} icmp_info_request;
 #pragma pack(pop)
+	static_assert(sizeof(icmp_info_request) == 8, "icmp_info_request size is not 8 bytes");
 
 	/**
 	 * @typedef icmp_info_reply
 	 * ICMP information reply message structure, same as icmp_info_request
 	 */
 	typedef icmp_info_request icmp_info_reply;
+	static_assert(sizeof(icmp_info_reply) == 8, "icmp_info_reply size is not 8 bytes");
 
 	/**
 	 * @class IcmpLayer

--- a/Packet++/header/IcmpV6Layer.h
+++ b/Packet++/header/IcmpV6Layer.h
@@ -110,6 +110,7 @@ namespace pcpp
 		uint16_t checksum;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(icmpv6hdr) == 4, "icmpv6hdr size is not 4 bytes");
 
 /**
  * @struct icmpv6_echo_hdr
@@ -124,6 +125,7 @@ namespace pcpp
 		uint16_t sequence;
 	} icmpv6_echo_hdr;
 #pragma pack(pop)
+	static_assert(sizeof(icmpv6_echo_hdr) == 8, "icmpv6_echo_hdr size is not 8 bytes");
 
 	/**
 	 * @class IcmpV6Layer

--- a/Packet++/header/IgmpLayer.h
+++ b/Packet++/header/IgmpLayer.h
@@ -29,6 +29,7 @@ namespace pcpp
 		 */
 		uint32_t groupAddress;
 	};
+	static_assert(sizeof(igmp_header) == 8, "igmp_header size is not 8 bytes");
 
 	/**
 	 * @struct igmpv3_query_header
@@ -52,6 +53,7 @@ namespace pcpp
 		/** This field specifies the number of source addresses present in the Query */
 		uint16_t numOfSources;
 	};
+	static_assert(sizeof(igmpv3_query_header) == 12, "igmpv3_query_header size is not 12 bytes");
 
 	/**
 	 * @struct igmpv3_report_header
@@ -70,6 +72,7 @@ namespace pcpp
 		/** This field specifies the number of group records present in the Report */
 		uint16_t numOfGroupRecords;
 	};
+	static_assert(sizeof(igmpv3_report_header) == 8, "igmpv3_report_header size is not 8 bytes");
 
 	/**
 	 * @struct igmpv3_group_record

--- a/Packet++/header/LLCLayer.h
+++ b/Packet++/header/LLCLayer.h
@@ -25,6 +25,7 @@ namespace pcpp
 		    control;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(llc_header) == 3, "llc_header size is not 3 bytes");
 
 	/**
 	 * @class LLCLayer

--- a/Packet++/header/MplsLayer.h
+++ b/Packet++/header/MplsLayer.h
@@ -26,6 +26,7 @@ namespace pcpp
 			uint8_t ttl;
 		};
 #pragma pack(pop)
+		static_assert(sizeof(mpls_header) == 4, "mpls_header size is not 4 bytes");
 
 		mpls_header* getMplsHeader() const
 		{

--- a/Packet++/header/NflogLayer.h
+++ b/Packet++/header/NflogLayer.h
@@ -27,6 +27,7 @@ namespace pcpp
 		uint16_t resourceId;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(nflog_header) == 4, "nflog_header size is not 4 bytes");
 
 	/**
 	 * @enum NflogTlvType

--- a/Packet++/header/NtpLayer.h
+++ b/Packet++/header/NtpLayer.h
@@ -116,6 +116,7 @@ namespace pcpp
 			    transmitTimestamp;
 		};
 #pragma pack(pop)
+		static_assert(sizeof(ntp_header) == 48, "ntp_header size is not 48 bytes");
 
 #pragma pack(push, 1)
 		struct ntp_v3_auth
@@ -126,6 +127,7 @@ namespace pcpp
 			uint8_t dgst[8];  // 64 bit DES based
 		};
 #pragma pack(pop)
+		static_assert(sizeof(ntp_v3_auth) == 12, "ntp_v3_auth size is not 12 bytes");
 
 #pragma pack(push, 1)
 		struct ntp_v4_auth_md5
@@ -136,6 +138,7 @@ namespace pcpp
 			uint8_t dgst[16];
 		};
 #pragma pack(pop)
+		static_assert(sizeof(ntp_v4_auth_md5) == 20, "ntp_v4_auth_md5 size is not 20 bytes");
 
 #pragma pack(push, 1)
 		struct ntp_v4_auth_sha1
@@ -146,10 +149,11 @@ namespace pcpp
 			uint8_t dgst[20];
 		};
 #pragma pack(pop)
+		static_assert(sizeof(ntp_v4_auth_sha1) == 24, "ntp_v4_auth_sha1 size is not 24 bytes");
 
 		ntp_header* getNtpHeader() const
 		{
-			return (ntp_header*)m_Data;
+			return reinterpret_cast<ntp_header*>(m_Data);
 		}
 
 	public:

--- a/Packet++/header/PPPoELayer.h
+++ b/Packet++/header/PPPoELayer.h
@@ -42,6 +42,7 @@ namespace pcpp
 		uint16_t payloadLength;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(pppoe_header) == 6, "pppoe_header size is not 6 bytes");
 
 	/**
 	 * @class PPPoELayer

--- a/Packet++/header/RadiusLayer.h
+++ b/Packet++/header/RadiusLayer.h
@@ -29,6 +29,7 @@ namespace pcpp
 		uint8_t authenticator[16];
 	};
 #pragma pack(pop)
+	static_assert(sizeof(radius_header) == 20, "radius_header size is not 20 bytes");
 
 	/**
 	 * @class RadiusAttribute

--- a/Packet++/header/S7CommLayer.h
+++ b/Packet++/header/S7CommLayer.h
@@ -26,6 +26,7 @@ namespace pcpp
 		uint16_t dataLength;
 	} s7commhdr;
 #pragma pack(pop)
+	static_assert(sizeof(s7commhdr) == 10, "s7commhdr size is not 10 bytes");
 
 /**
  * @struct s7comm_ack_data_hdr
@@ -40,6 +41,7 @@ namespace pcpp
 		uint8_t errorCode;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(s7comm_ack_data_hdr) == 12, "s7comm_ack_data_hdr size is not 12 bytes");
 
 	/**
 	 * @class S7CommParameter

--- a/Packet++/header/SSHLayer.h
+++ b/Packet++/header/SSHLayer.h
@@ -287,6 +287,7 @@ namespace pcpp
 			uint8_t messageCode;
 		};
 #pragma pack(pop)
+		static_assert(sizeof(ssh_message_base) == 6, "ssh_message_base size is not 6 bytes");
 
 		// this layer supports only parsing
 		SSHHandshakeMessage();

--- a/Packet++/header/SSLCommon.h
+++ b/Packet++/header/SSLCommon.h
@@ -30,6 +30,7 @@ namespace pcpp
 		uint16_t length;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(ssl_tls_record_layer) == 5, "ssl_tls_record_layer size is not 5 bytes");
 
 	/**
 	 * @struct ssl_tls_handshake_layer
@@ -46,6 +47,7 @@ namespace pcpp
 		uint16_t length2;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(ssl_tls_handshake_layer) == 4, "ssl_tls_handshake_layer size is not 4 bytes");
 
 	/**
 	 * @struct ssl_tls_client_server_hello
@@ -60,6 +62,7 @@ namespace pcpp
 		uint8_t random[32];
 	};
 #pragma pack(pop)
+	static_assert(sizeof(ssl_tls_client_server_hello) == 38, "ssl_tls_client_server_hello size is not 38 bytes");
 
 	/**
 	 * @struct ssl_tls_change_cipher_spec
@@ -72,6 +75,7 @@ namespace pcpp
 		uint8_t changeCipherSpec;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(ssl_tls_change_cipher_spec) == 1, "ssl_tls_change_cipher_spec size is not 1 byte");
 
 	/**
 	 * @struct ssl_tls_alert
@@ -86,6 +90,7 @@ namespace pcpp
 		uint8_t alertDescription;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(ssl_tls_alert) == 2, "ssl_tls_alert size is not 2 bytes");
 
 	/**
 	 * SSL/TLS message types

--- a/Packet++/header/Sll2Layer.h
+++ b/Packet++/header/Sll2Layer.h
@@ -41,6 +41,7 @@ namespace pcpp
 		uint8_t link_layer_addr[8];
 	};
 #pragma pack(pop)
+	static_assert(sizeof(sll2_header) == 20, "sll2_header size is not 20 bytes");
 
 	/**
 	 * @class Sll2Layer

--- a/Packet++/header/SllLayer.h
+++ b/Packet++/header/SllLayer.h
@@ -36,6 +36,7 @@ namespace pcpp
 		uint16_t protocol_type;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(sll_header) == 16, "sll_header size is not 16 bytes");
 
 	/**
 	 * @class SllLayer

--- a/Packet++/header/SomeIpLayer.h
+++ b/Packet++/header/SomeIpLayer.h
@@ -83,6 +83,7 @@ namespace pcpp
 			uint8_t returnCode;
 		};
 #pragma pack(pop)
+		static_assert(sizeof(someiphdr) == 16, "someiphdr size is not 16 bytes");
 
 		/**
 		 * A constructor that creates the layer from an existing packet raw data
@@ -391,6 +392,7 @@ namespace pcpp
 			uint32_t offsetAndFlag;
 		};
 #pragma pack(pop)
+		static_assert(sizeof(someiptphdr) == 20, "someiptphdr size is not 20 bytes");
 
 		/**
 		 * A constructor that creates the layer from an existing packet raw data

--- a/Packet++/header/SomeIpSdLayer.h
+++ b/Packet++/header/SomeIpSdLayer.h
@@ -80,6 +80,7 @@ namespace pcpp
 			uint8_t reserved;
 		};
 #pragma pack(pop)
+		static_assert(sizeof(someipsdhdroptionsbase) == 4, "someipsdhdroptionsbase size is not 4 bytes");
 
 		/**
 		 * Destroy the SOME/IP-SD Option object and delete allocated data if it has been allocated by a constructor
@@ -207,6 +208,7 @@ namespace pcpp
 			uint16_t portNumber;
 		};
 #pragma pack(pop)
+		static_assert(sizeof(someipsdhdroptionsipv4) == 12, "someipsdhdroptionsipv4 size is not 12 bytes");
 	};
 
 	/**
@@ -284,6 +286,7 @@ namespace pcpp
 			uint16_t portNumber;
 		};
 #pragma pack(pop)
+		static_assert(sizeof(someipsdhdroptionsipv6) == 24, "someipsdhdroptionsipv6 size is not 24 bytes");
 	};
 
 	/**
@@ -364,6 +367,7 @@ namespace pcpp
 			uint16_t weight;
 		};
 #pragma pack(pop)
+		static_assert(sizeof(someipsdhdroptionsload) == 8, "someipsdhdroptionsload size is not 8 bytes");
 	};
 
 	/**
@@ -434,6 +438,7 @@ namespace pcpp
 			uint32_t data;
 		};
 #pragma pack(pop)
+		static_assert(sizeof(someipsdhdrentry) == 16, "someipsdhdrentry size is not 16 bytes");
 
 		/**
 		 * Construct a new SOME/IP-SD Service Entry Type
@@ -770,6 +775,7 @@ namespace pcpp
 			uint8_t reserved3;
 		};
 #pragma pack(pop)
+		static_assert(sizeof(someipsdhdr) == 20, "someipsdhdr size is not 20 bytes");
 
 		uint32_t m_NumOptions;
 

--- a/Packet++/header/StpLayer.h
+++ b/Packet++/header/StpLayer.h
@@ -27,9 +27,11 @@ namespace pcpp
 		uint8_t type;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(stp_tcn_bpdu) == 4, "stp_tcn_bpdu size is not 4 bytes");
 
 	/// Spanning Tree protocol common header
 	typedef stp_tcn_bpdu stp_header;
+	static_assert(sizeof(stp_header) == 4, "stp_header size is not 4 bytes");
 
 /**
  * @struct stp_conf_bpdu
@@ -58,6 +60,7 @@ namespace pcpp
 		uint16_t forwardDelay;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(stp_conf_bpdu) == 35, "stp_conf_bpdu size is not 35 bytes");
 
 /**
  * @struct rstp_conf_bpdu
@@ -70,6 +73,7 @@ namespace pcpp
 		uint8_t version1Len;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(rstp_conf_bpdu) == 36, "rstp_conf_bpdu size is not 36 bytes");
 
 /**
  * @struct mstp_conf_bpdu
@@ -96,6 +100,7 @@ namespace pcpp
 		uint8_t remainId;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(mstp_conf_bpdu) == 102, "mstp_conf_bpdu size is not 102 bytes");
 
 /**
  * @struct msti_conf_msg
@@ -118,6 +123,7 @@ namespace pcpp
 		uint8_t remainingHops;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(msti_conf_msg) == 16, "msti_conf_msg size is not 16 bytes");
 
 	/**
 	 * @class StpLayer

--- a/Packet++/header/TcpLayer.h
+++ b/Packet++/header/TcpLayer.h
@@ -85,6 +85,7 @@ namespace pcpp
 		uint16_t urgentPointer;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(tcphdr) == 20, "tcphdr size is not 20 bytes");
 
 	/**
 	 * TCP options types

--- a/Packet++/header/TpktLayer.h
+++ b/Packet++/header/TpktLayer.h
@@ -27,6 +27,7 @@ namespace pcpp
 		uint16_t length;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(tpkthdr) == 4, "tpkthdr size is not 4 bytes");
 
 	/**
 	 * @class TpktLayer

--- a/Packet++/header/UdpLayer.h
+++ b/Packet++/header/UdpLayer.h
@@ -28,6 +28,7 @@ namespace pcpp
 		uint16_t headerChecksum;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(udphdr) == 8, "udphdr size is not 8 bytes");
 
 	/**
 	 * @class UdpLayer

--- a/Packet++/header/VlanLayer.h
+++ b/Packet++/header/VlanLayer.h
@@ -33,6 +33,7 @@ namespace pcpp
 		uint16_t etherType;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(vlan_header) == 4, "vlan_header size is not 4 bytes");
 
 	/**
 	 * @class VlanLayer

--- a/Packet++/header/VrrpLayer.h
+++ b/Packet++/header/VrrpLayer.h
@@ -106,6 +106,7 @@ namespace pcpp
 		/** This specifies one or more IPvX addresses that are associated with the virtual router. */
 		uint8_t* ipAddresses[];
 	};
+	static_assert(sizeof(vrrp_header) == 8, "vrrp_header size is not 8 bytes");
 
 	/**
 	 * @class VrrpLayer

--- a/Packet++/header/VxlanLayer.h
+++ b/Packet++/header/VxlanLayer.h
@@ -63,6 +63,7 @@ namespace pcpp
 		uint32_t pad : 8;
 	};
 #pragma pack(pop)
+	static_assert(sizeof(vxlan_header) == 8, "vxlan_header size is not 8 bytes");
 
 	/**
 	 * @class VxlanLayer

--- a/Packet++/header/WakeOnLanLayer.h
+++ b/Packet++/header/WakeOnLanLayer.h
@@ -34,6 +34,7 @@ namespace pcpp
 			uint8_t addrBody[6 * 16];
 		};
 #pragma pack(pop)
+		static_assert(sizeof(wol_header) == 102, "wol_header size is not 102 bytes");
 
 		/**
 		 * A constructor that creates the layer from an existing packet raw data

--- a/Packet++/header/WireGuardLayer.h
+++ b/Packet++/header/WireGuardLayer.h
@@ -33,6 +33,8 @@ namespace pcpp
 			uint8_t reserved[3];
 		};
 #pragma pack(pop)
+		static_assert(sizeof(wg_common_header) == 4, "wg_common_header size is not 4 bytes");
+
 		wg_common_header* getBasicHeader() const
 		{
 			return reinterpret_cast<wg_common_header*>(m_Data);


### PR DESCRIPTION
The PR adds cpp11 `static_assert` statements after the declarations of fixed length structured used throughout Packet++ for encoding/decoding raw data.