### PR TITLE
Fix potential UB in string concatenation for NFLog device name.

### DIFF
--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -427,7 +427,7 @@ namespace pcpp
 
 		if (isNflogDevice())
 		{
-			device_name += ":";
+			device_name += ":"; // prevent UB in string concatenation
 			device_name += std::to_string(config.nflogGroup & 0xffff);
 		}
 

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -427,7 +427,8 @@ namespace pcpp
 
 		if (isNflogDevice())
 		{
-			device_name += ":" + std::to_string(config.nflogGroup & 0xffff);
+			device_name += ":";
+			device_name += std::to_string(config.nflogGroup & 0xffff);
 		}
 
 		auto pcap = internal::PcapHandle(pcap_create(device_name.c_str(), errbuf));

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -427,7 +427,7 @@ namespace pcpp
 
 		if (isNflogDevice())
 		{
-			device_name += ":"; // prevent UB in string concatenation
+			device_name += ":";  // prevent UB in string concatenation
 			device_name += std::to_string(config.nflogGroup & 0xffff);
 		}
 


### PR DESCRIPTION
Fixes a build failure with GCC 12.2.0 on aarch64 due to overly aggressive optimizations and inlining when concatenating C-style and temporary C++ strings using operator+. The original code caused a -Werror=restrict warning about possible memory overlap in std::char_traits<char>::copy.

```code
inlined from ‘pcpp::internal::PcapHandle pcpp::PcapLiveDevice::doOpen(const DeviceConfiguration&)’ at app/connectivity/build/rpi64-rls/_deps/pcapplusplus-src/Pcap++/src/PcapLiveDevice.cpp:386:23:
app/connectivity/3rdparty/cross/rpi64/tools/gcc-12.2.0-64/aarch64-linux-gnu/include/c++/12.2.0/bits/char_traits.h:431:56: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ accessing 9223372036854775810 or more bytes at offsets [2, 9223372036854775807] and 1 may overlap up to 9223372036854775813 bytes at offset -3 [-Werror=restrict]
  431 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```