### PR TITLE
Extracted sendPacketsLoop to a helper function.

### DIFF
--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -928,44 +928,41 @@ namespace pcpp
 		return sendPacket(*rawPacket, false);
 	}
 
+	namespace
+	{
+		template <typename It, typename Func> int sendPacketsLoop(It begin, It end, Func sendFunc)
+		{
+			int packetsSent = 0;
+			size_t totalPackets = std::distance(begin, end);
+
+			for (It iter = begin; iter != end; ++iter)
+			{
+				if (sendFunc(*iter))
+					packetsSent++;
+			}
+
+			PCPP_LOG_DEBUG(packetsSent << " packets sent successfully. " << totalPackets - packetsSent
+			                           << " packets not sent");
+			return packetsSent;
+		}
+	}  // namespace
+
 	int PcapLiveDevice::sendPackets(RawPacket* rawPacketsArr, int arrLength, bool checkMtu)
 	{
-		int packetsSent = 0;
-		for (int i = 0; i < arrLength; i++)
-		{
-			if (sendPacket(rawPacketsArr[i], checkMtu))
-				packetsSent++;
-		}
-
-		PCPP_LOG_DEBUG(packetsSent << " packets sent successfully. " << arrLength - packetsSent << " packets not sent");
-		return packetsSent;
+		return sendPacketsLoop(rawPacketsArr, rawPacketsArr + arrLength,
+		                       [this, checkMtu](RawPacket* packet) { return sendPacket(*packet, checkMtu); });
 	}
 
 	int PcapLiveDevice::sendPackets(Packet** packetsArr, int arrLength, bool checkMtu)
 	{
-		int packetsSent = 0;
-		for (int i = 0; i < arrLength; i++)
-		{
-			if (sendPacket(packetsArr[i], checkMtu))
-				packetsSent++;
-		}
-
-		PCPP_LOG_DEBUG(packetsSent << " packets sent successfully. " << arrLength - packetsSent << " packets not sent");
-		return packetsSent;
+		return sendPacketsLoop(packetsArr, packetsArr + arrLength,
+		                       [this, checkMtu](Packet* packet) { return sendPacket(packet, checkMtu); });
 	}
 
 	int PcapLiveDevice::sendPackets(const RawPacketVector& rawPackets, bool checkMtu)
 	{
-		int packetsSent = 0;
-		for (RawPacketVector::ConstVectorIterator iter = rawPackets.begin(); iter != rawPackets.end(); iter++)
-		{
-			if (sendPacket(**iter, checkMtu))
-				packetsSent++;
-		}
-
-		PCPP_LOG_DEBUG(packetsSent << " packets sent successfully. " << (rawPackets.size() - packetsSent)
-		                           << " packets not sent");
-		return packetsSent;
+		return sendPacketsLoop(rawPackets.begin(), rawPackets.end(),
+		                       [this, checkMtu](const RawPacket& packet) { return sendPacket(packet, checkMtu); });
 	}
 
 	void PcapLiveDevice::setDeviceMtu()


### PR DESCRIPTION
This PR extracts the duplicated loop inside `sendPackets` overloads to a helper function, reducing code duplication.