### PR TITLE
Remove non-functional SSL 2 version code point

### DIFF
--- a/Packet++/header/SSLCommon.h
+++ b/Packet++/header/SSLCommon.h
@@ -100,8 +100,6 @@ namespace pcpp
 		/// SSL/TLS versions enum
 		enum SSLVersionEnum
 		{
-			/// SSL 2.0
-			SSL2 = 0x0200,
 			/// SSL 3.0
 			SSL3 = 0x0300,
 			/// TLS 1.0

--- a/Packet++/src/SSLCommon.cpp
+++ b/Packet++/src/SSLCommon.cpp
@@ -23,9 +23,6 @@ namespace pcpp
 				return static_cast<SSLVersion::SSLVersionEnum>(m_SSLVersionValue);
 		}
 
-		if (m_SSLVersionValue == 0x200)
-			return SSLVersion::SSL2;
-
 		return SSLVersion::Unknown;
 	}
 
@@ -81,8 +78,6 @@ namespace pcpp
 			return "TLS 1.3 (Facebook draft 26)";
 		case SSLVersion::Unknown:
 			return "Unknown";
-		case SSLVersion::SSL2:
-			return "SSL 2.0";
 		default:
 			return "Unknown";
 		}


### PR DESCRIPTION
SSL 2 uses a version field of 0x0002, not 0x0200.  This is confirmed not only in the original Netscape spec [1] and RFC draft of the time [2], but also in major implementations such as OpenSSL [3] and Wireshark [4].

[1] https://www-archive.mozilla.org/projects/security/pki/nss/ssl/draft02.html
[2] https://datatracker.ietf.org/doc/html/draft-hickman-netscape-ssl-00
[3] https://github.com/openssl/openssl/blob/OpenSSL_0_9_6m/ssl/ssl2.h#L66-L71
[4] https://github.com/wireshark/wireshark/blob/release-4.4/epan/dissectors/packet-tls-utils.h#L266-L277