### PR TITLE
Invoke rte_eal_cleanup on application exit

### DIFF
--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -65,6 +65,14 @@ namespace pcpp
 	DpdkDeviceList::~DpdkDeviceList()
 	{
 		m_DpdkDeviceListView.clear();
+		if (m_IsInitialized)
+		{
+			int ret = rte_eal_cleanup();
+			if (ret < 0)
+			{
+				PCPP_LOG_ERROR("failed to cleanup the DPDK EAL");
+			}
+		}
 	}
 
 	bool DpdkDeviceList::initDpdk(CoreMask coreMask, uint32_t mBufPoolSizePerDevice, uint16_t mBufDataSize,


### PR DESCRIPTION
Added call to DPDK EAL clean up function. This function must be called to clean up resources allocated using rte_eal_init according to https://doc.dpdk.org/api/rte__eal_8h.html#a7a745887f62a82dc83f1524e2ff2a236