### PR TITLE
Improvements to `PcapLiveDevice::sendPacket` and `PcapLiveDevice::sendPackets`.

### DIFF
--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -210,6 +210,34 @@ namespace pcpp
 			return m_Vector.end();
 		}
 
+		/// @brief Provides direct access to the underlying array of element pointers.
+		/// The pointer is such that range [data(), data() + size()) is a valid range.
+		///
+		/// If this::size() == 0, the data() pointer is not dereferenceable.
+		///
+		/// All pointers provided by this method should be considered non-owning.
+		/// Elements in the vector have their lifetime managed by the vector and should not be freed manually.
+		///
+		/// @return A pointer to the underlying array of elements.
+		T* const* data()
+		{
+			return m_Vector.data();
+		}
+
+		/// @brief Provides direct access to the underlying array of element pointers.
+		/// The pointer is such that range [data(), data() + size()) is a valid range.
+		///
+		/// If this::size() == 0, the data() pointer is not dereferenceable.
+		///
+		/// All pointers provided by this method should be considered non-owning.
+		/// Elements in the vector have their lifetime managed by the vector and should not be freed manually.
+		///
+		/// @return A const pointer to the underlying array of elements.
+		T const* const* data() const
+		{
+			return m_Vector.data();
+		}
+
 		/// Get number of elements in the vector
 		/// @return The number of elements in the vector
 		size_t size() const

--- a/Examples/ArpSpoofing/main.cpp
+++ b/Examples/ArpSpoofing/main.cpp
@@ -82,7 +82,7 @@ pcpp::MacAddress getMacAddress(const pcpp::IPv4Address& ipAddr, pcpp::PcapLiveDe
 	}
 
 	// send the arp request and wait for arp reply
-	pDevice->sendPacket(&arpRequest);
+	pDevice->sendPacket(arpRequest);
 	pcpp::RawPacketVector capturedPackets;
 	pDevice->startCapture(capturedPackets);
 	std::this_thread::sleep_for(std::chrono::seconds(2));
@@ -154,10 +154,10 @@ void doArpSpoofing(pcpp::PcapLiveDevice* pDevice, const pcpp::IPv4Address& gatew
 	std::cout << "Sending ARP replies to victim and to gateway every 5 seconds..." << std::endl << std::endl;
 	while (1)
 	{
-		pDevice->sendPacket(&gwArpReply);
+		pDevice->sendPacket(gwArpReply);
 		std::cout << "Sent ARP reply: " << gatewayAddr << " [gateway] is at MAC address " << deviceMacAddress << " [me]"
 		          << std::endl;
-		pDevice->sendPacket(&victimArpReply);
+		pDevice->sendPacket(victimArpReply);
 		std::cout << "Sent ARP reply: " << victimAddr << " [victim] is at MAC address " << deviceMacAddress << " [me]"
 		          << std::endl;
 		std::this_thread::sleep_for(std::chrono::seconds(5));

--- a/Examples/DnsSpoofing/main.cpp
+++ b/Examples/DnsSpoofing/main.cpp
@@ -239,7 +239,7 @@ void handleDnsRequest(pcpp::RawPacket* packet, pcpp::PcapLiveDevice* dev, void* 
 	dnsRequest.computeCalculateFields();
 
 	// send DNS response back to the network
-	if (!dev->sendPacket(&dnsRequest))
+	if (!dev->sendPacket(dnsRequest))
 		return;
 
 	args->stats.numOfSpoofedDnsRequests++;

--- a/Examples/IcmpFileTransfer/Common.cpp
+++ b/Examples/IcmpFileTransfer/Common.cpp
@@ -255,7 +255,7 @@ bool sendIcmpMessage(pcpp::PcapLiveDevice* dev, pcpp::MacAddress srcMacAddr, pcp
 	packet.computeCalculateFields();
 
 	// send the packet through the device
-	return dev->sendPacket(&packet);
+	return dev->sendPacket(packet);
 }
 
 bool sendIcmpRequest(pcpp::PcapLiveDevice* dev, pcpp::MacAddress srcMacAddr, const pcpp::MacAddress dstMacAddr,

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -602,6 +602,9 @@ namespace pcpp
 	protected:
 		internal::PcapHandle doOpen(const DeviceConfiguration& config);
 
+		// Sends a packet directly to the network.
+		bool sendPacketDirect(uint8_t const* packetData, int packetDataLength);
+
 	private:
 		bool isNflogDevice() const;
 	};

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -482,7 +482,24 @@ namespace pcpp
 		/// - Packet length is 0
 		/// - Packet length is larger than device MTU and checkMtu is true
 		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
-		bool sendPacket(Packet const* packet, bool checkMtu = true);
+		bool sendPacket(Packet const* packet, bool checkMtu = true)
+		{
+			return sendPacket(*packet, checkMtu);
+		}
+
+		/// Send a parsed Packet to the network
+		/// @param[in] packet A reference to the packet to send. This method treats the packet as read-only, it doesn't
+		/// change anything in it
+		/// @param[in] checkMtu Whether the length of the packet's payload should be checked against the MTU. Default
+		/// value is true, since the packet being passed in has already been parsed, so checking the MTU does not incur
+		/// significant processing overhead.
+		/// @return True if packet was sent successfully. False will be returned in the following cases (relevant log
+		/// error is printed in any case):
+		/// - Device is not opened
+		/// - Packet length is 0
+		/// - Packet length is larger than device MTU and checkMtu is true
+		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
+		bool sendPacket(Packet const& packet, bool checkMtu = true);
 
 		/// Send a RawPacket to the network
 		/// @param[in] rawPacket A reference to the raw packet to send. This method treats the raw packet as read-only,

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -482,6 +482,7 @@ namespace pcpp
 		/// - Packet length is 0
 		/// - Packet length is larger than device MTU and checkMtu is true
 		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
+		PCPP_DEPRECATED("This method is deprecated. Use sendPacket(Packet const& packet, bool checkMtu) instead")
 		bool sendPacket(Packet const* packet, bool checkMtu = true)
 		{
 			return sendPacket(*packet, checkMtu);

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -470,6 +470,20 @@ namespace pcpp
 		/// @return True if the packetPayloadLength is less than or equal to the device MTU
 		bool doMtuCheck(int packetPayloadLength) const;
 
+		/// Send a parsed Packet to the network
+		/// @param[in] packet A pointer to the packet to send. This method treats the packet as read-only, it doesn't
+		/// change anything in it
+		/// @param[in] checkMtu Whether the length of the packet's payload should be checked against the MTU. Default
+		/// value is true, since the packet being passed in has already been parsed, so checking the MTU does not incur
+		/// significant processing overhead.
+		/// @return True if packet was sent successfully. False will be returned in the following cases (relevant log
+		/// error is printed in any case):
+		/// - Device is not opened
+		/// - Packet length is 0
+		/// - Packet length is larger than device MTU and checkMtu is true
+		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
+		bool sendPacket(Packet const* packet, bool checkMtu = true);
+
 		/// Send a RawPacket to the network
 		/// @param[in] rawPacket A reference to the raw packet to send. This method treats the raw packet as read-only,
 		/// it doesn't change anything in it
@@ -518,20 +532,6 @@ namespace pcpp
 		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
 		bool sendPacket(const uint8_t* packetData, int packetDataLength, bool checkMtu = false,
 		                pcpp::LinkLayerType linkType = pcpp::LINKTYPE_ETHERNET);
-
-		/// Send a parsed Packet to the network
-		/// @param[in] packet A pointer to the packet to send. This method treats the packet as read-only, it doesn't
-		/// change anything in it
-		/// @param[in] checkMtu Whether the length of the packet's payload should be checked against the MTU. Default
-		/// value is true, since the packet being passed in has already been parsed, so checking the MTU does not incur
-		/// significant processing overhead.
-		/// @return True if packet was sent successfully. False will be returned in the following cases (relevant log
-		/// error is printed in any case):
-		/// - Device is not opened
-		/// - Packet length is 0
-		/// - Packet length is larger than device MTU and checkMtu is true
-		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
-		bool sendPacket(Packet const* packet, bool checkMtu = true);
 
 		/// Send an array of RawPacket objects to the network
 		/// @param[in] rawPacketsArr The array of RawPacket objects to send. This method treats all packets as

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -604,7 +604,15 @@ namespace pcpp
 
 		// Sends a packet directly to the network.
 		bool sendPacketDirect(uint8_t const* packetData, int packetDataLength);
-
+		
+		// Sends an array of packets directly to the network. Allows sending packets in bulk.
+		virtual int sendPacketsDirect(RawPacket const* packetsArr, int arrLength);
+		// Sends an array of packets directly to the network. Allows sending packets in bulk.
+		// Overload to accept an array of packet pointers.
+		virtual int sendPacketsDirect(RawPacket const* const* packetsArr, int arrLength);
+		// Sends an array of packets directly to the network. Allows sending packets in bulk.
+		// Overload to accept an array of packet pointers.
+		virtual int sendPacketsDirect(Packet const* const* packetsArr, int arrLength);
 	private:
 		bool isNflogDevice() const;
 	};

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -604,7 +604,7 @@ namespace pcpp
 
 		// Sends a packet directly to the network.
 		bool sendPacketDirect(uint8_t const* packetData, int packetDataLength);
-		
+
 		// Sends an array of packets directly to the network. Allows sending packets in bulk.
 		virtual int sendPacketsDirect(RawPacket const* packetsArr, int arrLength);
 		// Sends an array of packets directly to the network. Allows sending packets in bulk.
@@ -613,6 +613,7 @@ namespace pcpp
 		// Sends an array of packets directly to the network. Allows sending packets in bulk.
 		// Overload to accept an array of packet pointers.
 		virtual int sendPacketsDirect(Packet const* const* packetsArr, int arrLength);
+
 	private:
 		bool isNflogDevice() const;
 	};

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -531,7 +531,7 @@ namespace pcpp
 		/// - Packet length is 0
 		/// - Packet length is larger than device MTU and checkMtu is true
 		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
-		bool sendPacket(Packet* packet, bool checkMtu = true);
+		bool sendPacket(Packet const* packet, bool checkMtu = true);
 
 		/// Send an array of RawPacket objects to the network
 		/// @param[in] rawPacketsArr The array of RawPacket objects to send. This method treats all packets as
@@ -545,7 +545,7 @@ namespace pcpp
 		/// - Packet length is 0
 		/// - Packet length is larger than device MTU and checkMtu is true
 		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
-		virtual int sendPackets(RawPacket* rawPacketsArr, int arrLength, bool checkMtu = false);
+		virtual int sendPackets(RawPacket const* rawPacketsArr, int arrLength, bool checkMtu = false);
 
 		/// Send an array of pointers to Packet objects to the network
 		/// @param[in] packetsArr The array of pointers to Packet objects to send. This method treats all packets as
@@ -559,7 +559,7 @@ namespace pcpp
 		/// - Packet length is 0
 		/// - Packet length is larger than device MTU and checkMtu is true
 		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
-		virtual int sendPackets(Packet** packetsArr, int arrLength, bool checkMtu = true);
+		virtual int sendPackets(Packet const* const* packetsArr, int arrLength, bool checkMtu = true);
 
 		/// Send a vector of pointers to RawPacket objects to the network
 		/// @param[in] rawPackets The array of pointers to RawPacket objects to send. This method treats all packets as

--- a/Pcap++/header/WinPcapLiveDevice.h
+++ b/Pcap++/header/WinPcapLiveDevice.h
@@ -66,5 +66,9 @@ namespace pcpp
 		}
 
 		WinPcapLiveDevice* clone() const override;
+
+	protected:
+		// Override of the sendPackets method that uses pcap_sendqueue implementation.
+		int sendPacketsDirect(RawPacket const* rawPacketsArr, int arrLength) override;
 	};
 }  // namespace pcpp

--- a/Pcap++/header/WinPcapLiveDevice.h
+++ b/Pcap++/header/WinPcapLiveDevice.h
@@ -48,7 +48,7 @@ namespace pcpp
 		}
 
 		using PcapLiveDevice::sendPackets;
-		virtual int sendPackets(RawPacket* rawPacketsArr, int arrLength);
+		virtual int sendPackets(RawPacket const* rawPacketsArr, int arrLength);
 
 		/// WinPcap/Npcap have a feature (that doesn't exist in libpcap) to change the minimum amount of data in the
 		/// kernel buffer that causes a read from the application to return (unless the timeout expires). Please see

--- a/Pcap++/src/NetworkUtils.cpp
+++ b/Pcap++/src/NetworkUtils.cpp
@@ -152,7 +152,7 @@ namespace pcpp
 		device->startCapture(arpPacketReceived, &data);
 
 		// send the ARP request
-		device->sendPacket(&arpRequest);
+		device->sendPacket(arpRequest);
 
 		// block on the conditional mutex until capture thread signals or until timeout expires
 		// cppcheck-suppress localMutex
@@ -395,7 +395,7 @@ namespace pcpp
 		device->startCapture(dnsResponseReceived, &data);
 
 		// send the DNS request
-		device->sendPacket(&dnsRequest);
+		device->sendPacket(dnsRequest);
 
 		// block on the conditional mutex until capture thread signals or until timeout expires
 		// cppcheck-suppress localMutex

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -862,13 +862,14 @@ namespace pcpp
 			Packet parsedPacket = Packet(rPacket, OsiModelDataLinkLayer);
 			return sendPacket(&parsedPacket, true);
 		}
+
 		// Send packet without Mtu check
-		return sendPacket(rawPacket.getRawData(), rawPacket.getRawDataLen());
+		return sendPacketDirect(rawPacket.getRawData(), rawPacket.getRawDataLen());
 	}
 
 	bool PcapLiveDevice::sendPacket(const uint8_t* packetData, int packetDataLength, int packetPayloadLength)
 	{
-		return doMtuCheck(packetPayloadLength) && sendPacket(packetData, packetDataLength);
+		return doMtuCheck(packetPayloadLength) && sendPacketDirect(packetData, packetDataLength);
 	}
 
 	bool PcapLiveDevice::sendPacket(const uint8_t* packetData, int packetDataLength, bool checkMtu,
@@ -883,6 +884,11 @@ namespace pcpp
 			return sendPacket(&parsedPacket, true);
 		}
 
+		return sendPacketDirect(packetData, packetDataLength);
+	}
+
+	bool PcapLiveDevice::sendPacketDirect(uint8_t const* packetData,int packetDataLength)
+	{
 		if (!m_DeviceOpened)
 		{
 			PCPP_LOG_ERROR("Device '" << m_InterfaceDetails.name << "' not opened!");

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -913,7 +913,7 @@ namespace pcpp
 
 	bool PcapLiveDevice::sendPacket(Packet const* packet, bool checkMtu)
 	{
-		RawPacket* rawPacket = packet->getRawPacket();
+		RawPacket const* rawPacket = packet->getRawPacketReadOnly();
 		if (checkMtu)
 		{
 			int packetPayloadLength = 0;

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -956,20 +956,57 @@ namespace pcpp
 
 	int PcapLiveDevice::sendPackets(RawPacket const* rawPacketsArr, int arrLength, bool checkMtu)
 	{
+		if (!checkMtu)
+		{
+			return sendPacketsDirect(rawPacketsArr, arrLength);
+		}
+
 		return sendPacketsImpl(rawPacketsArr, rawPacketsArr + arrLength,
 		                       [this, checkMtu](RawPacket const& packet) { return sendPacket(packet, checkMtu); });
 	}
 
 	int PcapLiveDevice::sendPackets(Packet const* const* packetsArr, int arrLength, bool checkMtu)
 	{
+		if(!checkMtu)
+		{
+			return sendPacketsDirect(packetsArr, arrLength);
+		}
+
 		return sendPacketsImpl(packetsArr, packetsArr + arrLength,
 		                       [this, checkMtu](Packet const* packet) { return sendPacket(packet, checkMtu); });
 	}
 
 	int PcapLiveDevice::sendPackets(const RawPacketVector& rawPackets, bool checkMtu)
 	{
+		if (!checkMtu)
+		{
+			return sendPacketsDirect(rawPackets.data(), static_cast<int>(rawPackets.size()));
+		}
+
 		return sendPacketsImpl(rawPackets.begin(), rawPackets.end(),
 		                       [this, checkMtu](RawPacket const* packet) { return sendPacket(*packet, checkMtu); });
+	}
+
+	int PcapLiveDevice::sendPacketsDirect(RawPacket const* packetsArr, int arrLength)
+	{
+		return sendPacketsImpl(packetsArr, packetsArr + arrLength, [this](RawPacket const& packet) {
+			return sendPacketDirect(packet.getRawData(), packet.getRawDataLen());
+		});
+	}
+
+	int PcapLiveDevice::sendPacketsDirect(RawPacket const* const* packetsArr, int arrLength)
+	{
+		return sendPacketsImpl(packetsArr, packetsArr + arrLength, [this](RawPacket const* packet) {
+			return sendPacketDirect(packet->getRawData(), packet->getRawDataLen());
+		});
+	}
+
+	int PcapLiveDevice::sendPacketsDirect(Packet const* const* packetsArr,int arrLength)
+	{
+		return sendPacketsImpl(packetsArr, packetsArr + arrLength, [this](Packet const* packet) {
+			return sendPacketDirect(packet->getRawPacketReadOnly()->getRawData(),
+			                        packet->getRawPacketReadOnly()->getRawDataLen());
+		});
 	}
 
 	void PcapLiveDevice::setDeviceMtu()

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -905,7 +905,7 @@ namespace pcpp
 		return true;
 	}
 
-	bool PcapLiveDevice::sendPacket(Packet* packet, bool checkMtu)
+	bool PcapLiveDevice::sendPacket(Packet const* packet, bool checkMtu)
 	{
 		RawPacket* rawPacket = packet->getRawPacket();
 		if (checkMtu)
@@ -928,7 +928,7 @@ namespace pcpp
 		return sendPacket(*rawPacket, false);
 	}
 
-	int PcapLiveDevice::sendPackets(RawPacket* rawPacketsArr, int arrLength, bool checkMtu)
+	int PcapLiveDevice::sendPackets(RawPacket const* rawPacketsArr, int arrLength, bool checkMtu)
 	{
 		int packetsSent = 0;
 		for (int i = 0; i < arrLength; i++)
@@ -941,7 +941,7 @@ namespace pcpp
 		return packetsSent;
 	}
 
-	int PcapLiveDevice::sendPackets(Packet** packetsArr, int arrLength, bool checkMtu)
+	int PcapLiveDevice::sendPackets(Packet const* const* packetsArr, int arrLength, bool checkMtu)
 	{
 		int packetsSent = 0;
 		for (int i = 0; i < arrLength; i++)

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -937,14 +937,14 @@ namespace pcpp
 
 	namespace
 	{
-		template <typename It, typename Func> int sendPacketsImpl(It begin, It end, Func sendFunc, bool checkMtu)
+		template <typename It, typename Func> int sendPacketsImpl(It begin, It end, Func sendFunc)
 		{
 			int packetsSent = 0;
 			size_t totalPackets = std::distance(begin, end);
 
 			for (It iter = begin; iter != end; ++iter)
 			{
-				if (sendFunc(*iter, checkMtu))
+				if (sendFunc(*iter))
 					packetsSent++;
 			}
 
@@ -956,23 +956,20 @@ namespace pcpp
 
 	int PcapLiveDevice::sendPackets(RawPacket const* rawPacketsArr, int arrLength, bool checkMtu)
 	{
-		return sendPacketsImpl(
-		    rawPacketsArr, rawPacketsArr + arrLength,
-		    [this](RawPacket const& packet, bool checkMtu) { return sendPacket(packet, checkMtu); }, checkMtu);
+		return sendPacketsImpl(rawPacketsArr, rawPacketsArr + arrLength,
+		                       [this, checkMtu](RawPacket const& packet) { return sendPacket(packet, checkMtu); });
 	}
 
 	int PcapLiveDevice::sendPackets(Packet const* const* packetsArr, int arrLength, bool checkMtu)
 	{
-		return sendPacketsImpl(
-		    packetsArr, packetsArr + arrLength,
-		    [this](Packet const* packet, bool checkMtu) { return sendPacket(packet, checkMtu); }, checkMtu);
+		return sendPacketsImpl(packetsArr, packetsArr + arrLength,
+		                       [this, checkMtu](Packet const* packet) { return sendPacket(packet, checkMtu); });
 	}
 
 	int PcapLiveDevice::sendPackets(const RawPacketVector& rawPackets, bool checkMtu)
 	{
-		return sendPacketsImpl(
-		    rawPackets.begin(), rawPackets.end(),
-		    [this](RawPacket const* packet, bool checkMtu) { return sendPacket(*packet, checkMtu); }, checkMtu);
+		return sendPacketsImpl(rawPackets.begin(), rawPackets.end(),
+		                       [this, checkMtu](RawPacket const* packet) { return sendPacket(*packet, checkMtu); });
 	}
 
 	void PcapLiveDevice::setDeviceMtu()

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -967,7 +967,7 @@ namespace pcpp
 
 	int PcapLiveDevice::sendPackets(Packet const* const* packetsArr, int arrLength, bool checkMtu)
 	{
-		if(!checkMtu)
+		if (!checkMtu)
 		{
 			return sendPacketsDirect(packetsArr, arrLength);
 		}
@@ -1001,7 +1001,7 @@ namespace pcpp
 		});
 	}
 
-	int PcapLiveDevice::sendPacketsDirect(Packet const* const* packetsArr,int arrLength)
+	int PcapLiveDevice::sendPacketsDirect(Packet const* const* packetsArr, int arrLength)
 	{
 		return sendPacketsLoop(packetsArr, packetsArr + arrLength, [this](Packet const* packet) {
 			return sendPacketDirect(packet->getRawPacketReadOnly()->getRawData(),

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -856,15 +856,14 @@ namespace pcpp
 
 	bool PcapLiveDevice::sendPacket(RawPacket const& rawPacket, bool checkMtu)
 	{
-		if (checkMtu)
+		if (!checkMtu)
 		{
-			RawPacket* rPacket = const_cast<RawPacket*>(&rawPacket);
-			Packet parsedPacket = Packet(rPacket, OsiModelDataLinkLayer);
-			return sendPacket(&parsedPacket, true);
+			return sendPacketDirect(rawPacket.getRawData(), rawPacket.getRawDataLen());
 		}
 
-		// Send packet without Mtu check
-		return sendPacketDirect(rawPacket.getRawData(), rawPacket.getRawDataLen());
+		RawPacket* rPacket = const_cast<RawPacket*>(&rawPacket);
+		Packet parsedPacket = Packet(rPacket, OsiModelDataLinkLayer);
+		return sendPacket(&parsedPacket, true);
 	}
 
 	bool PcapLiveDevice::sendPacket(const uint8_t* packetData, int packetDataLength, int packetPayloadLength)
@@ -875,16 +874,16 @@ namespace pcpp
 	bool PcapLiveDevice::sendPacket(const uint8_t* packetData, int packetDataLength, bool checkMtu,
 	                                pcpp::LinkLayerType linkType)
 	{
-		if (checkMtu)
+		if (!checkMtu)
 		{
-			timeval time;
-			gettimeofday(&time, nullptr);
-			pcpp::RawPacket rawPacket(packetData, packetDataLength, time, false, linkType);
-			Packet parsedPacket = Packet(&rawPacket, pcpp::OsiModelDataLinkLayer);
-			return sendPacket(&parsedPacket, true);
+			return sendPacketDirect(packetData, packetDataLength);
 		}
 
-		return sendPacketDirect(packetData, packetDataLength);
+		timeval time;
+		gettimeofday(&time, nullptr);
+		pcpp::RawPacket rawPacket(packetData, packetDataLength, time, false, linkType);
+		Packet parsedPacket = Packet(&rawPacket, pcpp::OsiModelDataLinkLayer);
+		return sendPacket(&parsedPacket, true);
 	}
 
 	bool PcapLiveDevice::sendPacketDirect(uint8_t const* packetData, int packetDataLength)
@@ -914,24 +913,26 @@ namespace pcpp
 	bool PcapLiveDevice::sendPacket(Packet const* packet, bool checkMtu)
 	{
 		RawPacket const* rawPacket = packet->getRawPacketReadOnly();
-		if (checkMtu)
+
+		if (!checkMtu)
 		{
-			int packetPayloadLength = 0;
-			switch (packet->getFirstLayer()->getOsiModelLayer())
-			{
-			case (pcpp::OsiModelDataLinkLayer):
-				packetPayloadLength = static_cast<int>(packet->getFirstLayer()->getLayerPayloadSize());
-				break;
-			case (pcpp::OsiModelNetworkLayer):
-				packetPayloadLength = static_cast<int>(packet->getFirstLayer()->getDataLen());
-				break;
-			default:
-				// if packet layer is not known, do not perform MTU check.
-				return sendPacket(*rawPacket, false);
-			}
-			return doMtuCheck(packetPayloadLength) && sendPacket(*rawPacket, false);
+			return sendPacket(*rawPacket, false);
 		}
-		return sendPacket(*rawPacket, false);
+
+		int packetPayloadLength = 0;
+		switch (packet->getFirstLayer()->getOsiModelLayer())
+		{
+		case (pcpp::OsiModelDataLinkLayer):
+			packetPayloadLength = static_cast<int>(packet->getFirstLayer()->getLayerPayloadSize());
+			break;
+		case (pcpp::OsiModelNetworkLayer):
+			packetPayloadLength = static_cast<int>(packet->getFirstLayer()->getDataLen());
+			break;
+		default:
+			// if packet layer is not known, do not perform MTU check.
+			return sendPacket(*rawPacket, false);
+		}
+		return doMtuCheck(packetPayloadLength) && sendPacket(*rawPacket, false);
 	}
 
 	namespace

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -888,7 +888,7 @@ namespace pcpp
 
 		RawPacket* rPacket = const_cast<RawPacket*>(&rawPacket);
 		Packet parsedPacket = Packet(rPacket, OsiModelDataLinkLayer);
-		return sendPacket(&parsedPacket, true);
+		return sendPacket(parsedPacket, true);
 	}
 
 	bool PcapLiveDevice::sendPacket(const uint8_t* packetData, int packetDataLength, int packetPayloadLength)
@@ -908,7 +908,7 @@ namespace pcpp
 		gettimeofday(&time, nullptr);
 		pcpp::RawPacket rawPacket(packetData, packetDataLength, time, false, linkType);
 		Packet parsedPacket = Packet(&rawPacket, pcpp::OsiModelDataLinkLayer);
-		return sendPacket(&parsedPacket, true);
+		return sendPacket(parsedPacket, true);
 	}
 
 	bool PcapLiveDevice::sendPacketDirect(uint8_t const* packetData, int packetDataLength)
@@ -973,7 +973,7 @@ namespace pcpp
 		}
 
 		return sendPacketsLoop(packetsArr, packetsArr + arrLength,
-		                       [this, checkMtu](Packet const* packet) { return sendPacket(packet, checkMtu); });
+		                       [this, checkMtu](Packet const* packet) { return sendPacket(*packet, checkMtu); });
 	}
 
 	int PcapLiveDevice::sendPackets(const RawPacketVector& rawPackets, bool checkMtu)

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -854,9 +854,9 @@ namespace pcpp
 		return true;
 	}
 
-	bool PcapLiveDevice::sendPacket(Packet const* packet, bool checkMtu)
+	bool PcapLiveDevice::sendPacket(Packet const& packet, bool checkMtu)
 	{
-		RawPacket const* rawPacket = packet->getRawPacketReadOnly();
+		RawPacket const* rawPacket = packet.getRawPacketReadOnly();
 
 		if (!checkMtu)
 		{
@@ -864,13 +864,13 @@ namespace pcpp
 		}
 
 		int packetPayloadLength = 0;
-		switch (packet->getFirstLayer()->getOsiModelLayer())
+		switch (packet.getFirstLayer()->getOsiModelLayer())
 		{
 		case (pcpp::OsiModelDataLinkLayer):
-			packetPayloadLength = static_cast<int>(packet->getFirstLayer()->getLayerPayloadSize());
+			packetPayloadLength = static_cast<int>(packet.getFirstLayer()->getLayerPayloadSize());
 			break;
 		case (pcpp::OsiModelNetworkLayer):
-			packetPayloadLength = static_cast<int>(packet->getFirstLayer()->getDataLen());
+			packetPayloadLength = static_cast<int>(packet.getFirstLayer()->getDataLen());
 			break;
 		default:
 			// if packet layer is not known, do not perform MTU check.

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -937,7 +937,7 @@ namespace pcpp
 
 	namespace
 	{
-		template <typename It, typename Func> int sendPacketsImpl(It begin, It end, Func sendFunc)
+		template <typename It, typename Func> int sendPacketsLoop(It begin, It end, Func sendFunc)
 		{
 			int packetsSent = 0;
 			size_t totalPackets = std::distance(begin, end);
@@ -961,7 +961,7 @@ namespace pcpp
 			return sendPacketsDirect(rawPacketsArr, arrLength);
 		}
 
-		return sendPacketsImpl(rawPacketsArr, rawPacketsArr + arrLength,
+		return sendPacketsLoop(rawPacketsArr, rawPacketsArr + arrLength,
 		                       [this, checkMtu](RawPacket const& packet) { return sendPacket(packet, checkMtu); });
 	}
 
@@ -972,7 +972,7 @@ namespace pcpp
 			return sendPacketsDirect(packetsArr, arrLength);
 		}
 
-		return sendPacketsImpl(packetsArr, packetsArr + arrLength,
+		return sendPacketsLoop(packetsArr, packetsArr + arrLength,
 		                       [this, checkMtu](Packet const* packet) { return sendPacket(packet, checkMtu); });
 	}
 
@@ -983,27 +983,27 @@ namespace pcpp
 			return sendPacketsDirect(rawPackets.data(), static_cast<int>(rawPackets.size()));
 		}
 
-		return sendPacketsImpl(rawPackets.begin(), rawPackets.end(),
+		return sendPacketsLoop(rawPackets.begin(), rawPackets.end(),
 		                       [this, checkMtu](RawPacket const* packet) { return sendPacket(*packet, checkMtu); });
 	}
 
 	int PcapLiveDevice::sendPacketsDirect(RawPacket const* packetsArr, int arrLength)
 	{
-		return sendPacketsImpl(packetsArr, packetsArr + arrLength, [this](RawPacket const& packet) {
+		return sendPacketsLoop(packetsArr, packetsArr + arrLength, [this](RawPacket const& packet) {
 			return sendPacketDirect(packet.getRawData(), packet.getRawDataLen());
 		});
 	}
 
 	int PcapLiveDevice::sendPacketsDirect(RawPacket const* const* packetsArr, int arrLength)
 	{
-		return sendPacketsImpl(packetsArr, packetsArr + arrLength, [this](RawPacket const* packet) {
+		return sendPacketsLoop(packetsArr, packetsArr + arrLength, [this](RawPacket const* packet) {
 			return sendPacketDirect(packet->getRawData(), packet->getRawDataLen());
 		});
 	}
 
 	int PcapLiveDevice::sendPacketsDirect(Packet const* const* packetsArr,int arrLength)
 	{
-		return sendPacketsImpl(packetsArr, packetsArr + arrLength, [this](Packet const* packet) {
+		return sendPacketsLoop(packetsArr, packetsArr + arrLength, [this](Packet const* packet) {
 			return sendPacketDirect(packet->getRawPacketReadOnly()->getRawData(),
 			                        packet->getRawPacketReadOnly()->getRawDataLen());
 		});

--- a/Pcap++/src/WinPcapLiveDevice.cpp
+++ b/Pcap++/src/WinPcapLiveDevice.cpp
@@ -60,6 +60,11 @@ namespace pcpp
 
 	int WinPcapLiveDevice::sendPackets(RawPacket const* rawPacketsArr, int arrLength)
 	{
+		return sendPacketsDirect(rawPacketsArr, arrLength);
+	}
+
+	int WinPcapLiveDevice::sendPacketsDirect(RawPacket const* rawPacketsArr, int arrLength)
+	{
 		if (!m_DeviceOpened || m_PcapDescriptor == nullptr)
 		{
 			PCPP_LOG_ERROR("Device '" << m_InterfaceDetails.name << "' not opened");

--- a/Pcap++/src/WinPcapLiveDevice.cpp
+++ b/Pcap++/src/WinPcapLiveDevice.cpp
@@ -58,7 +58,7 @@ namespace pcpp
 		return PcapLiveDevice::startCapture(intervalInSecondsToUpdateStats, onStatsUpdate, onStatsUpdateUserCookie);
 	}
 
-	int WinPcapLiveDevice::sendPackets(RawPacket* rawPacketsArr, int arrLength)
+	int WinPcapLiveDevice::sendPackets(RawPacket const* rawPacketsArr, int arrLength)
 	{
 		if (!m_DeviceOpened || m_PcapDescriptor == nullptr)
 		{

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -797,7 +797,7 @@ PTF_TEST_CASE(TestSendPacket)
 
 		// send packet as parsed EthPacekt
 		pcpp::Packet packet(&rawPacket);
-		PTF_ASSERT_TRUE(liveDev->sendPacket(&packet));
+		PTF_ASSERT_TRUE(liveDev->sendPacket(packet));
 
 		packetsSent++;
 	}
@@ -891,7 +891,7 @@ PTF_TEST_CASE(TestMtuSize)
 	PTF_PRINT_VERBOSE("Small packet: " << smallPacket.getLayerOfType<pcpp::IPv4Layer>()->getDataLen());
 	PTF_ASSERT_EQUAL(smallPacket.getLayerOfType<pcpp::IPv4Layer>()->getDataLen(), (size_t)liveDev->getMtu(), ptr);
 	// Try sending the packet
-	PTF_ASSERT_TRUE(liveDev->sendPacket(&smallPacket));
+	PTF_ASSERT_TRUE(liveDev->sendPacket(smallPacket));
 	pcpp::RawPacket* rawSmallPacketPtr = smallPacket.getRawPacket();
 	pcpp::RawPacket& rawSmallPacketRef = *rawSmallPacketPtr;
 	PTF_ASSERT_TRUE(liveDev->sendPacket(rawSmallPacketRef, true));
@@ -924,7 +924,7 @@ PTF_TEST_CASE(TestMtuSize)
 	PTF_ASSERT_EQUAL(largePacket.getLayerOfType<pcpp::IPv4Layer>()->getDataLen(), (size_t)(liveDev->getMtu() + 1), ptr);
 	// Try sending the packet
 	pcpp::Logger::getInstance().suppressLogs();
-	PTF_ASSERT_FALSE(liveDev->sendPacket(&largePacket));
+	PTF_ASSERT_FALSE(liveDev->sendPacket(largePacket));
 
 	pcpp::RawPacket* rawLargePacketPtr = largePacket.getRawPacket();
 	pcpp::RawPacket& rawLargePacketRef = *rawLargePacketPtr;


### PR DESCRIPTION
## Changes:
- Added `sendPacketDirect` helper method to encapsulate pure packet sending logic.
- Refactored `sendPacket` to improve readability and provide a final leaf of the call stack in the form of `sendPacketDirect`.
- Added `sendPacketsDirect` helper methods to allow overload of bulk send processing operations when no checks are required.
`WinPcapLiveDevice` will now use `pcap_sendqueue` on `sendPackets(RawPacket const*, int arrLength, bool checkMtu)` when `checkMtu` is false.
- Changed `sendPackets` to forward to `sendPacketsDirect` if `checkMtu` is set to `false`.
- Extracted the `sendPackets` message loop into templated `sendPacketsLoop` function.
- Added new overload `sendPacket(Packet const& packet, bool checkMtu)`.
- Deprecated `sendPacket(Packet const* packet, bool checkMtu)` and updated usages.
- Added `data()` accessor to `PointerVector` to allow usages in C style pointer + size API.