### PR TITLE
Change Cmake to use target_compiler_features than CMAKE_CXX_STANDARD to define cpp standard.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,8 +139,12 @@ option(PCAPPP_USE_XDP "Setup PcapPlusPlus with XDP")
 option(PCAPPP_INSTALL "Install Pcap++" ${PCAPPP_MAIN_PROJECT})
 option(PCAPPP_PACKAGE "Package Pcap++ could require a recent version of CMake" OFF)
 
-# Set C++11
-set(CMAKE_CXX_STANDARD 11)
+# Set C++11 if not defined
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
 # popen()/pclose() are not C++ standards
 set(CMAKE_CXX_EXTENSIONS ON)
 # Set Position Independent Code for static libraries

--- a/Common++/CMakeLists.txt
+++ b/Common++/CMakeLists.txt
@@ -34,6 +34,8 @@ set(
 # Set the public header that will be installed
 set_property(TARGET Common++ PROPERTY PUBLIC_HEADER ${public_headers})
 
+target_compile_features(Common++ PUBLIC cxx_std_11)
+
 target_include_directories(
   Common++
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/header> $<INSTALL_INTERFACE:include/pcapplusplus>

--- a/Packet++/CMakeLists.txt
+++ b/Packet++/CMakeLists.txt
@@ -144,6 +144,8 @@ set(
 # Don't use set_target_properties CMake limit to 50 elements
 set_property(TARGET Packet++ PROPERTY PUBLIC_HEADER ${public_headers})
 
+target_compile_features(Packet++ PUBLIC cxx_std_11)
+
 target_include_directories(
   Packet++
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/header> $<INSTALL_INTERFACE:include/pcapplusplus>

--- a/Pcap++/CMakeLists.txt
+++ b/Pcap++/CMakeLists.txt
@@ -63,6 +63,8 @@ endif()
 
 set_property(TARGET Pcap++ PROPERTY PUBLIC_HEADER ${public_headers})
 
+target_compile_features(Pcap++ PUBLIC cxx_std_11)
+
 if(APPLE)
   target_link_libraries(Pcap++ PRIVATE "-framework CoreFoundation" "-framework SystemConfiguration")
 elseif(WIN32)


### PR DESCRIPTION
- Added `target_compiler_features` clause to `Common++`, `Packet++` and `Pcap++`. Linking projects will automatically select a CPP standard that satisfies all required features by dependent targets.
- Made `CMAKE_CXX_STANDARD` optionally defined only if not set externally.
