### PR TITLE
Added `internal::DeviceListBase` as a common base for device list classes.

### DIFF
--- a/Pcap++/CMakeLists.txt
+++ b/Pcap++/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(
 set(
   public_headers
   header/Device.h
+  header/DeviceListBase.h
   header/NetworkUtils.h
   header/PcapDevice.h
   header/PcapFileDevice.h

--- a/Pcap++/header/DeviceListBase.h
+++ b/Pcap++/header/DeviceListBase.h
@@ -23,6 +23,10 @@ namespace pcpp
 			DeviceListBase& operator=(DeviceListBase&&) = default;
 
 		public:
+			using value_type = T*;
+			using size_type = std::size_t;
+			using difference_type = std::ptrdiff_t;
+
 			using iterator = typename PointerVector<T, Deleter>::VectorIterator;
 			using const_iterator = typename PointerVector<T, Deleter>::ConstVectorIterator;
 

--- a/Pcap++/header/DeviceListBase.h
+++ b/Pcap++/header/DeviceListBase.h
@@ -1,0 +1,86 @@
+#pragma once
+#include "PointerVector.h"
+
+namespace pcpp
+{
+	namespace internal
+	{
+		/// @brief A base class for device lists, providing common functionality for managing a list of devices.
+		template <typename T, typename Deleter = std::default_delete<T>> class DeviceListBase
+		{
+		protected:
+			DeviceListBase() = default;
+
+			explicit DeviceListBase(PointerVector<T, Deleter> devices) : m_DeviceList(std::move(devices))
+			{}
+			
+			DeviceListBase(DeviceListBase const&) = default;
+			DeviceListBase(DeviceListBase&&) = default;
+			// Protected destructor to disallow deletion of derived class through a base class pointer
+			~DeviceListBase() = default;
+
+			DeviceListBase& operator=(DeviceListBase const&) = default;
+			DeviceListBase& operator=(DeviceListBase&&) = default;
+		public:
+			using value_type = T*;
+			using size_type = std::size_t;
+			using difference_type = std::ptrdiff_t;
+
+			using iterator = typename PointerVector<T, Deleter>::VectorIterator;
+			using const_iterator = typename PointerVector<T, Deleter>::ConstVectorIterator;
+
+			/// @brief Get an iterator to the beginning of the device list
+			iterator begin()
+			{
+				return m_DeviceList.begin();
+			}
+
+			/// @brief Get an iterator to the beginning of the device list
+			const_iterator begin() const
+			{
+				return m_DeviceList.begin();
+			}
+
+			/// @brief Get a const iterator to the beginning of the device list
+			const_iterator cbegin() const
+			{
+				return m_DeviceList.cbegin();
+			}
+
+			/// @brief Get an iterator to the end of the device list
+			iterator end()
+			{
+				return m_DeviceList.end();
+			}
+
+			/// @brief Get an iterator to the end of the device list
+			const_iterator end() const
+			{
+				return m_DeviceList.end();
+			}
+
+			/// @brief Get a const iterator to the end of the device list
+			const_iterator cend() const
+			{
+				return m_DeviceList.cend();
+			}
+
+			/// @brief Check if the device list is empty  
+			/// @return True if the device list is empty, false otherwise  
+			bool empty() const  
+			{  
+				return m_DeviceList.empty();  
+			}
+
+			/// @brief Get the number of devices in the list
+			/// @return The number of devices in the list
+			size_type size() const
+			{
+				return m_DeviceList.size();
+			}
+
+		protected:
+			PointerVector<T, Deleter> m_DeviceList;
+		};
+	}  // namespace internal
+}  // namespace pcap

--- a/Pcap++/header/DeviceListBase.h
+++ b/Pcap++/header/DeviceListBase.h
@@ -23,9 +23,7 @@ namespace pcpp
 			DeviceListBase& operator=(DeviceListBase&&) = default;
 
 		public:
-			using value_type = T*;
 			using size_type = std::size_t;
-			using difference_type = std::ptrdiff_t;
 
 			using iterator = typename PointerVector<T, Deleter>::VectorIterator;
 			using const_iterator = typename PointerVector<T, Deleter>::ConstVectorIterator;

--- a/Pcap++/header/DeviceListBase.h
+++ b/Pcap++/header/DeviceListBase.h
@@ -23,10 +23,6 @@ namespace pcpp
 			DeviceListBase& operator=(DeviceListBase&&) = default;
 
 		public:
-			using value_type = T*;
-			using size_type = std::size_t;
-			using difference_type = std::ptrdiff_t;
-
 			using iterator = typename PointerVector<T, Deleter>::VectorIterator;
 			using const_iterator = typename PointerVector<T, Deleter>::ConstVectorIterator;
 

--- a/Pcap++/header/DeviceListBase.h
+++ b/Pcap++/header/DeviceListBase.h
@@ -13,7 +13,7 @@ namespace pcpp
 
 			explicit DeviceListBase(PointerVector<T, Deleter> devices) : m_DeviceList(std::move(devices))
 			{}
-			
+
 			DeviceListBase(DeviceListBase const&) = default;
 			DeviceListBase(DeviceListBase&&) = default;
 			// Protected destructor to disallow deletion of derived class through a base class pointer
@@ -21,6 +21,7 @@ namespace pcpp
 
 			DeviceListBase& operator=(DeviceListBase const&) = default;
 			DeviceListBase& operator=(DeviceListBase&&) = default;
+
 		public:
 			using value_type = T*;
 			using size_type = std::size_t;
@@ -65,11 +66,11 @@ namespace pcpp
 				return m_DeviceList.cend();
 			}
 
-			/// @brief Check if the device list is empty  
-			/// @return True if the device list is empty, false otherwise  
-			bool empty() const  
-			{  
-				return m_DeviceList.empty();  
+			/// @brief Check if the device list is empty
+			/// @return True if the device list is empty, false otherwise
+			bool empty() const
+			{
+				return m_DeviceList.empty();
 			}
 
 			/// @brief Get the number of devices in the list
@@ -83,4 +84,4 @@ namespace pcpp
 			PointerVector<T, Deleter> m_DeviceList;
 		};
 	}  // namespace internal
-}  // namespace pcap
+}  // namespace pcpp

--- a/Pcap++/header/PcapLiveDeviceList.h
+++ b/Pcap++/header/PcapLiveDeviceList.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "IpAddress.h"
+#include "DeviceListBase.h"
 #include "PcapLiveDevice.h"
 #include <vector>
 #include <memory>
@@ -16,10 +17,11 @@ namespace pcpp
 	/// (on Windows) instances. All live devices are initialized on startup and wrap the network interfaces installed on
 	/// the machine. This class enables access to them through their IP addresses or get a vector of all of them so the
 	/// user can search them in some other way
-	class PcapLiveDeviceList
+	class PcapLiveDeviceList : public internal::DeviceListBase<PcapLiveDevice>
 	{
 	private:
-		std::vector<std::unique_ptr<PcapLiveDevice>> m_LiveDeviceList;
+		using Base = internal::DeviceListBase<PcapLiveDevice>;
+
 		// Vector of raw device pointers to keep the signature of getPcapLiveDevicesList, as it returns a reference.
 		std::vector<PcapLiveDevice*> m_LiveDeviceListView;
 
@@ -28,7 +30,7 @@ namespace pcpp
 		// private c'tor
 		PcapLiveDeviceList();
 
-		static std::vector<std::unique_ptr<PcapLiveDevice>> fetchAllLocalDevices();
+		static PointerVector<PcapLiveDevice> fetchAllLocalDevices();
 		static std::vector<IPv4Address> fetchDnsServers();
 
 	public:


### PR DESCRIPTION
Split of #1488

Overview of changes:
- Added the base class `internal::DeviceListBase` that provides storage and common iterator API for a list of devices.
- Converted `PcapLiveDeviceList` to utilize `internal::DeviceListBase`.