### PR TITLE
Added new overload `sendPacket(Packet const& packet, bool checkMtu)`

### DIFF
--- a/Examples/ArpSpoofing/main.cpp
+++ b/Examples/ArpSpoofing/main.cpp
@@ -82,7 +82,7 @@ pcpp::MacAddress getMacAddress(const pcpp::IPv4Address& ipAddr, pcpp::PcapLiveDe
 	}
 
 	// send the arp request and wait for arp reply
-	pDevice->sendPacket(&arpRequest);
+	pDevice->sendPacket(arpRequest);
 	pcpp::RawPacketVector capturedPackets;
 	pDevice->startCapture(capturedPackets);
 	std::this_thread::sleep_for(std::chrono::seconds(2));
@@ -154,10 +154,10 @@ void doArpSpoofing(pcpp::PcapLiveDevice* pDevice, const pcpp::IPv4Address& gatew
 	std::cout << "Sending ARP replies to victim and to gateway every 5 seconds..." << std::endl << std::endl;
 	while (1)
 	{
-		pDevice->sendPacket(&gwArpReply);
+		pDevice->sendPacket(gwArpReply);
 		std::cout << "Sent ARP reply: " << gatewayAddr << " [gateway] is at MAC address " << deviceMacAddress << " [me]"
 		          << std::endl;
-		pDevice->sendPacket(&victimArpReply);
+		pDevice->sendPacket(victimArpReply);
 		std::cout << "Sent ARP reply: " << victimAddr << " [victim] is at MAC address " << deviceMacAddress << " [me]"
 		          << std::endl;
 		std::this_thread::sleep_for(std::chrono::seconds(5));

--- a/Examples/DnsSpoofing/main.cpp
+++ b/Examples/DnsSpoofing/main.cpp
@@ -239,7 +239,7 @@ void handleDnsRequest(pcpp::RawPacket* packet, pcpp::PcapLiveDevice* dev, void* 
 	dnsRequest.computeCalculateFields();
 
 	// send DNS response back to the network
-	if (!dev->sendPacket(&dnsRequest))
+	if (!dev->sendPacket(dnsRequest))
 		return;
 
 	args->stats.numOfSpoofedDnsRequests++;

--- a/Examples/IcmpFileTransfer/Common.cpp
+++ b/Examples/IcmpFileTransfer/Common.cpp
@@ -255,7 +255,7 @@ bool sendIcmpMessage(pcpp::PcapLiveDevice* dev, pcpp::MacAddress srcMacAddr, pcp
 	packet.computeCalculateFields();
 
 	// send the packet through the device
-	return dev->sendPacket(&packet);
+	return dev->sendPacket(packet);
 }
 
 bool sendIcmpRequest(pcpp::PcapLiveDevice* dev, pcpp::MacAddress srcMacAddr, const pcpp::MacAddress dstMacAddr,

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -470,6 +470,39 @@ namespace pcpp
 		/// @return True if the packetPayloadLength is less than or equal to the device MTU
 		bool doMtuCheck(int packetPayloadLength) const;
 
+		/// Send a parsed Packet to the network
+		/// @param[in] packet A pointer to the packet to send. This method treats the packet as read-only, it doesn't
+		/// change anything in it
+		/// @param[in] checkMtu Whether the length of the packet's payload should be checked against the MTU. Default
+		/// value is true, since the packet being passed in has already been parsed, so checking the MTU does not incur
+		/// significant processing overhead.
+		/// @return True if packet was sent successfully. False will be returned in the following cases (relevant log
+		/// error is printed in any case):
+		/// - Device is not opened
+		/// - Packet length is 0
+		/// - Packet length is larger than device MTU and checkMtu is true
+		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
+		/// @deprecated This method is deprecated. Use sendPacket(Packet const& packet, bool checkMtu) instead.
+		PCPP_DEPRECATED("This method is deprecated. Use sendPacket(Packet const& packet, bool checkMtu) instead")
+		bool sendPacket(Packet* packet, bool checkMtu = true)
+		{
+			return sendPacket(*packet, checkMtu);
+		}
+
+		/// Send a parsed Packet to the network
+		/// @param[in] packet A reference to the packet to send. This method treats the packet as read-only, it doesn't
+		/// change anything in it
+		/// @param[in] checkMtu Whether the length of the packet's payload should be checked against the MTU. Default
+		/// value is true, since the packet being passed in has already been parsed, so checking the MTU does not incur
+		/// significant processing overhead.
+		/// @return True if packet was sent successfully. False will be returned in the following cases (relevant log
+		/// error is printed in any case):
+		/// - Device is not opened
+		/// - Packet length is 0
+		/// - Packet length is larger than device MTU and checkMtu is true
+		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
+		bool sendPacket(Packet const& packet, bool checkMtu = true);
+
 		/// Send a RawPacket to the network
 		/// @param[in] rawPacket A reference to the raw packet to send. This method treats the raw packet as read-only,
 		/// it doesn't change anything in it
@@ -518,20 +551,6 @@ namespace pcpp
 		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
 		bool sendPacket(const uint8_t* packetData, int packetDataLength, bool checkMtu = false,
 		                pcpp::LinkLayerType linkType = pcpp::LINKTYPE_ETHERNET);
-
-		/// Send a parsed Packet to the network
-		/// @param[in] packet A pointer to the packet to send. This method treats the packet as read-only, it doesn't
-		/// change anything in it
-		/// @param[in] checkMtu Whether the length of the packet's payload should be checked against the MTU. Default
-		/// value is true, since the packet being passed in has already been parsed, so checking the MTU does not incur
-		/// significant processing overhead.
-		/// @return True if packet was sent successfully. False will be returned in the following cases (relevant log
-		/// error is printed in any case):
-		/// - Device is not opened
-		/// - Packet length is 0
-		/// - Packet length is larger than device MTU and checkMtu is true
-		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
-		bool sendPacket(Packet* packet, bool checkMtu = true);
 
 		/// Send an array of RawPacket objects to the network
 		/// @param[in] rawPacketsArr The array of RawPacket objects to send. This method treats all packets as

--- a/Pcap++/src/NetworkUtils.cpp
+++ b/Pcap++/src/NetworkUtils.cpp
@@ -152,7 +152,7 @@ namespace pcpp
 		device->startCapture(arpPacketReceived, &data);
 
 		// send the ARP request
-		device->sendPacket(&arpRequest);
+		device->sendPacket(arpRequest);
 
 		// block on the conditional mutex until capture thread signals or until timeout expires
 		// cppcheck-suppress localMutex
@@ -395,7 +395,7 @@ namespace pcpp
 		device->startCapture(dnsResponseReceived, &data);
 
 		// send the DNS request
-		device->sendPacket(&dnsRequest);
+		device->sendPacket(dnsRequest);
 
 		// block on the conditional mutex until capture thread signals or until timeout expires
 		// cppcheck-suppress localMutex

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -893,24 +893,26 @@ namespace pcpp
 	bool PcapLiveDevice::sendPacket(Packet const& packet, bool checkMtu)
 	{
 		RawPacket const* rawPacket = packet.getRawPacketReadOnly();
-		if (checkMtu)
+
+		if (!checkMtu)
 		{
-			int packetPayloadLength = 0;
-			switch (packet.getFirstLayer()->getOsiModelLayer())
-			{
-			case (pcpp::OsiModelDataLinkLayer):
-				packetPayloadLength = static_cast<int>(packet.getFirstLayer()->getLayerPayloadSize());
-				break;
-			case (pcpp::OsiModelNetworkLayer):
-				packetPayloadLength = static_cast<int>(packet.getFirstLayer()->getDataLen());
-				break;
-			default:
-				// if packet layer is not known, do not perform MTU check.
-				return sendPacket(*rawPacket, false);
-			}
-			return doMtuCheck(packetPayloadLength) && sendPacket(*rawPacket, false);
+			return sendPacket(*rawPacket, false);
 		}
-		return sendPacket(*rawPacket, false);
+
+		int packetPayloadLength = 0;
+		switch (packet.getFirstLayer()->getOsiModelLayer())
+		{
+		case (pcpp::OsiModelDataLinkLayer):
+			packetPayloadLength = static_cast<int>(packet.getFirstLayer()->getLayerPayloadSize());
+			break;
+		case (pcpp::OsiModelNetworkLayer):
+			packetPayloadLength = static_cast<int>(packet.getFirstLayer()->getDataLen());
+			break;
+		default:
+			// if packet layer is not known, do not perform MTU check.
+			return sendPacket(*rawPacket, false);
+		}
+		return doMtuCheck(packetPayloadLength) && sendPacket(*rawPacket, false);
 	}
 
 	bool PcapLiveDevice::sendPacket(RawPacket const& rawPacket, bool checkMtu)

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -797,7 +797,7 @@ PTF_TEST_CASE(TestSendPacket)
 
 		// send packet as parsed EthPacekt
 		pcpp::Packet packet(&rawPacket);
-		PTF_ASSERT_TRUE(liveDev->sendPacket(&packet));
+		PTF_ASSERT_TRUE(liveDev->sendPacket(packet));
 
 		packetsSent++;
 	}
@@ -891,7 +891,7 @@ PTF_TEST_CASE(TestMtuSize)
 	PTF_PRINT_VERBOSE("Small packet: " << smallPacket.getLayerOfType<pcpp::IPv4Layer>()->getDataLen());
 	PTF_ASSERT_EQUAL(smallPacket.getLayerOfType<pcpp::IPv4Layer>()->getDataLen(), (size_t)liveDev->getMtu(), ptr);
 	// Try sending the packet
-	PTF_ASSERT_TRUE(liveDev->sendPacket(&smallPacket));
+	PTF_ASSERT_TRUE(liveDev->sendPacket(smallPacket));
 	pcpp::RawPacket* rawSmallPacketPtr = smallPacket.getRawPacket();
 	pcpp::RawPacket& rawSmallPacketRef = *rawSmallPacketPtr;
 	PTF_ASSERT_TRUE(liveDev->sendPacket(rawSmallPacketRef, true));
@@ -924,7 +924,7 @@ PTF_TEST_CASE(TestMtuSize)
 	PTF_ASSERT_EQUAL(largePacket.getLayerOfType<pcpp::IPv4Layer>()->getDataLen(), (size_t)(liveDev->getMtu() + 1), ptr);
 	// Try sending the packet
 	pcpp::Logger::getInstance().suppressLogs();
-	PTF_ASSERT_FALSE(liveDev->sendPacket(&largePacket));
+	PTF_ASSERT_FALSE(liveDev->sendPacket(largePacket));
 
 	pcpp::RawPacket* rawLargePacketPtr = largePacket.getRawPacket();
 	pcpp::RawPacket& rawLargePacketRef = *rawLargePacketPtr;


### PR DESCRIPTION
Added a new overload to `sendPacket` that takes a `Packet const&` instead of `Packet*` as parameter due to reference parameters being safer to use when `nullptr` isn't a valid value.

Deprecated `sendPacket(Packet* packet, bool checkMtu)` and updated all usages in examples and tests to the new version.