### PR TITLE
Simplified function names for fetching pcap live devices.

### DIFF
--- a/Examples/ArpSpoofing/main.cpp
+++ b/Examples/ArpSpoofing/main.cpp
@@ -237,7 +237,7 @@ int main(int argc, char* argv[])
 		EXIT_WITH_ERROR("Gateway address is not valid");
 	}
 
-	pcpp::PcapLiveDevice* pIfaceDevice = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ifaceAddr);
+	pcpp::PcapLiveDevice* pIfaceDevice = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(ifaceAddr);
 
 	// Verifying interface is valid
 	if (pIfaceDevice == nullptr)

--- a/Examples/Arping/main.cpp
+++ b/Examples/Arping/main.cpp
@@ -198,7 +198,7 @@ int main(int argc, char* argv[])
 	// Search interface by name or IP
 	if (!ifaceNameOrIP.empty())
 	{
-		dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(ifaceNameOrIP);
+		dev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(ifaceNameOrIP);
 		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 	}

--- a/Examples/DNSResolver/main.cpp
+++ b/Examples/DNSResolver/main.cpp
@@ -182,7 +182,7 @@ int main(int argc, char* argv[])
 	// if interface name or IP was provided - find the device accordingly
 	if (interfaceNameOrIPProvided)
 	{
-		dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
+		dev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(interfaceNameOrIP);
 		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 	}

--- a/Examples/DnsSpoofing/main.cpp
+++ b/Examples/DnsSpoofing/main.cpp
@@ -450,7 +450,7 @@ int main(int argc, char* argv[])
 		EXIT_WITH_ERROR("Interface name or IP weren't provided. Please use the -i switch or -h for help");
 	}
 
-	dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
+	dev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(interfaceNameOrIP);
 	if (dev == nullptr)
 		EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 

--- a/Examples/HttpAnalyzer/main.cpp
+++ b/Examples/HttpAnalyzer/main.cpp
@@ -570,7 +570,7 @@ int main(int argc, char* argv[])
 	else  // analyze in live traffic mode
 	{
 		pcpp::PcapLiveDevice* dev =
-		    pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
+		    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(interfaceNameOrIP);
 		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 

--- a/Examples/HttpAnalyzer/main.cpp
+++ b/Examples/HttpAnalyzer/main.cpp
@@ -569,8 +569,7 @@ int main(int argc, char* argv[])
 	}
 	else  // analyze in live traffic mode
 	{
-		pcpp::PcapLiveDevice* dev =
-		    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(interfaceNameOrIP);
+		pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(interfaceNameOrIP);
 		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 

--- a/Examples/IcmpFileTransfer/Common.cpp
+++ b/Examples/IcmpFileTransfer/Common.cpp
@@ -175,7 +175,7 @@ void readCommandLineArguments(int argc, char* argv[], const std::string& thisSid
 	}
 	catch (const std::exception&)
 	{
-		pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByName(interfaceNameOrIP);
+		pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByName(interfaceNameOrIP);
 		if (dev == nullptr)
 			EXIT_WITH_ERROR_PRINT_USAGE("Cannot find interface by provided name");
 

--- a/Examples/IcmpFileTransfer/IcmpFileTransfer-catcher.cpp
+++ b/Examples/IcmpFileTransfer/IcmpFileTransfer-catcher.cpp
@@ -203,7 +203,7 @@ static bool getFileContent(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev
 void receiveFile(pcpp::IPv4Address pitcherIP, pcpp::IPv4Address catcherIP)
 {
 	// identify the interface to listen and send packets to
-	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(catcherIP);
+	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(catcherIP);
 	if (dev == nullptr)
 		EXIT_WITH_ERROR("Cannot find network interface with IP '" << catcherIP << "'");
 
@@ -416,7 +416,7 @@ static bool sendContent(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev, v
 void sendFile(const std::string& filePath, pcpp::IPv4Address pitcherIP, pcpp::IPv4Address catcherIP, size_t blockSize)
 {
 	// identify the interface to listen and send packets to
-	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(catcherIP);
+	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(catcherIP);
 	if (dev == nullptr)
 		EXIT_WITH_ERROR("Cannot find network interface with IP '" << catcherIP << "'");
 

--- a/Examples/IcmpFileTransfer/IcmpFileTransfer-pitcher.cpp
+++ b/Examples/IcmpFileTransfer/IcmpFileTransfer-pitcher.cpp
@@ -221,7 +221,7 @@ static void getFileContent(pcpp::RawPacket* rawPacket, pcpp::PcapLiveDevice* dev
 void receiveFile(pcpp::IPv4Address pitcherIP, pcpp::IPv4Address catcherIP, int packetPerSec)
 {
 	// identify the interface to listen and send packets to
-	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(pitcherIP);
+	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(pitcherIP);
 	if (dev == nullptr)
 		EXIT_WITH_ERROR("Cannot find network interface with IP '" << pitcherIP << "'");
 
@@ -404,7 +404,7 @@ void sendFile(const std::string& filePath, pcpp::IPv4Address pitcherIP, pcpp::IP
               int packetPerSec)
 {
 	// identify the interface to listen and send packets to
-	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(pitcherIP);
+	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(pitcherIP);
 	if (dev == nullptr)
 		EXIT_WITH_ERROR("Cannot find network interface with IP '" << pitcherIP << "'");
 

--- a/Examples/SSLAnalyzer/main.cpp
+++ b/Examples/SSLAnalyzer/main.cpp
@@ -531,8 +531,7 @@ int main(int argc, char* argv[])
 	else  // analyze in live traffic mode
 	{
 		// extract pcap live device by interface name or IP address
-		pcpp::PcapLiveDevice* dev =
-		    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(interfaceNameOrIP);
+		pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(interfaceNameOrIP);
 		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 

--- a/Examples/SSLAnalyzer/main.cpp
+++ b/Examples/SSLAnalyzer/main.cpp
@@ -532,7 +532,7 @@ int main(int argc, char* argv[])
 	{
 		// extract pcap live device by interface name or IP address
 		pcpp::PcapLiveDevice* dev =
-		    pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
+		    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(interfaceNameOrIP);
 		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 

--- a/Examples/TLSFingerprinting/main.cpp
+++ b/Examples/TLSFingerprinting/main.cpp
@@ -463,7 +463,7 @@ void doTlsFingerprintingOnLiveTraffic(const std::string& interfaceNameOrIP, std:
                                       const std::string& separator, bool chFP, bool shFP, const std::string& bpfFilter)
 {
 	// extract pcap live device by interface name or IP address
-	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
+	pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(interfaceNameOrIP);
 	if (dev == nullptr)
 		EXIT_WITH_ERROR("Couldn't find interface by given IP address or name");
 

--- a/Examples/TcpReassembly/main.cpp
+++ b/Examples/TcpReassembly/main.cpp
@@ -690,7 +690,7 @@ int main(int argc, char* argv[])
 	{
 		// extract pcap live device by interface name or IP address
 		pcpp::PcapLiveDevice* dev =
-		    pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(interfaceNameOrIP);
+		    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(interfaceNameOrIP);
 		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 

--- a/Examples/TcpReassembly/main.cpp
+++ b/Examples/TcpReassembly/main.cpp
@@ -689,8 +689,7 @@ int main(int argc, char* argv[])
 	else  // analyze in live traffic mode
 	{
 		// extract pcap live device by interface name or IP address
-		pcpp::PcapLiveDevice* dev =
-		    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(interfaceNameOrIP);
+		pcpp::PcapLiveDevice* dev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(interfaceNameOrIP);
 		if (dev == nullptr)
 			EXIT_WITH_ERROR("Couldn't find interface by provided IP address or name");
 

--- a/Examples/Tutorials/Tutorial-LiveTraffic/main.cpp
+++ b/Examples/Tutorials/Tutorial-LiveTraffic/main.cpp
@@ -110,7 +110,7 @@ int main(int argc, char* argv[])
 	std::string interfaceIPAddr = "10.0.0.1";
 
 	// find the interface by IP address
-	auto* dev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(interfaceIPAddr);
+	auto* dev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(interfaceIPAddr);
 	if (dev == nullptr)
 	{
 		std::cerr << "Cannot find interface with IPv4 address of '" << interfaceIPAddr << "'" << std::endl;

--- a/Pcap++/header/PcapLiveDeviceList.h
+++ b/Pcap++/header/PcapLiveDeviceList.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "DeprecationUtils.h"
 #include "IpAddress.h"
 #include "PcapLiveDevice.h"
 #include <vector>
@@ -54,33 +55,60 @@ namespace pcpp
 		/// Get a pointer to the live device by its IP address. IP address can be both IPv4 or IPv6
 		/// @param[in] ipAddr The IP address defined for the device
 		/// @return A pointer to the live device if this IP address exists. nullptr otherwise
-		PcapLiveDevice* getPcapLiveDeviceByIp(const IPAddress& ipAddr) const;
+		PCPP_DEPRECATED("Use `getDeviceByIp`") PcapLiveDevice* getPcapLiveDeviceByIp(const IPAddress& ipAddr) const;
+		/// Get a pointer to the live device by its IP address. IP address can be both IPv4 or IPv6
+		/// @param[in] ipAddr The IP address defined for the device
+		/// @return A pointer to the live device if this IP address exists. nullptr otherwise
+		PcapLiveDevice* getDeviceByIp(const IPAddress& ipAddr) const;
 
 		/// Get a pointer to the live device by its IPv4 address
 		/// @param[in] ipAddr The IPv4 address defined for the device
 		/// @return A pointer to the live device if this IPv4 address exists. nullptr otherwise
-		PcapLiveDevice* getPcapLiveDeviceByIp(const IPv4Address& ipAddr) const;
+		PCPP_DEPRECATED("Use `getDeviceByIp`") PcapLiveDevice* getPcapLiveDeviceByIp(const IPv4Address& ipAddr) const;
+		/// Get a pointer to the live device by its IPv4 address
+		/// @param[in] ipAddr The IPv4 address defined for the device
+		/// @return A pointer to the live device if this IPv4 address exists. nullptr otherwise
+		PcapLiveDevice* getDeviceByIp(const IPv4Address& ipAddr) const;
 
 		/// Get a pointer to the live device by its IPv6 address
 		/// @param[in] ip6Addr The IPv6 address defined for the device
 		/// @return A pointer to the live device if this IPv6 address exists. nullptr otherwise
-		PcapLiveDevice* getPcapLiveDeviceByIp(const IPv6Address& ip6Addr) const;
+		PCPP_DEPRECATED("Use `getDeviceByIp`") PcapLiveDevice* getPcapLiveDeviceByIp(const IPv6Address& ip6Addr) const;
+		/// Get a pointer to the live device by its IPv6 address
+		/// @param[in] ip6Addr The IPv6 address defined for the device
+		/// @return A pointer to the live device if this IPv6 address exists. nullptr otherwise
+		PcapLiveDevice* getDeviceByIp(const IPv6Address& ip6Addr) const;
 
 		/// Get a pointer to the live device by its IP address represented as string. IP address can be both IPv4 or
 		/// IPv6
 		/// @param[in] ipAddrAsString The IP address defined for the device as string
 		/// @return A pointer to the live device if this IP address is valid and exists. nullptr otherwise
+		PCPP_DEPRECATED("Use `getDeviceByIp`")
 		PcapLiveDevice* getPcapLiveDeviceByIp(const std::string& ipAddrAsString) const;
+		/// Get a pointer to the live device by its IP address represented as string. IP address can be both IPv4 or
+		/// IPv6
+		/// @param[in] ipAddrAsString The IP address defined for the device as string
+		/// @return A pointer to the live device if this IP address is valid and exists. nullptr otherwise
+		PcapLiveDevice* getDeviceByIp(const std::string& ipAddrAsString) const;
 
 		/// Get a pointer to the live device by its name
 		/// @param[in] name The name of the interface (e.g eth0)
 		/// @return A pointer to the live device if this name exists. nullptr otherwise
-		PcapLiveDevice* getPcapLiveDeviceByName(const std::string& name) const;
+		PCPP_DEPRECATED("Use `getDeviceByName`") PcapLiveDevice* getPcapLiveDeviceByName(const std::string& name) const;
+		/// Get a pointer to the live device by its name
+		/// @param[in] name The name of the interface (e.g eth0)
+		/// @return A pointer to the live device if this name exists. nullptr otherwise
+		PcapLiveDevice* getDeviceByName(const std::string& name) const;
 
 		/// Get a pointer to the live device by its IP address or name
 		/// @param[in] ipOrName An IP address or name of the interface
 		/// @return A pointer to the live device if exists, nullptr otherwise
+		PCPP_DEPRECATED("Use `getDeviceByIpOrName`")
 		PcapLiveDevice* getPcapLiveDeviceByIpOrName(const std::string& ipOrName) const;
+		/// Get a pointer to the live device by its IP address or name
+		/// @param[in] ipOrName An IP address or name of the interface
+		/// @return A pointer to the live device if exists, nullptr otherwise
+		PcapLiveDevice* getDeviceByIpOrName(const std::string& ipOrName) const;
 
 		/// @return A list of all DNS servers defined for this machine. If this list is empty it means no DNS servers
 		/// were defined or they couldn't be extracted from some reason

--- a/Pcap++/header/PcapLiveDeviceList.h
+++ b/Pcap++/header/PcapLiveDeviceList.h
@@ -55,7 +55,9 @@ namespace pcpp
 		/// Get a pointer to the live device by its IP address. IP address can be both IPv4 or IPv6
 		/// @param[in] ipAddr The IP address defined for the device
 		/// @return A pointer to the live device if this IP address exists. nullptr otherwise
-		PCPP_DEPRECATED("Use `getDeviceByIp`") PcapLiveDevice* getPcapLiveDeviceByIp(const IPAddress& ipAddr) const;
+		PCPP_DEPRECATED("Use `getDeviceByIp`")
+		PcapLiveDevice* getPcapLiveDeviceByIp(const IPAddress& ipAddr) const;
+
 		/// Get a pointer to the live device by its IP address. IP address can be both IPv4 or IPv6
 		/// @param[in] ipAddr The IP address defined for the device
 		/// @return A pointer to the live device if this IP address exists. nullptr otherwise
@@ -64,7 +66,9 @@ namespace pcpp
 		/// Get a pointer to the live device by its IPv4 address
 		/// @param[in] ipAddr The IPv4 address defined for the device
 		/// @return A pointer to the live device if this IPv4 address exists. nullptr otherwise
-		PCPP_DEPRECATED("Use `getDeviceByIp`") PcapLiveDevice* getPcapLiveDeviceByIp(const IPv4Address& ipAddr) const;
+		PCPP_DEPRECATED("Use `getDeviceByIp`")
+		PcapLiveDevice* getPcapLiveDeviceByIp(const IPv4Address& ipAddr) const;
+
 		/// Get a pointer to the live device by its IPv4 address
 		/// @param[in] ipAddr The IPv4 address defined for the device
 		/// @return A pointer to the live device if this IPv4 address exists. nullptr otherwise
@@ -73,7 +77,9 @@ namespace pcpp
 		/// Get a pointer to the live device by its IPv6 address
 		/// @param[in] ip6Addr The IPv6 address defined for the device
 		/// @return A pointer to the live device if this IPv6 address exists. nullptr otherwise
-		PCPP_DEPRECATED("Use `getDeviceByIp`") PcapLiveDevice* getPcapLiveDeviceByIp(const IPv6Address& ip6Addr) const;
+		PCPP_DEPRECATED("Use `getDeviceByIp`")
+		PcapLiveDevice* getPcapLiveDeviceByIp(const IPv6Address& ip6Addr) const;
+
 		/// Get a pointer to the live device by its IPv6 address
 		/// @param[in] ip6Addr The IPv6 address defined for the device
 		/// @return A pointer to the live device if this IPv6 address exists. nullptr otherwise
@@ -85,6 +91,7 @@ namespace pcpp
 		/// @return A pointer to the live device if this IP address is valid and exists. nullptr otherwise
 		PCPP_DEPRECATED("Use `getDeviceByIp`")
 		PcapLiveDevice* getPcapLiveDeviceByIp(const std::string& ipAddrAsString) const;
+
 		/// Get a pointer to the live device by its IP address represented as string. IP address can be both IPv4 or
 		/// IPv6
 		/// @param[in] ipAddrAsString The IP address defined for the device as string
@@ -94,7 +101,9 @@ namespace pcpp
 		/// Get a pointer to the live device by its name
 		/// @param[in] name The name of the interface (e.g eth0)
 		/// @return A pointer to the live device if this name exists. nullptr otherwise
-		PCPP_DEPRECATED("Use `getDeviceByName`") PcapLiveDevice* getPcapLiveDeviceByName(const std::string& name) const;
+		PCPP_DEPRECATED("Use `getDeviceByName`")
+		PcapLiveDevice* getPcapLiveDeviceByName(const std::string& name) const;
+
 		/// Get a pointer to the live device by its name
 		/// @param[in] name The name of the interface (e.g eth0)
 		/// @return A pointer to the live device if this name exists. nullptr otherwise

--- a/Pcap++/header/PcapLiveDeviceList.h
+++ b/Pcap++/header/PcapLiveDeviceList.h
@@ -114,6 +114,7 @@ namespace pcpp
 		/// @return A pointer to the live device if exists, nullptr otherwise
 		PCPP_DEPRECATED("Use `getDeviceByIpOrName`")
 		PcapLiveDevice* getPcapLiveDeviceByIpOrName(const std::string& ipOrName) const;
+
 		/// Get a pointer to the live device by its IP address or name
 		/// @param[in] ipOrName An IP address or name of the interface
 		/// @return A pointer to the live device if exists, nullptr otherwise

--- a/Pcap++/src/PcapLiveDeviceList.cpp
+++ b/Pcap++/src/PcapLiveDeviceList.cpp
@@ -269,6 +269,7 @@ namespace pcpp
 	{
 		return getDeviceByIp(ipAddr);
 	}
+
 	PcapLiveDevice* PcapLiveDeviceList::getDeviceByIp(const IPAddress& ipAddr) const
 	{
 		if (ipAddr.getType() == IPAddress::IPv4AddressType)
@@ -285,6 +286,7 @@ namespace pcpp
 	{
 		return getDeviceByIp(ipAddr);
 	}
+
 	PcapLiveDevice* PcapLiveDeviceList::getDeviceByIp(const IPv4Address& ipAddr) const
 	{
 		auto it = std::find_if(m_LiveDeviceList.begin(), m_LiveDeviceList.end(),
@@ -299,6 +301,7 @@ namespace pcpp
 	{
 		return getDeviceByIp(ip6Addr);
 	}
+
 	PcapLiveDevice* PcapLiveDeviceList::getDeviceByIp(const IPv6Address& ip6Addr) const
 	{
 		auto it = std::find_if(m_LiveDeviceList.begin(), m_LiveDeviceList.end(),
@@ -313,6 +316,7 @@ namespace pcpp
 	{
 		return getDeviceByIp(ipAddrAsString);
 	}
+
 	PcapLiveDevice* PcapLiveDeviceList::getDeviceByIp(const std::string& ipAddrAsString) const
 	{
 		IPAddress ipAddr;
@@ -334,6 +338,7 @@ namespace pcpp
 	{
 		return getDeviceByName(name);
 	}
+
 	PcapLiveDevice* PcapLiveDeviceList::getDeviceByName(const std::string& name) const
 	{
 		PCPP_LOG_DEBUG("Searching all live devices...");
@@ -354,6 +359,7 @@ namespace pcpp
 	{
 		return getDeviceByIpOrName(ipOrName);
 	}
+
 	PcapLiveDevice* PcapLiveDeviceList::getDeviceByIpOrName(const std::string& ipOrName) const
 	{
 		try

--- a/Pcap++/src/PcapLiveDeviceList.cpp
+++ b/Pcap++/src/PcapLiveDeviceList.cpp
@@ -267,17 +267,25 @@ namespace pcpp
 
 	PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const IPAddress& ipAddr) const
 	{
+		return getDeviceByIp(ipAddr);
+	}
+	PcapLiveDevice* PcapLiveDeviceList::getDeviceByIp(const IPAddress& ipAddr) const
+	{
 		if (ipAddr.getType() == IPAddress::IPv4AddressType)
 		{
-			return getPcapLiveDeviceByIp(ipAddr.getIPv4());
+			return getDeviceByIp(ipAddr.getIPv4());
 		}
 		else  // IPAddress::IPv6AddressType
 		{
-			return getPcapLiveDeviceByIp(ipAddr.getIPv6());
+			return getDeviceByIp(ipAddr.getIPv6());
 		}
 	}
 
 	PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const IPv4Address& ipAddr) const
+	{
+		return getDeviceByIp(ipAddr);
+	}
+	PcapLiveDevice* PcapLiveDeviceList::getDeviceByIp(const IPv4Address& ipAddr) const
 	{
 		auto it = std::find_if(m_LiveDeviceList.begin(), m_LiveDeviceList.end(),
 		                       [&ipAddr](std::unique_ptr<PcapLiveDevice> const& devPtr) {
@@ -289,6 +297,10 @@ namespace pcpp
 
 	PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const IPv6Address& ip6Addr) const
 	{
+		return getDeviceByIp(ip6Addr);
+	}
+	PcapLiveDevice* PcapLiveDeviceList::getDeviceByIp(const IPv6Address& ip6Addr) const
+	{
 		auto it = std::find_if(m_LiveDeviceList.begin(), m_LiveDeviceList.end(),
 		                       [&ip6Addr](std::unique_ptr<PcapLiveDevice> const& devPtr) {
 			                       auto devIP = devPtr->getIPv6Address();
@@ -298,6 +310,10 @@ namespace pcpp
 	}
 
 	PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIp(const std::string& ipAddrAsString) const
+	{
+		return getDeviceByIp(ipAddrAsString);
+	}
+	PcapLiveDevice* PcapLiveDeviceList::getDeviceByIp(const std::string& ipAddrAsString) const
 	{
 		IPAddress ipAddr;
 		try
@@ -310,11 +326,15 @@ namespace pcpp
 			return nullptr;
 		}
 
-		PcapLiveDevice* result = PcapLiveDeviceList::getPcapLiveDeviceByIp(ipAddr);
+		PcapLiveDevice* result = getDeviceByIp(ipAddr);
 		return result;
 	}
 
 	PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByName(const std::string& name) const
+	{
+		return getDeviceByName(name);
+	}
+	PcapLiveDevice* PcapLiveDeviceList::getDeviceByName(const std::string& name) const
 	{
 		PCPP_LOG_DEBUG("Searching all live devices...");
 		auto devIter =
@@ -332,14 +352,18 @@ namespace pcpp
 
 	PcapLiveDevice* PcapLiveDeviceList::getPcapLiveDeviceByIpOrName(const std::string& ipOrName) const
 	{
+		return getDeviceByIpOrName(ipOrName);
+	}
+	PcapLiveDevice* PcapLiveDeviceList::getDeviceByIpOrName(const std::string& ipOrName) const
+	{
 		try
 		{
 			IPAddress interfaceIP = IPAddress(ipOrName);
-			return PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(interfaceIP);
+			return getDeviceByIp(interfaceIP);
 		}
 		catch (std::exception&)
 		{
-			return PcapLiveDeviceList::getInstance().getPcapLiveDeviceByName(ipOrName);
+			return getDeviceByName(ipOrName);
 		}
 	}
 

--- a/Tests/Pcap++Test/Tests/FilterTests.cpp
+++ b/Tests/Pcap++Test/Tests/FilterTests.cpp
@@ -37,7 +37,7 @@ PTF_TEST_CASE(TestPcapFiltersLive)
 {
 	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
-	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
+	liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(ipToSearch);
 	PTF_ASSERT_NOT_NULL(liveDev);
 
 	std::string filterAsString;

--- a/Tests/Pcap++Test/Tests/IpMacTests.cpp
+++ b/Tests/Pcap++Test/Tests/IpMacTests.cpp
@@ -355,7 +355,7 @@ PTF_TEST_CASE(TestGetMacAddress)
 {
 	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
-	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
+	liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(ipToSearch);
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_TRUE(liveDev->open());
 	DeviceTeardown devTeardown(liveDev);

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -272,23 +272,23 @@ PTF_TEST_CASE(TestPcapLiveDeviceList)
 PTF_TEST_CASE(TestPcapLiveDeviceListSearch)
 {
 	pcpp::PcapLiveDevice* liveDev = nullptr;
-	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+	liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(liveDev);
 
 	std::string devName(liveDev->getName());
 	pcpp::PcapLiveDevice* liveDev2 = nullptr;
-	liveDev2 = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByName(devName);
+	liveDev2 = pcpp::PcapLiveDeviceList::getInstance().getDeviceByName(devName);
 	PTF_ASSERT_NOT_NULL(liveDev2);
 	PTF_ASSERT_EQUAL(liveDev->getName(), liveDev2->getName());
 
-	pcpp::PcapLiveDevice* liveDev3 = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(devName);
+	pcpp::PcapLiveDevice* liveDev3 = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(devName);
 	PTF_ASSERT_EQUAL(liveDev3, liveDev2, ptr);
 	liveDev3 =
-	    pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIpOrName(PcapTestGlobalArgs.ipToSendReceivePackets);
+	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(PcapTestGlobalArgs.ipToSendReceivePackets);
 	PTF_ASSERT_EQUAL(liveDev3, liveDev, ptr);
 
-	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp("255.255.255.250");
+	liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp("255.255.255.250");
 	PTF_ASSERT_NULL(liveDev);
 }  // TestPcapLiveDeviceListSearch
 
@@ -296,7 +296,7 @@ PTF_TEST_CASE(TestPcapLiveDevice)
 {
 	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
-	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
+	liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(ipToSearch);
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_GREATER_THAN(liveDev->getMtu(), 0);
 	PTF_ASSERT_TRUE(liveDev->open());
@@ -350,7 +350,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceClone)
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 
 	{
-		pcpp::PcapLiveDevice* originalDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
+		pcpp::PcapLiveDevice* originalDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(ipToSearch);
 		PTF_ASSERT_NOT_NULL(originalDev);
 
 #ifdef _WIN32
@@ -429,7 +429,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceNoNetworking)
 	// a negative test - check invalid IP address
 	liveDev = nullptr;
 	pcpp::Logger::getInstance().suppressLogs();
-	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp("eth0");
+	liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp("eth0");
 	pcpp::Logger::getInstance().enableLogs();
 	PTF_ASSERT_NULL(liveDev);
 
@@ -437,7 +437,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceNoNetworking)
 
 PTF_TEST_CASE(TestPcapLiveDeviceStatsMode)
 {
-	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_TRUE(liveDev->open());
@@ -488,7 +488,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceBlockingMode)
 	for (const auto& config : configs)
 	{
 		// open device
-		pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+		pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 		    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 		PTF_ASSERT_NOT_NULL(liveDev);
 		PTF_ASSERT_TRUE(liveDev->open(config));
@@ -579,7 +579,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceWithLambda)
 {
 	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
-	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
+	liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(ipToSearch);
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_GREATER_THAN(liveDev->getMtu(), 0);
 	PTF_ASSERT_TRUE(liveDev->open());
@@ -626,7 +626,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceBlockingModeWithLambda)
 	};
 
 	// open device
-	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_TRUE(liveDev->open());
@@ -646,7 +646,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceBlockingModeWithLambda)
 
 PTF_TEST_CASE(TestPcapLiveDeviceSpecialCfg)
 {
-	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(liveDev);
 
@@ -718,7 +718,7 @@ PTF_TEST_CASE(TestWinPcapLiveDevice)
 {
 #if defined(_WIN32)
 
-	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_EQUAL(liveDev->getDeviceType(), pcpp::PcapLiveDevice::WinPcapDevice, enum);
@@ -755,7 +755,7 @@ PTF_TEST_CASE(TestWinPcapLiveDevice)
 	pcpp::Logger::getInstance().enableLogs();
 
 #else
-	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_EQUAL(liveDev->getDeviceType(), pcpp::PcapLiveDevice::LibPcapDevice, enum);
@@ -767,7 +767,7 @@ PTF_TEST_CASE(TestSendPacket)
 {
 	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
-	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
+	liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(ipToSearch);
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_TRUE(liveDev->open());
 	DeviceTeardown devTeardown(liveDev);
@@ -816,7 +816,7 @@ PTF_TEST_CASE(TestSendPackets)
 {
 	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
-	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
+	liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(ipToSearch);
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_TRUE(liveDev->open());
 	DeviceTeardown devTeardown(liveDev);
@@ -853,7 +853,7 @@ PTF_TEST_CASE(TestMtuSize)
 {
 	pcpp::PcapLiveDevice* liveDev = nullptr;
 	pcpp::IPv4Address ipToSearch(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
-	liveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(ipToSearch);
+	liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(ipToSearch);
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_TRUE(liveDev->open());
 	DeviceTeardown devTearDown(liveDev);

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -272,8 +272,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceList)
 PTF_TEST_CASE(TestPcapLiveDeviceListSearch)
 {
 	pcpp::PcapLiveDevice* liveDev = nullptr;
-	liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(liveDev);
 
 	std::string devName(liveDev->getName());
@@ -284,8 +283,7 @@ PTF_TEST_CASE(TestPcapLiveDeviceListSearch)
 
 	pcpp::PcapLiveDevice* liveDev3 = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(devName);
 	PTF_ASSERT_EQUAL(liveDev3, liveDev2, ptr);
-	liveDev3 =
-	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(PcapTestGlobalArgs.ipToSendReceivePackets);
+	liveDev3 = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIpOrName(PcapTestGlobalArgs.ipToSendReceivePackets);
 	PTF_ASSERT_EQUAL(liveDev3, liveDev, ptr);
 
 	liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp("255.255.255.250");
@@ -437,8 +435,8 @@ PTF_TEST_CASE(TestPcapLiveDeviceNoNetworking)
 
 PTF_TEST_CASE(TestPcapLiveDeviceStatsMode)
 {
-	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	pcpp::PcapLiveDevice* liveDev =
+	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_TRUE(liveDev->open());
 	DeviceTeardown devTeardown(liveDev);
@@ -488,8 +486,8 @@ PTF_TEST_CASE(TestPcapLiveDeviceBlockingMode)
 	for (const auto& config : configs)
 	{
 		// open device
-		pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-		    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+		pcpp::PcapLiveDevice* liveDev =
+		    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 		PTF_ASSERT_NOT_NULL(liveDev);
 		PTF_ASSERT_TRUE(liveDev->open(config));
 		DeviceTeardown devTeardown(liveDev);
@@ -626,8 +624,8 @@ PTF_TEST_CASE(TestPcapLiveDeviceBlockingModeWithLambda)
 	};
 
 	// open device
-	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	pcpp::PcapLiveDevice* liveDev =
+	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_TRUE(liveDev->open());
 	DeviceTeardown devTeardown(liveDev);
@@ -646,8 +644,8 @@ PTF_TEST_CASE(TestPcapLiveDeviceBlockingModeWithLambda)
 
 PTF_TEST_CASE(TestPcapLiveDeviceSpecialCfg)
 {
-	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	pcpp::PcapLiveDevice* liveDev =
+	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(liveDev);
 
 	// open device in default mode
@@ -718,8 +716,8 @@ PTF_TEST_CASE(TestWinPcapLiveDevice)
 {
 #if defined(_WIN32)
 
-	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	pcpp::PcapLiveDevice* liveDev =
+	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_EQUAL(liveDev->getDeviceType(), pcpp::PcapLiveDevice::WinPcapDevice, enum);
 
@@ -755,8 +753,8 @@ PTF_TEST_CASE(TestWinPcapLiveDevice)
 	pcpp::Logger::getInstance().enableLogs();
 
 #else
-	pcpp::PcapLiveDevice* liveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	pcpp::PcapLiveDevice* liveDev =
+	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(liveDev);
 	PTF_ASSERT_EQUAL(liveDev->getDeviceType(), pcpp::PcapLiveDevice::LibPcapDevice, enum);
 #endif

--- a/Tests/Pcap++Test/Tests/PfRingTests.cpp
+++ b/Tests/Pcap++Test/Tests/PfRingTests.cpp
@@ -202,7 +202,7 @@ PTF_TEST_CASE(TestPfRingDevice)
 	pcpp::PfRingDeviceList& devList = pcpp::PfRingDeviceList::getInstance();
 	PTF_ASSERT_GREATER_THAN(devList.getPfRingDevicesList().size(), 0);
 	PTF_ASSERT_NOT_EQUAL(devList.getPfRingVersion(), "");
-	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(pcapLiveDev);
 	pcpp::PfRingDevice* dev = devList.getPfRingDeviceByName(pcapLiveDev->getName());
@@ -252,7 +252,7 @@ PTF_TEST_CASE(TestPfRingDeviceSingleChannel)
 #ifdef USE_PF_RING
 
 	pcpp::PfRingDeviceList& devList = pcpp::PfRingDeviceList::getInstance();
-	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(pcapLiveDev);
 	pcpp::PfRingDevice* dev = devList.getPfRingDeviceByName(pcapLiveDev->getName());
@@ -293,7 +293,7 @@ PTF_TEST_CASE(TestPfRingDeviceMultiThread)
 {
 #ifdef USE_PF_RING
 	pcpp::PfRingDeviceList& devList = pcpp::PfRingDeviceList::getInstance();
-	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(pcapLiveDev);
 	pcpp::PfRingDevice* dev = devList.getPfRingDeviceByName(pcapLiveDev->getName());
@@ -434,7 +434,7 @@ PTF_TEST_CASE(TestPfRingSendPacket)
 {
 #ifdef USE_PF_RING
 	pcpp::PfRingDeviceList& devList = pcpp::PfRingDeviceList::getInstance();
-	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(pcapLiveDev);
 	pcpp::PfRingDevice* dev = devList.getPfRingDeviceByName(pcapLiveDev->getName());
@@ -499,7 +499,7 @@ PTF_TEST_CASE(TestPfRingSendPackets)
 {
 #ifdef USE_PF_RING
 	pcpp::PfRingDeviceList& devList = pcpp::PfRingDeviceList::getInstance();
-	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(pcapLiveDev);
 	pcpp::PfRingDevice* dev = devList.getPfRingDeviceByName(pcapLiveDev->getName());
@@ -542,7 +542,7 @@ PTF_TEST_CASE(TestPfRingFilters)
 {
 #ifdef USE_PF_RING
 	pcpp::PfRingDeviceList& devList = pcpp::PfRingDeviceList::getInstance();
-	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(pcapLiveDev);
 	pcpp::PfRingDevice* dev = devList.getPfRingDeviceByName(pcapLiveDev->getName());

--- a/Tests/Pcap++Test/Tests/PfRingTests.cpp
+++ b/Tests/Pcap++Test/Tests/PfRingTests.cpp
@@ -202,8 +202,8 @@ PTF_TEST_CASE(TestPfRingDevice)
 	pcpp::PfRingDeviceList& devList = pcpp::PfRingDeviceList::getInstance();
 	PTF_ASSERT_GREATER_THAN(devList.getPfRingDevicesList().size(), 0);
 	PTF_ASSERT_NOT_EQUAL(devList.getPfRingVersion(), "");
-	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	pcpp::PcapLiveDevice* pcapLiveDev =
+	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(pcapLiveDev);
 	pcpp::PfRingDevice* dev = devList.getPfRingDeviceByName(pcapLiveDev->getName());
 
@@ -252,8 +252,8 @@ PTF_TEST_CASE(TestPfRingDeviceSingleChannel)
 #ifdef USE_PF_RING
 
 	pcpp::PfRingDeviceList& devList = pcpp::PfRingDeviceList::getInstance();
-	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	pcpp::PcapLiveDevice* pcapLiveDev =
+	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(pcapLiveDev);
 	pcpp::PfRingDevice* dev = devList.getPfRingDeviceByName(pcapLiveDev->getName());
 	PTF_ASSERT_NOT_NULL(dev);
@@ -293,8 +293,8 @@ PTF_TEST_CASE(TestPfRingDeviceMultiThread)
 {
 #ifdef USE_PF_RING
 	pcpp::PfRingDeviceList& devList = pcpp::PfRingDeviceList::getInstance();
-	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	pcpp::PcapLiveDevice* pcapLiveDev =
+	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(pcapLiveDev);
 	pcpp::PfRingDevice* dev = devList.getPfRingDeviceByName(pcapLiveDev->getName());
 	PTF_ASSERT_NOT_NULL(dev);
@@ -434,8 +434,8 @@ PTF_TEST_CASE(TestPfRingSendPacket)
 {
 #ifdef USE_PF_RING
 	pcpp::PfRingDeviceList& devList = pcpp::PfRingDeviceList::getInstance();
-	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	pcpp::PcapLiveDevice* pcapLiveDev =
+	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(pcapLiveDev);
 	pcpp::PfRingDevice* dev = devList.getPfRingDeviceByName(pcapLiveDev->getName());
 	PTF_ASSERT_NOT_NULL(dev);
@@ -499,8 +499,8 @@ PTF_TEST_CASE(TestPfRingSendPackets)
 {
 #ifdef USE_PF_RING
 	pcpp::PfRingDeviceList& devList = pcpp::PfRingDeviceList::getInstance();
-	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	pcpp::PcapLiveDevice* pcapLiveDev =
+	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(pcapLiveDev);
 	pcpp::PfRingDevice* dev = devList.getPfRingDeviceByName(pcapLiveDev->getName());
 	PTF_ASSERT_NOT_NULL(dev);
@@ -542,8 +542,8 @@ PTF_TEST_CASE(TestPfRingFilters)
 {
 #ifdef USE_PF_RING
 	pcpp::PfRingDeviceList& devList = pcpp::PfRingDeviceList::getInstance();
-	pcpp::PcapLiveDevice* pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	pcpp::PcapLiveDevice* pcapLiveDev =
+	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	PTF_ASSERT_NOT_NULL(pcapLiveDev);
 	pcpp::PfRingDevice* dev = devList.getPfRingDeviceByName(pcapLiveDev->getName());
 	PTF_ASSERT_NOT_NULL(dev);

--- a/Tests/Pcap++Test/Tests/XdpTests.cpp
+++ b/Tests/Pcap++Test/Tests/XdpTests.cpp
@@ -35,8 +35,8 @@ bool assertConfig(const pcpp::XdpDevice::XdpDeviceConfiguration* config,
 
 std::string getDeviceName()
 {
-	auto pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
-	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
+	auto pcapLiveDev =
+	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	if (pcapLiveDev)
 	{
 		return pcapLiveDev->getName();

--- a/Tests/Pcap++Test/Tests/XdpTests.cpp
+++ b/Tests/Pcap++Test/Tests/XdpTests.cpp
@@ -35,7 +35,7 @@ bool assertConfig(const pcpp::XdpDevice::XdpDeviceConfiguration* config,
 
 std::string getDeviceName()
 {
-	auto pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getPcapLiveDeviceByIp(
+	auto pcapLiveDev = pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(
 	    PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	if (pcapLiveDev)
 	{


### PR DESCRIPTION
This PR shortens all `PcapLiveDeviceList::getPcapLiveDeviceBy***` methods to `PcapLiveDeviceList::getDeviceBy***`.

IMO, having `PcapLiveDevice` in the method name is redundant as the list name already informs the user of the type of devices it contains.