### PR TITLE
Improves the readability of `PcapLiveDevice::sendPacket`

### DIFF
--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -602,6 +602,9 @@ namespace pcpp
 	protected:
 		internal::PcapHandle doOpen(const DeviceConfiguration& config);
 
+		// Sends a packet directly to the network.
+		bool sendPacketDirect(uint8_t const* packetData, int packetDataLength);
+
 	private:
 		bool isNflogDevice() const;
 	};

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -531,7 +531,7 @@ namespace pcpp
 		/// - Packet length is 0
 		/// - Packet length is larger than device MTU and checkMtu is true
 		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
-		bool sendPacket(Packet* packet, bool checkMtu = true);
+		bool sendPacket(Packet const* packet, bool checkMtu = true);
 
 		/// Send an array of RawPacket objects to the network
 		/// @param[in] rawPacketsArr The array of RawPacket objects to send. This method treats all packets as
@@ -545,7 +545,7 @@ namespace pcpp
 		/// - Packet length is 0
 		/// - Packet length is larger than device MTU and checkMtu is true
 		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
-		virtual int sendPackets(RawPacket* rawPacketsArr, int arrLength, bool checkMtu = false);
+		virtual int sendPackets(RawPacket const* rawPacketsArr, int arrLength, bool checkMtu = false);
 
 		/// Send an array of pointers to Packet objects to the network
 		/// @param[in] packetsArr The array of pointers to Packet objects to send. This method treats all packets as
@@ -559,7 +559,7 @@ namespace pcpp
 		/// - Packet length is 0
 		/// - Packet length is larger than device MTU and checkMtu is true
 		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
-		virtual int sendPackets(Packet** packetsArr, int arrLength, bool checkMtu = true);
+		virtual int sendPackets(Packet const* const* packetsArr, int arrLength, bool checkMtu = true);
 
 		/// Send a vector of pointers to RawPacket objects to the network
 		/// @param[in] rawPackets The array of pointers to RawPacket objects to send. This method treats all packets as

--- a/Pcap++/header/WinPcapLiveDevice.h
+++ b/Pcap++/header/WinPcapLiveDevice.h
@@ -48,7 +48,7 @@ namespace pcpp
 		}
 
 		using PcapLiveDevice::sendPackets;
-		virtual int sendPackets(RawPacket* rawPacketsArr, int arrLength);
+		virtual int sendPackets(RawPacket const* rawPacketsArr, int arrLength);
 
 		/// WinPcap/Npcap have a feature (that doesn't exist in libpcap) to change the minimum amount of data in the
 		/// kernel buffer that causes a read from the application to return (unless the timeout expires). Please see

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -862,13 +862,14 @@ namespace pcpp
 			Packet parsedPacket = Packet(rPacket, OsiModelDataLinkLayer);
 			return sendPacket(&parsedPacket, true);
 		}
+
 		// Send packet without Mtu check
-		return sendPacket(rawPacket.getRawData(), rawPacket.getRawDataLen());
+		return sendPacketDirect(rawPacket.getRawData(), rawPacket.getRawDataLen());
 	}
 
 	bool PcapLiveDevice::sendPacket(const uint8_t* packetData, int packetDataLength, int packetPayloadLength)
 	{
-		return doMtuCheck(packetPayloadLength) && sendPacket(packetData, packetDataLength);
+		return doMtuCheck(packetPayloadLength) && sendPacketDirect(packetData, packetDataLength);
 	}
 
 	bool PcapLiveDevice::sendPacket(const uint8_t* packetData, int packetDataLength, bool checkMtu,
@@ -883,6 +884,11 @@ namespace pcpp
 			return sendPacket(&parsedPacket, true);
 		}
 
+		return sendPacketDirect(packetData, packetDataLength);
+	}
+
+	bool PcapLiveDevice::sendPacketDirect(uint8_t const* packetData,int packetDataLength)
+	{
 		if (!m_DeviceOpened)
 		{
 			PCPP_LOG_ERROR("Device '" << m_InterfaceDetails.name << "' not opened!");

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -913,7 +913,7 @@ namespace pcpp
 
 	bool PcapLiveDevice::sendPacket(Packet const* packet, bool checkMtu)
 	{
-		RawPacket* rawPacket = packet->getRawPacket();
+		RawPacket const* rawPacket = packet->getRawPacketReadOnly();
 		if (checkMtu)
 		{
 			int packetPayloadLength = 0;

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -905,7 +905,7 @@ namespace pcpp
 		return true;
 	}
 
-	bool PcapLiveDevice::sendPacket(Packet* packet, bool checkMtu)
+	bool PcapLiveDevice::sendPacket(Packet const* packet, bool checkMtu)
 	{
 		RawPacket* rawPacket = packet->getRawPacket();
 		if (checkMtu)
@@ -928,7 +928,7 @@ namespace pcpp
 		return sendPacket(*rawPacket, false);
 	}
 
-	int PcapLiveDevice::sendPackets(RawPacket* rawPacketsArr, int arrLength, bool checkMtu)
+	int PcapLiveDevice::sendPackets(RawPacket const* rawPacketsArr, int arrLength, bool checkMtu)
 	{
 		int packetsSent = 0;
 		for (int i = 0; i < arrLength; i++)
@@ -941,7 +941,7 @@ namespace pcpp
 		return packetsSent;
 	}
 
-	int PcapLiveDevice::sendPackets(Packet** packetsArr, int arrLength, bool checkMtu)
+	int PcapLiveDevice::sendPackets(Packet const* const* packetsArr, int arrLength, bool checkMtu)
 	{
 		int packetsSent = 0;
 		for (int i = 0; i < arrLength; i++)

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -856,15 +856,14 @@ namespace pcpp
 
 	bool PcapLiveDevice::sendPacket(RawPacket const& rawPacket, bool checkMtu)
 	{
-		if (checkMtu)
+		if (!checkMtu)
 		{
-			RawPacket* rPacket = const_cast<RawPacket*>(&rawPacket);
-			Packet parsedPacket = Packet(rPacket, OsiModelDataLinkLayer);
-			return sendPacket(&parsedPacket, true);
+			return sendPacketDirect(rawPacket.getRawData(), rawPacket.getRawDataLen());
 		}
 
-		// Send packet without Mtu check
-		return sendPacketDirect(rawPacket.getRawData(), rawPacket.getRawDataLen());
+		RawPacket* rPacket = const_cast<RawPacket*>(&rawPacket);
+		Packet parsedPacket = Packet(rPacket, OsiModelDataLinkLayer);
+		return sendPacket(&parsedPacket, true);
 	}
 
 	bool PcapLiveDevice::sendPacket(const uint8_t* packetData, int packetDataLength, int packetPayloadLength)
@@ -875,16 +874,16 @@ namespace pcpp
 	bool PcapLiveDevice::sendPacket(const uint8_t* packetData, int packetDataLength, bool checkMtu,
 	                                pcpp::LinkLayerType linkType)
 	{
-		if (checkMtu)
+		if (!checkMtu)
 		{
-			timeval time;
-			gettimeofday(&time, nullptr);
-			pcpp::RawPacket rawPacket(packetData, packetDataLength, time, false, linkType);
-			Packet parsedPacket = Packet(&rawPacket, pcpp::OsiModelDataLinkLayer);
-			return sendPacket(&parsedPacket, true);
+			return sendPacketDirect(packetData, packetDataLength);
 		}
 
-		return sendPacketDirect(packetData, packetDataLength);
+		timeval time;
+		gettimeofday(&time, nullptr);
+		pcpp::RawPacket rawPacket(packetData, packetDataLength, time, false, linkType);
+		Packet parsedPacket = Packet(&rawPacket, pcpp::OsiModelDataLinkLayer);
+		return sendPacket(&parsedPacket, true);
 	}
 
 	bool PcapLiveDevice::sendPacketDirect(uint8_t const* packetData,int packetDataLength)
@@ -914,24 +913,26 @@ namespace pcpp
 	bool PcapLiveDevice::sendPacket(Packet const* packet, bool checkMtu)
 	{
 		RawPacket const* rawPacket = packet->getRawPacketReadOnly();
-		if (checkMtu)
+
+		if (!checkMtu)
 		{
-			int packetPayloadLength = 0;
-			switch (packet->getFirstLayer()->getOsiModelLayer())
-			{
-			case (pcpp::OsiModelDataLinkLayer):
-				packetPayloadLength = static_cast<int>(packet->getFirstLayer()->getLayerPayloadSize());
-				break;
-			case (pcpp::OsiModelNetworkLayer):
-				packetPayloadLength = static_cast<int>(packet->getFirstLayer()->getDataLen());
-				break;
-			default:
-				// if packet layer is not known, do not perform MTU check.
-				return sendPacket(*rawPacket, false);
-			}
-			return doMtuCheck(packetPayloadLength) && sendPacket(*rawPacket, false);
+			return sendPacket(*rawPacket, false);
 		}
-		return sendPacket(*rawPacket, false);
+
+		int packetPayloadLength = 0;
+		switch (packet->getFirstLayer()->getOsiModelLayer())
+		{
+		case (pcpp::OsiModelDataLinkLayer):
+			packetPayloadLength = static_cast<int>(packet->getFirstLayer()->getLayerPayloadSize());
+			break;
+		case (pcpp::OsiModelNetworkLayer):
+			packetPayloadLength = static_cast<int>(packet->getFirstLayer()->getDataLen());
+			break;
+		default:
+			// if packet layer is not known, do not perform MTU check.
+			return sendPacket(*rawPacket, false);
+		}
+		return doMtuCheck(packetPayloadLength) && sendPacket(*rawPacket, false);
 	}
 
 	int PcapLiveDevice::sendPackets(RawPacket const* rawPacketsArr, int arrLength, bool checkMtu)

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -886,30 +886,6 @@ namespace pcpp
 		return sendPacket(&parsedPacket, true);
 	}
 
-	bool PcapLiveDevice::sendPacketDirect(uint8_t const* packetData,int packetDataLength)
-	{
-		if (!m_DeviceOpened)
-		{
-			PCPP_LOG_ERROR("Device '" << m_InterfaceDetails.name << "' not opened!");
-			return false;
-		}
-
-		if (packetDataLength == 0)
-		{
-			PCPP_LOG_ERROR("Trying to send a packet with length 0");
-			return false;
-		}
-
-		if (pcap_sendpacket(m_PcapSendDescriptor, packetData, packetDataLength) == -1)
-		{
-			PCPP_LOG_ERROR("Error sending packet: " << pcap_geterr(m_PcapSendDescriptor));
-			return false;
-		}
-
-		PCPP_LOG_DEBUG("Packet sent successfully. Packet length: " << packetDataLength);
-		return true;
-	}
-
 	bool PcapLiveDevice::sendPacket(Packet const* packet, bool checkMtu)
 	{
 		RawPacket const* rawPacket = packet->getRawPacketReadOnly();
@@ -933,6 +909,30 @@ namespace pcpp
 			return sendPacket(*rawPacket, false);
 		}
 		return doMtuCheck(packetPayloadLength) && sendPacket(*rawPacket, false);
+	}
+
+	bool PcapLiveDevice::sendPacketDirect(uint8_t const* packetData, int packetDataLength)
+	{
+		if (!m_DeviceOpened)
+		{
+			PCPP_LOG_ERROR("Device '" << m_InterfaceDetails.name << "' not opened!");
+			return false;
+		}
+
+		if (packetDataLength == 0)
+		{
+			PCPP_LOG_ERROR("Trying to send a packet with length 0");
+			return false;
+		}
+
+		if (pcap_sendpacket(m_PcapSendDescriptor, packetData, packetDataLength) == -1)
+		{
+			PCPP_LOG_ERROR("Error sending packet: " << pcap_geterr(m_PcapSendDescriptor));
+			return false;
+		}
+
+		PCPP_LOG_DEBUG("Packet sent successfully. Packet length: " << packetDataLength);
+		return true;
 	}
 
 	int PcapLiveDevice::sendPackets(RawPacket const* rawPacketsArr, int arrLength, bool checkMtu)

--- a/Pcap++/src/WinPcapLiveDevice.cpp
+++ b/Pcap++/src/WinPcapLiveDevice.cpp
@@ -58,7 +58,7 @@ namespace pcpp
 		return PcapLiveDevice::startCapture(intervalInSecondsToUpdateStats, onStatsUpdate, onStatsUpdateUserCookie);
 	}
 
-	int WinPcapLiveDevice::sendPackets(RawPacket* rawPacketsArr, int arrLength)
+	int WinPcapLiveDevice::sendPackets(RawPacket const* rawPacketsArr, int arrLength)
 	{
 		if (!m_DeviceOpened || m_PcapDescriptor == nullptr)
 		{


### PR DESCRIPTION
Split of #1824 

This PR improves the readability of `sendPacket` by providing a designated leaf call `sendPacketDirect` that just handles data transmission.

Additionally the PR reduces indentation the indentation level of the functions by redirecting `if(!checkMtu)` early and avoiding having most of the function be under an if block.