### PR TITLE
Simplified the implementation of `PcapNgFileWriterDevice` opening.

### DIFF
--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -220,6 +220,21 @@ namespace pcpp
 		void close();
 	};
 
+	/// @struct PcapNgMetadata
+	/// @brief A struct for holding the metadata of a pcap-ng file. The metadata includes the operating system,
+	/// hardware, capture application and file comment.
+	struct PcapNgMetadata
+	{
+		/// The operating system that was used for capturing the packets
+		std::string os;
+		/// The hardware that was used for capturing the packets
+		std::string hardware;
+		/// The capture application that was used for capturing the packets
+		std::string captureApplication;
+		/// The comment that was written inside the file
+		std::string comment;
+	};
+
 	/// @class PcapNgFileReaderDevice
 	/// A class for opening a pcap-ng file in read-only mode. This class enable to open the file and read all packets,
 	/// packet-by-packet
@@ -453,22 +468,6 @@ namespace pcpp
 			close();
 		}
 
-		/// Open the file in a write mode. If file doesn't exist, it will be created. If it does exist it will be
-		/// overwritten, meaning all its current content will be deleted. As opposed to open(), this method also allows
-		/// writing several metadata attributes that will be stored in the header of the file
-		/// @param[in] os A string describing the operating system that was used to capture the packets. If this string
-		/// is empty or null it will be ignored
-		/// @param[in] hardware A string describing the hardware that was used to capture the packets. If this string is
-		/// empty or null it will be ignored
-		/// @param[in] captureApp A string describing the application that was used to capture the packets. If this
-		/// string is empty or null it will be ignored
-		/// @param[in] fileComment A string containing a user-defined comment that will be part of the metadata of the
-		/// file. If this string is empty or null it will be ignored
-		/// @return True if file was opened/created successfully or if file is already opened. False if opening the file
-		/// failed for some reason (an error will be printed to log)
-		bool open(const std::string& os, const std::string& hardware, const std::string& captureApp,
-		          const std::string& fileComment);
-
 		/// The pcap-ng format allows adding a user-defined comment for each stored packet. This method writes a
 		/// RawPacket to the file and adds a comment to it. Before using this method please verify the file is opened
 		/// using open(). This method won't change the written packet or the input comment
@@ -501,7 +500,7 @@ namespace pcpp
 		/// overwritten, meaning all its current content will be deleted
 		/// @return True if file was opened/created successfully or if file is already opened. False if opening the file
 		/// failed for some reason (an error will be printed to log)
-		bool open();
+		bool open() override;
 
 		/// Same as open(), but enables to open the file in append mode in which packets will be appended to the file
 		/// instead of overwrite its current content. In append mode file must exist, otherwise opening will fail
@@ -510,7 +509,31 @@ namespace pcpp
 		/// @return True of managed to open the file successfully. In case appendMode is set to true, false will be
 		/// returned if file wasn't found or couldn't be read, if file type is not pcap-ng. In case appendMode is set to
 		/// false, please refer to open() for return values
-		bool open(bool appendMode);
+		bool open(bool appendMode) override;
+
+		/// @brief Opens the file in write mode. If file doesn't exist, it will be created. If it does exist it will be
+		/// overwritten, meaning all its current content will be deleted. This method also allows writing metadata that
+		/// will be stored in the header of the file.
+		/// @param metadata A PcapNgMetadata object containing the metadata to be written in the file header.
+		/// @return True if the file was opened/created successfully or if the file is already opened. False if opening
+		/// the file failed for some reason (an error will be printed to log).
+		bool open(PcapNgMetadata const& metadata);
+
+		/// Open the file in a write mode. If file doesn't exist, it will be created. If it does exist it will be
+		/// overwritten, meaning all its current content will be deleted. As opposed to open(), this method also allows
+		/// writing several metadata attributes that will be stored in the header of the file
+		/// @param[in] os A string describing the operating system that was used to capture the packets. If this string
+		/// is empty or null it will be ignored
+		/// @param[in] hardware A string describing the hardware that was used to capture the packets. If this string is
+		/// empty or null it will be ignored
+		/// @param[in] captureApp A string describing the application that was used to capture the packets. If this
+		/// string is empty or null it will be ignored
+		/// @param[in] fileComment A string containing a user-defined comment that will be part of the metadata of the
+		/// file. If this string is empty or null it will be ignored
+		/// @return True if file was opened/created successfully or if file is already opened. False if opening the file
+		/// failed for some reason (an error will be printed to log)
+		bool open(const std::string& os, const std::string& hardware, const std::string& captureApp,
+		          const std::string& fileComment);
 
 		/// Flush packets to the pcap-ng file
 		void flush();
@@ -527,6 +550,9 @@ namespace pcpp
 		/// (http://biot.com/capstats/bpf.html)
 		/// @return True if filter set successfully, false otherwise
 		bool setFilter(std::string filterAsString);
+
+	private:
+		bool openImpl(bool appendMode, PcapNgMetadata const* metadata = nullptr);
 	};
 
 }  // namespace pcpp

--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -260,6 +260,12 @@ namespace pcpp
 			close();
 		}
 
+		/// @brief The pcap-ng format allows storing metadata at the header of the file. This method fetches the
+		/// metadata if it exists.
+		/// @return A PcapNgMetadata object containing the metadata. If the file is not opened or the metadata is
+		/// missing an empty object is returned.
+		PcapNgMetadata getMetadata() const;
+
 		/// The pcap-ng format allows storing metadata at the header of the file. Part of this metadata is a string
 		/// specifying the operating system that was used for capturing the packets. This method reads this string from
 		/// the metadata (if exists) and returns it

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -469,80 +469,56 @@ namespace pcpp
 		PCPP_LOG_DEBUG("File reader closed for file '" << m_FileName << "'");
 	}
 
-	std::string PcapNgFileReaderDevice::getOS() const
+	PcapNgMetadata PcapNgFileReaderDevice::getMetadata() const
 	{
 		if (m_LightPcapNg == nullptr)
 		{
 			PCPP_LOG_ERROR("Pcapng file device '" << m_FileName << "' not opened");
-			return "";
+			return PcapNgMetadata{};
 		}
 
 		light_pcapng_file_info* fileInfo = light_pcang_get_file_info((light_pcapng_t*)m_LightPcapNg);
 		if (fileInfo == nullptr)
-			return "";
-		char* res = fileInfo->os_desc;
-		size_t len = fileInfo->os_desc_size;
-		if (len == 0 || res == nullptr)
-			return "";
+			return PcapNgMetadata{};
 
-		return std::string(res, len);
+		PcapNgMetadata metadata;
+		if (fileInfo->os_desc != nullptr && fileInfo->os_desc_size > 0)
+		{
+			metadata.os = std::string(fileInfo->os_desc, fileInfo->os_desc_size);
+		}
+		if (fileInfo->hardware_desc != nullptr && fileInfo->hardware_desc_size > 0)
+		{
+			metadata.hardware = std::string(fileInfo->hardware_desc, fileInfo->hardware_desc_size);
+		}
+		if (fileInfo->user_app_desc != nullptr && fileInfo->user_app_desc_size > 0)
+		{
+			metadata.captureApplication = std::string(fileInfo->user_app_desc, fileInfo->user_app_desc_size);
+		}
+		if (fileInfo->file_comment != nullptr && fileInfo->file_comment_size > 0)
+		{
+			metadata.comment = std::string(fileInfo->file_comment, fileInfo->file_comment_size);
+		}
+		return metadata;
+	}
+
+	std::string PcapNgFileReaderDevice::getOS() const
+	{
+		return getMetadata().os;
 	}
 
 	std::string PcapNgFileReaderDevice::getHardware() const
 	{
-		if (m_LightPcapNg == nullptr)
-		{
-			PCPP_LOG_ERROR("Pcapng file device '" << m_FileName << "' not opened");
-			return "";
-		}
-
-		light_pcapng_file_info* fileInfo = light_pcang_get_file_info((light_pcapng_t*)m_LightPcapNg);
-		if (fileInfo == nullptr)
-			return "";
-		char* res = fileInfo->hardware_desc;
-		size_t len = fileInfo->hardware_desc_size;
-		if (len == 0 || res == nullptr)
-			return "";
-
-		return std::string(res, len);
+		return getMetadata().hardware;
 	}
 
 	std::string PcapNgFileReaderDevice::getCaptureApplication() const
 	{
-		if (m_LightPcapNg == nullptr)
-		{
-			PCPP_LOG_ERROR("Pcapng file device '" << m_FileName << "' not opened");
-			return "";
-		}
-
-		light_pcapng_file_info* fileInfo = light_pcang_get_file_info((light_pcapng_t*)m_LightPcapNg);
-		if (fileInfo == nullptr)
-			return "";
-		char* res = fileInfo->user_app_desc;
-		size_t len = fileInfo->user_app_desc_size;
-		if (len == 0 || res == nullptr)
-			return "";
-
-		return std::string(res, len);
+		return getMetadata().captureApplication;
 	}
 
 	std::string PcapNgFileReaderDevice::getCaptureFileComment() const
 	{
-		if (m_LightPcapNg == nullptr)
-		{
-			PCPP_LOG_ERROR("Pcapng file device '" << m_FileName << "' not opened");
-			return "";
-		}
-
-		light_pcapng_file_info* fileInfo = light_pcang_get_file_info((light_pcapng_t*)m_LightPcapNg);
-		if (fileInfo == nullptr)
-			return "";
-		char* res = fileInfo->file_comment;
-		size_t len = fileInfo->file_comment_size;
-		if (len == 0 || res == nullptr)
-			return "";
-
-		return std::string(res, len);
+		return getMetadata().comment;
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -903,6 +903,12 @@ namespace pcpp
 
 		if (appendMode)
 		{
+			if (metadata != nullptr)
+			{
+				PCPP_LOG_ERROR("Pcap-ng file writer device cannot be opened in append mode with metadata");
+				return false;
+			}
+
 			m_LightPcapNg = light_pcapng_open_append(m_FileName.c_str());
 			if (m_LightPcapNg == nullptr)
 			{
@@ -925,17 +931,17 @@ namespace pcpp
 				                              metadata->captureApplication.c_str(), metadata->comment.c_str());
 			}
 
-		m_LightPcapNg = light_pcapng_open_write(m_FileName.c_str(), info, m_CompressionLevel);
-		if (m_LightPcapNg == nullptr)
-		{
-			PCPP_LOG_ERROR("Error opening file writer device for file '"
-			               << m_FileName << "': light_pcapng_open_write returned nullptr");
+			m_LightPcapNg = light_pcapng_open_write(m_FileName.c_str(), info, m_CompressionLevel);
+			if (m_LightPcapNg == nullptr)
+			{
+				PCPP_LOG_ERROR("Error opening file writer device for file '"
+				               << m_FileName << "': light_pcapng_open_write returned nullptr");
 
-			light_free_file_info(info);
+				light_free_file_info(info);
 
-			m_DeviceOpened = false;
-			return false;
-		}
+				m_DeviceOpened = false;
+				return false;
+			}
 		}
 
 		m_DeviceOpened = true;


### PR DESCRIPTION
The purpose of this PR is streamlining of the `PcapNgFileWriterDevice` infrastructure for opening the devices. The current opening code has many duplicated fragments as different modes require only minor changes to the main opening logic. In addition it also provides a common struct for storing `pcapng` metadata that can be read/written by pcpp.

`PcapNgFileReaderDevice` changes:
- Added new `PcapNgMetadata` struct that can hold the metadata of PcapNg file that can be read/write by pcpp.
- Added a new method `PcapNgFileReaderDevice::getMetadata` that returns `PcapNgMetadata` object.

`PcapNgFileWriterDevice` changes:
- Consolidated all device opening logic under `PcapNgFileWriterDevice::openImpl` to remove duplicated opening logic.
- Added `override` keyword to overridden methods.
- Added a new `open(PcapNgMetadata const&)` method that opens the device in write mode and writes the metadata to the header. This method is supposed to be an alternative to `open(const std::string& os, const std::string& hardware, const std::string& captureApp, const std::string& fileComment)`.