### PR TITLE
Fix CMake config file comments

### DIFF
--- a/cmake/PcapPlusPlusConfig.cmake.in
+++ b/cmake/PcapPlusPlusConfig.cmake.in
@@ -1,8 +1,7 @@
 # ~~~
 # - Config file for the PcapPlusPlus package
 # It defines the following variables
-#  PcapPlusPlus_INCLUDE_DIRS - include directories for PcapPlusPlus
-#  PcapPlusPlus_LIBRARIES    - libraries to link against
+#  PcapPlusPlus_INCLUDE_DIR  - include directories for PcapPlusPlus
 # ~~~
 
 @PACKAGE_INIT@


### PR DESCRIPTION
- Updated documentation comment to use PcapPlusPlus_INCLUDE_DIR instead of PcapPlusPlus_INCLUDE_DIRS to match actual variable name used in code
- Removed PcapPlusPlus_LIBRARIES reference from comments as this variable is not defined anymore