### PR TITLE
[DRAFT] Add decoding and encoding of `ObjectIdentifier` ASN.1 records

### DIFF
--- a/Packet++/header/Asn1Codec.h
+++ b/Packet++/header/Asn1Codec.h
@@ -574,4 +574,104 @@ namespace pcpp
 			return {};
 		}
 	};
+
+	/**
+	 * @class Asn1ObjectIdentifier
+	 * Represents an ASN.1 Object Identifier (OID).
+	 *
+	 * Stores the numeric components of an OID. Provides methods for adding components
+	 * and converting the OID to a human-readable string.
+	 */
+	class Asn1ObjectIdentifier
+	{
+	public:
+		Asn1ObjectIdentifier() = default;
+
+		explicit Asn1ObjectIdentifier(const uint8_t* data, size_t dataLen);
+
+		/**
+		 * @brief Constructs an OID from its string representation (e.g., "1.2.840.113549").
+		 * @param oidString The string representation of the OID.
+		 * @throws std::invalid_argument if the string is malformed or contains invalid components.
+		 */
+		explicit Asn1ObjectIdentifier(const std::string& oidString);
+
+		/**
+		 * @brief Returns the vector of OID components.
+		 * @return A const reference to the internal vector of components.
+		 */
+		const std::vector<uint32_t>& getComponents() const
+		{
+			return m_Components;
+		}
+
+		/**
+		 * @brief Equality operator to compare two OIDs.
+		 * @param other Another Asn1ObjectIdentifier instance.
+		 * @return true if the OIDs have the same components; false otherwise.
+		 */
+		bool operator==(const Asn1ObjectIdentifier& other) const
+		{
+			return m_Components == other.m_Components;
+		}
+
+		bool operator!=(const Asn1ObjectIdentifier& other) const
+		{
+			return m_Components != other.m_Components;
+		}
+
+		/**
+		 * @brief Converts the OID to its string representation (e.g., "1.2.840.113549").
+		 * @return A string representing the OID.
+		 */
+		std::string toString() const
+		{
+			if (m_Components.empty())
+			{
+				return "";
+			}
+
+			std::ostringstream stream;
+			stream << m_Components[0];
+
+			for (size_t i = 1; i < m_Components.size(); ++i)
+			{
+				stream << "." << m_Components[i];
+			}
+			return stream.str();
+		}
+
+		std::vector<uint8_t> toBytes() const;
+
+		friend std::ostream& operator<<(std::ostream& os, const Asn1ObjectIdentifier& oid)
+		{
+			return os << oid.toString();
+		}
+
+	private:
+		std::vector<uint32_t> m_Components;
+	};
+
+	/// @class Asn1OidRecord
+	/// Represents an ASN.1 record with a value of type ObjectIdentifier
+	class Asn1OidRecord : public Asn1PrimitiveRecord
+	{
+		friend class Asn1Record;
+
+	public:
+		const Asn1ObjectIdentifier& getValue()
+		{
+			decodeValueIfNeeded();
+			return m_Value;
+		}
+
+	protected:
+		void decodeValue(uint8_t* data, bool lazy) override;
+		std::vector<uint8_t> encodeValue() const override;
+
+		std::vector<std::string> toStringList() override;
+
+	private:
+		Asn1ObjectIdentifier m_Value;
+	};
 }  // namespace pcpp

--- a/Packet++/header/Asn1Codec.h
+++ b/Packet++/header/Asn1Codec.h
@@ -624,22 +624,7 @@ namespace pcpp
 		 * @brief Converts the OID to its string representation (e.g., "1.2.840.113549").
 		 * @return A string representing the OID.
 		 */
-		std::string toString() const
-		{
-			if (m_Components.empty())
-			{
-				return "";
-			}
-
-			std::ostringstream stream;
-			stream << m_Components[0];
-
-			for (size_t i = 1; i < m_Components.size(); ++i)
-			{
-				stream << "." << m_Components[i];
-			}
-			return stream.str();
-		}
+		std::string toString() const;
 
 		std::vector<uint8_t> toBytes() const;
 
@@ -652,9 +637,9 @@ namespace pcpp
 		std::vector<uint32_t> m_Components;
 	};
 
-	/// @class Asn1OidRecord
+	/// @class Asn1ObjectIdentifierRecord
 	/// Represents an ASN.1 record with a value of type ObjectIdentifier
-	class Asn1OidRecord : public Asn1PrimitiveRecord
+	class Asn1ObjectIdentifierRecord : public Asn1PrimitiveRecord
 	{
 		friend class Asn1Record;
 

--- a/Packet++/src/Asn1Codec.cpp
+++ b/Packet++/src/Asn1Codec.cpp
@@ -343,7 +343,7 @@ namespace pcpp
 				}
 				case Asn1UniversalTagType::ObjectIdentifier:
 				{
-					newRecord = new Asn1OidRecord();
+					newRecord = new Asn1ObjectIdentifierRecord();
 					break;
 				}
 				default:
@@ -867,6 +867,23 @@ namespace pcpp
 		m_Components = components;
 	}
 
+	std::string Asn1ObjectIdentifier::toString() const
+	{
+		if (m_Components.empty())
+		{
+			return "";
+		}
+
+		std::ostringstream stream;
+		stream << m_Components[0];
+
+		for (size_t i = 1; i < m_Components.size(); ++i)
+		{
+			stream << "." << m_Components[i];
+		}
+		return stream.str();
+	}
+
 	std::vector<uint8_t> Asn1ObjectIdentifier::toBytes() const
 	{
 		if (m_Components.size() < 2)
@@ -916,17 +933,17 @@ namespace pcpp
 		return encoded;
 	}
 
-	void Asn1OidRecord::decodeValue(uint8_t* data, bool lazy)
+	void Asn1ObjectIdentifierRecord::decodeValue(uint8_t* data, bool lazy)
 	{
 		m_Value = Asn1ObjectIdentifier(data, m_ValueLength);
 	}
 
-	std::vector<uint8_t> Asn1OidRecord::encodeValue() const
+	std::vector<uint8_t> Asn1ObjectIdentifierRecord::encodeValue() const
 	{
 		return m_Value.toBytes();
 	}
 
-	std::vector<std::string> Asn1OidRecord::toStringList()
+	std::vector<std::string> Asn1ObjectIdentifierRecord::toStringList()
 	{
 		return { Asn1Record::toStringList().front() + ", Value: " + getValue().toString() };
 	}

--- a/Tests/Packet++Test/TestDefinition.h
+++ b/Tests/Packet++Test/TestDefinition.h
@@ -262,6 +262,7 @@ PTF_TEST_CASE(SmtpEditTests);
 // Implemented in Asn1Tests.cpp
 PTF_TEST_CASE(Asn1DecodingTest);
 PTF_TEST_CASE(Asn1EncodingTest);
+PTF_TEST_CASE(Asn1ObjectIdentifierTest);
 
 // Implemented in LdapTests.cpp
 PTF_TEST_CASE(LdapParsingTest);

--- a/Tests/Packet++Test/Tests/Asn1Tests.cpp
+++ b/Tests/Packet++Test/Tests/Asn1Tests.cpp
@@ -2,6 +2,8 @@
 #include "Asn1Codec.h"
 #include "RawPacket.h"
 #include "GeneralUtils.h"
+
+#include <array>
 #include <functional>
 #include <cstring>
 #include <sstream>
@@ -197,6 +199,20 @@ PTF_TEST_CASE(Asn1DecodingTest)
 		PTF_ASSERT_EQUAL(record->getValueLength(), 0);
 		PTF_ASSERT_NOT_NULL(record->castAs<pcpp::Asn1NullRecord>());
 		PTF_ASSERT_EQUAL(record->toString(), "Null, Length: 2+0");
+	}
+
+	// ObjectIdentifier (OID)
+	{
+		uint8_t data[20];
+		auto dataLen = pcpp::hexStringToByteArray("06092a864886f70d01010b", data, 20);
+		auto record = pcpp::Asn1Record::decode(data, dataLen);
+
+		PTF_ASSERT_EQUAL(record->getTagClass(), pcpp::Asn1TagClass::Universal, enumclass);
+		PTF_ASSERT_FALSE(record->isConstructed());
+		PTF_ASSERT_EQUAL(record->getUniversalTagType(), pcpp::Asn1UniversalTagType::ObjectIdentifier, enumclass);
+		PTF_ASSERT_EQUAL(record->getTotalLength(), 11);
+		PTF_ASSERT_EQUAL(record->getValueLength(), 9);
+		PTF_ASSERT_EQUAL(record->castAs<pcpp::Asn1OidRecord>()->getValue(), "1.2.840.113549.1.1.11");
 	}
 
 	// Sequence
@@ -736,3 +752,85 @@ PTF_TEST_CASE(Asn1EncodingTest)
 		PTF_ASSERT_BUF_COMPARE(encodedValue.data(), data, dataLen);
 	}
 }  // Asn1EncodingTest
+
+PTF_TEST_CASE(Asn1ObjectIdentifierTest)
+{
+	// Generate from byte array - First byte
+	{
+		std::vector<std::pair<std::vector<uint8_t>, std::string>> encodedDataAndExpectedStrings = {
+			{ { 0x16 }, "0.22" },
+			{ { 0x35 }, "1.13" },
+			{ { 0x76 }, "2.38" },
+		};
+
+		for (auto encodedDataAndExpectedString : encodedDataAndExpectedStrings)
+		{
+			pcpp::Asn1ObjectIdentifier oid(encodedDataAndExpectedString.first.data(),
+			                               encodedDataAndExpectedString.first.size());
+			PTF_ASSERT_EQUAL(oid.toString(), encodedDataAndExpectedString.second);
+		}
+	}
+
+	// Generate from byte array - Small and large value components
+	{
+		std::vector<std::pair<std::vector<uint8_t>, std::string>> encodedDataAndExpectedStrings = {
+			{ { 0x2a, 0x26, 0x7f },                         "1.2.38.127"        },
+			{ { 0x2a, 0x95, 0x8c, 0x4e },                   "1.2.345678"        },
+			{ { 0x2a, 0x95, 0x8c, 0x4e, 0x01, 0xcd, 0x14 }, "1.2.345678.1.9876" },
+		};
+
+		for (auto encodedDataAndExpectedString : encodedDataAndExpectedStrings)
+		{
+			pcpp::Asn1ObjectIdentifier oid(encodedDataAndExpectedString.first.data(),
+			                               encodedDataAndExpectedString.first.size());
+			PTF_ASSERT_EQUAL(oid.toString(), encodedDataAndExpectedString.second);
+		}
+	}
+
+	// Generate from byte array - Invalid values
+	{
+		PTF_ASSERT_RAISES(pcpp::Asn1ObjectIdentifier(nullptr, 2), std::invalid_argument,
+		                  "Malformed OID: Not enough bytes for the first component");
+		PTF_ASSERT_RAISES(pcpp::Asn1ObjectIdentifier(std::vector<uint8_t>({ 0x85 }).data(), 0), std::invalid_argument,
+		                  "Malformed OID: Not enough bytes for the first component");
+		PTF_ASSERT_RAISES(pcpp::Asn1ObjectIdentifier(std::vector<uint8_t>({ 0x2a, 0x95 }).data(), 2),
+		                  std::invalid_argument, "Malformed OID: Incomplete component at end of data");
+	}
+
+	// Generate from string - Valid values
+	{
+		std::vector<std::pair<std::string, std::vector<uint32_t>>> inputAndExpectedComponents = {
+			{ "0.9.2342.19200300.100.1.1", { 0x0, 0x9, 0x926, 0x124F92C, 0x64, 0x1, 0x1 } },
+			{ "1.3.6.1.4.1.12345",         { 0x1, 0x3, 0x6, 0x1, 0x4, 0x1, 0x3039 }       },
+			{ "2.5.4.3",                   { 0x2, 0x5, 0x4, 0x3 }                         }
+		};
+
+		for (auto inputAndExpectedComponent : inputAndExpectedComponents)
+		{
+			pcpp::Asn1ObjectIdentifier oid(inputAndExpectedComponent.first);
+			PTF_ASSERT_VECTORS_EQUAL(oid.getComponents(), inputAndExpectedComponent.second);
+			PTF_ASSERT_EQUAL(oid.toString(), inputAndExpectedComponent.first)
+		}
+	}
+
+	// Generate from string - Invalid values
+	{
+		std::vector<std::pair<std::string, std::string>> malformedValuesAndExceptions = {
+			{ "invalid",          "Malformed OID: invalid component"                                                    },
+			{ "1.invalid",        "Malformed OID: invalid component"                                                    },
+			{ "1..1",             "Malformed OID: empty component"                                                      },
+			{ "1.2.999999999999", "Malformed OID: component out of uint32_t range"                                      },
+			{ "1",                "Malformed OID: an OID must have at least two components"                             },
+			{ "3.2",              "Malformed OID: first component must be 0, 1, or 2"                                   },
+			{ "0.40",             "Malformed OID: second component must be less than 40 when first component is 0 or 1" },
+			{ "1.40",             "Malformed OID: second component must be less than 40 when first component is 0 or 1" }
+		};
+
+		for (auto malformedValuesAndException : malformedValuesAndExceptions)
+		{
+			PTF_ASSERT_RAISES(pcpp::Asn1ObjectIdentifier oid(malformedValuesAndException.first), std::invalid_argument,
+			                  malformedValuesAndException.second);
+		}
+	}
+
+}  // Asn1ObjectIdentifierTest

--- a/Tests/Packet++Test/Tests/Asn1Tests.cpp
+++ b/Tests/Packet++Test/Tests/Asn1Tests.cpp
@@ -212,7 +212,7 @@ PTF_TEST_CASE(Asn1DecodingTest)
 		PTF_ASSERT_EQUAL(record->getUniversalTagType(), pcpp::Asn1UniversalTagType::ObjectIdentifier, enumclass);
 		PTF_ASSERT_EQUAL(record->getTotalLength(), 11);
 		PTF_ASSERT_EQUAL(record->getValueLength(), 9);
-		PTF_ASSERT_EQUAL(record->castAs<pcpp::Asn1OidRecord>()->getValue(), "1.2.840.113549.1.1.11");
+		PTF_ASSERT_EQUAL(record->castAs<pcpp::Asn1ObjectIdentifierRecord>()->getValue(), "1.2.840.113549.1.1.11");
 	}
 
 	// Sequence

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -332,6 +332,7 @@ int main(int argc, char* argv[])
 
 	PTF_RUN_TEST(Asn1DecodingTest, "asn1");
 	PTF_RUN_TEST(Asn1EncodingTest, "asn1");
+	PTF_RUN_TEST(Asn1ObjectIdentifierTest, "asn1");
 
 	PTF_RUN_TEST(LdapParsingTest, "ldap");
 	PTF_RUN_TEST(LdapCreationTest, "ldap");


### PR DESCRIPTION
As part of https://github.com/seladb/PcapPlusPlus/issues/1835, X509 certificates require support for ASN.1 records of type `ObjectIdentifier`