### PR TITLE
[WIP] Attempt to flatten the `BgpLayer` inheritance chain.

### DIFF
--- a/Common++/CMakeLists.txt
+++ b/Common++/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(
 set(
   public_headers
   header/DeprecationUtils.h
+  header/EnumFlagUtils.h
   header/GeneralUtils.h
   header/IpAddress.h
   header/IpAddressUtils.h

--- a/Common++/header/EnumFlagUtils.h
+++ b/Common++/header/EnumFlagUtils.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <type_traits>
+
+namespace pcpp
+{
+	namespace internal
+	{
+		template <typename EnumClass> struct EnableBitMaskOperators : std::false_type
+		{
+		};
+
+		template <typename EnumClass>
+		using EnableIfBitMask = typename std::enable_if<EnableBitMaskOperators<EnumClass>::value, EnumClass>::type;
+
+		template <typename EnumClass> constexpr EnableIfBitMask<EnumClass> operator|(EnumClass lhs, EnumClass rhs)
+		{
+			return static_cast<EnumClass>(static_cast<std::underlying_type<EnumClass>::type>(lhs) |
+			                              static_cast<std::underlying_type<EnumClass>::type>(rhs));
+		}
+
+		template <typename EnumClass> constexpr EnableIfBitMask<EnumClass> operator&(EnumClass lhs, EnumClass rhs)
+		{
+			return static_cast<EnumClass>(static_cast<std::underlying_type<EnumClass>::type>(lhs) &
+			                              static_cast<std::underlying_type<EnumClass>::type>(rhs));
+		}
+
+		template <typename EnumClass> constexpr EnableIfBitMask<EnumClass> operator^(EnumClass lhs, EnumClass rhs)
+		{
+			return static_cast<EnumClass>(static_cast<std::underlying_type<EnumClass>::type>(lhs) ^
+			                              static_cast<std::underlying_type<EnumClass>::type>(rhs));
+		}
+
+		template <typename EnumClass> constexpr EnableIfBitMask<EnumClass> operator~(EnumClass rhs)
+		{
+			return static_cast<EnumClass>(~static_cast<std::underlying_type<EnumClass>::type>(rhs));
+		}
+
+		template <typename EnumClass> constexpr EnableIfBitMask<EnumClass>& operator|=(EnumClass& lhs, EnumClass rhs)
+		{
+			return lhs = lhs | rhs;
+		}
+
+		template <typename EnumClass> constexpr EnableIfBitMask<EnumClass>& operator&=(EnumClass& lhs, EnumClass rhs)
+		{
+			return lhs = lhs & rhs;
+		}
+
+		template <typename EnumClass> constexpr EnableIfBitMask<EnumClass>& operator^=(EnumClass& lhs, EnumClass rhs)
+		{
+			return lhs = lhs ^ rhs;
+		}
+
+		template <typename EnumClass> constexpr bool hasFlag(EnableIfBitMask<EnumClass> value, EnumClass flag)
+		{
+			return (value & flag) == flag;
+		}
+	}  // namespace internal
+}  // namespace pcpp
+
+#define PCPP_DECLARE_ENUM_FLAG(EnumClass)                                                                              \
+	template <> struct ::pcpp::internal::EnableBitMaskOperators<EnumClass> : std::true_type                            \
+	{                                                                                                                  \
+	};
+
+#define PCPP_USING_ENUM_FLAG_OPERATORS()                                                                               \
+	using ::pcpp::internal::operator|;                                                                                 \
+	using ::pcpp::internal::operator&;                                                                                 \
+	using ::pcpp::internal::operator^;                                                                                 \
+	using ::pcpp::internal::operator~;                                                                                 \
+	using ::pcpp::internal::operator|=;                                                                                \
+	using ::pcpp::internal::operator&=;                                                                                \
+	using ::pcpp::internal::operator^=;                                                                                \
+	using ::pcpp::internal::hasFlag;

--- a/Common++/header/EnumFlagUtils.h
+++ b/Common++/header/EnumFlagUtils.h
@@ -15,25 +15,25 @@ namespace pcpp
 
 		template <typename EnumClass> constexpr EnableIfBitMask<EnumClass> operator|(EnumClass lhs, EnumClass rhs)
 		{
-			return static_cast<EnumClass>(static_cast<std::underlying_type<EnumClass>::type>(lhs) |
-			                              static_cast<std::underlying_type<EnumClass>::type>(rhs));
+			return static_cast<EnumClass>(static_cast<typename std::underlying_type<EnumClass>::type>(lhs) |
+			                              static_cast<typename std::underlying_type<EnumClass>::type>(rhs));
 		}
 
 		template <typename EnumClass> constexpr EnableIfBitMask<EnumClass> operator&(EnumClass lhs, EnumClass rhs)
 		{
-			return static_cast<EnumClass>(static_cast<std::underlying_type<EnumClass>::type>(lhs) &
-			                              static_cast<std::underlying_type<EnumClass>::type>(rhs));
+			return static_cast<EnumClass>(static_cast<typename std::underlying_type<EnumClass>::type>(lhs) &
+			                              static_cast<typename std::underlying_type<EnumClass>::type>(rhs));
 		}
 
 		template <typename EnumClass> constexpr EnableIfBitMask<EnumClass> operator^(EnumClass lhs, EnumClass rhs)
 		{
-			return static_cast<EnumClass>(static_cast<std::underlying_type<EnumClass>::type>(lhs) ^
-			                              static_cast<std::underlying_type<EnumClass>::type>(rhs));
+			return static_cast<EnumClass>(static_cast<typename std::underlying_type<EnumClass>::type>(lhs) ^
+			                              static_cast<typename std::underlying_type<EnumClass>::type>(rhs));
 		}
 
 		template <typename EnumClass> constexpr EnableIfBitMask<EnumClass> operator~(EnumClass rhs)
 		{
-			return static_cast<EnumClass>(~static_cast<std::underlying_type<EnumClass>::type>(rhs));
+			return static_cast<EnumClass>(~static_cast<typename std::underlying_type<EnumClass>::type>(rhs));
 		}
 
 		template <typename EnumClass> constexpr EnableIfBitMask<EnumClass>& operator|=(EnumClass& lhs, EnumClass rhs)
@@ -59,9 +59,15 @@ namespace pcpp
 }  // namespace pcpp
 
 #define PCPP_DECLARE_ENUM_FLAG(EnumClass)                                                                              \
-	template <> struct ::pcpp::internal::EnableBitMaskOperators<EnumClass> : std::true_type                            \
+	namespace pcpp                                                                                                     \
 	{                                                                                                                  \
-	};
+		namespace internal                                                                                             \
+		{                                                                                                              \
+			template <> struct EnableBitMaskOperators<EnumClass> : std::true_type                                      \
+			{                                                                                                          \
+			};                                                                                                         \
+		}                                                                                                              \
+	}
 
 #define PCPP_USING_ENUM_FLAG_OPERATORS()                                                                               \
 	using ::pcpp::internal::operator|;                                                                                 \

--- a/Common++/header/IpAddress.h
+++ b/Common++/header/IpAddress.h
@@ -106,6 +106,15 @@ namespace pcpp
 			return !(*this == rhs);
 		}
 
+        /// @brief Apply a subnet mask to the address
+		/// @param prefixLen The prefix length of the subnet mask (0-32)
+		/// @throws std::invalid_argument If the prefix length is not between 0 and 32
+        void applySubnetMask(uint8_t prefixLen);
+
+		/// @brief Apply a subnet mask to the address
+		/// @param mask The subnet mask to apply
+		void applySubnetMask(const IPv4Address& mask);
+
 		/// Checks whether the address matches a network.
 		/// @param network An IPv4Network network
 		/// @return True if the address matches the network or false otherwise
@@ -138,6 +147,7 @@ namespace pcpp
 		static const IPv4Address MulticastRangeUpperBound;
 
 	private:
+		// Stored address in network byte order
 		std::array<uint8_t, 4> m_Bytes = { 0 };
 	};  // class IPv4Address
 

--- a/Common++/src/IpAddress.cpp
+++ b/Common++/src/IpAddress.cpp
@@ -54,6 +54,27 @@ namespace pcpp
 		}
 	}
 
+	void IPv4Address::applySubnetMask(uint8_t prefixLen)
+	{
+		if (prefixLen > 32)
+		{
+			throw std::invalid_argument("prefixLen must be an integer between 0 and 32");
+		}
+		const uint32_t mask = 0xffffffff ^ (prefixLen < 32 ? 0xffffffff >> prefixLen : 0);
+		m_Bytes[0] &= mask >> 24;
+		m_Bytes[1] &= mask >> 16;
+		m_Bytes[2] &= mask >> 8;
+		m_Bytes[3] &= mask;
+	}
+
+	void IPv4Address::applySubnetMask(const IPv4Address& maskAddress)
+	{
+		m_Bytes[0] &= maskAddress.m_Bytes[0];
+		m_Bytes[1] &= maskAddress.m_Bytes[1];
+		m_Bytes[2] &= maskAddress.m_Bytes[2];
+		m_Bytes[3] &= maskAddress.m_Bytes[3];
+	}
+
 	bool IPv4Address::matchNetwork(const IPv4Network& network) const
 	{
 		return network.includes(*this);

--- a/Packet++/header/BgpLayer.h
+++ b/Packet++/header/BgpLayer.h
@@ -49,6 +49,14 @@ namespace pcpp
 {
 	namespace internal
 	{
+		/// @brief Helper struct to skip validation of a view.
+		struct nocheck_t
+		{
+		};
+
+		/// @brief Helper variable to skip validation of a view.
+		constexpr nocheck_t nocheck;
+
 #pragma pack(push, 1)
 		/// @struct bgp_common_header
 		/// Represents the common fields of a BGP 4 message
@@ -251,6 +259,11 @@ namespace pcpp
 				if (m_Layer.getHeaderLen() < sizeof(bgp_common_header))
 					throw std::invalid_argument("Layer contains no BGP header");
 			}
+			explicit BgpMessageViewBase(nocheck_t, BgpLayerRef layer) : m_Layer(layer)
+			{
+				// No validation
+			}
+
 			~BgpMessageViewBase() = default;
 
 			BgpLayerRef m_Layer;
@@ -292,6 +305,11 @@ namespace pcpp
 		};
 
 		explicit BgpOpenMessageConstView(BgpLayer const& layer);
+		explicit BgpOpenMessageConstView(internal::nocheck_t nc, BgpLayer const& layer)
+		    : BgpBasicHeaderConstView(nc, layer)
+		{
+			// No validation
+		}
 
 		IPv4Address getBgpId() const
 		{
@@ -315,6 +333,10 @@ namespace pcpp
 		using OptionalParameter = BgpOpenMessageConstView::OptionalParameter;
 
 		explicit BgpOpenMessageView(BgpLayer& layer);
+		explicit BgpOpenMessageView(internal::nocheck_t nc, BgpLayer& layer) : BgpBasicHeaderView(nc, layer)
+		{
+			// No validation
+		}
 
 		IPv4Address getBgpId() const
 		{
@@ -424,6 +446,8 @@ namespace pcpp
 				return m_Length;
 			}
 
+			size_t writeToBuffer(uint8_t* buffer, size_t bufferLen) const;
+
 		private:
 			static constexpr uint16_t MAX_INLINE_DATA_SIZE = 32u;
 
@@ -446,6 +470,11 @@ namespace pcpp
 		};
 
 		explicit BgpUpdateMessageConstView(BgpLayer const& layer);
+		explicit BgpUpdateMessageConstView(internal::nocheck_t nc, BgpLayer const& layer)
+		    : BgpBasicHeaderConstView(nc, layer)
+		{
+			// No validation
+		}
 
 		size_t getWithdrawnRoutesByteLength() const;
 		void getWithdrawnRoutes(std::vector<PrefixAndIp>& outWithdrawnRoutes) const;
@@ -454,7 +483,7 @@ namespace pcpp
 		void getPathAttributes(std::vector<PathAttribute>& outPathAttributes) const;
 
 		size_t getNetworkLayerReachabilityInfoByteLength() const;
-		void getNetworkLayerReachabilityInfo(std::vector<PrefixAndIp>& outNetworkLayerreachabilityInfo) const;
+		void getNetworkLayerReachabilityInfo(std::vector<PrefixAndIp>& outNlri) const;
 	};
 
 	class BgpUpdateMessageView : protected BgpBasicHeaderView
@@ -464,6 +493,10 @@ namespace pcpp
 		using PathAttribute = BgpUpdateMessageConstView::PathAttribute;
 
 		explicit BgpUpdateMessageView(BgpLayer& layer);
+		explicit BgpUpdateMessageView(internal::nocheck_t nc, BgpLayer& layer) : BgpBasicHeaderView(nc, layer)
+		{
+			// No validation
+		}
 
 		size_t getWithdrawnRoutesByteLength() const;
 		void getWithdrawnRoutes(std::vector<PrefixAndIp>& outWithdrawnRoutes) const;
@@ -476,8 +509,8 @@ namespace pcpp
 		void clearPathAttributes();
 
 		size_t getNetworkLayerReachabilityInfoByteLength() const;
-		void getNetworkLayerReachabilityInfo(std::vector<PrefixAndIp>& outNetworkLayerreachabilityInfo) const;
-		void setNetworkLayerReachabilityInfo(const std::vector<PrefixAndIp>& networkLayerReachabilityInfo);
+		void getNetworkLayerReachabilityInfo(std::vector<PrefixAndIp>& outNlri) const;
+		void setNetworkLayerReachabilityInfo(const std::vector<PrefixAndIp>& Nlri);
 		void clearNetworkLayerReachabilityInfo();
 	};
 

--- a/Packet++/header/BgpLayer.h
+++ b/Packet++/header/BgpLayer.h
@@ -82,8 +82,8 @@ namespace pcpp
 		/// @return The size of the BGP message
 		size_t getHeaderLen() const override;
 
-		/// Multiple BGP messages can reside in a single packet, and the only layer that can come after a BGP message
-		/// is another BGP message. This method checks for remaining data and parses it as another BGP layer
+		/// Multiple BGP messages can reside in a single packet, and the only layer that can come after a BGP
+		/// message is another BGP message. This method checks for remaining data and parses it as another BGP layer
 		void parseNextLayer() override;
 
 		std::string toString() const override;
@@ -174,13 +174,13 @@ namespace pcpp
 		/// @param[in] myAutonomousSystem The Autonomous System number of the sender
 		/// @param[in] holdTime The number of seconds the sender proposes for the value of the Hold Timer
 		/// @param[in] bgpId The BGP Identifier of the sender
-		/// @param[in] optionalParams A vector of optional parameters. This parameter is optional and if not provided no
-		/// parameters will be set on the message
+		/// @param[in] optionalParams A vector of optional parameters. This parameter is optional and if not
+		/// provided no parameters will be set on the message
 		BgpOpenMessageLayer(uint16_t myAutonomousSystem, uint16_t holdTime, const IPv4Address& bgpId,
 		                    const std::vector<optional_parameter>& optionalParams = std::vector<optional_parameter>());
 
-		/// Get a pointer to the open message data. Notice this points directly to the data, so any change will modify
-		/// the actual packet data
+		/// Get a pointer to the open message data. Notice this points directly to the data, so any change will
+		/// modify the actual packet data
 		/// @return A pointer to a bgp_open_message structure containing the data
 		bgp_open_message* getOpenMsgHeader() const
 		{
@@ -205,10 +205,10 @@ namespace pcpp
 		/// @return The length in [bytes] of the optional parameters data in the message
 		size_t getOptionalParametersLength();
 
-		/// Set optional parameters in the message. This method will override all existing optional parameters currently
-		/// in the message. If the input is an empty vector all optional parameters will be cleared. This method
-		/// automatically sets the bgp_common_header#length and the bgp_open_message#optionalParameterLength fields on
-		/// the message
+		/// Set optional parameters in the message. This method will override all existing optional parameters
+		/// currently in the message. If the input is an empty vector all optional parameters will be cleared. This
+		/// method automatically sets the bgp_common_header#length and the bgp_open_message#optionalParameterLength
+		/// fields on the message
 		/// @param[in] optionalParameters A vector of new optional parameters to set in the message
 		/// @return True if all optional parameters were set successfully or false otherwise. In case of an error an
 		/// appropriate message will be printed to log
@@ -216,8 +216,8 @@ namespace pcpp
 
 		/// Clear all optional parameters currently in the message. This is equivalent to calling
 		/// setOptionalParameters() with an empty vector as a parameter
-		/// @return True if all optional parameters were successfully cleared or false otherwise. In case of an error an
-		/// appropriate message will be printed to log
+		/// @return True if all optional parameters were successfully cleared or false otherwise. In case of an
+		/// error an appropriate message will be printed to log
 		bool clearOptionalParameters();
 
 		// implement abstract methods
@@ -279,9 +279,9 @@ namespace pcpp
 			/// A c'tor that initializes the values of the struct
 			/// @param[in] flagsVal Path attribute flags value
 			/// @param[in] typeVal Path attribute type value
-			/// @param[in] dataAsHexString Path attribute data as hex string. The path_attribute#length field will be
-			/// set accordingly. If this parameter is not a valid hex string the data will remain zeroed and length will
-			/// be also set to zero
+			/// @param[in] dataAsHexString Path attribute data as hex string. The path_attribute#length field will
+			/// be set accordingly. If this parameter is not a valid hex string the data will remain zeroed and
+			/// length will be also set to zero
 			path_attribute(uint8_t flagsVal, uint8_t typeVal, const std::string& dataAsHexString);
 		};
 
@@ -301,12 +301,12 @@ namespace pcpp
 		static bool isDataValid(const uint8_t* data, size_t dataSize);
 
 		/// A c'tor that creates a new BGP UPDATE message
-		/// @param[in] withdrawnRoutes A vector of withdrawn routes data. If left empty (which is the default value) no
-		/// withdrawn route information will be written to the message
-		/// @param[in] pathAttributes A vector of path attributes data. If left empty (which is the default value) no
-		/// path attribute information will be written to the message
-		/// @param[in] nlri A vector of network layer reachability data. If left empty (which is the default value) no
-		/// reachability information will be written to the message
+		/// @param[in] withdrawnRoutes A vector of withdrawn routes data. If left empty (which is the default value)
+		/// no withdrawn route information will be written to the message
+		/// @param[in] pathAttributes A vector of path attributes data. If left empty (which is the default value)
+		/// no path attribute information will be written to the message
+		/// @param[in] nlri A vector of network layer reachability data. If left empty (which is the default value)
+		/// no reachability information will be written to the message
 		explicit BgpUpdateMessageLayer(
 		    const std::vector<prefix_and_ip>& withdrawnRoutes = std::vector<prefix_and_ip>(),
 		    const std::vector<path_attribute>& pathAttributes = std::vector<path_attribute>(),
@@ -335,10 +335,10 @@ namespace pcpp
 		/// appropriate message will be printed to log
 		bool setWithdrawnRoutes(const std::vector<prefix_and_ip>& withdrawnRoutes);
 
-		/// Clear all Withdrawn Routes data currently in the message. This is equivalent to calling setWithdrawnRoutes()
-		/// with an empty vector as a parameter
-		/// @return True if all Withdrawn Routes were successfully cleared or false otherwise. In case of an error an
-		/// appropriate message will be printed to log
+		/// Clear all Withdrawn Routes data currently in the message. This is equivalent to calling
+		/// setWithdrawnRoutes() with an empty vector as a parameter
+		/// @return True if all Withdrawn Routes were successfully cleared or false otherwise. In case of an error
+		/// an appropriate message will be printed to log
 		bool clearWithdrawnRoutes();
 
 		/// @return The size in [bytes] of the Path Attributes data
@@ -348,16 +348,16 @@ namespace pcpp
 		/// @param[out] pathAttributes A reference to a vector the Path Attributes data will be written to
 		void getPathAttributes(std::vector<path_attribute>& pathAttributes);
 
-		/// Set Path Attributes in this message. This method will override any existing Path Attributes in the message.
-		/// If the input is an empty vector all Path Attributes will be removed. This method automatically sets the
-		/// bgp_common_header#length and the Path Attributes length fields in the message
+		/// Set Path Attributes in this message. This method will override any existing Path Attributes in the
+		/// message. If the input is an empty vector all Path Attributes will be removed. This method automatically
+		/// sets the bgp_common_header#length and the Path Attributes length fields in the message
 		/// @param[in] pathAttributes New Path Attributes to set in the message
 		/// @return True if all Path Attributes were set successfully or false otherwise. In case of an error an
 		/// appropriate message will be printed to log
 		bool setPathAttributes(const std::vector<path_attribute>& pathAttributes);
 
-		/// Clear all Path Attributes data currently in the message. This is equivalent to calling setPathAttributes()
-		/// with an empty vector as a parameter
+		/// Clear all Path Attributes data currently in the message. This is equivalent to calling
+		/// setPathAttributes() with an empty vector as a parameter
 		/// @return True if all Path Attributes were successfully cleared or false otherwise. In case of an error an
 		/// appropriate message will be printed to log
 		bool clearPathAttributes();
@@ -373,14 +373,14 @@ namespace pcpp
 		/// If the input is an empty vector all NLRI data will be removed. This method automatically sets the
 		/// bgp_common_header#length field in the message
 		/// @param[in] nlri New NLRI data to set in the message
-		/// @return True if all NLRI data was set successfully or false otherwise. In case of an error an appropriate
-		/// message will be printed to log
+		/// @return True if all NLRI data was set successfully or false otherwise. In case of an error an
+		/// appropriate message will be printed to log
 		bool setNetworkLayerReachabilityInfo(const std::vector<prefix_and_ip>& nlri);
 
 		/// Clear all NLRI data currently in the message. This is equivalent to calling
 		/// setNetworkLayerReachabilityInfo() with an empty vector as a parameter
-		/// @return True if all NLRI were successfully cleared or false otherwise. In case of an error an appropriate
-		/// message will be printed to log
+		/// @return True if all NLRI were successfully cleared or false otherwise. In case of an error an
+		/// appropriate message will be printed to log
 		bool clearNetworkLayerReachabilityInfo();
 
 		// implement abstract methods
@@ -442,29 +442,29 @@ namespace pcpp
 		/// A c'tor that creates a new BGP Notification message
 		/// @param[in] errorCode BGP notification error code
 		/// @param[in] errorSubCode BGP notification error sub code
-		/// @param[in] notificationData A hex string that contains the notification data. This string will be converted
-		/// to a byte array that will be added to the message. If the input isn't a valid hex string notification data
-		/// will remain empty and an error will be printed to log
+		/// @param[in] notificationData A hex string that contains the notification data. This string will be
+		/// converted to a byte array that will be added to the message. If the input isn't a valid hex string
+		/// notification data will remain empty and an error will be printed to log
 		BgpNotificationMessageLayer(uint8_t errorCode, uint8_t errorSubCode, const std::string& notificationData);
 
-		/// Get a pointer to the notification message data. Notice this points directly to the data, so any change will
-		/// modify the actual packet data
+		/// Get a pointer to the notification message data. Notice this points directly to the data, so any change
+		/// will modify the actual packet data
 		/// @return A pointer to a bgp_notification_message structure containing the data
 		bgp_notification_message* getNotificationMsgHeader() const
 		{
 			return reinterpret_cast<bgp_notification_message*>(m_Data);
 		}
 
-		/// @return The size in [bytes] of the notification data. Notification data is a variable-length field used to
-		/// diagnose the reason for the BGP NOTIFICATION
+		/// @return The size in [bytes] of the notification data. Notification data is a variable-length field used
+		/// to diagnose the reason for the BGP NOTIFICATION
 		size_t getNotificationDataLen() const;
 
-		/// @return A pointer to the notification data. Notification data is a variable-length field used to diagnose
-		/// the reason for the BGP NOTIFICATION
+		/// @return A pointer to the notification data. Notification data is a variable-length field used to
+		/// diagnose the reason for the BGP NOTIFICATION
 		uint8_t* getNotificationData() const;
 
-		/// @return A hex string which represents the notification data. Notification data is a variable-length field
-		/// used to diagnose the reason for the BGP NOTIFICATION
+		/// @return A hex string which represents the notification data. Notification data is a variable-length
+		/// field used to diagnose the reason for the BGP NOTIFICATION
 		std::string getNotificationDataAsHexString() const;
 
 		/// Set the notification data. This method will extend or shorten the existing layer to include the new
@@ -472,17 +472,17 @@ namespace pcpp
 		/// data will be set to none.
 		/// @param[in] newNotificationData A byte array containing the new notification data
 		/// @param[in] newNotificationDataLen The size of the byte array
-		/// @return True if notification data was set successfully or false if any error occurred. In case of an error
-		/// an appropriate error message will be printed to log
+		/// @return True if notification data was set successfully or false if any error occurred. In case of an
+		/// error an appropriate error message will be printed to log
 		bool setNotificationData(const uint8_t* newNotificationData, size_t newNotificationDataLen);
 
 		/// Set the notification data. This method will extend or shorten the existing layer to include the new
-		/// notification data. If newNotificationDataAsHexString is an empty string then notification data will be set
-		/// to none.
-		/// @param[in] newNotificationDataAsHexString A hex string representing the new notification data. If the string
-		/// is not a valid hex string no data will be changed and an error will be returned
-		/// @return True if notification data was set successfully or false if any error occurred or if the string is
-		/// not a valid hex string. In case of an error an appropriate error message will be printed to log
+		/// notification data. If newNotificationDataAsHexString is an empty string then notification data will be
+		/// set to none.
+		/// @param[in] newNotificationDataAsHexString A hex string representing the new notification data. If the
+		/// string is not a valid hex string no data will be changed and an error will be returned
+		/// @return True if notification data was set successfully or false if any error occurred or if the string
+		/// is not a valid hex string. In case of an error an appropriate error message will be printed to log
 		bool setNotificationData(const std::string& newNotificationDataAsHexString);
 
 		// implement abstract methods
@@ -567,8 +567,8 @@ namespace pcpp
 		/// @param[in] safi The Subsequent Address Family Identifier (SAFI) value to set in the message
 		BgpRouteRefreshMessageLayer(uint16_t afi, uint8_t safi);
 
-		/// Get a pointer to the ROUTE-REFRESH message data. Notice this points directly to the data, so any change will
-		/// modify the actual packet data
+		/// Get a pointer to the ROUTE-REFRESH message data. Notice this points directly to the data, so any change
+		/// will modify the actual packet data
 		/// @return A pointer to a bgp_route_refresh_message structure containing the data
 		bgp_route_refresh_message* getRouteRefreshHeader() const
 		{

--- a/Packet++/src/BgpLayer.cpp
+++ b/Packet++/src/BgpLayer.cpp
@@ -628,7 +628,7 @@ namespace pcpp
 	}  // namespace
 
 	BgpUpdateMessageConstView::PrefixAndIp::PrefixAndIp(uint8_t prefixLen, IPv4Address const& ipAddr)
-	    : m_prefixLength(prefixLen), ipAddress(ipAddr)
+	    : ipAddress(ipAddr), m_prefixLength(prefixLen)
 	{
 		if (prefixLen > 32)
 			throw std::invalid_argument("Prefix must be between 0 and 32");

--- a/Packet++/src/BgpLayer.cpp
+++ b/Packet++/src/BgpLayer.cpp
@@ -292,26 +292,17 @@ namespace pcpp
 
 	size_t BgpOpenMessageView::getOptionalPrametersLength() const
 	{
-		// Optional param length is 1 byte. Endianness shouldn't matter;
-		static_assert(sizeof(bgp_open_message::optionalParameterLength) == 1, "Optional param length must be 1 byte");
-		return getOpenMsgHeader()->optionalParameterLength;
+		return BgpOpenMessageConstView(internal::nocheck, m_Layer).getOptionalPrametersLength();
 	}
 
 	std::vector<BgpOpenMessageView::OptionalParameter> BgpOpenMessageView::getOptionalParameters() const
 	{
-		std::vector<BgpOpenMessageView::OptionalParameter> result;
-		getOptionalParameters(result);
-		return result;
+		return BgpOpenMessageConstView(internal::nocheck, m_Layer).getOptionalParameters();
 	}
 
 	void BgpOpenMessageView::getOptionalParameters(std::vector<OptionalParameter>& outOptionalParameters) const
 	{
-		size_t const optionalParamsLen = getOptionalPrametersLength();
-		if (optionalParamsLen == 0)
-			return;
-
-		uint8_t const* optionalParamsData = m_Layer.getData() + sizeof(bgp_open_message);
-		open::readOptionalParamsFromBuffer(optionalParamsData, optionalParamsLen, outOptionalParameters);
+		return BgpOpenMessageConstView(internal::nocheck, m_Layer).getOptionalParameters(outOptionalParameters);
 	}
 
 	bool BgpOpenMessageView::setOptionalParameters(const std::vector<OptionalParameter>& optionalParameters)

--- a/Packet++/src/BgpLayer.cpp
+++ b/Packet++/src/BgpLayer.cpp
@@ -397,7 +397,7 @@ namespace pcpp
 				}
 
 				uint8_t const* withdrawnLenPtr = buffer + sizeof(internal::bgp_common_header);
-				uint16_t withdrawnRoutesLen = be16toh(*withdrawnLenPtr);
+				uint16_t withdrawnRoutesLen = be16toh((withdrawnLenPtr[0] << 8 | withdrawnLenPtr[1]));
 				return withdrawnRoutesLen;
 			}
 
@@ -421,7 +421,7 @@ namespace pcpp
 
 				uint8_t const* pathAttrLenPtr =
 				    buffer + sizeof(internal::bgp_common_header) + sizeof(uint16_t) + withdrawnRoutesLen;
-				uint16_t pathAttributesLen = be16toh(*pathAttrLenPtr);
+				uint16_t pathAttributesLen = be16toh((pathAttrLenPtr[0] << 8 | pathAttrLenPtr[1]));
 
 				PathAttributeLengthData result;
 				result.withdrawnRoutesLen = withdrawnRoutesLen;

--- a/Packet++/src/BgpLayer.cpp
+++ b/Packet++/src/BgpLayer.cpp
@@ -372,8 +372,8 @@ namespace pcpp
 			constexpr size_t MIN_BGP_UPDATE_HEADER_SIZE =
 			    sizeof(internal::bgp_common_header) + 2 * sizeof(uint16_t);  // 23 bytes
 			static_assert(MIN_BGP_UPDATE_HEADER_SIZE == 23, "MIN_BGP_UPDATE_HEADER_SIZE is 23 bytes by spec");
-
-			struct PathAttirbuteLengthData
+			       
+			struct PathAttributeLengthData
 			{
 				size_t withdrawnRoutesLen = 0;
 				size_t pathAttributesLen = 0;
@@ -401,7 +401,7 @@ namespace pcpp
 				return withdrawnRoutesLen;
 			}
 
-			PathAttirbuteLengthData readPathAttributesLen(uint8_t const* buffer, size_t bufferLen)
+			PathAttributeLengthData readPathAttributesLen(uint8_t const* buffer, size_t bufferLen)
 			{
 				if (buffer == nullptr)
 					throw std::invalid_argument("Buffer is null");
@@ -423,7 +423,7 @@ namespace pcpp
 				    buffer + sizeof(internal::bgp_common_header) + sizeof(uint16_t) + withdrawnRoutesLen;
 				uint16_t pathAttributesLen = be16toh(*pathAttrLenPtr);
 
-				PathAttirbuteLengthData result;
+				PathAttributeLengthData result;
 				result.withdrawnRoutesLen = withdrawnRoutesLen;
 				result.pathAttributesLen = pathAttributesLen;
 				return result;
@@ -441,7 +441,7 @@ namespace pcpp
 					    "Buffer length is smaller than BGP UPDATE minimal message header size (23 bytes)");
 				}
 
-				PathAttirbuteLengthData const pathAttrLenData = readPathAttributesLen(buffer, bufferLen);
+				PathAttributeLengthData const pathAttrLenData = readPathAttributesLen(buffer, bufferLen);
 
 				size_t const withdrawnRoutesLen = pathAttrLenData.withdrawnRoutesLen;
 				size_t const pathAttributesLen = pathAttrLenData.pathAttributesLen;

--- a/Packet++/src/BgpLayer.cpp
+++ b/Packet++/src/BgpLayer.cpp
@@ -549,6 +549,7 @@ namespace pcpp
 					uint8_t const* ipData = buffer + offset;
 
 					// Copy the variable length IP address data to a fixed size array
+					// Garbage in the trailing bits is zeroed in IPv4Address::applySubnetMask
 					std::array<uint8_t, 4> ipBuffer;
 					std::copy(ipData, ipData + ipDataLen, ipBuffer.begin());
 

--- a/Packet++/src/BgpLayer.cpp
+++ b/Packet++/src/BgpLayer.cpp
@@ -667,7 +667,7 @@ namespace pcpp
 		{
 			buffer[0] = m_prefixLength;
 			auto const& ipBytes = ipAddress.toByteArray();
-			for (size_t i = 0; i < (m_prefixLength + 7) / 8; ++i)
+			for (size_t i = 0; i < (static_cast<size_t>(m_prefixLength) + 7) / 8; ++i)
 			{
 				buffer[i + 1] = ipBytes[i];
 			}

--- a/Packet++/src/BgpLayer.cpp
+++ b/Packet++/src/BgpLayer.cpp
@@ -705,7 +705,8 @@ namespace pcpp
 		if (dataLen > MAX_INLINE_DATA_SIZE)
 		{
 			// Allocate memory for the data
-			m_HeapData = std::make_unique<uint8_t[]>(dataLen);
+			// TODO: Replace with std::make_unique
+			m_HeapData = std::unique_ptr<uint8_t[]>(new uint8_t[dataLen]);
 			m_Length = dataLen;
 			if (hexStringToByteArray(dataAsHexString, m_HeapData.get(), m_Length) != dataLen)
 			{
@@ -748,7 +749,8 @@ namespace pcpp
 			if (m_HeapData == nullptr)
 			{
 				// Allocate memory for the data
-				m_HeapData = std::make_unique<uint8_t[]>(dataLen);
+				// TODO: Replace with std::make_unique
+				m_HeapData = std::unique_ptr<uint8_t[]>(new uint8_t[dataLen]);
 			}
 			else if (m_HeapData && m_Length < dataLen)
 			{

--- a/Packet++/src/BgpLayer.cpp
+++ b/Packet++/src/BgpLayer.cpp
@@ -414,7 +414,7 @@ namespace pcpp
 
 				size_t const withdrawnRoutesLen = readWithdrawnRoutesLen(buffer, bufferLen);
 
-				if (withdrawnRoutesLen > bufferLen + MIN_BGP_UPDATE_HEADER_SIZE)
+				if (withdrawnRoutesLen > bufferLen - MIN_BGP_UPDATE_HEADER_SIZE)
 				{
 					throw std::runtime_error("Recorded withdrawn routes length exceeds buffer length");
 				}
@@ -445,7 +445,7 @@ namespace pcpp
 
 				size_t const withdrawnRoutesLen = pathAttrLenData.withdrawnRoutesLen;
 				size_t const pathAttributesLen = pathAttrLenData.pathAttributesLen;
-				if (withdrawnRoutesLen + pathAttributesLen > bufferLen + MIN_BGP_UPDATE_HEADER_SIZE)
+				if (withdrawnRoutesLen + pathAttributesLen > bufferLen - MIN_BGP_UPDATE_HEADER_SIZE)
 				{
 					throw std::runtime_error(
 					    "Recorded withdrawn routes and path attributes length exceeds buffer length");
@@ -453,7 +453,7 @@ namespace pcpp
 				size_t const NlriLen =
 				    bufferLen - (MIN_BGP_UPDATE_HEADER_SIZE + withdrawnRoutesLen + pathAttributesLen);
 
-				if (withdrawnRoutesLen + pathAttributesLen + NlriLen > bufferLen + MIN_BGP_UPDATE_HEADER_SIZE)
+				if (withdrawnRoutesLen + pathAttributesLen + NlriLen > bufferLen - MIN_BGP_UPDATE_HEADER_SIZE)
 				{
 					throw std::runtime_error("Recorded NLRI length exceeds buffer length");
 				}


### PR DESCRIPTION
## Overview
This PR is a draft attempt to flatten the inheritance chain of `BgpLayer` and separate the protocol layer parsing logic from the message payload parsing logic. 

In the current implementation each BGP message has a dedicated derived BGP layer class. This introduces limitations where the message payload cannot be switched to a different type without destroying the layer object and creating a new one, requiring the layer to be extracted from the stack and then readded to it. 

This PR aims to simplify the following operations by providing the following objects:
- "MessageView" proxies - thin wrappers over a `BgpLayer` that parse the payload as a specific message.
They exist in two flavors "View" and "ConstView" with the former allowing in-place data modifications and the latter being read-only.
- "Message" objects - lightweight struct objects that can be passed to the `BgpLayer`'s constructor or a dedicated method to completely replace the underlying message with a message of a different type. Similar to the ArpLayer's [helper structs](https://github.com/seladb/PcapPlusPlus/blob/a49a79e0b67b402ad75ffa96c1795def36df75c8/Packet%2B%2B/header/ArpLayer.h#L63-L139).

### The "View" object
The view object is a thin wrapper over a `BgpLayer` that holds a reference to the layer it has been created from. It provides accessors and mutators for reading and writing message specific data directly to the underlying buffer. Each view is intended to be passed by value and should be no larger than a pointer (the reference to the `BgpLayer`), if possible.

Each view should maintain message integrity. During construction the View should validate a minimally viable message of the type can be parsed from the buffer. Full validation can be deferred until use of accessors and/or mutators of the view object.

### BGP Layer Enhancements

#### Improved support of full length update message path attributes.
The previous version supported path attributes with data up to 32 bytes. The new `PathAttribute` class supports the full spectrum of variable data lengths a path attribute block can contain specified by  [RFC 4271 Section 4.3](https://www.rfc-editor.org/rfc/rfc4271#section-4.3). 
The attribute can support a data buffer of:
- standard length attribute - up to 255 bytes
- extended length attribute - unlimited, restricted by total message length of 4096 bytes.

### Other enhancements

#### Addition of utility functions for `enum class` flags.
This PR adds the header `EnumFlagUtils.h` to the `Common++` package. The header provides operators for bitwise operators and helper functions of `enum class` objects when they satisfy the trait `EnableBitMaskOperators`. 

In addition the header defines the following macros:
- `PCPP_DECLARE_ENUM_FLAG` - to enable the operators to be used for a class.
- `PCPP_USING_ENUM_FLAG_OPERATORS`  - to declare aliases to all templated operators in the scope this macro is used to satisfy ADL.
