### PR TITLE
Add support for DPDK 23.11 and 24.11

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -170,11 +170,9 @@ jobs:
     strategy:
       matrix:
         include:
+          - image: ubuntu2204-dpdk2411
+          - image: ubuntu2204-dpdk2311
           - image: ubuntu2204-dpdk2211
-          - image: ubuntu2004-dpdk2111
-            additional-flags: -DPCAPPP_USE_DPDK_KNI=ON
-          - image: ubuntu2004-dpdk2011
-            additional-flags: -DPCAPPP_USE_DPDK_KNI=ON
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -170,8 +170,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - image: ubuntu2204-dpdk2411
-          - image: ubuntu2204-dpdk2311
+          - image: ubuntu2404-dpdk2411
+          - image: ubuntu2404-dpdk2311
           - image: ubuntu2204-dpdk2211
 
     steps:


### PR DESCRIPTION
Add DPDK 23.11 and 24.11 to CI and remove DPDK 20.11 and 21.11

Addresses this issue: https://github.com/seladb/PcapPlusPlus/issues/1770