### PR TITLE
Changed `m_PfRingDescriptors` to only contain active channels.

### DIFF
--- a/Pcap++/header/PfRingDevice.h
+++ b/Pcap++/header/PfRingDevice.h
@@ -60,7 +60,6 @@ namespace pcpp
 		};
 
 		std::vector<pfring*> m_PfRingDescriptors;
-		uint8_t m_NumOfOpenedRxChannels;
 		std::string m_DeviceName;
 		int m_InterfaceIndex;
 		MacAddress m_MacAddress;
@@ -79,6 +78,8 @@ namespace pcpp
 		void captureThreadMain(std::shared_ptr<StartupBlock> startupBlock);
 
 		int openSingleRxChannel(const char* deviceName, pfring*& ring);
+		/// Closes all opened RX channels and clears the opened channels list (m_PfRingDescriptors)
+		void closeAllRxChannels();
 
 		bool getIsHwClockEnable()
 		{
@@ -211,7 +212,7 @@ namespace pcpp
 		/// @return Number of opened RX channels
 		uint8_t getNumOfOpenedRxChannels() const
 		{
-			return m_NumOfOpenedRxChannels;
+			return static_cast<uint8_t>(m_PfRingDescriptors.size());
 		}
 
 		/// Gets the total number of RX channels (RX queues) this interface has

--- a/Pcap++/header/PfRingDevice.h
+++ b/Pcap++/header/PfRingDevice.h
@@ -89,7 +89,7 @@ namespace pcpp
 		bool setPfRingDeviceClock(pfring* ring);
 
 		void clearCoreConfiguration();
-		int getCoresInUseCount() const;
+		size_t getCoresInUseCount() const;
 
 		void setPfRingDeviceAttributes();
 

--- a/Pcap++/src/PfRingDevice.cpp
+++ b/Pcap++/src/PfRingDevice.cpp
@@ -164,6 +164,11 @@ namespace pcpp
 			return false;
 		}
 
+		if (numOfChannelIds < 0)
+		{
+			throw std::invalid_argument("numOfChannelIds must be >= 0");
+		}
+
 		// I needed to add this verification because PF_RING doesn't provide it.
 		// It allows opening the device on a channel that doesn't exist, but of course no packets will be captured
 		uint8_t totalChannels = getTotalNumOfRxChannels();
@@ -207,7 +212,7 @@ namespace pcpp
 			break;
 		}
 
-		if (m_PfRingDescriptors.size() < numOfChannelIds)
+		if (m_PfRingDescriptors.size() < static_cast<size_t>(numOfChannelIds))
 		{
 			// if an error occurred, close all rings from index=0 to index=m_NumOfOpenedRxChannels-1
 			// there's no need to close m_PfRingDescriptors[m_NumOfOpenedRxChannels] because it has already been
@@ -730,7 +735,7 @@ namespace pcpp
 			config.clear();
 	}
 
-	int PfRingDevice::getCoresInUseCount() const
+	size_t PfRingDevice::getCoresInUseCount() const
 	{
 		return std::count_if(m_CoreConfiguration.begin(), m_CoreConfiguration.end(),
 		                     [](const CoreConfiguration& config) { return config.IsInUse; });

--- a/Pcap++/src/PfRingDevice.cpp
+++ b/Pcap++/src/PfRingDevice.cpp
@@ -892,8 +892,12 @@ namespace pcpp
 				packetsSent++;
 		}
 
-		// The following method isn't supported in PF_RING aware drivers, probably only in DNA and ZC
-		pfring_flush_tx_packets(m_PfRingDescriptors[0]);
+		// In case of failure due to closed device, there are not handles to flush.
+		if (m_PfRingDescriptors.size() > 0)
+		{
+			// The following method isn't supported in PF_RING aware drivers, probably only in DNA and ZC
+			pfring_flush_tx_packets(m_PfRingDescriptors[0]);
+		}
 
 		PCPP_LOG_DEBUG(packetsSent << " out of " << arrLength << " raw packets were sent successfully");
 
@@ -912,8 +916,12 @@ namespace pcpp
 				packetsSent++;
 		}
 
-		// The following method isn't supported in PF_RING aware drivers, probably only in DNA and ZC
-		pfring_flush_tx_packets(m_PfRingDescriptors[0]);
+		// In case of failure due to closed device, there are not handles to flush.
+		if (m_PfRingDescriptors.size() > 0)
+		{
+			// The following method isn't supported in PF_RING aware drivers, probably only in DNA and ZC
+			pfring_flush_tx_packets(m_PfRingDescriptors[0]);
+		}
 
 		PCPP_LOG_DEBUG(packetsSent << " out of " << arrLength << " packets were sent successfully");
 
@@ -930,9 +938,13 @@ namespace pcpp
 			else
 				packetsSent++;
 		}
-
-		// The following method isn't supported in PF_RING aware drivers, probably only in DNA and ZC
-		pfring_flush_tx_packets(m_PfRingDescriptors[0]);
+		
+		// In case of failure due to closed device, there are not handles to flush.
+		if (m_PfRingDescriptors.size() > 0)
+		{
+			// The following method isn't supported in PF_RING aware drivers, probably only in DNA and ZC
+			pfring_flush_tx_packets(m_PfRingDescriptors[0]);
+		}
 
 		PCPP_LOG_DEBUG(packetsSent << " out of " << rawPackets.size() << " raw packets were sent successfully");
 

--- a/Pcap++/src/PfRingDevice.cpp
+++ b/Pcap++/src/PfRingDevice.cpp
@@ -938,7 +938,7 @@ namespace pcpp
 			else
 				packetsSent++;
 		}
-		
+
 		// In case of failure due to closed device, there are not handles to flush.
 		if (m_PfRingDescriptors.size() > 0)
 		{


### PR DESCRIPTION
- `m_PfRingDescriptors` is no longer initialized to MAX_NUM_RX_CHANNELS. Instead the buffer is only reserved.
- New channels are added to `m_PfRingDescriptors` only after passing initialization.
- Added helper function `closeAllRxChannels` that closes and clears `m_PfRingDescriptors`.
- Removed variable `m_NumOfOpenedRxChannels`. `m_PfRingDescriptors::size()` should be used to fetch the number of active channels instead.
- Replaced `for` loops with `foreach` loops where possible.