### PR TITLE
Add decoding and encoding of `BitString` ASN.1 records

### DIFF
--- a/Packet++/header/Asn1Codec.h
+++ b/Packet++/header/Asn1Codec.h
@@ -574,4 +574,59 @@ namespace pcpp
 			return {};
 		}
 	};
+
+	/// @class Asn1BitStringRecord
+	/// Represents an ASN.1 record with a value of type BitString
+	class Asn1BitStringRecord : public Asn1PrimitiveRecord
+	{
+		friend class Asn1Record;
+
+	public:
+		/// A constructor to create a record of type BitString
+		/// @param value A bit string to set as the record value
+		/// @throw std::invalid_argument if the string is not a valid bit string
+		explicit Asn1BitStringRecord(const std::string& value);
+
+		/// @return The bit string value of this record
+		std::string getValue()
+		{
+			decodeValueIfNeeded();
+			return m_Value.toString();
+		};
+
+	protected:
+		void decodeValue(uint8_t* data, bool lazy) override;
+		std::vector<uint8_t> encodeValue() const override;
+
+		std::vector<std::string> toStringList() override;
+
+	private:
+		class BitSet
+		{
+		public:
+			BitSet() = default;
+			explicit BitSet(const std::string& value);
+			BitSet(const uint8_t* data, size_t numBits);
+
+			BitSet& operator=(const std::string& value);
+
+			size_t sizeInBytes() const;
+			std::string toString() const;
+			std::vector<uint8_t> toBytes() const;
+			size_t getNumBits() const
+			{
+				return m_NumBits;
+			}
+
+		private:
+			void initFromString(const std::string& value);
+
+			std::vector<std::bitset<8>> m_Data;
+			size_t m_NumBits = 0;
+		};
+
+		Asn1BitStringRecord() = default;
+
+		BitSet m_Value;
+	};
 }  // namespace pcpp

--- a/Packet++/header/Asn1Codec.h
+++ b/Packet++/header/Asn1Codec.h
@@ -5,6 +5,7 @@
 #include <typeinfo>
 #include <stdexcept>
 #include <sstream>
+#include <bitset>
 #include "PointerVector.h"
 
 /// @file

--- a/Packet++/src/Asn1Codec.cpp
+++ b/Packet++/src/Asn1Codec.cpp
@@ -796,7 +796,7 @@ namespace pcpp
 				m_Data.push_back(bs);
 				i += 8;
 			}
-			catch (std::invalid_argument e)
+			catch (const std::invalid_argument&)
 			{
 				throw std::invalid_argument("Invalid bit string");
 			}

--- a/Packet++/src/Asn1Codec.cpp
+++ b/Packet++/src/Asn1Codec.cpp
@@ -828,12 +828,9 @@ namespace pcpp
 
 	std::string Asn1BitStringRecord::BitSet::toString() const
 	{
-		std::string result;
-		for (const auto bs : m_Data)
-		{
-			result += bs.to_string();
-		}
-		return result.substr(0, m_NumBits);
+		return std::accumulate(m_Data.begin(), m_Data.end(), std::string(),
+		                       [](const std::string& acc, const auto& bs) { return acc + bs.to_string(); })
+		    .substr(0, m_NumBits);
 	}
 
 	std::vector<uint8_t> Asn1BitStringRecord::BitSet::toBytes() const

--- a/Packet++/src/Asn1Codec.cpp
+++ b/Packet++/src/Asn1Codec.cpp
@@ -1268,7 +1268,8 @@ namespace pcpp
 	std::vector<uint8_t> Asn1BitStringRecord::BitSet::toBytes() const
 	{
 		std::vector<uint8_t> result;
-		for (const auto bs : m_Data)
+		result.reserve(m_Data.size());
+		for (const auto& bs : m_Data)
 		{
 			result.push_back(static_cast<uint8_t>(bs.to_ulong()));
 		}

--- a/Packet++/src/Asn1Codec.cpp
+++ b/Packet++/src/Asn1Codec.cpp
@@ -1260,9 +1260,14 @@ namespace pcpp
 
 	std::string Asn1BitStringRecord::BitSet::toString() const
 	{
-		return std::accumulate(m_Data.begin(), m_Data.end(), std::string(),
-		                       [](const std::string& acc, const auto& bs) { return acc + bs.to_string(); })
-		    .substr(0, m_NumBits);
+		std::string result;
+		result.reserve(m_Data.size() * 8);
+		for (const auto bs : m_Data)
+		{
+			result += bs.to_string();
+		}
+		result.resize(m_NumBits);
+		return result;
 	}
 
 	std::vector<uint8_t> Asn1BitStringRecord::BitSet::toBytes() const

--- a/Tests/Packet++Test/Tests/Asn1Tests.cpp
+++ b/Tests/Packet++Test/Tests/Asn1Tests.cpp
@@ -199,6 +199,36 @@ PTF_TEST_CASE(Asn1DecodingTest)
 		PTF_ASSERT_EQUAL(record->toString(), "Null, Length: 2+0");
 	}
 
+	// BitString with 0 unused bytes
+	{
+		uint8_t data[20];
+		auto dataLen = pcpp::hexStringToByteArray("030300a3b5", data, 20);
+		auto record = pcpp::Asn1Record::decode(data, dataLen);
+
+		PTF_ASSERT_EQUAL(record->getTagClass(), pcpp::Asn1TagClass::Universal, enumclass);
+		PTF_ASSERT_FALSE(record->isConstructed());
+		PTF_ASSERT_EQUAL(record->getUniversalTagType(), pcpp::Asn1UniversalTagType::BitString, enumclass);
+		PTF_ASSERT_EQUAL(record->getTotalLength(), 5);
+		PTF_ASSERT_EQUAL(record->getValueLength(), 3);
+		PTF_ASSERT_EQUAL(record->castAs<pcpp::Asn1BitStringRecord>()->getValue(), "1010001110110101");
+		PTF_ASSERT_EQUAL(record->toString(), "BitString, Length: 2+3, Value: 1010001110110101");
+	}
+
+	// BitString with unused bytes
+	{
+		uint8_t data[20];
+		auto dataLen = pcpp::hexStringToByteArray("030306b2c0", data, 20);
+		auto record = pcpp::Asn1Record::decode(data, dataLen);
+
+		PTF_ASSERT_EQUAL(record->getTagClass(), pcpp::Asn1TagClass::Universal, enumclass);
+		PTF_ASSERT_FALSE(record->isConstructed());
+		PTF_ASSERT_EQUAL(record->getUniversalTagType(), pcpp::Asn1UniversalTagType::BitString, enumclass);
+		PTF_ASSERT_EQUAL(record->getTotalLength(), 5);
+		PTF_ASSERT_EQUAL(record->getValueLength(), 3);
+		PTF_ASSERT_EQUAL(record->castAs<pcpp::Asn1BitStringRecord>()->getValue(), "1011001011");
+		PTF_ASSERT_EQUAL(record->toString(), "BitString, Length: 2+3, Value: 1011001011");
+	}
+
 	// Sequence
 	{
 		uint8_t data[20];
@@ -654,6 +684,35 @@ PTF_TEST_CASE(Asn1EncodingTest)
 		auto encodedValue = record.encode();
 		PTF_ASSERT_EQUAL(encodedValue.size(), dataLen);
 		PTF_ASSERT_BUF_COMPARE(encodedValue.data(), data, dataLen)
+	}
+
+	// BitString with 0 unused bytes
+	{
+		pcpp::Asn1BitStringRecord record("1010001110110101");
+
+		uint8_t data[20];
+		auto dataLen = pcpp::hexStringToByteArray("030300a3b5", data, 20);
+
+		auto encodedValue = record.encode();
+		PTF_ASSERT_EQUAL(encodedValue.size(), dataLen);
+		PTF_ASSERT_BUF_COMPARE(encodedValue.data(), data, dataLen)
+	}
+
+	// BitString with unused bytes
+	{
+		pcpp::Asn1BitStringRecord record("1011001011");
+
+		uint8_t data[20];
+		auto dataLen = pcpp::hexStringToByteArray("030306b2c0", data, 20);
+
+		auto encodedValue = record.encode();
+		PTF_ASSERT_EQUAL(encodedValue.size(), dataLen);
+		PTF_ASSERT_BUF_COMPARE(encodedValue.data(), data, dataLen)
+	}
+
+	// BitString invalid value
+	{
+		PTF_ASSERT_RAISES(pcpp::Asn1BitStringRecord record("0011invalid"), std::invalid_argument, "Invalid bit string");
 	}
 
 	// Sequence

--- a/cppcheckSuppressions.txt
+++ b/cppcheckSuppressions.txt
@@ -9,6 +9,7 @@ unusedStructMember:*
 
 noExplicitConstructor:Common++/header/IpAddress.h
 noExplicitConstructor:Common++/header/MacAddress.h
+useStlAlgorithm:Packet++/src/Asn1Codec.cpp
 noExplicitConstructor:Pcap++/header/PcapFileDevice.h
 
 missingOverride:Pcap++/*


### PR DESCRIPTION
As part of https://github.com/seladb/PcapPlusPlus/issues/1835, X509 certificates require support for ASN.1 records of type `BitString`