### PR TITLE
Cleanup of RawPacket construction.

### DIFF
--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -262,7 +262,7 @@ namespace pcpp
 		int m_RawDataLen = 0;
 		int m_FrameLength = 0;
 		timespec m_TimeStamp{};  // Zero initialized
-		bool m_DeleteRawDataAtDestructor = false;
+		bool m_DeleteRawDataAtDestructor = true;
 		bool m_RawPacketSet = false;
 		LinkLayerType m_LinkLayerType = LinkLayerType::LINKTYPE_ETHERNET;
 
@@ -272,8 +272,10 @@ namespace pcpp
 		/// A default constructor that initializes class'es attributes to default value:
 		/// - data pointer is set to nullptr
 		/// - data length is set to 0
+		/// - frame length is set to 0
 		/// - deleteRawDataAtDestructor is set to 'true'
 		/// - timestamp is set to 0
+		/// - layer type is set to Ethernet
 		RawPacket() = default;
 
 		/// A constructor that receives a pointer to the raw data (allocated elsewhere). This constructor is usually

--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -258,17 +258,24 @@ namespace pcpp
 	class RawPacket
 	{
 	protected:
-		uint8_t* m_RawData;
-		int m_RawDataLen;
-		int m_FrameLength;
-		timespec m_TimeStamp;
-		bool m_DeleteRawDataAtDestructor;
-		bool m_RawPacketSet;
-		LinkLayerType m_LinkLayerType;
-		void init(bool deleteRawDataAtDestructor = true);
+		uint8_t* m_RawData = nullptr;
+		int m_RawDataLen = 0;
+		int m_FrameLength = 0;
+		timespec m_TimeStamp{};  // Zero initialized
+		bool m_DeleteRawDataAtDestructor = false;
+		bool m_RawPacketSet = false;
+		LinkLayerType m_LinkLayerType = LinkLayerType::LINKTYPE_ETHERNET;
+
 		void copyDataFrom(const RawPacket& other, bool allocateData = true);
 
 	public:
+		/// A default constructor that initializes class'es attributes to default value:
+		/// - data pointer is set to nullptr
+		/// - data length is set to 0
+		/// - deleteRawDataAtDestructor is set to 'true'
+		/// - timestamp is set to 0
+		RawPacket() = default;
+
 		/// A constructor that receives a pointer to the raw data (allocated elsewhere). This constructor is usually
 		/// used when packet is captured using a packet capturing engine (like libPcap. WinPcap, Npcap, PF_RING, etc.).
 		/// The capturing engine allocates the raw data memory and give the user a pointer to it + a timestamp it has
@@ -294,13 +301,6 @@ namespace pcpp
 		/// @param[in] layerType The link layer type of this raw packet. The default is Ethernet
 		RawPacket(const uint8_t* pRawData, int rawDataLen, timespec timestamp, bool deleteRawDataAtDestructor,
 		          LinkLayerType layerType = LINKTYPE_ETHERNET);
-
-		/// A default constructor that initializes class'es attributes to default value:
-		/// - data pointer is set to nullptr
-		/// - data length is set to 0
-		/// - deleteRawDataAtDestructor is set to 'true'
-		/// @todo timestamp isn't set here to a default value
-		RawPacket();
 
 		/// A destructor for this class. Frees the raw data if deleteRawDataAtDestructor was set to 'true'
 		virtual ~RawPacket();

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -102,6 +102,7 @@ namespace pcpp
 	bool RawPacket::initWithRawData(const uint8_t* pRawData, int rawDataLen, timespec timestamp,
 	                                LinkLayerType layerType)
 	{
+		m_DeleteRawDataAtDestructor = false;
 		return setRawData(pRawData, rawDataLen, timestamp, layerType);
 	}
 

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -20,15 +20,14 @@ namespace pcpp
 	RawPacket::RawPacket(const uint8_t* pRawData, int rawDataLen, timeval timestamp, bool deleteRawDataAtDestructor,
 	                     LinkLayerType layerType)
 	    : RawPacket(pRawData, rawDataLen, toTimespec(timestamp), deleteRawDataAtDestructor, layerType)
-	{
-	}
+	{}
 
 	RawPacket::RawPacket(const uint8_t* pRawData, int rawDataLen, timespec timestamp, bool deleteRawDataAtDestructor,
 	                     LinkLayerType layerType)
-	    : m_RawData(const_cast<uint8_t*>(pRawData)), m_RawDataLen(rawDataLen), m_FrameLength(rawDataLen), m_TimeStamp(timestamp),
-	      m_DeleteRawDataAtDestructor(deleteRawDataAtDestructor), m_RawPacketSet(true), m_LinkLayerType(layerType)
-	{
-	}
+	    : m_RawData(const_cast<uint8_t*>(pRawData)), m_RawDataLen(rawDataLen), m_FrameLength(rawDataLen),
+	      m_TimeStamp(timestamp), m_DeleteRawDataAtDestructor(deleteRawDataAtDestructor), m_RawPacketSet(true),
+	      m_LinkLayerType(layerType)
+	{}
 
 	RawPacket::~RawPacket()
 	{

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -7,36 +7,27 @@
 
 namespace pcpp
 {
-
-	void RawPacket::init(bool deleteRawDataAtDestructor)
+	namespace
 	{
-		m_RawData = nullptr;
-		m_RawDataLen = 0;
-		m_FrameLength = 0;
-		m_DeleteRawDataAtDestructor = deleteRawDataAtDestructor;
-		m_RawPacketSet = false;
-		m_LinkLayerType = LINKTYPE_ETHERNET;
-	}
+		timespec toTimespec(timeval value)
+		{
+			timespec nsec_time = {};
+			TIMEVAL_TO_TIMESPEC(&value, &nsec_time);
+			return nsec_time;
+		}
+	}  // namespace
 
 	RawPacket::RawPacket(const uint8_t* pRawData, int rawDataLen, timeval timestamp, bool deleteRawDataAtDestructor,
 	                     LinkLayerType layerType)
+	    : RawPacket(pRawData, rawDataLen, toTimespec(timestamp), deleteRawDataAtDestructor, layerType)
 	{
-		timespec nsec_time = {};
-		TIMEVAL_TO_TIMESPEC(&timestamp, &nsec_time);
-		init(deleteRawDataAtDestructor);
-		setRawData(pRawData, rawDataLen, nsec_time, layerType);
 	}
 
 	RawPacket::RawPacket(const uint8_t* pRawData, int rawDataLen, timespec timestamp, bool deleteRawDataAtDestructor,
 	                     LinkLayerType layerType)
+	    : m_RawData(const_cast<uint8_t*>(pRawData)), m_RawDataLen(rawDataLen), m_FrameLength(rawDataLen), m_TimeStamp(timestamp),
+	      m_DeleteRawDataAtDestructor(deleteRawDataAtDestructor), m_RawPacketSet(true), m_LinkLayerType(layerType)
 	{
-		init(deleteRawDataAtDestructor);
-		setRawData(pRawData, rawDataLen, timestamp, layerType);
-	}
-
-	RawPacket::RawPacket()
-	{
-		init();
 	}
 
 	RawPacket::~RawPacket()
@@ -112,7 +103,6 @@ namespace pcpp
 	bool RawPacket::initWithRawData(const uint8_t* pRawData, int rawDataLen, timespec timestamp,
 	                                LinkLayerType layerType)
 	{
-		init(false);
 		return setRawData(pRawData, rawDataLen, timestamp, layerType);
 	}
 

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -80,9 +80,7 @@ namespace pcpp
 	bool RawPacket::setRawData(const uint8_t* pRawData, int rawDataLen, timeval timestamp, LinkLayerType layerType,
 	                           int frameLength)
 	{
-		timespec nsec_time;
-		TIMEVAL_TO_TIMESPEC(&timestamp, &nsec_time);
-		return setRawData(pRawData, rawDataLen, nsec_time, layerType, frameLength);
+		return setRawData(pRawData, rawDataLen, toTimespec(timestamp), layerType, frameLength);
 	}
 
 	bool RawPacket::setRawData(const uint8_t* pRawData, int rawDataLen, timespec timestamp, LinkLayerType layerType,
@@ -189,9 +187,7 @@ namespace pcpp
 
 	bool RawPacket::setPacketTimeStamp(timeval timestamp)
 	{
-		timespec nsec_time;
-		TIMEVAL_TO_TIMESPEC(&timestamp, &nsec_time);
-		return setPacketTimeStamp(nsec_time);
+		return setPacketTimeStamp(toTimespec(timestamp));
 	}
 
 	bool RawPacket::setPacketTimeStamp(timespec timestamp)

--- a/Pcap++/header/MBufRawPacket.h
+++ b/Pcap++/header/MBufRawPacket.h
@@ -163,7 +163,7 @@ namespace pcpp
 		/// size, if initialization failed or if copying the data to the mbuf failed. In all of these cases an error
 		/// will be printed to log
 		bool setRawData(const uint8_t* pRawData, int rawDataLen, timespec timestamp,
-		                LinkLayerType layerType = LINKTYPE_ETHERNET, int frameLength = -1);
+		                LinkLayerType layerType = LINKTYPE_ETHERNET, int frameLength = -1) override;
 
 		/// Clears the object and frees the mbuf
 		void clear();


### PR DESCRIPTION
This PR updates the construction implementation of RawPacket to utilize C++ 11 practices.

Changes include:
- `init()` method has been replaced with default member initializers.
- Changed constructor implementation to utilize member initialization list.