### PR TITLE
Change `PfRingDevice::m_CoreConfiguration` to std::array

### DIFF
--- a/Common++/header/SystemUtils.h
+++ b/Common++/header/SystemUtils.h
@@ -8,6 +8,7 @@
 
 /// @file
 
+// @todo Change to constexpr when C++17 is minimum supported version
 enum : uint8_t
 {
 	MAX_NUM_OF_CORES = 32

--- a/Pcap++/header/PfRingDevice.h
+++ b/Pcap++/header/PfRingDevice.h
@@ -6,6 +6,7 @@
 #include "MacAddress.h"
 #include "SystemUtils.h"
 #include "Packet.h"
+#include <array>
 #include <thread>
 #include <mutex>
 #include <condition_variable>
@@ -57,7 +58,7 @@ namespace pcpp
 		int m_InterfaceIndex;
 		MacAddress m_MacAddress;
 		int m_DeviceMTU;
-		CoreConfiguration m_CoreConfiguration[MAX_NUM_OF_CORES];
+		std::array<CoreConfiguration, MAX_NUM_OF_CORES> m_CoreConfiguration;
 		bool m_StopThread;
 		OnPfRingPacketsArriveCallback m_OnPacketsArriveCallback;
 		void* m_OnPacketsArriveUserCookie;

--- a/Pcap++/src/PfRingDevice.cpp
+++ b/Pcap++/src/PfRingDevice.cpp
@@ -10,6 +10,7 @@
 #include <pfring.h>
 #include <pthread.h>
 #include <chrono>
+#include <algorithm>
 
 #define DEFAULT_PF_RING_SNAPLEN 1600
 
@@ -714,18 +715,14 @@ namespace pcpp
 
 	void PfRingDevice::clearCoreConfiguration()
 	{
-		for (int i = 0; i < MAX_NUM_OF_CORES; i++)
-			m_CoreConfiguration[i].clear();
+		for (auto& config : m_CoreConfiguration)
+			config.clear();
 	}
 
 	int PfRingDevice::getCoresInUseCount() const
 	{
-		int res = 0;
-		for (int i = 0; i < MAX_NUM_OF_CORES; i++)
-			if (m_CoreConfiguration[i].IsInUse)
-				res++;
-
-		return res;
+		return std::count_if(m_CoreConfiguration.begin(), m_CoreConfiguration.end(),
+		                     [](const CoreConfiguration& config) { return config.IsInUse; });
 	}
 
 	void PfRingDevice::setPfRingDeviceAttributes()


### PR DESCRIPTION
Split of #1668

- Changes `m_CoreConfiguration` to `std::array`
- Changes `clearCoreConfiguration` to for-each loop.
- Changes `getCoresInUseCount` to use `std::count_if`.
- Adds todo comment to `MAX_NUM_OF_CORES` to be changed to `constexpr` when C++17 is the minimum supported verison.