### PR TITLE
Use lowercase for Windows headers

### DIFF
--- a/3rdParty/LightPcapNg/LightPcapNg/include/light_pcapng_ext.h
+++ b/3rdParty/LightPcapNg/LightPcapNg/include/light_pcapng_ext.h
@@ -33,7 +33,7 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 #ifdef _MSC_VER
-#include <Winsock2.h>
+#include <winsock2.h>
 #include <time.h>
 #else
 #include <sys/time.h>

--- a/Packet++/header/IcmpLayer.h
+++ b/Packet++/header/IcmpLayer.h
@@ -3,7 +3,7 @@
 #include "Layer.h"
 #include "IPv4Layer.h"
 #ifdef _MSC_VER
-#	include <Winsock2.h>
+#	include <winsock2.h>
 #else
 #	include <sys/time.h>
 #endif

--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -2,7 +2,7 @@
 
 #include <stdint.h>
 #ifdef _MSC_VER
-#	include <WinSock2.h>
+#	include <winsock2.h>
 #	include <time.h>
 #else
 #	include <sys/time.h>


### PR DESCRIPTION
These are all in _MSC_VER which is Windows-only, but let them be lower for consistency.