### PR TITLE
Few fixes to support DPDK 23.11 and 24.11

### DIFF
--- a/Pcap++/header/DpdkDevice.h
+++ b/Pcap++/header/DpdkDevice.h
@@ -405,7 +405,8 @@ namespace pcpp
 
 		/// Get the link status (link up/down, link speed and link duplex)
 		/// @param[out] linkStatus A reference to object the result shall be written to
-		void getLinkStatus(LinkStatus& linkStatus) const;
+		/// @return True if managed to fetch the link status and `linkStatus` was updated, false otherwise
+		bool getLinkStatus(LinkStatus& linkStatus) const;
 
 		/// @return The core ID used in this context
 		uint32_t getCurrentCoreId() const;

--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -105,6 +105,18 @@ namespace pcpp
 		0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A, 0x6D, 0x5A,
 	};
 
+	static bool getDeviceInfo(uint16_t devId, rte_eth_dev_info& devInfo)
+	{
+		auto ret = rte_eth_dev_info_get(devId, &devInfo);
+		if (ret < 0)
+		{
+			PCPP_LOG_ERROR("Couldn't get device info, error was: " << rte_strerror(ret) << " (" << ret << ")");
+			return false;
+		}
+
+		return true;
+	}
+
 	DpdkDevice::DpdkDevice(int port, uint32_t mBufPoolSize, uint16_t mBufDataSize)
 	    : m_Id(port), m_MacAddress(MacAddress::Zero),
 	      m_MBufDataSize(mBufDataSize < 1 ? RTE_MBUF_DEFAULT_BUF_SIZE : mBufDataSize)
@@ -348,10 +360,8 @@ namespace pcpp
 	bool DpdkDevice::initQueues(uint8_t numOfRxQueuesToInit, uint8_t numOfTxQueuesToInit)
 	{
 		rte_eth_dev_info devInfo;
-		auto ret = rte_eth_dev_info_get(m_Id, &devInfo);
-		if (ret < 0)
+		if (!getDeviceInfo(m_Id, devInfo))
 		{
-			PCPP_LOG_ERROR("Couldn't get device info, error was: " << rte_strerror(ret) << " (" << ret << ")");
 			return false;
 		}
 
@@ -508,10 +518,8 @@ namespace pcpp
 	void DpdkDevice::setDeviceInfo()
 	{
 		rte_eth_dev_info portInfo;
-		auto ret = rte_eth_dev_info_get(m_Id, &portInfo);
-		if (ret < 0)
+		if (!getDeviceInfo(m_Id, portInfo))
 		{
-			PCPP_LOG_ERROR("Couldn't get device info, error was: " << rte_strerror(ret) << " (" << ret << ")");
 			return;
 		}
 
@@ -1300,10 +1308,8 @@ namespace pcpp
 		if (rssHF == (uint64_t)-1)
 		{
 			rte_eth_dev_info devInfo;
-			auto ret = rte_eth_dev_info_get(m_Id, &devInfo);
-			if (ret < 0)
+			if (!getDeviceInfo(m_Id, devInfo))
 			{
-				PCPP_LOG_ERROR("Couldn't get device info, error was: " << rte_strerror(ret) << " (" << ret << ")");
 				return 0;
 			}
 
@@ -1452,10 +1458,8 @@ namespace pcpp
 		uint64_t dpdkRssHF = convertRssHfToDpdkRssHf(rssHFMask);
 
 		rte_eth_dev_info devInfo;
-		auto ret = rte_eth_dev_info_get(m_Id, &devInfo);
-		if (ret < 0)
+		if (!getDeviceInfo(m_Id, devInfo))
 		{
-			PCPP_LOG_ERROR("Couldn't get device info, error was: " << rte_strerror(ret) << " (" << ret << ")");
 			return false;
 		}
 
@@ -1465,10 +1469,8 @@ namespace pcpp
 	uint64_t DpdkDevice::getSupportedRssHashFunctions() const
 	{
 		rte_eth_dev_info devInfo;
-		auto ret = rte_eth_dev_info_get(m_Id, &devInfo);
-		if (ret < 0)
+		if (!getDeviceInfo(m_Id, devInfo))
 		{
-			PCPP_LOG_ERROR("Couldn't get device info, error was: " << rte_strerror(ret) << " (" << ret << ")");
 			return 0;
 		}
 

--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -273,6 +273,8 @@ namespace pcpp
 		{
 			PCPP_LOG_DEBUG("PMD '" << m_PMDName << "' doesn't support RSS, setting RSS hash functions to 0");
 			m_Config.rssHashFunction = RSS_NONE;
+			m_Config.rssKey = nullptr;
+			m_Config.rssKeyLength = 0;
 		}
 
 		if (!isDeviceSupportRssHashFunction(getConfiguredRssHashFunction()))

--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -348,8 +348,10 @@ namespace pcpp
 	bool DpdkDevice::initQueues(uint8_t numOfRxQueuesToInit, uint8_t numOfTxQueuesToInit)
 	{
 		rte_eth_dev_info devInfo;
-		if (rte_eth_dev_info_get(m_Id, &devInfo) < 0)
+		auto ret = rte_eth_dev_info_get(m_Id, &devInfo);
+		if (ret < 0)
 		{
+			PCPP_LOG_ERROR("Couldn't get device info, error was: " << rte_strerror(ret) << " (" << ret << ")");
 			return false;
 		}
 
@@ -506,8 +508,10 @@ namespace pcpp
 	void DpdkDevice::setDeviceInfo()
 	{
 		rte_eth_dev_info portInfo;
-		if (rte_eth_dev_info_get(m_Id, &portInfo) < 0)
+		auto ret = rte_eth_dev_info_get(m_Id, &portInfo);
+		if (ret < 0)
 		{
+			PCPP_LOG_ERROR("Couldn't get device info, error was: " << rte_strerror(ret) << " (" << ret << ")");
 			return;
 		}
 
@@ -592,8 +596,10 @@ namespace pcpp
 	bool DpdkDevice::getLinkStatus(LinkStatus& linkStatus) const
 	{
 		struct rte_eth_link link;
-		if (rte_eth_link_get((uint8_t)m_Id, &link) < 0)
+		auto ret = rte_eth_link_get((uint8_t)m_Id, &link);
+		if (ret < 0)
 		{
+			PCPP_LOG_ERROR("Couldn't get link info, error was: " << rte_strerror(ret) << " (" << ret << ")");
 			return false;
 		}
 
@@ -1294,8 +1300,10 @@ namespace pcpp
 		if (rssHF == (uint64_t)-1)
 		{
 			rte_eth_dev_info devInfo;
-			if (rte_eth_dev_info_get(m_Id, &devInfo) < 0)
+			auto ret = rte_eth_dev_info_get(m_Id, &devInfo);
+			if (ret < 0)
 			{
+				PCPP_LOG_ERROR("Couldn't get device info, error was: " << rte_strerror(ret) << " (" << ret << ")");
 				return 0;
 			}
 
@@ -1444,8 +1452,10 @@ namespace pcpp
 		uint64_t dpdkRssHF = convertRssHfToDpdkRssHf(rssHFMask);
 
 		rte_eth_dev_info devInfo;
-		if (rte_eth_dev_info_get(m_Id, &devInfo) < 0)
+		auto ret = rte_eth_dev_info_get(m_Id, &devInfo);
+		if (ret < 0)
 		{
+			PCPP_LOG_ERROR("Couldn't get device info, error was: " << rte_strerror(ret) << " (" << ret << ")");
 			return false;
 		}
 
@@ -1455,8 +1465,10 @@ namespace pcpp
 	uint64_t DpdkDevice::getSupportedRssHashFunctions() const
 	{
 		rte_eth_dev_info devInfo;
-		if (rte_eth_dev_info_get(m_Id, &devInfo) < 0)
+		auto ret = rte_eth_dev_info_get(m_Id, &devInfo);
+		if (ret < 0)
 		{
+			PCPP_LOG_ERROR("Couldn't get device info, error was: " << rte_strerror(ret) << " (" << ret << ")");
 			return 0;
 		}
 

--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -348,7 +348,11 @@ namespace pcpp
 	bool DpdkDevice::initQueues(uint8_t numOfRxQueuesToInit, uint8_t numOfTxQueuesToInit)
 	{
 		rte_eth_dev_info devInfo;
-		rte_eth_dev_info_get(m_Id, &devInfo);
+		if (rte_eth_dev_info_get(m_Id, &devInfo) < 0)
+		{
+			return false;
+		}
+
 		if (numOfRxQueuesToInit > devInfo.max_rx_queues)
 		{
 			PCPP_LOG_ERROR("Num of RX queues requested for open [" << numOfRxQueuesToInit
@@ -502,7 +506,11 @@ namespace pcpp
 	void DpdkDevice::setDeviceInfo()
 	{
 		rte_eth_dev_info portInfo;
-		rte_eth_dev_info_get(m_Id, &portInfo);
+		if (rte_eth_dev_info_get(m_Id, &portInfo) < 0)
+		{
+			return;
+		}
+
 		m_PMDName = std::string(portInfo.driver_name);
 
 		if (m_PMDName == "eth_bond")
@@ -581,14 +589,20 @@ namespace pcpp
 		}
 	}
 
-	void DpdkDevice::getLinkStatus(LinkStatus& linkStatus) const
+	bool DpdkDevice::getLinkStatus(LinkStatus& linkStatus) const
 	{
 		struct rte_eth_link link;
-		rte_eth_link_get((uint8_t)m_Id, &link);
+		if (rte_eth_link_get((uint8_t)m_Id, &link) < 0)
+		{
+			return false;
+		}
+
 		linkStatus.linkUp = link.link_status;
 		linkStatus.linkSpeedMbps = (unsigned)link.link_speed;
 		linkStatus.linkDuplex =
 		    (link.link_duplex == DPDK_CONFIG_ETH_LINK_FULL_DUPLEX) ? LinkStatus::FULL_DUPLEX : LinkStatus::HALF_DUPLEX;
+
+		return true;
 	}
 
 	bool DpdkDevice::initCoreConfigurationByCoreMask(CoreMask coreMask)
@@ -1280,7 +1294,11 @@ namespace pcpp
 		if (rssHF == (uint64_t)-1)
 		{
 			rte_eth_dev_info devInfo;
-			rte_eth_dev_info_get(m_Id, &devInfo);
+			if (rte_eth_dev_info_get(m_Id, &devInfo) < 0)
+			{
+				return 0;
+			}
+
 			return devInfo.flow_type_rss_offloads;
 		}
 
@@ -1426,7 +1444,10 @@ namespace pcpp
 		uint64_t dpdkRssHF = convertRssHfToDpdkRssHf(rssHFMask);
 
 		rte_eth_dev_info devInfo;
-		rte_eth_dev_info_get(m_Id, &devInfo);
+		if (rte_eth_dev_info_get(m_Id, &devInfo) < 0)
+		{
+			return false;
+		}
 
 		return ((devInfo.flow_type_rss_offloads & dpdkRssHF) == dpdkRssHF);
 	}
@@ -1434,7 +1455,10 @@ namespace pcpp
 	uint64_t DpdkDevice::getSupportedRssHashFunctions() const
 	{
 		rte_eth_dev_info devInfo;
-		rte_eth_dev_info_get(m_Id, &devInfo);
+		if (rte_eth_dev_info_get(m_Id, &devInfo) < 0)
+		{
+			return 0;
+		}
 
 		return convertDpdkRssHfToRssHf(devInfo.flow_type_rss_offloads);
 	}

--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -1056,7 +1056,7 @@ namespace pcpp
 			return 0;
 		}
 
-		rte_mbuf* mBufArr[MAX_BURST_SIZE];
+		rte_mbuf* mBufArr[MAX_BURST_SIZE] = {};
 
 		int packetIndex = 0;
 		int mBufArrIndex = 0;

--- a/Pcap++/src/MBufRawPacket.cpp
+++ b/Pcap++/src/MBufRawPacket.cpp
@@ -333,9 +333,9 @@ namespace pcpp
 			return;
 		}
 
-		m_MBuf = mBuf;
 		RawPacket::setRawData(rte_pktmbuf_mtod(mBuf, const uint8_t*), rte_pktmbuf_pkt_len(mBuf), timestamp,
 		                      LINKTYPE_ETHERNET);
+		m_MBuf = mBuf;							  
 	}
 
 }  // namespace pcpp

--- a/Pcap++/src/MBufRawPacket.cpp
+++ b/Pcap++/src/MBufRawPacket.cpp
@@ -335,7 +335,7 @@ namespace pcpp
 
 		RawPacket::setRawData(rte_pktmbuf_mtod(mBuf, const uint8_t*), rte_pktmbuf_pkt_len(mBuf), timestamp,
 		                      LINKTYPE_ETHERNET);
-		m_MBuf = mBuf;							  
+		m_MBuf = mBuf;
 	}
 
 }  // namespace pcpp

--- a/Tests/Pcap++Test/Tests/DpdkTests.cpp
+++ b/Tests/Pcap++Test/Tests/DpdkTests.cpp
@@ -200,7 +200,6 @@ public:
 	{
 		if (!m_Initialized)
 		{
-			std::cout << "Error: Thread " << coreId << " was not initialized" << std::endl;
 			return false;
 		}
 
@@ -208,7 +207,6 @@ public:
 
 		if (m_DpdkDevice == NULL)
 		{
-			std::cout << "Error: DpdkDevice is NULL";
 			return false;
 		}
 
@@ -225,7 +223,6 @@ public:
 			uint16_t packetsSent = m_DpdkDevice->sendPackets(mBufArr, packetReceived, m_QueueId);
 			if (packetsSent != packetReceived)
 			{
-				std::cout << "Error: Couldn't send all received packets on thread " << m_CoreId;
 				return false;
 			}
 		}

--- a/Tests/Pcap++Test/Tests/DpdkTests.cpp
+++ b/Tests/Pcap++Test/Tests/DpdkTests.cpp
@@ -329,7 +329,7 @@ PTF_TEST_CASE(TestDpdkDevice)
 	PTF_ASSERT_EQUAL(dev->getNumOfOpenedRxQueues(), 1);
 	PTF_ASSERT_EQUAL(dev->getNumOfOpenedTxQueues(), 1);
 	pcpp::DpdkDevice::LinkStatus linkStatus;
-	dev->getLinkStatus(linkStatus);
+	PTF_ASSERT_TRUE(dev->getLinkStatus(linkStatus));
 	PTF_ASSERT_TRUE(linkStatus.linkUp);
 	PTF_ASSERT_GREATER_THAN(linkStatus.linkSpeedMbps, 0);
 


### PR DESCRIPTION
The first PR to address issue https://github.com/seladb/PcapPlusPlus/issues/1770 (there'll be a follow-up PR).

I'm working on adding DPDK 23.11 and 24.11. These fixes are needed to support these versions. They should all be backward-compatible and work on older DPDK versions as well.

Once this PR is merged, I'll add Docker images for DPDK 23.11 and 24.11 (here is a draft PR for it: https://github.com/seladb/PcapPlusPlus-DockerImages/pull/49) and open another PR to update our CI with the new images. 