### PR TITLE
Added guard clause to `stopCapture` to prevent incomplete shutdown.

### DIFF
--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -494,6 +494,7 @@ namespace pcpp
 
 		/// Stop a currently running packet capture. This method terminates gracefully both packet capture thread and
 		/// periodic stats collection thread (both if exist)
+		/// @remarks This method should not be called from the onPacketArrives callback, as it will cause a deadlock.
 		void stopCapture();
 
 		/// Check if a capture thread is running

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -844,6 +844,11 @@ namespace pcpp
 		if (m_cbOnPacketArrivesBlockingMode != nullptr)
 			return;
 
+		if (m_CaptureThread.get_id() == std::this_thread::get_id())
+		{
+			throw std::runtime_error("Cannot stop capture from the capture thread itself");
+		}
+
 		m_StopThread = true;
 		if (m_CaptureThreadStarted)
 		{

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -844,7 +844,7 @@ namespace pcpp
 		if (m_cbOnPacketArrivesBlockingMode != nullptr)
 			return;
 
-		if (m_CaptureThread.get_id() == std::this_thread::get_id())
+		if (m_CaptureThread.get_id() != std::thread::id{} && m_CaptureThread.get_id() == std::this_thread::get_id())
 		{
 			throw std::runtime_error("Cannot stop capture from the capture thread itself");
 		}


### PR DESCRIPTION
This PR adds a guard clause to `stopCapture` to raise an exception if the method has been called from the thread executing the background capture, as doing so would produce an incomplete shutdown and cause an error when the capture thread attempts to join with itself.