### PR TITLE
Add decoding and encoding of ASN.1 string records 

### DIFF
--- a/Packet++/header/Asn1Codec.h
+++ b/Packet++/header/Asn1Codec.h
@@ -8,6 +8,8 @@
 #include <chrono>
 #include "PointerVector.h"
 
+#include <iostream>
+
 /// @file
 
 /// @namespace pcpp
@@ -491,9 +493,35 @@ namespace pcpp
 		Asn1EnumeratedRecord() = default;
 	};
 
+	/// @class Asn1StringRecord
+	/// An abstract class for representing ASN.1 string records.
+	/// This class is not instantiable, users should use the derived classes
+	class Asn1StringRecord : public Asn1PrimitiveRecord
+	{
+	public:
+		/// @return The string value of this record
+		std::string getValue()
+		{
+			decodeValueIfNeeded();
+			return m_Value;
+		};
+
+	protected:
+		Asn1StringRecord() = default;
+		Asn1StringRecord(const std::string& value, Asn1UniversalTagType tagType);
+		Asn1StringRecord(const uint8_t* value, size_t valueLength, Asn1UniversalTagType tagType);
+
+		void decodeValue(uint8_t* data, bool lazy) override;
+		std::vector<uint8_t> encodeValue() const override;
+
+		std::vector<std::string> toStringList() override;
+
+		std::string m_Value;
+	};
+
 	/// @class Asn1OctetStringRecord
 	/// Represents an ASN.1 record with a value of type Octet String
-	class Asn1OctetStringRecord : public Asn1PrimitiveRecord
+	class Asn1OctetStringRecord : public Asn1StringRecord
 	{
 		friend class Asn1Record;
 
@@ -507,21 +535,11 @@ namespace pcpp
 		/// @param valueLength The length of the byte array
 		explicit Asn1OctetStringRecord(const uint8_t* value, size_t valueLength);
 
-		/// @return The string value of this record
-		std::string getValue()
-		{
-			decodeValueIfNeeded();
-			return m_Value;
-		};
-
 	protected:
 		void decodeValue(uint8_t* data, bool lazy) override;
 		std::vector<uint8_t> encodeValue() const override;
 
-		std::vector<std::string> toStringList() override;
-
 	private:
-		std::string m_Value;
 		bool m_IsPrintable = true;
 
 		Asn1OctetStringRecord() = default;

--- a/Packet++/header/Asn1Codec.h
+++ b/Packet++/header/Asn1Codec.h
@@ -545,6 +545,28 @@ namespace pcpp
 		Asn1OctetStringRecord() = default;
 	};
 
+	class Asn1UTF8StringRecord : public Asn1StringRecord
+	{
+		friend class Asn1Record;
+
+	public:
+		explicit Asn1UTF8StringRecord(const std::string& value);
+
+	private:
+		Asn1UTF8StringRecord() = default;
+	};
+
+	class Asn1PrintableStringRecord : public Asn1StringRecord
+	{
+		friend class Asn1Record;
+
+	public:
+		explicit Asn1PrintableStringRecord(const std::string& value);
+
+	private:
+		Asn1PrintableStringRecord() = default;
+	};
+
 	/// @class Asn1BooleanRecord
 	/// Represents an ASN.1 record with a value of type Boolean
 	class Asn1BooleanRecord : public Asn1PrimitiveRecord

--- a/Packet++/src/Asn1Codec.cpp
+++ b/Packet++/src/Asn1Codec.cpp
@@ -333,6 +333,16 @@ namespace pcpp
 					newRecord = new Asn1OctetStringRecord();
 					break;
 				}
+				case Asn1UniversalTagType::UTF8String:
+				{
+					newRecord = new Asn1UTF8StringRecord();
+					break;
+				}
+				case Asn1UniversalTagType::PrintableString:
+				{
+					newRecord = new Asn1PrintableStringRecord();
+					break;
+				}
 				case Asn1UniversalTagType::Boolean:
 				{
 					newRecord = new Asn1BooleanRecord();
@@ -775,6 +785,12 @@ namespace pcpp
 		hexStringToByteArray(m_Value, rawValue.data(), rawValueSize);
 		return rawValue;
 	}
+
+	Asn1UTF8StringRecord::Asn1UTF8StringRecord(const std::string& value) : Asn1StringRecord(value, Asn1UniversalTagType::UTF8String)
+	{}
+
+	Asn1PrintableStringRecord::Asn1PrintableStringRecord(const std::string& value) : Asn1StringRecord(value, Asn1UniversalTagType::PrintableString)
+	{}
 
 	Asn1BooleanRecord::Asn1BooleanRecord(bool value) : Asn1PrimitiveRecord(Asn1UniversalTagType::Boolean)
 	{

--- a/Packet++/src/Asn1Codec.cpp
+++ b/Packet++/src/Asn1Codec.cpp
@@ -343,6 +343,11 @@ namespace pcpp
 					newRecord = new Asn1PrintableStringRecord();
 					break;
 				}
+				case Asn1UniversalTagType::IA5String:
+				{
+					newRecord = new Asn1IA5StringRecord();
+					break;
+				}
 				case Asn1UniversalTagType::Boolean:
 				{
 					newRecord = new Asn1BooleanRecord();
@@ -714,44 +719,12 @@ namespace pcpp
 		m_TagType = static_cast<uint8_t>(Asn1UniversalTagType::Enumerated);
 	}
 
-	Asn1StringRecord::Asn1StringRecord(const std::string& value, Asn1UniversalTagType tagType)
-	    : Asn1PrimitiveRecord(tagType)
-	{
-		m_Value = value;
-		m_ValueLength = value.size();
-		m_TotalLength = m_ValueLength + 2;
-	}
-
-	Asn1StringRecord::Asn1StringRecord(const uint8_t* value, size_t valueLength, Asn1UniversalTagType tagType)
-	    : Asn1PrimitiveRecord(tagType)
+	Asn1OctetStringRecord::Asn1OctetStringRecord(const uint8_t* value, size_t valueLength) : m_IsPrintable(false)
 	{
 		m_Value = byteArrayToHexString(value, valueLength);
 		m_ValueLength = valueLength;
 		m_TotalLength = m_ValueLength + 2;
 	}
-
-	void Asn1StringRecord::decodeValue(uint8_t* data, bool lazy)
-	{
-		m_Value = std::string(reinterpret_cast<char*>(data), m_ValueLength);
-	}
-
-	std::vector<uint8_t> Asn1StringRecord::encodeValue() const
-	{
-		return { m_Value.begin(), m_Value.end() };
-	}
-
-	std::vector<std::string> Asn1StringRecord::toStringList()
-	{
-		return { Asn1Record::toStringList().front() + ", Value: " + getValue() };
-	}
-
-	Asn1OctetStringRecord::Asn1OctetStringRecord(const std::string& value)
-	    : Asn1StringRecord(value, Asn1UniversalTagType::OctetString)
-	{}
-
-	Asn1OctetStringRecord::Asn1OctetStringRecord(const uint8_t* value, size_t valueLength)
-	    : Asn1StringRecord(value, valueLength, Asn1UniversalTagType::OctetString), m_IsPrintable(false)
-	{}
 
 	void Asn1OctetStringRecord::decodeValue(uint8_t* data, bool lazy)
 	{
@@ -785,12 +758,6 @@ namespace pcpp
 		hexStringToByteArray(m_Value, rawValue.data(), rawValueSize);
 		return rawValue;
 	}
-
-	Asn1UTF8StringRecord::Asn1UTF8StringRecord(const std::string& value) : Asn1StringRecord(value, Asn1UniversalTagType::UTF8String)
-	{}
-
-	Asn1PrintableStringRecord::Asn1PrintableStringRecord(const std::string& value) : Asn1StringRecord(value, Asn1UniversalTagType::PrintableString)
-	{}
 
 	Asn1BooleanRecord::Asn1BooleanRecord(bool value) : Asn1PrimitiveRecord(Asn1UniversalTagType::Boolean)
 	{

--- a/Tests/Packet++Test/Tests/Asn1Tests.cpp
+++ b/Tests/Packet++Test/Tests/Asn1Tests.cpp
@@ -173,7 +173,6 @@ PTF_TEST_CASE(Asn1DecodingTest)
 
 	// OctetString with non-printable value
 	{
-		std::cout << "START TEST" << std::endl;
 		uint8_t data[20];
 		auto dataLen = pcpp::hexStringToByteArray("04083006020201f40400", data, 20);
 		auto record = pcpp::Asn1Record::decode(data, dataLen);
@@ -185,7 +184,36 @@ PTF_TEST_CASE(Asn1DecodingTest)
 		PTF_ASSERT_EQUAL(record->getValueLength(), 8);
 		PTF_ASSERT_EQUAL(record->castAs<pcpp::Asn1OctetStringRecord>()->getValue(), "3006020201f40400");
 		PTF_ASSERT_EQUAL(record->toString(), "OctetString, Length: 2+8, Value: 3006020201f40400");
-		std::cout << "END TEST" << std::endl;
+	}
+
+	// UTF8String
+	{
+		uint8_t data[32];
+		auto dataLen = pcpp::hexStringToByteArray("0c1ce0a4b8e0a4bee0a4a7e0a4bee0a4b0e0a4a320e0a4a8e0a4bee0a4ae", data, 32);
+		auto record = pcpp::Asn1Record::decode(data, dataLen);
+
+		PTF_ASSERT_EQUAL(record->getTagClass(), pcpp::Asn1TagClass::Universal, enumclass);
+		PTF_ASSERT_FALSE(record->isConstructed());
+		PTF_ASSERT_EQUAL(record->getUniversalTagType(), pcpp::Asn1UniversalTagType::UTF8String, enumclass);
+		PTF_ASSERT_EQUAL(record->getTotalLength(), 30);
+		PTF_ASSERT_EQUAL(record->getValueLength(), 28);
+		PTF_ASSERT_EQUAL(record->castAs<pcpp::Asn1UTF8StringRecord>()->getValue(), "साधारण नाम");
+		PTF_ASSERT_EQUAL(record->toString(), "UTF8String, Length: 2+28, Value: साधारण नाम");
+	}
+
+	// PrintableString
+	{
+		uint8_t data[20];
+		auto dataLen = pcpp::hexStringToByteArray("13027573", data, 20);
+		auto record = pcpp::Asn1Record::decode(data, dataLen);
+
+		PTF_ASSERT_EQUAL(record->getTagClass(), pcpp::Asn1TagClass::Universal, enumclass);
+		PTF_ASSERT_FALSE(record->isConstructed());
+		PTF_ASSERT_EQUAL(record->getUniversalTagType(), pcpp::Asn1UniversalTagType::PrintableString, enumclass);
+		PTF_ASSERT_EQUAL(record->getTotalLength(), 4);
+		PTF_ASSERT_EQUAL(record->getValueLength(), 2);
+		PTF_ASSERT_EQUAL(record->castAs<pcpp::Asn1PrintableStringRecord>()->getValue(), "us");
+		PTF_ASSERT_EQUAL(record->toString(), "PrintableString, Length: 2+2, Value: us");
 	}
 
 	// Null
@@ -755,6 +783,44 @@ PTF_TEST_CASE(Asn1EncodingTest)
 
 		uint8_t data[20];
 		auto dataLen = pcpp::hexStringToByteArray("0411737562736368656d61537562656e747279", data, 20);
+
+		auto encodedValue = record.encode();
+		PTF_ASSERT_EQUAL(encodedValue.size(), dataLen);
+		PTF_ASSERT_BUF_COMPARE(encodedValue.data(), data, dataLen)
+	}
+
+	// UTF8String
+	{
+		pcpp::Asn1UTF8StringRecord record("साधारण नाम");
+
+		PTF_ASSERT_EQUAL(record.getTagClass(), pcpp::Asn1TagClass::Universal, enumclass);
+		PTF_ASSERT_FALSE(record.isConstructed());
+		PTF_ASSERT_EQUAL(record.getUniversalTagType(), pcpp::Asn1UniversalTagType::UTF8String, enumclass);
+		PTF_ASSERT_EQUAL(record.getTotalLength(), 30);
+		PTF_ASSERT_EQUAL(record.getValueLength(), 28);
+		PTF_ASSERT_EQUAL(record.getValue(), "साधारण नाम");
+
+		uint8_t data[32];
+		auto dataLen = pcpp::hexStringToByteArray("0c1ce0a4b8e0a4bee0a4a7e0a4bee0a4b0e0a4a320e0a4a8e0a4bee0a4ae", data, 32);
+
+		auto encodedValue = record.encode();
+		PTF_ASSERT_EQUAL(encodedValue.size(), dataLen);
+		PTF_ASSERT_BUF_COMPARE(encodedValue.data(), data, dataLen)
+	}
+
+	// PrintableString
+	{
+		pcpp::Asn1PrintableStringRecord record("us");
+
+		PTF_ASSERT_EQUAL(record.getTagClass(), pcpp::Asn1TagClass::Universal, enumclass);
+		PTF_ASSERT_FALSE(record.isConstructed());
+		PTF_ASSERT_EQUAL(record.getUniversalTagType(), pcpp::Asn1UniversalTagType::PrintableString, enumclass);
+		PTF_ASSERT_EQUAL(record.getTotalLength(), 4);
+		PTF_ASSERT_EQUAL(record.getValueLength(), 2);
+		PTF_ASSERT_EQUAL(record.getValue(), "us");
+
+		uint8_t data[20];
+		auto dataLen = pcpp::hexStringToByteArray("13027573", data, 20);
 
 		auto encodedValue = record.encode();
 		PTF_ASSERT_EQUAL(encodedValue.size(), dataLen);

--- a/Tests/Packet++Test/Tests/Asn1Tests.cpp
+++ b/Tests/Packet++Test/Tests/Asn1Tests.cpp
@@ -173,6 +173,7 @@ PTF_TEST_CASE(Asn1DecodingTest)
 
 	// OctetString with non-printable value
 	{
+		std::cout << "START TEST" << std::endl;
 		uint8_t data[20];
 		auto dataLen = pcpp::hexStringToByteArray("04083006020201f40400", data, 20);
 		auto record = pcpp::Asn1Record::decode(data, dataLen);
@@ -184,6 +185,7 @@ PTF_TEST_CASE(Asn1DecodingTest)
 		PTF_ASSERT_EQUAL(record->getValueLength(), 8);
 		PTF_ASSERT_EQUAL(record->castAs<pcpp::Asn1OctetStringRecord>()->getValue(), "3006020201f40400");
 		PTF_ASSERT_EQUAL(record->toString(), "OctetString, Length: 2+8, Value: 3006020201f40400");
+		std::cout << "END TEST" << std::endl;
 	}
 
 	// Null


### PR DESCRIPTION
As part of https://github.com/seladb/PcapPlusPlus/issues/1835, X509 certificates require support for ASN.1 records of types `UTF8String`, `PrintableString` and  `IA5String`

- Create an abstract template base class `Asn1StringRecord`
- Refactor `Asn1OctetStringRecord` to inherit from `Asn1StringRecord`
- Create the new record classes: `Asn1UTF8StringRecord`, `Asn1PrintableStringRecord`, `Asn1IA5StringRecord`