### PR TITLE
Replaced usages of `void*` to `internal::LightPcapNgHandle*`

### DIFF
--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -14,6 +14,13 @@ typedef struct pcap_dumper pcap_dumper_t;
 /// @brief The main namespace for the PcapPlusPlus lib
 namespace pcpp
 {
+	namespace internal
+	{
+		/// @struct LightPcapNgHandle
+		/// An opaque struct representing a handle for pcapng files.
+		struct LightPcapNgHandle;
+	}  // namespace internal
+
 	/// @enum FileTimestampPrecision
 	/// An enumeration representing the precision of timestamps in a pcap file.
 	/// The precision can be Unknown, Micro, or Nano.
@@ -226,7 +233,7 @@ namespace pcpp
 	class PcapNgFileReaderDevice : public IFileReaderDevice
 	{
 	private:
-		void* m_LightPcapNg;
+		internal::LightPcapNgHandle* m_LightPcapNg;
 		BpfFilterWrapper m_BpfWrapper;
 
 		// private copy c'tor
@@ -430,7 +437,7 @@ namespace pcpp
 	class PcapNgFileWriterDevice : public IFileWriterDevice
 	{
 	private:
-		void* m_LightPcapNg;
+		internal::LightPcapNgHandle* m_LightPcapNg;
 		int m_CompressionLevel;
 		BpfFilterWrapper m_BpfWrapper;
 


### PR DESCRIPTION
This PR aims to improve the type safety of the PcapNg file device classes by removing the usage of a `void*` and replacing it with a pointer to an opaque struct `internal::LightPcapNgHandle`, while avoiding pollution of the global namespace by directly exposing the `light_pcapng_t` handle.

Changes:
- Added an opaque struct `internal::LightPcapNgHandle` that is to act as a placeholder type instead of `void` while not polluting the global namespace.
- Added functions `toLightPcapNgHandle` and `toLightPcapNgT` to encapsulate the conversion between pointer types of `internal::LightPcapNgHandle` and `light_pcapng_t`.
- Replaced usages of C-style casts and `reinterpret_cast` with `toLightPcapNgHandle` and `toLightPcapNgT`.