### PR TITLE
Add stop token contract to encapsulate shutdown signal interface.

### DIFF
--- a/Pcap++/CMakeLists.txt
+++ b/Pcap++/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
   $<$<BOOL:${PCAPPP_USE_PF_RING}>:src/PfRingDeviceList.cpp>
   $<$<BOOL:${PCAPPP_USE_XDP}>:src/XdpDevice.cpp>
   src/RawSocketDevice.cpp
+  src/StopToken.cpp
   $<$<BOOL:${WIN32}>:src/WinPcapLiveDevice.cpp>
   # Force light pcapng to be link fully static
   $<TARGET_OBJECTS:light_pcapng>
@@ -35,6 +36,7 @@ set(
   header/PcapLiveDevice.h
   header/PcapLiveDeviceList.h
   header/RawSocketDevice.h
+  header/StopToken.h
 )
 
 if(PCAPPP_USE_DPDK)

--- a/Pcap++/header/PfRingDevice.h
+++ b/Pcap++/header/PfRingDevice.h
@@ -6,6 +6,7 @@
 #include "MacAddress.h"
 #include "SystemUtils.h"
 #include "Packet.h"
+#include "StopToken.h"
 #include <array>
 #include <thread>
 #include <mutex>
@@ -59,7 +60,8 @@ namespace pcpp
 		MacAddress m_MacAddress;
 		int m_DeviceMTU;
 		std::array<CoreConfiguration, MAX_NUM_OF_CORES> m_CoreConfiguration;
-		bool m_StopThread;
+		// An empty stop token source is used to indicate that no capture is running
+		internal::StopTokenSource m_StopTokenSource{ internal::NoStopStateTag{} };
 		OnPfRingPacketsArriveCallback m_OnPacketsArriveCallback;
 		void* m_OnPacketsArriveUserCookie;
 		bool m_ReentrantMode;

--- a/Pcap++/header/PfRingDevice.h
+++ b/Pcap++/header/PfRingDevice.h
@@ -71,7 +71,7 @@ namespace pcpp
 		PfRingDevice(const char* deviceName);
 
 		bool initCoreConfigurationByCoreMask(CoreMask coreMask);
-		void captureThreadMain(std::shared_ptr<StartupBlock> startupBlock);
+		void captureThreadMain(std::shared_ptr<StartupBlock> startupBlock, internal::StopToken stopToken);
 
 		int openSingleRxChannel(const char* deviceName, pfring** ring);
 

--- a/Pcap++/header/StopToken.h
+++ b/Pcap++/header/StopToken.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <memory>
+
+namespace pcpp
+{
+	namespace internal
+	{
+		class StopToken;
+
+		/// Tag type used to construct a StopTokenSource without a shared state.
+		struct NoStopStateTag
+		{
+		};
+
+		/// @class StopTokenSource
+		/// @brief A source that can be used to request a stop operation.
+		class StopTokenSource
+		{
+			friend class StopToken;
+
+		public:
+			/// Creates a new StopTokenSource.
+			StopTokenSource();
+			/// Creates a new StopTokenSource without a shared state.
+			explicit StopTokenSource(NoStopStateTag) noexcept : m_SharedState(nullptr)
+			{}
+
+			/// Returns a StopToken that is associated with this source.
+			/// @return A StopToken associated with this StopTokenSource.
+			StopToken getToken() const noexcept;
+
+			/// Requests a stop operation. This will notify all associated StopTokens
+			/// that a stop has been requested.
+			/// @return True if the stop request was successful, false otherwise.
+			bool requestStop() noexcept;
+
+			/// Checks if a stop has been requested for this StopTokenSource.
+			/// @return True if a stop has been requested, false otherwise.
+			bool stopRequested() const noexcept;
+
+			/// Checks if a stop can be requested for this StopTokenSource.
+			/// @return True if a stop can be requested, false otherwise.
+			bool stopPossible() const noexcept;
+
+		private:
+			struct SharedState;
+
+			std::shared_ptr<SharedState> m_SharedState;
+		};
+
+		/// @class StopToken
+		/// @brief A token that can be used to check if a stop has been requested.
+		///
+		/// The StopToken class is used to check if a stop has been requested by a StopTokenSource.
+		/// It holds a shared state with the StopTokenSource to determine if a stop has been requested.
+		class StopToken
+		{
+			friend class StopTokenSource;
+
+		public:
+			/// @brief Default constructor for StopToken.
+			/// Constructs a StopToken with no associated shared state.
+			StopToken() noexcept = default;
+
+			/// @brief Checks if a stop has been requested.
+			/// @return True if a stop has been requested, false otherwise.
+			bool stopRequested() const noexcept;
+
+			/// @brief Checks if a stop can be requested.
+			/// @return True if a stop can be requested, false otherwise.
+			bool stopPossible() const noexcept;
+
+		private:
+			/// @brief Constructs a StopToken with the given shared state.
+			/// @param sharedState The shared state associated with this StopToken.
+			explicit StopToken(std::shared_ptr<StopTokenSource::SharedState> sharedState) noexcept
+			    : m_SharedState(std::move(sharedState))
+			{}
+
+			/// @brief The shared state associated with this StopToken.
+			std::shared_ptr<StopTokenSource::SharedState> m_SharedState;
+		};
+
+		inline StopToken StopTokenSource::getToken() const noexcept
+		{
+			return StopToken(m_SharedState);
+		}
+	}  // namespace internal
+}  // namespace pcpp

--- a/Pcap++/src/StopToken.cpp
+++ b/Pcap++/src/StopToken.cpp
@@ -1,0 +1,47 @@
+#include "StopToken.h"
+
+#include <atomic>
+#include <memory>
+
+namespace pcpp
+{
+	namespace internal
+	{
+		struct StopTokenSource::SharedState
+		{
+			std::atomic<bool> IsCancellationRequested{ false };
+		};
+
+		StopTokenSource::StopTokenSource() : m_SharedState(std::make_shared<SharedState>())
+		{}
+
+		bool StopTokenSource::requestStop() noexcept
+		{
+			if (m_SharedState == nullptr)
+				return false;
+
+			// Try to set the flag to true. If it was already true, return false
+			// This is done to prevent multiple threads from setting the flag to true
+			bool expected = false;
+			return m_SharedState->IsCancellationRequested.compare_exchange_strong(expected, true,
+			                                                                      std::memory_order_relaxed);
+		}
+		bool StopTokenSource::stopRequested() const noexcept
+		{
+			return m_SharedState != nullptr && m_SharedState->IsCancellationRequested.load(std::memory_order_relaxed);
+		}
+		bool StopTokenSource::stopPossible() const noexcept
+		{
+			return m_SharedState != nullptr;
+		}
+
+		bool StopToken::stopRequested() const noexcept
+		{
+			return m_SharedState != nullptr && m_SharedState->IsCancellationRequested.load(std::memory_order_relaxed);
+		}
+		bool StopToken::stopPossible() const noexcept
+		{
+			return m_SharedState != nullptr;
+		}
+	}  // namespace internal
+}  // namespace pcpp

--- a/Tests/Pcap++Test/CMakeLists.txt
+++ b/Tests/Pcap++Test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(
   Tests/PacketParsingTests.cpp
   Tests/PfRingTests.cpp
   Tests/RawSocketTests.cpp
+  Tests/StopTokenTests.cpp
   Tests/SystemUtilsTests.cpp
   Tests/TcpReassemblyTests.cpp
   Tests/XdpTests.cpp

--- a/Tests/Pcap++Test/TestDefinition.h
+++ b/Tests/Pcap++Test/TestDefinition.h
@@ -118,6 +118,9 @@ PTF_TEST_CASE(TestKniDeviceSendReceive);
 // Implemented in RawSocketTests.cpp
 PTF_TEST_CASE(TestRawSockets);
 
+// Implemented in StopTokenTests.cpp
+PTF_TEST_CASE(TestStopToken);
+
 // Implemented in SystemUtilsTests.cpp
 PTF_TEST_CASE(TestSystemCoreUtils);
 

--- a/Tests/Pcap++Test/Tests/StopTokenTests.cpp
+++ b/Tests/Pcap++Test/Tests/StopTokenTests.cpp
@@ -1,0 +1,52 @@
+#include "../TestDefinition.h"
+
+#include "StopToken.h"
+
+PTF_TEST_CASE(TestStopToken)
+{
+	using pcpp::internal::NoStopStateTag;
+	using pcpp::internal::StopToken;
+	using pcpp::internal::StopTokenSource;
+
+	{
+		// A stop token source without a shared state should not be able to request a stop.
+		StopTokenSource stopTokenSource{ NoStopStateTag{} };
+
+		PTF_ASSERT_FALSE(stopTokenSource.stopPossible());
+		PTF_ASSERT_FALSE(stopTokenSource.stopRequested());
+		PTF_ASSERT_FALSE(stopTokenSource.requestStop());
+
+		// A stop token source without a shared state should generate an empty stop token.
+		StopToken stopToken = stopTokenSource.getToken();
+
+		PTF_ASSERT_FALSE(stopToken.stopRequested());
+		PTF_ASSERT_FALSE(stopTokenSource.stopPossible());
+	}
+
+	{
+		// A default constructed stop token source should have a shared state and not have a stop requested.
+		StopTokenSource stopTokenSource;
+
+		PTF_ASSERT_TRUE(stopTokenSource.stopPossible());
+		PTF_ASSERT_FALSE(stopTokenSource.stopRequested());
+
+		// A stop token source with a shared state should generate a stop token that reflects the state of the source.
+		StopToken stopToken = stopTokenSource.getToken();
+		PTF_ASSERT_TRUE(stopToken.stopPossible());
+		PTF_ASSERT_FALSE(stopToken.stopRequested());
+
+		// Request a stop and check if the stop token reflects the change.
+		PTF_ASSERT_TRUE(stopTokenSource.requestStop());
+		PTF_ASSERT_TRUE(stopTokenSource.stopRequested());
+		PTF_ASSERT_TRUE(stopToken.stopRequested());
+
+		// Requesting a stop again should not change the state
+		PTF_ASSERT_FALSE(stopTokenSource.requestStop());
+		PTF_ASSERT_TRUE(stopTokenSource.stopRequested());
+		PTF_ASSERT_TRUE(stopToken.stopRequested());
+
+		// Creating a new stop token should reflect the state of the source.
+		StopToken stopToken2 = stopTokenSource.getToken();
+		PTF_ASSERT_TRUE(stopToken2.stopRequested());
+	}
+}

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -304,6 +304,8 @@ int main(int argc, char* argv[])
 
 	PTF_RUN_TEST(TestRawSockets, "raw_sockets");
 
+	PTF_RUN_TEST(TestStopToken, "no_network");
+
 	PTF_RUN_TEST(TestSystemCoreUtils, "no_network;system_utils");
 
 	PTF_RUN_TEST(TestXdpDeviceReceivePackets, "xdp");


### PR DESCRIPTION
Split of #1668 

- Adds `StopToken` and `StopTokenSource` to encapsulate a stop token contract.
- Replace `PfRingDevice::m_stopThread` with a stop token source.
- Remove the check of the startup block `state` variable to stop the capture thread early due to an error.
- Added waiting for all started threads to shutdown if an exceptional state happened during capture thread startup.