### PR TITLE
Updated `DpdkDeviceList` to use `internal::DeviceListBase`.

### DIFF
--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -218,25 +218,13 @@ namespace pcpp
 		}
 
 		/// @return A pointer of the first element in the vector
-		T* front()
-		{
-			return m_Vector.front();
-		}
-
-		/// @return A pointer to the first element in the vector
-		T const* front() const
+		T* front() const
 		{
 			return m_Vector.front();
 		}
 
 		/// @return A pointer to the last element in the vector
-		T* back()
-		{
-			return m_Vector.back();
-		}
-
-		/// @return A pointer to the last element in the vector.
-		T const* back() const
+		T* back() const
 		{
 			return m_Vector.back();
 		}
@@ -297,15 +285,7 @@ namespace pcpp
 		/// Return a pointer to the element in a certain index
 		/// @param[in] index The index to retrieve the element from
 		/// @return The element at the specified position in the vector
-		T* at(int index)
-		{
-			return m_Vector.at(index);
-		}
-
-		/// Return a const pointer to the element in a certain index
-		/// @param[in] index The index to retrieve the element from
-		/// @return The element at the specified position in the vector
-		const T* at(int index) const
+		T* at(int index) const
 		{
 			return m_Vector.at(index);
 		}

--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -4,6 +4,7 @@
 
 #include "SystemUtils.h"
 #include "DpdkDevice.h"
+#include "DeviceListBase.h"
 #include "Logger.h"
 #include <vector>
 
@@ -54,17 +55,19 @@ namespace pcpp
 	///      once in every application at its startup process
 	///    - it contains the list of DpdkDevice instances and enables access to them
 	///    - it has methods to start and stop worker threads. See more details in startDpdkWorkerThreads()
-	class DpdkDeviceList
+	class DpdkDeviceList : internal::DeviceListBase<DpdkDevice>
 	{
 		friend class KniDeviceList;
 
 	private:
+		using Base = internal::DeviceListBase<DpdkDevice>;
+
 		bool m_IsInitialized;
 		static bool m_IsDpdkInitialized;
 		static uint32_t m_MBufPoolSizePerDevice;
 		static uint16_t m_MBufDataSize;
 		static CoreMask m_CoreMask;
-		std::vector<DpdkDevice*> m_DpdkDeviceList;
+		std::vector<DpdkDevice*> m_DpdkDeviceListView;
 		std::vector<DpdkWorkerThread*> m_WorkerThreads;
 
 		DpdkDeviceList();
@@ -139,7 +142,7 @@ namespace pcpp
 		/// @return A vector of all DpdkDevice instances
 		const std::vector<DpdkDevice*>& getDpdkDeviceList() const
 		{
-			return m_DpdkDeviceList;
+			return m_DpdkDeviceListView;
 		}
 
 		/// @return DPDK master core which is the core that initializes the application


### PR DESCRIPTION
Changes:
- `PointerVector`'s `front()`, `back()` and `at()` changed to return T* even in `const` on the rationale that modifying the pointee does not modify the vector's contents (the pointer in the vector isn't modified).
- Updated `DpdkDeviceList` to use `internal::DeviceListBase`.