### PR TITLE
[WIP] General refactor of `RawPacket` to remove ambiguity in API and streamline logic.

### DIFF
--- a/Common++/header/Logger.h
+++ b/Common++/header/Logger.h
@@ -27,8 +27,9 @@
 // Allows for conditional removal of unwanted log calls at compile time.
 #define PCPP_LOG_LEVEL_OFF 0
 #define PCPP_LOG_LEVEL_ERROR 1
-#define PCPP_LOG_LEVEL_INFO 2
-#define PCPP_LOG_LEVEL_DEBUG 3
+#define PCPP_LOG_LEVEL_WARN 2
+#define PCPP_LOG_LEVEL_INFO 3
+#define PCPP_LOG_LEVEL_DEBUG 4
 
 // All log messages built via a PCPP_LOG_* macro below the PCPP_ACTIVE_LOG_LEVEL will be removed at compile time.
 // Uses the PCPP_ACTIVE_LOG_LEVEL if it is defined, otherwise defaults to PCAP_LOG_LEVEL_DEBUG
@@ -146,6 +147,7 @@ namespace pcpp
 	{
 		Off = PCPP_LOG_LEVEL_OFF,      ///< No log messages are emitted.
 		Error = PCPP_LOG_LEVEL_ERROR,  ///< Error level logs are emitted.
+		Warn = PCPP_LOG_LEVEL_WARN,    ///< Warning level logs and above are emitted.
 		Info = PCPP_LOG_LEVEL_INFO,    ///< Info level logs and above are emitted.
 		Debug = PCPP_LOG_LEVEL_DEBUG   ///< Debug level logs and above are emitted.
 	};
@@ -434,6 +436,12 @@ namespace pcpp
 #	define PCPP_LOG_INFO(message) PCPP_LOG(pcpp::LogLevel::Info, message)
 #else
 #	define PCPP_LOG_INFO(message) (void)0
+#endif
+
+#if PCPP_ACTIVE_LOG_LEVEL >= PCPP_LOG_LEVEL_WARN
+#	define PCPP_LOG_WARN(message) PCPP_LOG(pcpp::LogLevel::Warn, message)
+#else
+#	define PCPP_LOG_WARN(message) (void)0
 #endif
 
 #if PCPP_ACTIVE_LOG_LEVEL >= PCPP_LOG_LEVEL_ERROR

--- a/Packet++/header/IPReassembly.h
+++ b/Packet++/header/IPReassembly.h
@@ -399,7 +399,7 @@ namespace pcpp
 		/// - If the input fragment is the last one and the reassembled packet is ready - a pointer to the reassembled
 		///   packet is returned. Notice it's the user's responsibility to free this pointer when done using it
 		/// - If the reassembled packet isn't ready then nullptr is returned
-		Packet* processPacket(RawPacket* fragment, ReassemblyStatus& status, ProtocolType parseUntil = UnknownProtocol,
+		Packet* processPacket(IRawPacket* fragment, ReassemblyStatus& status, ProtocolType parseUntil = UnknownProtocol,
 		                      OsiModelLayer parseUntilLayer = OsiModelLayerUnknown);
 
 		/// Get a partially reassembled packet. This method returns all the reassembled data that was gathered so far

--- a/Packet++/header/Packet.h
+++ b/Packet++/header/Packet.h
@@ -23,7 +23,7 @@ namespace pcpp
 		friend class Layer;
 
 	private:
-		RawPacket* m_RawPacket;
+		IRawPacket* m_RawPacket;
 		Layer* m_FirstLayer;
 		Layer* m_LastLayer;
 		size_t m_MaxPacketLen;
@@ -65,7 +65,7 @@ namespace pcpp
 		/// model (inclusive). Can be useful for cases when you need to parse only up to a certain OSI layer (for
 		/// example transport layer) and want to avoid the performance impact and memory consumption of parsing the
 		/// whole packet. Default value is ::OsiModelLayerUnknown which means don't take this parameter into account
-		explicit Packet(RawPacket* rawPacket, bool freeRawPacket = false, ProtocolType parseUntil = UnknownProtocol,
+		explicit Packet(IRawPacket* rawPacket, bool freeRawPacket = false, ProtocolType parseUntil = UnknownProtocol,
 		                OsiModelLayer parseUntilLayer = OsiModelLayerUnknown);
 
 		/// A constructor for creating a packet out of already allocated RawPacket. Very useful when parsing packets
@@ -77,7 +77,7 @@ namespace pcpp
 		/// @param[in] parseUntil Parse the packet until you reach a certain protocol (inclusive). Can be useful for
 		/// cases when you need to parse only up to a certain layer and want to avoid the performance impact and memory
 		/// consumption of parsing the whole packet
-		explicit Packet(RawPacket* rawPacket, ProtocolType parseUntil);
+		explicit Packet(IRawPacket* rawPacket, ProtocolType parseUntil);
 
 		/// A constructor for creating a packet out of already allocated RawPacket. Very useful when parsing packets
 		/// that came from the network. When using this constructor a pointer to the RawPacket is saved (data isn't
@@ -88,7 +88,7 @@ namespace pcpp
 		/// @param[in] parseUntilFamily Parse the packet until you reach a certain protocol family (inclusive). Can be
 		/// useful for cases when you need to parse only up to a certain layer and want to avoid the performance impact
 		/// and memory consumption of parsing the whole packet
-		explicit Packet(RawPacket* rawPacket, ProtocolTypeFamily parseUntilFamily);
+		explicit Packet(IRawPacket* rawPacket, ProtocolTypeFamily parseUntilFamily);
 
 		/// A constructor for creating a packet out of already allocated RawPacket. Very useful when parsing packets
 		/// that came from the network. When using this constructor a pointer to the RawPacket is saved (data isn't
@@ -101,7 +101,7 @@ namespace pcpp
 		/// model (inclusive). Can be useful for cases when you need to parse only up to a certain OSI layer (for
 		/// example transport layer) and want to avoid the performance impact and memory consumption of parsing the
 		/// whole packet
-		explicit Packet(RawPacket* rawPacket, OsiModelLayer parseUntilLayer);
+		explicit Packet(IRawPacket* rawPacket, OsiModelLayer parseUntilLayer);
 
 		/// A destructor for this class. Frees all layers allocated by this instance (Notice: it doesn't free layers
 		/// that weren't allocated by this class, for example layers that were added by addLayer() or insertLayer() ).
@@ -130,7 +130,7 @@ namespace pcpp
 
 		/// Get a pointer to the Packet's RawPacket
 		/// @return A pointer to the Packet's RawPacket
-		RawPacket* getRawPacket() const
+		IRawPacket* getRawPacket() const
 		{
 			return m_RawPacket;
 		}
@@ -147,12 +147,12 @@ namespace pcpp
 		/// you need to parse only up to a certain layer and want to avoid the performance impact and memory consumption
 		/// of parsing the whole packet. Default value is ::OsiModelLayerUnknown which means don't take this parameter
 		/// into account
-		void setRawPacket(RawPacket* rawPacket, bool freeRawPacket, ProtocolTypeFamily parseUntil = UnknownProtocol,
+		void setRawPacket(IRawPacket* rawPacket, bool freeRawPacket, ProtocolTypeFamily parseUntil = UnknownProtocol,
 		                  OsiModelLayer parseUntilLayer = OsiModelLayerUnknown);
 
 		/// Get a pointer to the Packet's RawPacket in a read-only manner
 		/// @return A pointer to the Packet's RawPacket
-		const RawPacket* getRawPacketReadOnly() const
+		const IRawPacket* getRawPacketReadOnly() const
 		{
 			return m_RawPacket;
 		}

--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -377,6 +377,7 @@ namespace pcpp
 			return m_TimeStamp;
 		}
 
+		using IRawPacket::setPacketTimeStamp;
 		bool setPacketTimeStamp(timespec timestamp) override final;
 
 	protected:

--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -429,7 +429,7 @@ namespace pcpp
 		bool m_ReallocationsAllowed = true;
 		bool m_RawPacketSet = false;
 
-		void copyDataFrom(const RawPacket& other, bool allocateData = true);
+		void copyDataFrom(const RawPacket& other);
 
 	public:
 		static bool isBufferPolicySupported(RawPacketBufferPolicy policy)

--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -428,9 +428,7 @@ namespace pcpp
 		// capacity
 		bool m_ReallocationsAllowed = true;
 		bool m_RawPacketSet = false;
-
-		void copyDataFrom(const RawPacket& other);
-
+	
 	public:
 		static bool isBufferPolicySupported(RawPacketBufferPolicy policy)
 		{

--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -477,6 +477,10 @@ namespace pcpp
 		RawPacket(RawPacketBufferPolicy bufPolicy, BufferInfo const& rawDataBuf, timespec timestamp,
 		          LinkLayerType layerType = LINKTYPE_ETHERNET);
 
+		/// @brief A conversion constructor that creates a RawPacket from an IRawPacket instance.
+		/// @param source The IRawPacket instance to convert to a RawPacket.
+		explicit RawPacket(IRawPacket const& source);
+
 		/// A destructor for this class. Frees the raw data if deleteRawDataAtDestructor was set to 'true'
 		~RawPacket() override;
 

--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -281,6 +281,22 @@ namespace pcpp
 		SoftReference,
 	};
 
+	struct BufferInfo
+	{
+		/// @brief Pointer to the raw data buffer. This pointer may be null if the buffer is empty or not allocated.
+		uint8_t* ptr = nullptr;
+		/// @brief The size of the buffer, i.e. the number of bytes currently in use.
+		size_t size = 0;
+		/// @brief The capacity of the buffer, i.e. the maximum size it can grow to without reallocation.
+		size_t capacity = 0;
+
+		BufferInfo() = default;
+		BufferInfo(uint8_t* p, size_t s) : ptr(p), size(s), capacity(s)
+		{}
+		BufferInfo(uint8_t* p, size_t s, size_t c) : ptr(p), size(s), capacity(c)
+		{}
+	};
+
 	class IRawPacket
 	{
 	protected:
@@ -334,10 +350,10 @@ namespace pcpp
 
 		virtual bool supportsBufferPolicy(RawPacketBufferPolicy policy) const = 0;
 
-		bool setRawData(RawPacketBufferPolicy bufPolicy, uint8_t* pRawData, int rawDataLen, timeval timestamp,
+		bool setRawData(RawPacketBufferPolicy bufPolicy, BufferInfo const& rawDataBuf, timeval timestamp,
 		                LinkLayerType layerType = LINKTYPE_ETHERNET, int frameLength = -1);
 
-		virtual bool setRawData(RawPacketBufferPolicy bufPolicy, uint8_t* pRawData, int rawDataLen, timespec timestamp,
+		virtual bool setRawData(RawPacketBufferPolicy bufPolicy, BufferInfo const& rawDataBuf, timespec timestamp,
 		                        LinkLayerType layerType = LINKTYPE_ETHERNET, int frameLength = -1) = 0;
 
 		virtual void clear() = 0;
@@ -453,9 +469,9 @@ namespace pcpp
 		RawPacket(const uint8_t* pRawData, int rawDataLen, timespec timestamp, bool deleteRawDataAtDestructor,
 		          LinkLayerType layerType = LINKTYPE_ETHERNET);
 
-		RawPacket(RawPacketBufferPolicy bufPolicy, uint8_t* pRawData, int rawDataLen, timeval timestamp,
+		RawPacket(RawPacketBufferPolicy bufPolicy, BufferInfo const& rawDataBuf, timeval timestamp,
 		          LinkLayerType layerType = LINKTYPE_ETHERNET);
-		RawPacket(RawPacketBufferPolicy bufPolicy, uint8_t* pRawData, int rawDataLen, timespec timestamp,
+		RawPacket(RawPacketBufferPolicy bufPolicy, BufferInfo const& rawDataBuf, timespec timestamp,
 		          LinkLayerType layerType = LINKTYPE_ETHERNET);
 
 		/// A destructor for this class. Frees the raw data if deleteRawDataAtDestructor was set to 'true'
@@ -518,7 +534,7 @@ namespace pcpp
 		virtual bool setRawData(const uint8_t* pRawData, int rawDataLen, timespec timestamp,
 		                        LinkLayerType layerType = LINKTYPE_ETHERNET, int frameLength = -1);
 
-		bool setRawData(RawPacketBufferPolicy bufPolicy, uint8_t* pRawData, int rawDataLen, timespec timestamp,
+		bool setRawData(RawPacketBufferPolicy bufPolicy, BufferInfo const& rawDataBuf, timespec timestamp,
 		                LinkLayerType layerType = LINKTYPE_ETHERNET, int frameLength = -1) override final;
 
 		/// Initialize a raw packet with data. The main difference between this method and setRawData() is that

--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -427,7 +427,6 @@ namespace pcpp
 		// Controls whether the raw data can be reallocated or not to allow for appending data exceeding the current
 		// capacity
 		bool m_ReallocationsAllowed = true;
-		bool m_RawPacketSet = false;
 	
 	public:
 		static bool isBufferPolicySupported(RawPacketBufferPolicy policy)
@@ -593,7 +592,7 @@ namespace pcpp
 		/// for example: if the instance was created using the default constructor or clear() was called
 		bool isPacketSet() const
 		{
-			return m_RawPacketSet;
+			return m_RawData != nullptr;
 		}
 
 		/// Clears all members of this instance, meaning setting raw data to nullptr, raw data length to 0, etc.

--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -327,6 +327,10 @@ namespace pcpp
 		/// @return The raw data of this packet
 		virtual uint8_t const* getRawData() const = 0;
 		virtual uint8_t* getRawData() = 0;
+		uint8_t const* getRawDataReadOnly() const
+		{
+			return getRawData();
+		}
 
 		/// @return The length of the raw data buffer in bytes
 		virtual int getRawDataLen() const = 0;

--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -360,9 +360,9 @@ namespace pcpp
 		RawPacketBase(timespec timestamp, LinkLayerType layerType = LinkLayerType::LINKTYPE_ETHERNET);
 		RawPacketBase(timeval timestamp, LinkLayerType layerType = LinkLayerType::LINKTYPE_ETHERNET);
 
-		RawPacketBase(const RawPacketBase& other);
+		RawPacketBase(const RawPacketBase& other) = default;
 
-		RawPacketBase& operator=(const RawPacketBase& other);
+		RawPacketBase& operator=(const RawPacketBase& other) = default;
 
 		~RawPacketBase() override = default;
 

--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -453,6 +453,7 @@ namespace pcpp
 		/// @param[in] deleteRawDataAtDestructor An indicator whether raw data pointer should be freed when the instance
 		/// is freed or not. If set to 'true' than pRawData will be freed when instanced is being freed
 		/// @param[in] layerType The link layer type of this raw packet. The default is Ethernet
+		PCPP_DEPRECATED("Use constructors with RawPacketBufferPolicy parameter instead")
 		RawPacket(const uint8_t* pRawData, int rawDataLen, timeval timestamp, bool deleteRawDataAtDestructor,
 		          LinkLayerType layerType = LINKTYPE_ETHERNET);
 
@@ -466,6 +467,7 @@ namespace pcpp
 		/// @param[in] deleteRawDataAtDestructor An indicator whether raw data pointer should be freed when the instance
 		/// is freed or not. If set to 'true' than pRawData will be freed when instanced is being freed
 		/// @param[in] layerType The link layer type of this raw packet. The default is Ethernet
+		PCPP_DEPRECATED("Use constructors with RawPacketBufferPolicy parameter instead")
 		RawPacket(const uint8_t* pRawData, int rawDataLen, timespec timestamp, bool deleteRawDataAtDestructor,
 		          LinkLayerType layerType = LINKTYPE_ETHERNET);
 

--- a/Packet++/src/IPReassembly.cpp
+++ b/Packet++/src/IPReassembly.cpp
@@ -513,7 +513,7 @@ namespace pcpp
 		return nullptr;
 	}
 
-	Packet* IPReassembly::processPacket(RawPacket* fragment, ReassemblyStatus& status, ProtocolType parseUntil,
+	Packet* IPReassembly::processPacket(IRawPacket* fragment, ReassemblyStatus& status, ProtocolType parseUntil,
 	                                    OsiModelLayer parseUntilLayer)
 	{
 		Packet* parsedFragment = new Packet(fragment, false, parseUntil, parseUntilLayer);

--- a/Packet++/src/IPReassembly.cpp
+++ b/Packet++/src/IPReassembly.cpp
@@ -367,8 +367,9 @@ namespace pcpp
 				auto rawData = new uint8_t[rawDataLen];
 				memcpy(rawData, fragmentRawPacket->getRawData(), rawDataLen);
 
-				fragData->data = new RawPacket(rawData, rawDataLen, fragmentRawPacket->getPacketTimeStamp(), true,
-				                               fragmentRawPacket->getLinkLayerType());
+				fragData->data =
+				    new RawPacket(RawPacketBufferPolicy::Move, BufferInfo(rawData, rawDataLen),
+				                  fragmentRawPacket->getPacketTimeStamp(), fragmentRawPacket->getLinkLayerType());
 				fragData->currentOffset = fragWrapper->getIPLayerPayloadSize();
 				status = FIRST_FRAGMENT;
 

--- a/Packet++/src/IPReassembly.cpp
+++ b/Packet++/src/IPReassembly.cpp
@@ -364,11 +364,9 @@ namespace pcpp
 				auto fragmentRawPacket = fragment->getRawPacket();
 				auto rawDataLen = fragWrapper->getIPLayerPayload() - fragmentRawPacket->getRawData() +
 				                  fragWrapper->getIPLayerPayloadSize();
-				auto rawData = new uint8_t[rawDataLen];
-				memcpy(rawData, fragmentRawPacket->getRawData(), rawDataLen);
 
 				fragData->data =
-				    new RawPacket(RawPacketBufferPolicy::Move, BufferInfo(rawData, rawDataLen),
+				    new RawPacket(RawPacketBufferPolicy::Copy, BufferInfo(fragmentRawPacket->getRawData(), rawDataLen),
 				                  fragmentRawPacket->getPacketTimeStamp(), fragmentRawPacket->getLinkLayerType());
 				fragData->currentOffset = fragWrapper->getIPLayerPayloadSize();
 				status = FIRST_FRAGMENT;

--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -45,7 +45,7 @@ namespace pcpp
 		m_RawPacket = new RawPacket(RawPacketBufferPolicy::StrictReference, BufferInfo(buffer, 0, bufferSize), time, linkType);
 	}
 
-	void Packet::setRawPacket(RawPacket* rawPacket, bool freeRawPacket, ProtocolTypeFamily parseUntil,
+	void Packet::setRawPacket(IRawPacket* rawPacket, bool freeRawPacket, ProtocolTypeFamily parseUntil,
 	                          OsiModelLayer parseUntilLayer)
 	{
 		destructPacketData();
@@ -114,7 +114,7 @@ namespace pcpp
 		}
 	}
 
-	Packet::Packet(RawPacket* rawPacket, bool freeRawPacket, ProtocolType parseUntil, OsiModelLayer parseUntilLayer)
+	Packet::Packet(IRawPacket* rawPacket, bool freeRawPacket, ProtocolType parseUntil, OsiModelLayer parseUntilLayer)
 	{
 		m_FreeRawPacket = false;
 		m_RawPacket = nullptr;
@@ -122,7 +122,7 @@ namespace pcpp
 		setRawPacket(rawPacket, freeRawPacket, parseUntil, parseUntilLayer);
 	}
 
-	Packet::Packet(RawPacket* rawPacket, ProtocolType parseUntil)
+	Packet::Packet(IRawPacket* rawPacket, ProtocolType parseUntil)
 	{
 		m_FreeRawPacket = false;
 		m_RawPacket = nullptr;
@@ -131,7 +131,7 @@ namespace pcpp
 		setRawPacket(rawPacket, false, parseUntilFamily, OsiModelLayerUnknown);
 	}
 
-	Packet::Packet(RawPacket* rawPacket, ProtocolTypeFamily parseUntilFamily)
+	Packet::Packet(IRawPacket* rawPacket, ProtocolTypeFamily parseUntilFamily)
 	{
 		m_FreeRawPacket = false;
 		m_RawPacket = nullptr;
@@ -139,7 +139,7 @@ namespace pcpp
 		setRawPacket(rawPacket, false, parseUntilFamily, OsiModelLayerUnknown);
 	}
 
-	Packet::Packet(RawPacket* rawPacket, OsiModelLayer parseUntilLayer)
+	Packet::Packet(IRawPacket* rawPacket, OsiModelLayer parseUntilLayer)
 	{
 		m_FreeRawPacket = false;
 		m_RawPacket = nullptr;
@@ -175,7 +175,7 @@ namespace pcpp
 
 	void Packet::copyDataFrom(const Packet& other)
 	{
-		m_RawPacket = new RawPacket(*(other.m_RawPacket));
+		m_RawPacket = other.m_RawPacket->clone();
 		m_FreeRawPacket = true;
 		m_MaxPacketLen = other.m_MaxPacketLen;
 		m_FirstLayer = createFirstLayer(m_RawPacket->getLinkLayerType());

--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -595,7 +595,7 @@ namespace pcpp
 		// this move operation occurs on already allocated memory, which is backed by the reallocation if's provided
 		// above if offsetInLayer == layer->getHeaderLen() insertData will not move any data but only increase the
 		// packet size by numOfBytesToExtend
-		m_RawPacket->insertData(indexToInsertData, nullptr, numOfBytesToExtend);
+		m_RawPacket->insertUninitializedData(indexToInsertData, numOfBytesToExtend);
 
 		// re-calculate all layers data ptr and data length
 		const uint8_t* dataPtr = m_RawPacket->getRawData();

--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -31,7 +31,7 @@ namespace pcpp
 		gettimeofday(&time, nullptr);
 		uint8_t* data = new uint8_t[maxPacketLen];
 		memset(data, 0, maxPacketLen);
-		m_RawPacket = new RawPacket(data, 0, time, true, linkType);
+		m_RawPacket = new RawPacket(RawPacketBufferPolicy::Move, BufferInfo(data, 0, maxPacketLen), time, linkType);
 	}
 
 	Packet::Packet(uint8_t* buffer, size_t bufferSize, LinkLayerType linkType)
@@ -41,7 +41,8 @@ namespace pcpp
 		timeval time;
 		gettimeofday(&time, nullptr);
 		memset(buffer, 0, bufferSize);
-		m_RawPacket = new RawPacket(buffer, 0, time, false, linkType);
+		// Using StrictReference to ensure backwards compatibility with existing code that expects it.
+		m_RawPacket = new RawPacket(RawPacketBufferPolicy::StrictReference, BufferInfo(buffer, 0, bufferSize), time, linkType);
 	}
 
 	void Packet::setRawPacket(RawPacket* rawPacket, bool freeRawPacket, ProtocolTypeFamily parseUntil,

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -145,7 +145,7 @@ namespace pcpp
 		}
 
 		m_FrameLength = other.m_FrameLength;
-		m_RawDataCapacity = other.m_RawDataCapacity;
+		m_RawPacketSet = other.m_RawPacketSet;
 		return *this;
 	}
 

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -125,26 +125,27 @@ namespace pcpp
 
 	RawPacket& RawPacket::operator=(const RawPacket& other)
 	{
-		if (this != &other)
+		if (this == &other)
 		{
-			// TODO: Potential reuse of existing buffer if it matches the policy and capacity
-			clear();
-
-			RawPacketBase::operator=(other);
-
-			if (!reserve(other.m_RawDataLen))
-				throw std::runtime_error("Failed to reserve memory for RawPacket");
-
-			if (other.m_RawData != nullptr)
-			{
-				if (appendData(other.m_RawData, other.m_RawDataLen) != other.m_RawDataLen)
-					throw std::runtime_error("Failed to copy data to RawPacket");
-			}
-
-			m_FrameLength = other.m_FrameLength;
-			m_RawDataCapacity = other.m_RawDataCapacity;
+			return *this;
 		}
 
+		// TODO: Potential reuse of existing buffer if it matches the policy and capacity
+		clear();
+
+		RawPacketBase::operator=(other);
+
+		if (!reserve(other.m_RawDataLen))
+			throw std::runtime_error("Failed to reserve memory for RawPacket");
+
+		if (other.m_RawData != nullptr)
+		{
+			if (appendData(other.m_RawData, other.m_RawDataLen) != other.m_RawDataLen)
+				throw std::runtime_error("Failed to copy data to RawPacket");
+		}
+
+		m_FrameLength = other.m_FrameLength;
+		m_RawDataCapacity = other.m_RawDataCapacity;
 		return *this;
 	}
 

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -101,6 +101,12 @@ namespace pcpp
 		m_FrameLength = rawDataBuf.size;
 	}
 
+	RawPacket::RawPacket(IRawPacket const& source)
+	    : RawPacket(RawPacketBufferPolicy::Copy,
+	                BufferInfo(const_cast<uint8_t*>(source.getRawData()), source.getRawDataLen()),
+	                source.getPacketTimeStamp(), source.getLinkLayerType())
+	{}
+
 	RawPacket::~RawPacket()
 	{
 		clear();

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -99,7 +99,6 @@ namespace pcpp
 
 		m_RawDataLen = rawDataBuf.size;
 		m_FrameLength = rawDataBuf.size;
-		m_RawPacketSet = true;
 	}
 
 	RawPacket::~RawPacket()
@@ -110,6 +109,7 @@ namespace pcpp
 	RawPacket::RawPacket(const RawPacket& other)
 	{
 		// Reserves memory for the raw data buffer and copies the data from the other packet
+		// If the other packet has no raw data, it will reserve 0 bytes which is a noop.
 		if (!reserve(other.m_RawDataLen))
 			throw std::runtime_error("Failed to reserve memory for RawPacket");
 
@@ -120,7 +120,6 @@ namespace pcpp
 		}
 
 		m_FrameLength = other.m_FrameLength;
-		m_RawPacketSet = other.m_RawPacketSet;
 	}
 
 	RawPacket& RawPacket::operator=(const RawPacket& other)
@@ -145,7 +144,6 @@ namespace pcpp
 		}
 
 		m_FrameLength = other.m_FrameLength;
-		m_RawPacketSet = other.m_RawPacketSet;
 		return *this;
 	}
 
@@ -238,7 +236,6 @@ namespace pcpp
 		m_FrameLength = (frameLength == -1) ? rawDataBuf.size : frameLength;
 		setPacketTimeStamp(timestamp);
 		setLinkLayerType(layerType);
-		m_RawPacketSet = true;
 		return true;
 	}
 
@@ -261,7 +258,6 @@ namespace pcpp
 		m_FrameLength = 0;
 		m_RawDataCapacity = 0;
 		m_ReallocationsAllowed = true;
-		m_RawPacketSet = false;
 	}
 
 	size_t RawPacket::appendData(const uint8_t* dataToAppend, size_t dataToAppendLen)

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -115,7 +115,7 @@ namespace pcpp
 
 		if (other.m_RawData != nullptr)
 		{
-			if (appendData(other.m_RawData, other.m_RawDataLen) != other.m_RawDataLen)
+			if (appendData(other.m_RawData, other.m_RawDataLen) != static_cast<size_t>(other.m_RawDataLen))
 				throw std::runtime_error("Failed to copy data to RawPacket");
 		}
 
@@ -140,7 +140,7 @@ namespace pcpp
 
 		if (other.m_RawData != nullptr)
 		{
-			if (appendData(other.m_RawData, other.m_RawDataLen) != other.m_RawDataLen)
+			if (appendData(other.m_RawData, other.m_RawDataLen) != static_cast<size_t>(other.m_RawDataLen))
 				throw std::runtime_error("Failed to copy data to RawPacket");
 		}
 

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -307,7 +307,16 @@ namespace pcpp
 
 	size_t RawPacket::insertData(int atIndex, const uint8_t* dataToInsert, size_t dataToInsertLen)
 	{
-		if (dataToInsert == nullptr || dataToInsertLen == 0)
+		if (dataToInsert == nullptr)
+		{
+			PCPP_LOG_WARN("Using RawPacket::insertData with nullptr data buffer to extend uninitialized buffer. "
+				            "This behaviour has been deprecated and will result errors in the future. "
+				            "Please use insertUninitializedData() instead to insert an uninitialized block of data.");
+			// Forward the call to insertUninitializedData for the duration of the deprecation period
+			return insertUninitializedData(atIndex, dataToInsertLen);
+		}
+
+		if (dataToInsertLen == 0)
 			return 0;
 
 		// Insert an empty data block at the specified index

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -44,7 +44,8 @@ namespace pcpp
 
 	RawPacket::RawPacket(const uint8_t* pRawData, int rawDataLen, timeval timestamp, bool deleteRawDataAtDestructor,
 	                     LinkLayerType layerType)
-	    : RawPacket(pRawData, rawDataLen, toTimespec(timestamp), deleteRawDataAtDestructor, layerType)
+	    : RawPacket(deleteRawDataAtDestructor ? RawPacketBufferPolicy::Move : RawPacketBufferPolicy::SoftReference,
+	                BufferInfo(const_cast<uint8_t*>(pRawData), rawDataLen), timestamp, layerType)
 	{}
 
 	RawPacket::RawPacket(const uint8_t* pRawData, int rawDataLen, timespec timestamp, bool deleteRawDataAtDestructor,

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -112,7 +112,7 @@ namespace pcpp
 		clear();
 	}
 
-	RawPacket::RawPacket(const RawPacket& other)
+	RawPacket::RawPacket(const RawPacket& other) : RawPacketBase(other)
 	{
 		// Reserves memory for the raw data buffer and copies the data from the other packet
 		// If the other packet has no raw data, it will reserve 0 bytes which is a noop.

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -68,6 +68,7 @@ namespace pcpp
 		case RawPacketBufferPolicy::Copy:
 		{
 			m_RawData = new uint8_t[rawDataBuf.size];
+			m_RawDataCapacity = rawDataBuf.size;
 			m_DeleteRawDataAtDestructor = true;
 			std::memcpy(m_RawData, rawDataBuf.ptr, rawDataBuf.size);
 			break;
@@ -75,6 +76,7 @@ namespace pcpp
 		case RawPacketBufferPolicy::Move:
 		{
 			m_RawData = rawDataBuf.ptr;
+			m_RawDataCapacity = rawDataBuf.capacity;
 			m_DeleteRawDataAtDestructor = true;
 			break;
 		}
@@ -87,6 +89,7 @@ namespace pcpp
 		case RawPacketBufferPolicy::SoftReference:
 		{
 			m_RawData = rawDataBuf.ptr;
+			m_RawDataCapacity = rawDataBuf.capacity;
 			m_DeleteRawDataAtDestructor = false;  // no deletion of raw data at destructor
 			break;
 		}
@@ -96,7 +99,6 @@ namespace pcpp
 
 		m_RawDataLen = rawDataBuf.size;
 		m_FrameLength = rawDataBuf.size;
-		m_RawDataCapacity = rawDataBuf.capacity;
 		m_RawPacketSet = true;
 	}
 
@@ -201,6 +203,7 @@ namespace pcpp
 		{
 			// TODO: Consider reusing previous allocated buffer if the packet owns it and capacity is enough.
 			m_RawData = new uint8_t[rawDataBuf.size];
+			m_RawDataCapacity = rawDataBuf.size;
 			m_DeleteRawDataAtDestructor = true;
 			std::memcpy(m_RawData, rawDataBuf.ptr, rawDataBuf.size);
 			break;
@@ -208,6 +211,7 @@ namespace pcpp
 		case RawPacketBufferPolicy::Move:
 		{
 			m_RawData = rawDataBuf.ptr;
+			m_RawDataCapacity = rawDataBuf.capacity;
 			m_DeleteRawDataAtDestructor = true;
 			break;
 		}
@@ -220,6 +224,7 @@ namespace pcpp
 		case RawPacketBufferPolicy::SoftReference:
 		{
 			m_RawData = rawDataBuf.ptr;
+			m_RawDataCapacity = rawDataBuf.capacity;
 			m_DeleteRawDataAtDestructor = false;
 			break;
 		}
@@ -227,7 +232,6 @@ namespace pcpp
 
 		m_RawDataLen = rawDataBuf.size;
 		m_FrameLength = (frameLength == -1) ? rawDataBuf.size : frameLength;
-		m_RawDataCapacity = rawDataBuf.capacity;
 		setPacketTimeStamp(timestamp);
 		setLinkLayerType(layerType);
 		m_RawPacketSet = true;

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -190,6 +190,9 @@ namespace pcpp
 
 		clear();
 
+		// Set the flag to allow reallocations by default, as this is the most common use case
+		m_ReallocationsAllowed = true;
+
 		switch (bufPolicy)
 		{
 		case RawPacketBufferPolicy::Copy:

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -154,22 +154,6 @@ namespace pcpp
 		return new RawPacket(*this);
 	}
 
-	void RawPacket::copyDataFrom(const RawPacket& other)
-	{
-		reserve(other.m_RawDataLen);
-		appendData(other.m_RawData, other.m_RawDataLen);
-
-		m_RawData = new uint8_t[other.m_RawDataLen];
-		m_RawDataCapacity = other.m_RawDataLen;
-		m_DeleteRawDataAtDestructor = true;
-		m_RawDataLen = other.m_RawDataLen;
-
-		std::memcpy(m_RawData, other.m_RawData, other.m_RawDataLen);
-		setLinkLayerType(other.getLinkLayerType());
-		m_FrameLength = other.m_FrameLength;
-		m_RawPacketSet = true;
-	}
-
 	bool RawPacket::setRawData(const uint8_t* pRawData, int rawDataLen, timeval timestamp, LinkLayerType layerType,
 	                           int frameLength)
 	{

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -296,8 +296,8 @@ namespace pcpp
 		if (dataToInsert == nullptr)
 		{
 			PCPP_LOG_WARN("Using RawPacket::insertData with nullptr data buffer to extend uninitialized buffer. "
-				            "This behaviour has been deprecated and will result errors in the future. "
-				            "Please use insertUninitializedData() instead to insert an uninitialized block of data.");
+			              "This behaviour has been deprecated and will result errors in the future. "
+			              "Please use insertUninitializedData() instead to insert an uninitialized block of data.");
 			// Forward the call to insertUninitializedData for the duration of the deprecation period
 			return insertUninitializedData(atIndex, dataToInsertLen);
 		}

--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -329,10 +329,10 @@ namespace pcpp
 
 	bool RawPacket::reallocateData(size_t newBufferLength)
 	{
-		if ((int)newBufferLength == m_RawDataLen)
+		if (newBufferLength == static_cast<size_t>(m_RawDataLen))
 			return true;
 
-		if ((int)newBufferLength < m_RawDataLen)
+		if (newBufferLength < static_cast<size_t>(m_RawDataLen))
 		{
 			PCPP_LOG_ERROR("Cannot reallocate raw packet to a smaller size. Current data length: "
 			               << m_RawDataLen << "; requested length: " << newBufferLength);

--- a/Pcap++/header/Device.h
+++ b/Pcap++/header/Device.h
@@ -11,7 +11,7 @@
 namespace pcpp
 {
 	/// A vector of pointers to RawPacket
-	typedef PointerVector<RawPacket> RawPacketVector;
+	typedef PointerVector<IRawPacket> RawPacketVector;
 
 	/// @class IDevice
 	/// An abstract interface representing all packet processing devices. It stands as the root class for all devices.

--- a/Pcap++/header/MBufRawPacket.h
+++ b/Pcap++/header/MBufRawPacket.h
@@ -41,7 +41,7 @@ namespace pcpp
 	///      create a linked list of mbufs. This is good for Jumbo packets or other uses. MBufRawPacket doesn't support
 	///      this capability so there is no way to access the mbufs linked to the mbuf wrapped by MBufRawPacket
 	///      instance. I hope I'll be able to add this support in the future
-	class MBufRawPacket : public RawPacket
+	class MBufRawPacket : public RawPacketBase
 	{
 		friend class DpdkDevice;
 #ifdef USE_DPDK_KNI
@@ -63,7 +63,7 @@ namespace pcpp
 		/// order to allocate an mbuf the user should call the init() method. Without calling init() the instance of
 		/// this class is not usable. This c'tor can be used for initializing an array of MBufRawPacket (which requires
 		/// an empty c'tor)
-		MBufRawPacket() : RawPacket(), m_MBuf(nullptr), m_Mempool(nullptr), m_MbufDataSize(0), m_FreeMbuf(true)
+		MBufRawPacket() : RawPacketBase(), m_MBuf(nullptr), m_Mempool(nullptr), m_MbufDataSize(0), m_FreeMbuf(true)
 		{
 			m_DeleteRawDataAtDestructor = false;
 		}

--- a/Pcap++/header/PcapDevice.h
+++ b/Pcap++/header/PcapDevice.h
@@ -159,7 +159,7 @@ namespace pcpp
 		/// @param[in] filter A filter class to test against
 		/// @param[in] rawPacket A pointer to the raw packet to match the filter with
 		/// @return True if raw packet matches the filter or false otherwise
-		static bool matchPacketWithFilter(GeneralFilter& filter, RawPacket* rawPacket);
+		static bool matchPacketWithFilter(GeneralFilter& filter, IRawPacket* rawPacket);
 
 		// implement abstract methods
 

--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -328,7 +328,7 @@ namespace pcpp
 		virtual ~IFileWriterDevice()
 		{}
 
-		virtual bool writePacket(RawPacket const& packet) = 0;
+		virtual bool writePacket(IRawPacket const& packet) = 0;
 
 		virtual bool writePackets(const RawPacketVector& packets) = 0;
 
@@ -379,7 +379,7 @@ namespace pcpp
 		/// @return True if a packet was written successfully. False will be returned if the file isn't opened
 		/// or if the packet link layer type is different than the one defined for the file
 		/// (in all cases, an error will be printed to log)
-		bool writePacket(RawPacket const& packet) override;
+		bool writePacket(IRawPacket const& packet) override;
 
 		/// Write multiple RawPacket to the file. Before using this method please verify the file is opened using
 		/// open(). This method won't change the written packets or the RawPacketVector instance
@@ -472,7 +472,7 @@ namespace pcpp
 		/// ignored
 		/// @return True if a packet was written successfully. False will be returned if the file isn't opened (an error
 		/// will be printed to log)
-		bool writePacket(RawPacket const& packet, const std::string& comment);
+		bool writePacket(IRawPacket const& packet, const std::string& comment);
 
 		// overridden methods
 
@@ -481,7 +481,7 @@ namespace pcpp
 		/// @param[in] packet A reference for an existing RawPcket to write to the file
 		/// @return True if a packet was written successfully. False will be returned if the file isn't opened (an error
 		/// will be printed to log)
-		bool writePacket(RawPacket const& packet) override;
+		bool writePacket(IRawPacket const& packet) override;
 
 		/// Write multiple RawPacket to the file. Before using this method please verify the file is opened using
 		/// open(). This method won't change the written packets or the RawPacketVector instance

--- a/Pcap++/header/PcapFilter.h
+++ b/Pcap++/header/PcapFilter.h
@@ -144,7 +144,7 @@ namespace pcpp
 		/// Match a raw packet with a given BPF filter.
 		/// @param[in] rawPacket A pointer to the raw packet to match the BPF filter with
 		/// @return True if a raw packet matches the BPF filter or false otherwise
-		bool matchPacketWithFilter(RawPacket* rawPacket);
+		bool matchPacketWithFilter(IRawPacket* rawPacket);
 
 		GeneralFilter()
 		{}

--- a/Pcap++/header/PcapFilter.h
+++ b/Pcap++/header/PcapFilter.h
@@ -111,7 +111,7 @@ namespace pcpp
 		/// @param[in] rawPacket A pointer to a raw packet which the filter will be matched against
 		/// @return True if the filter matches (or if it's empty). False if the packet doesn't match or if the filter
 		/// could not be compiled
-		bool matchPacketWithFilter(const RawPacket* rawPacket);
+		bool matchPacketWithFilter(const IRawPacket* rawPacket);
 
 		/// Match a packet data with the filter stored in this object. If the filter is empty the method returns "true".
 		/// If the link type provided is different than the one set in setFilter(), the filter will be re-compiled

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -555,7 +555,7 @@ namespace pcpp
 		/// - Packet length is 0
 		/// - Packet length is larger than device MTU
 		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
-		bool sendPacket(RawPacket const& rawPacket, bool checkMtu = false);
+		bool sendPacket(IRawPacket const& rawPacket, bool checkMtu = false);
 
 		/// Send a buffer containing packet raw data (including all layers) to the network.
 		/// This particular version of the sendPacket method should only be used if you already have access to the size
@@ -604,7 +604,7 @@ namespace pcpp
 		/// - Packet length is 0
 		/// - Packet length is larger than device MTU and checkMtu is true
 		/// - Packet could not be sent due to some error in libpcap/WinPcap/Npcap
-		virtual int sendPackets(RawPacket* rawPacketsArr, int arrLength, bool checkMtu = false);
+		virtual int sendPackets(IRawPacket* rawPacketsArr, int arrLength, bool checkMtu = false);
 
 		/// Send an array of pointers to Packet objects to the network
 		/// @param[in] packetsArr The array of pointers to Packet objects to send. This method treats all packets as

--- a/Pcap++/header/RawSocketDevice.h
+++ b/Pcap++/header/RawSocketDevice.h
@@ -104,7 +104,7 @@ namespace pcpp
 		/// @param[in] rawPacket The packet to send
 		/// @return True if packet was sent successfully or false if the socket is not open, if the packet is not
 		/// Ethernet or if there was a failure sending the packet
-		bool sendPacket(const RawPacket* rawPacket);
+		bool sendPacket(const IRawPacket* rawPacket);
 
 		/// Send a set of Ethernet packets to the network. L2 protocols other than Ethernet are not supported by raw
 		/// sockets. The entire packet is sent as is, including the original Ethernet and IP data. This method is only

--- a/Pcap++/src/PcapDevice.cpp
+++ b/Pcap++/src/PcapDevice.cpp
@@ -150,7 +150,7 @@ namespace pcpp
 		return m_PcapDescriptor.clearFilter();
 	}
 
-	bool IPcapDevice::matchPacketWithFilter(GeneralFilter& filter, RawPacket* rawPacket)
+	bool IPcapDevice::matchPacketWithFilter(GeneralFilter& filter, IRawPacket* rawPacket)
 	{
 		return filter.matchPacketWithFilter(rawPacket);
 	}

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -592,7 +592,7 @@ namespace pcpp
 		}
 	}
 
-	bool PcapFileWriterDevice::writePacket(RawPacket const& packet)
+	bool PcapFileWriterDevice::writePacket(IRawPacket const& packet)
 	{
 		if ((!m_AppendMode && m_PcapDescriptor == nullptr) || (m_PcapDumpHandler == nullptr))
 		{
@@ -852,7 +852,7 @@ namespace pcpp
 		m_CompressionLevel = compressionLevel;
 	}
 
-	bool PcapNgFileWriterDevice::writePacket(RawPacket const& packet, const std::string& comment)
+	bool PcapNgFileWriterDevice::writePacket(IRawPacket const& packet, const std::string& comment)
 	{
 		if (m_LightPcapNg == nullptr)
 		{
@@ -890,7 +890,7 @@ namespace pcpp
 		return true;
 	}
 
-	bool PcapNgFileWriterDevice::writePacket(RawPacket const& packet)
+	bool PcapNgFileWriterDevice::writePacket(IRawPacket const& packet)
 	{
 		return writePacket(packet, std::string());
 	}

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -609,9 +609,9 @@ namespace pcpp
 		}
 
 		pcap_pkthdr pktHdr;
-		pktHdr.caplen = ((RawPacket&)packet).getRawDataLen();
-		pktHdr.len = ((RawPacket&)packet).getFrameLength();
-		timespec packet_timestamp = ((RawPacket&)packet).getPacketTimeStamp();
+		pktHdr.caplen = packet.getRawDataLen();
+		pktHdr.len = packet.getFrameLength();
+		timespec packet_timestamp = packet.getPacketTimeStamp();
 #if defined(PCAP_TSTAMP_PRECISION_NANO)
 		if (m_Precision != FileTimestampPrecision::Nanoseconds)
 		{
@@ -626,7 +626,7 @@ namespace pcpp
 		TIMESPEC_TO_TIMEVAL(&pktHdr.ts, &packet_timestamp);
 #endif
 		if (!m_AppendMode)
-			pcap_dump((uint8_t*)m_PcapDumpHandler, &pktHdr, ((RawPacket&)packet).getRawData());
+			pcap_dump((uint8_t*)m_PcapDumpHandler, &pktHdr, packet.getRawData());
 		else
 		{
 			// Below are actually the lines run by pcap_dump. The reason I had to put them instead pcap_dump is that on
@@ -644,7 +644,7 @@ namespace pcpp
 			pktHdrTemp.caplen = pktHdr.caplen;
 			pktHdrTemp.len = pktHdr.len;
 			fwrite(&pktHdrTemp, sizeof(pktHdrTemp), 1, m_File);
-			fwrite(((RawPacket&)packet).getRawData(), pktHdrTemp.caplen, 1, m_File);
+			fwrite(packet.getRawData(), pktHdrTemp.caplen, 1, m_File);
 		}
 		PCPP_LOG_DEBUG("Packet written successfully to '" << m_FileName << "'");
 		m_NumOfPacketsWritten++;
@@ -867,14 +867,14 @@ namespace pcpp
 		}
 
 		light_packet_header pktHeader;
-		pktHeader.captured_length = ((RawPacket&)packet).getRawDataLen();
-		pktHeader.original_length = ((RawPacket&)packet).getFrameLength();
-		pktHeader.timestamp = ((RawPacket&)packet).getPacketTimeStamp();
-		pktHeader.data_link = (uint16_t)packet.getLinkLayerType();
+		pktHeader.captured_length = packet.getRawDataLen();
+		pktHeader.original_length = packet.getFrameLength();
+		pktHeader.timestamp = packet.getPacketTimeStamp();
+		pktHeader.data_link = static_cast<uint16_t>(packet.getLinkLayerType());
 		pktHeader.interface_id = 0;
 		if (!comment.empty())
 		{
-			pktHeader.comment = (char*)comment.c_str();
+			pktHeader.comment = const_cast<char*>(comment.c_str());
 			pktHeader.comment_length = static_cast<uint16_t>(comment.size());
 		}
 		else
@@ -883,7 +883,7 @@ namespace pcpp
 			pktHeader.comment_length = 0;
 		}
 
-		const uint8_t* pktData = ((RawPacket&)packet).getRawData();
+		const uint8_t* pktData = packet.getRawData();
 
 		light_write_packet(toLightPcapNgT(m_LightPcapNg), &pktHeader, pktData);
 		m_NumOfPacketsWritten++;

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -239,8 +239,8 @@ namespace pcpp
 #else
 		struct timeval ts = pkthdr.ts;
 #endif
-		if (!rawPacket.setRawData(pMyPacketData, pkthdr.caplen, ts, static_cast<LinkLayerType>(m_PcapLinkLayerType),
-		                          pkthdr.len))
+		if (!rawPacket.setRawData(RawPacketBufferPolicy::Move, pMyPacketData, pkthdr.caplen, ts,
+		                          static_cast<LinkLayerType>(m_PcapLinkLayerType), pkthdr.len))
 		{
 			PCPP_LOG_ERROR("Couldn't set data to raw packet");
 			return false;
@@ -346,8 +346,8 @@ namespace pcpp
 		}
 		timespec ts = { static_cast<time_t>(be32toh(snoop_packet_header.time_sec)),
 			            static_cast<long>(be32toh(snoop_packet_header.time_usec)) * 1000 };
-		if (!rawPacket.setRawData((const uint8_t*)packetData.release(), packetSize, ts,
-		                          static_cast<LinkLayerType>(m_PcapLinkLayerType)))
+		if (!rawPacket.setRawData(RawPacketBufferPolicy::Move, reinterpret_cast<uint8_t*>(packetData.release()),
+		                          packetSize, ts, static_cast<LinkLayerType>(m_PcapLinkLayerType)))
 		{
 			PCPP_LOG_ERROR("Couldn't set data to raw packet");
 			return false;
@@ -442,8 +442,8 @@ namespace pcpp
 			PCPP_LOG_ERROR("Link layer type of raw packet could not be determined");
 		}
 
-		if (!rawPacket.setRawData(myPacketData, pktHeader.captured_length, pktHeader.timestamp, linkType,
-		                          pktHeader.original_length))
+		if (!rawPacket.setRawData(RawPacketBufferPolicy::Move, myPacketData, pktHeader.captured_length,
+		                          pktHeader.timestamp, linkType, pktHeader.original_length))
 		{
 			PCPP_LOG_ERROR("Couldn't set data to raw packet");
 			return false;

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -239,7 +239,7 @@ namespace pcpp
 #else
 		struct timeval ts = pkthdr.ts;
 #endif
-		if (!rawPacket.setRawData(RawPacketBufferPolicy::Move, pMyPacketData, pkthdr.caplen, ts,
+		if (!rawPacket.setRawData(RawPacketBufferPolicy::Move, BufferInfo(pMyPacketData, pkthdr.caplen), ts,
 		                          static_cast<LinkLayerType>(m_PcapLinkLayerType), pkthdr.len))
 		{
 			PCPP_LOG_ERROR("Couldn't set data to raw packet");
@@ -346,8 +346,9 @@ namespace pcpp
 		}
 		timespec ts = { static_cast<time_t>(be32toh(snoop_packet_header.time_sec)),
 			            static_cast<long>(be32toh(snoop_packet_header.time_usec)) * 1000 };
-		if (!rawPacket.setRawData(RawPacketBufferPolicy::Move, reinterpret_cast<uint8_t*>(packetData.release()),
-		                          packetSize, ts, static_cast<LinkLayerType>(m_PcapLinkLayerType)))
+		if (!rawPacket.setRawData(RawPacketBufferPolicy::Move,
+		                          BufferInfo(reinterpret_cast<uint8_t*>(packetData.release()), packetSize), ts,
+		                          static_cast<LinkLayerType>(m_PcapLinkLayerType)))
 		{
 			PCPP_LOG_ERROR("Couldn't set data to raw packet");
 			return false;
@@ -442,7 +443,7 @@ namespace pcpp
 			PCPP_LOG_ERROR("Link layer type of raw packet could not be determined");
 		}
 
-		if (!rawPacket.setRawData(RawPacketBufferPolicy::Move, myPacketData, pktHeader.captured_length,
+		if (!rawPacket.setRawData(RawPacketBufferPolicy::Move, BufferInfo(myPacketData, pktHeader.captured_length),
 		                          pktHeader.timestamp, linkType, pktHeader.original_length))
 		{
 			PCPP_LOG_ERROR("Couldn't set data to raw packet");

--- a/Pcap++/src/PcapFilter.cpp
+++ b/Pcap++/src/PcapFilter.cpp
@@ -18,7 +18,7 @@ namespace pcpp
 
 	static const int DEFAULT_SNAPLEN = 9000;
 
-	bool GeneralFilter::matchPacketWithFilter(RawPacket* rawPacket)
+	bool GeneralFilter::matchPacketWithFilter(IRawPacket* rawPacket)
 	{
 		std::string filterStr;
 		parseToString(filterStr);

--- a/Pcap++/src/PcapFilter.cpp
+++ b/Pcap++/src/PcapFilter.cpp
@@ -91,7 +91,7 @@ namespace pcpp
 		m_FilterStr.clear();
 	}
 
-	bool BpfFilterWrapper::matchPacketWithFilter(const RawPacket* rawPacket)
+	bool BpfFilterWrapper::matchPacketWithFilter(const IRawPacket* rawPacket)
 	{
 		return matchPacketWithFilter(rawPacket->getRawData(), rawPacket->getRawDataLen(),
 		                             rawPacket->getPacketTimeStamp(), rawPacket->getLinkLayerType());

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -928,7 +928,7 @@ namespace pcpp
 
 	bool PcapLiveDevice::sendPacket(Packet const& packet, bool checkMtu)
 	{
-		RawPacket const* rawPacket = packet.getRawPacketReadOnly();
+		IRawPacket const* rawPacket = packet.getRawPacketReadOnly();
 
 		if (!checkMtu)
 		{
@@ -951,14 +951,14 @@ namespace pcpp
 		return doMtuCheck(packetPayloadLength) && sendPacket(*rawPacket, false);
 	}
 
-	bool PcapLiveDevice::sendPacket(RawPacket const& rawPacket, bool checkMtu)
+	bool PcapLiveDevice::sendPacket(IRawPacket const& rawPacket, bool checkMtu)
 	{
 		if (!checkMtu)
 		{
 			return sendPacketDirect(rawPacket.getRawData(), rawPacket.getRawDataLen());
 		}
 
-		RawPacket* rPacket = const_cast<RawPacket*>(&rawPacket);
+		IRawPacket* rPacket = const_cast<IRawPacket*>(&rawPacket);
 		Packet parsedPacket = Packet(rPacket, OsiModelDataLinkLayer);
 		return sendPacket(parsedPacket, true);
 	}
@@ -1028,10 +1028,10 @@ namespace pcpp
 		}
 	}  // namespace
 
-	int PcapLiveDevice::sendPackets(RawPacket* rawPacketsArr, int arrLength, bool checkMtu)
+	int PcapLiveDevice::sendPackets(IRawPacket* rawPacketsArr, int arrLength, bool checkMtu)
 	{
 		return sendPacketsLoop(rawPacketsArr, rawPacketsArr + arrLength,
-		                       [this, checkMtu](RawPacket const& packet) { return sendPacket(packet, checkMtu); });
+		                       [this, checkMtu](IRawPacket const& packet) { return sendPacket(packet, checkMtu); });
 	}
 
 	int PcapLiveDevice::sendPackets(Packet** packetsArr, int arrLength, bool checkMtu)
@@ -1043,7 +1043,7 @@ namespace pcpp
 	int PcapLiveDevice::sendPackets(const RawPacketVector& rawPackets, bool checkMtu)
 	{
 		return sendPacketsLoop(rawPackets.begin(), rawPackets.end(),
-		                       [this, checkMtu](RawPacket const* packet) { return sendPacket(*packet, checkMtu); });
+		                       [this, checkMtu](IRawPacket const* packet) { return sendPacket(*packet, checkMtu); });
 	}
 
 	void PcapLiveDevice::setDeviceMtu()

--- a/Pcap++/src/PfRingDevice.cpp
+++ b/Pcap++/src/PfRingDevice.cpp
@@ -667,7 +667,7 @@ namespace pcpp
 				//				continue;
 				//			}
 
-				RawPacket rawPacket(bufferPtr, pktHdr.caplen, pktHdr.ts, false);
+				RawPacket rawPacket(RawPacketBufferPolicy::StrictReference, BufferInfo(bufferPtr, pktHdr.caplen), pktHdr.ts);
 				this->m_OnPacketsArriveCallback(&rawPacket, 1, coreId, this, this->m_OnPacketsArriveUserCookie);
 			}
 			else if (recvRes < 0)

--- a/Pcap++/src/RawSocketDevice.cpp
+++ b/Pcap++/src/RawSocketDevice.cpp
@@ -259,7 +259,7 @@ namespace pcpp
 		return packetCount;
 	}
 
-	bool RawSocketDevice::sendPacket(const RawPacket* rawPacket)
+	bool RawSocketDevice::sendPacket(const IRawPacket* rawPacket)
 	{
 #if defined(_WIN32)
 

--- a/Pcap++/src/RawSocketDevice.cpp
+++ b/Pcap++/src/RawSocketDevice.cpp
@@ -136,7 +136,8 @@ namespace pcpp
 		{
 			timeval time;
 			gettimeofday(&time, nullptr);
-			rawPacket.setRawData((const uint8_t*)buffer, bufferLen, time, LINKTYPE_DLT_RAW1);
+			rawPacket.setRawData(RawPacketBufferPolicy::Move, reinterpret_cast<uint8_t*>(buffer), bufferLen, time,
+			                     LINKTYPE_DLT_RAW1);
 			return RecvSuccess;
 		}
 
@@ -199,7 +200,8 @@ namespace pcpp
 		{
 			timeval time;
 			gettimeofday(&time, nullptr);
-			rawPacket.setRawData((const uint8_t*)buffer, bufferLen, time, LINKTYPE_ETHERNET);
+			rawPacket.setRawData(RawPacketBufferPolicy::Move, reinterpret_cast<uint8_t*>(buffer), bufferLen, time,
+			                     LINKTYPE_ETHERNET);
 			return RecvSuccess;
 		}
 

--- a/Pcap++/src/RawSocketDevice.cpp
+++ b/Pcap++/src/RawSocketDevice.cpp
@@ -136,8 +136,8 @@ namespace pcpp
 		{
 			timeval time;
 			gettimeofday(&time, nullptr);
-			rawPacket.setRawData(RawPacketBufferPolicy::Move, reinterpret_cast<uint8_t*>(buffer), bufferLen, time,
-			                     LINKTYPE_DLT_RAW1);
+			rawPacket.setRawData(RawPacketBufferPolicy::Move, BufferInfo(reinterpret_cast<uint8_t*>(buffer), bufferLen),
+			                     time, LINKTYPE_DLT_RAW1);
 			return RecvSuccess;
 		}
 
@@ -200,7 +200,7 @@ namespace pcpp
 		{
 			timeval time;
 			gettimeofday(&time, nullptr);
-			rawPacket.setRawData(RawPacketBufferPolicy::Move, reinterpret_cast<uint8_t*>(buffer), bufferLen, time,
+			rawPacket.setRawData(RawPacketBufferPolicy::Move, BufferInfo(reinterpret_cast<uint8_t*>(buffer), bufferLen), time,
 			                     LINKTYPE_ETHERNET);
 			return RecvSuccess;
 		}

--- a/Tests/Packet++Test/Tests/BgpTests.cpp
+++ b/Tests/Packet++Test/Tests/BgpTests.cpp
@@ -454,7 +454,8 @@ PTF_TEST_CASE(BgpLayerEditTest)
 	PTF_ASSERT_BUF_COMPARE(bgpNotificationMessage1->getData(), bgpNotificationMessage2->getData(),
 	                       bgpNotificationMessage2->getDataLen());
 
-	pcpp::RawPacket rawPacket1Tag(origBuffer, bufferLength1, time, false);
+	pcpp::RawPacket rawPacket1Tag(pcpp::RawPacketBufferPolicy::SoftReference,
+	                              pcpp::BufferInfo(origBuffer, bufferLength1), time);
 	bgpNotificationPacket1.setRawPacket(&rawPacket1Tag, false);
 	bgpNotificationMessage1 = bgpNotificationPacket1.getLayerOfType<pcpp::BgpNotificationMessageLayer>();
 	std::string notificationData =

--- a/Tests/Packet++Test/Tests/CiscoHdlcTests.cpp
+++ b/Tests/Packet++Test/Tests/CiscoHdlcTests.cpp
@@ -57,7 +57,8 @@ PTF_TEST_CASE(CiscoHdlcParsingTest)
 	// Malformed Cisco HDLC + IPv4
 	{
 		auto data = std::vector<uint8_t>{ 0x0f, 0x00, 0x08, 0x00, 0x45, 0xc0 };
-		auto rawPacket = pcpp::RawPacket(data.data(), data.size(), time, false, pcpp::LINKTYPE_C_HDLC);
+		auto rawPacket = pcpp::RawPacket(pcpp::RawPacketBufferPolicy::StrictReference,
+		                                 pcpp::BufferInfo(data.data(), data.size()), time, pcpp::LINKTYPE_C_HDLC);
 
 		const pcpp::Packet ciscoHdlcPacket(&rawPacket);
 

--- a/Tests/Packet++Test/Tests/EthAndArpTests.cpp
+++ b/Tests/Packet++Test/Tests/EthAndArpTests.cpp
@@ -47,7 +47,7 @@ PTF_TEST_CASE(EthPacketCreation)
 	PTF_ASSERT_EQUAL(ethPacket.getLayerOfType<pcpp::EthLayer>()->getSourceMac(), srcMac);
 	PTF_ASSERT_EQUAL(ethPacket.getLayerOfType<pcpp::EthLayer>()->getEthHeader()->etherType, be16toh(PCPP_ETHERTYPE_IP));
 
-	pcpp::RawPacket* rawPacket = ethPacket.getRawPacket();
+	pcpp::IRawPacket* rawPacket = ethPacket.getRawPacket();
 	PTF_ASSERT_NOT_NULL(rawPacket);
 	PTF_ASSERT_EQUAL(rawPacket->getRawDataLen(), 18);
 
@@ -77,7 +77,7 @@ PTF_TEST_CASE(EthPacketPointerCreation)
 	PTF_ASSERT_EQUAL(ethPacket->getLayerOfType<pcpp::EthLayer>()->getEthHeader()->etherType,
 	                 be16toh(PCPP_ETHERTYPE_IP));
 
-	pcpp::RawPacket* rawPacket = ethPacket->getRawPacket();
+	pcpp::IRawPacket* rawPacket = ethPacket->getRawPacket();
 	PTF_ASSERT_NOT_NULL(rawPacket);
 	PTF_ASSERT_EQUAL(rawPacket->getRawDataLen(), 18);
 

--- a/Tests/Packet++Test/Tests/IPv4Tests.cpp
+++ b/Tests/Packet++Test/Tests/IPv4Tests.cpp
@@ -34,7 +34,7 @@ PTF_TEST_CASE(IPv4PacketCreation)
 	PTF_ASSERT_FALSE(tmpPacket.addLayer(&ethLayer));
 	pcpp::Logger::getInstance().enableLogs();
 
-	pcpp::RawPacket* rawPacket = ip4Packet.getRawPacket();
+	pcpp::IRawPacket* rawPacket = ip4Packet.getRawPacket();
 	PTF_ASSERT_NOT_NULL(rawPacket);
 	PTF_ASSERT_EQUAL(rawPacket->getRawDataLen(), 14);
 

--- a/Tests/Packet++Test/Utils/TestUtils.h
+++ b/Tests/Packet++Test/Utils/TestUtils.h
@@ -34,11 +34,14 @@ namespace pcpp_tests
 
 #define READ_FILE_AND_CREATE_PACKET(num, filename)                                                                     \
 	READ_FILE_INTO_BUFFER(num, filename);                                                                              \
-	pcpp::RawPacket rawPacket##num(static_cast<const uint8_t*>(buffer##num), bufferLength##num, time, true)
+	pcpp::RawPacket rawPacket##num(pcpp::RawPacketBufferPolicy::Move,                                                  \
+	                               pcpp::BufferInfo(static_cast<uint8_t*>(buffer##num), bufferLength##num), time)
 
 #define READ_FILE_AND_CREATE_PACKET_LINKTYPE(num, filename, linktype)                                                  \
 	READ_FILE_INTO_BUFFER(num, filename);                                                                              \
-	pcpp::RawPacket rawPacket##num(static_cast<const uint8_t*>(buffer##num), bufferLength##num, time, true, linktype)
+	pcpp::RawPacket rawPacket##num(pcpp::RawPacketBufferPolicy::Move,                                                  \
+	                               pcpp::BufferInfo(static_cast<uint8_t*>(buffer##num), bufferLength##num), time,      \
+	                               linktype)
 
 #ifdef PCPP_TESTS_DEBUG
 	void savePacketToPcap(pcpp::Packet& packet, const std::string& fileName);

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -892,8 +892,8 @@ PTF_TEST_CASE(TestMtuSize)
 	PTF_ASSERT_EQUAL(smallPacket.getLayerOfType<pcpp::IPv4Layer>()->getDataLen(), (size_t)liveDev->getMtu(), ptr);
 	// Try sending the packet
 	PTF_ASSERT_TRUE(liveDev->sendPacket(smallPacket));
-	pcpp::RawPacket* rawSmallPacketPtr = smallPacket.getRawPacket();
-	pcpp::RawPacket& rawSmallPacketRef = *rawSmallPacketPtr;
+	pcpp::IRawPacket* rawSmallPacketPtr = smallPacket.getRawPacket();
+	pcpp::IRawPacket& rawSmallPacketRef = *rawSmallPacketPtr;
 	PTF_ASSERT_TRUE(liveDev->sendPacket(rawSmallPacketRef, true));
 	PTF_ASSERT_TRUE(liveDev->sendPacket(rawSmallPacketPtr->getRawData(), rawSmallPacketPtr->getRawDataLen(), true,
 	                                    pcpp::LINKTYPE_ETHERNET));
@@ -926,8 +926,8 @@ PTF_TEST_CASE(TestMtuSize)
 	pcpp::Logger::getInstance().suppressLogs();
 	PTF_ASSERT_FALSE(liveDev->sendPacket(largePacket));
 
-	pcpp::RawPacket* rawLargePacketPtr = largePacket.getRawPacket();
-	pcpp::RawPacket& rawLargePacketRef = *rawLargePacketPtr;
+	pcpp::IRawPacket* rawLargePacketPtr = largePacket.getRawPacket();
+	pcpp::IRawPacket& rawLargePacketRef = *rawLargePacketPtr;
 	PTF_ASSERT_FALSE(liveDev->sendPacket(rawLargePacketRef, true));
 	PTF_ASSERT_FALSE(liveDev->sendPacket(rawLargePacketPtr->getRawData(), rawLargePacketPtr->getRawDataLen(), true,
 	                                     pcpp::LINKTYPE_ETHERNET));
@@ -999,7 +999,7 @@ PTF_TEST_CASE(TestRemoteCapture)
 
 	// send multiple packets
 	pcpp::RawPacketVector packetsToSend;
-	std::vector<pcpp::RawPacket*>::iterator iter = capturedPackets.begin();
+	auto iter = capturedPackets.begin();
 
 	size_t capturedPacketsSize = capturedPackets.size();
 	while (iter != capturedPackets.end())

--- a/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
+++ b/Tests/Pcap++Test/Tests/TcpReassemblyTests.cpp
@@ -338,8 +338,8 @@ static pcpp::RawPacket tcpReassemblyAddRetransmissions(pcpp::RawPacket rawPacket
 	packet.computeCalculateFields();
 
 	delete[] newPayload;
-
-	return *(packet.getRawPacket());
+	// Static downcast to RawPacket because we know that the packet is a RawPacket
+	return *static_cast<pcpp::RawPacket*>(packet.getRawPacket());
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is a general refactor of `RawPacket` to fix some core design issues with the class.
Due to the fact that it is a core library change, it will probably need to be merged prior to a major revision version.

### Fixed const correctness of input buffer parameter
Previously `RawPacket` accepted `const uint8_t*` as a pointer to the buffer and immediately stripped the const in the constructor. This violates const correctness. The new constructors accept `uint8_t*` as a pointer to the buffer to require the user to knowingly strip const ness if usage of const buffer is required.

### Explicit buffer policies
Previously,`RawPacket`'s `setRawData` relied on the value of flag `m_DeleteRawDataAtDestructor` to choose if the raw packet owned the input buffer or just referenced it. This ambiguity can lead to critical errors as users have no way to query the value after construction, leading to memory leaks, dangling pointers, or UB by calling `delete` on stack allocated data.

The PR adds an enum `RawPacketBufferPolicy` to explicitly specify the type of ownership relation a `RawPacket` object will have with its underlying buffer on every operation that replaces it. The users can choose from one of 4 policies (Copy, Move, SoftReference, StrictReference). The latter two policies utilize the input buffer without assuming ownership, but SoftReference allows transfer of the packet data to an internal buffer if resize is required, while strict reference will refuse reallocation requests.

### New base classes: `IRawPacket` and `RawPacketBase`
The inheritance hierarchy of raw packets has been expanded. `MBufRawPacket` no longer inherits from `RawPacket` and instead inherits from `RawPacketBase` as it was previously made to work around `RawPacket`'s methods. The new interface `IRawPacket` is supposed to provide common methods through which higher level abstractions (`Packet`) can interact with the raw data buffers.
The class `RawPacketBase` is to provide common functionality between `RawPacket` and `MBufRawPacket`, namely timestamp and link layer fields.

### Enhanced buffer capacity tracking in `RawPacket`
The PR adds the capability for `RawPacket` to track its internal (or external) buffer capacity. Previously, the object relied on users to correctly know the buffer capacity via external means, allowing the possibility of buffer overflow via improper usage of `appendData` and `insertData`. The added field `m_RawDataCapacity` tracks the buffer capacity independently of the used buffer data `m_RawDataLen`. The change allows `RawPacket` to track its internal buffer and fail operations that would result a buffer overflow without compromising the memory integrity.

The methods `appendData` and `insertData`'s return values have been changed to `size_t` to report success or error and the number of bytes written.

### Added separate API call for inserting block for overwrite in the middle of a packet.
Added a new method `insertUninitializedData` that replaces the previous usage of `insertData(atIndex, nullptr, blockLen)`. The latter method's public documentation implies to expect a valid data buffer, so allowing `nullptr` as a valid buffer value and extending the buffer with uninitialized data violates the principle of least surprise.

The old signature `insertData(atIndex, nullptr, blockLen)` is now an error.
