### PR TITLE
CI: windows, remove 2019, add 2025

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -579,11 +579,11 @@ jobs:
       matrix:
         include:
           - os: "windows-2025"
-            platform: "Visual Studio 16 2019"
+            platform: "Visual Studio 17 2022"
             arch: "x64"
             pcap_lib: "npcap"
           - os: windows-2025
-            platform: "Visual Studio 16 2019"
+            platform: "Visual Studio 17 2022"
             arch: Win32
             pcap_lib: "winpcap"
           - os: windows-2022

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -581,12 +581,12 @@ jobs:
           - os: windows-2025
             platform: "Visual Studio 17 2022"
             arch: Win32
-            pcap_lib: "winpcap"
+            pcap_lib: "npcap"
           - os: windows-2025
             platform: "Visual Studio 17 2022"
             arch: "x64"
             pcap_lib: "winpcap"
-          - os: windows-2025
+          - os: windows-2022
             platform: "Visual Studio 17 2022"
             arch: "x64"
             pcap_lib: "npcap"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -578,11 +578,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: "windows-2019"
+          - os: "windows-2025"
             platform: "Visual Studio 16 2019"
             arch: "x64"
             pcap_lib: "npcap"
-          - os: windows-2019
+          - os: windows-2025
             platform: "Visual Studio 16 2019"
             arch: Win32
             pcap_lib: "winpcap"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -578,19 +578,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: "windows-2025"
-            platform: "Visual Studio 17 2022"
-            arch: "x64"
-            pcap_lib: "npcap"
           - os: windows-2025
             platform: "Visual Studio 17 2022"
             arch: Win32
             pcap_lib: "winpcap"
-          - os: windows-2022
+          - os: windows-2025
             platform: "Visual Studio 17 2022"
             arch: "x64"
             pcap_lib: "winpcap"
-          - os: windows-2022
+          - os: windows-2025
             platform: "Visual Studio 17 2022"
             arch: "x64"
             pcap_lib: "npcap"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -266,7 +266,7 @@ jobs:
   visual-studio:
     strategy:
       matrix:
-        os: [ windows-2019, windows-2022 ]
+        os: [ windows-2025, windows-2022 ]
         arch: [ Win32, x64 ]
         configuration: [ Debug, Release ]
 
@@ -289,7 +289,7 @@ jobs:
 
       - name: Configure PcapPlusPlus
         run: |
-          $platform = if ("${{ matrix.os }}" -eq "windows-2019") { "Visual Studio 16 2019" } else { "Visual Studio 17 2022" }
+          $platform = "Visual Studio 17 2022"
           cmake -A ${{ matrix.arch }} -G "$platform" -DPCAP_ROOT=${{ env.PCAP_SDK_DIR }} -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -DPCAPPP_PACKAGE=ON -S . -B "$env:BUILD_DIR"
 
       - name: Build PcapPlusPlus

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -266,7 +266,7 @@ jobs:
   visual-studio:
     strategy:
       matrix:
-        os: [ windows-2025, windows-2022 ]
+        os: [ windows-2025 ]
         arch: [ Win32, x64 ]
         configuration: [ Debug, Release ]
 

--- a/cmake/package/READMEs/README.release.win.vs
+++ b/cmake/package/READMEs/README.release.win.vs
@@ -24,8 +24,8 @@ In order to compile your application with these binaries you need to:
  - In addition make sure that the package you downloaded matches the configuration you need: Win32 / x64 and Debug / Release
  - Make sure you have WinPcap or Npcap Developer's pack installed (WinPcap Dev Pack can be downloaded from https://www.winpcap.org/devel.htm, Npcap SDK can be downloaded from https://nmap.org/npcap/#download)
  - If your application uses CMake, you can add `PcapPlusPlus_ROOT=<PACKAGE_DIR>`, `PCAP_ROOT=<WinPcap_OR_Npcap_DIR>` and `Packet_ROOT=<WinPcap_OR_Npcap_DIR>``
-   when running CMake. For example: if you downloaded the package for VS 2019, x64 and Release, you need to run the following commands:
-   - `cmake -A x64 -G "Visual Studio 16 2019"  -S . -B build -DPcapPlusPlus_ROOT=<PACKAGE_DIR> -DPCAP_ROOT=<WinPcap_OR_Npcap_DIR> -DPacket_ROOT=<WinPcap_OR_Npcap_DIR>`
+   when running CMake. For example: if you downloaded the package for VS 2022, x64 and Release, you need to run the following commands:
+   - `cmake -A x64 -G "Visual Studio 17 2022"  -S . -B build -DPcapPlusPlus_ROOT=<PACKAGE_DIR> -DPCAP_ROOT=<WinPcap_OR_Npcap_DIR> -DPacket_ROOT=<WinPcap_OR_Npcap_DIR>`
    - `cmake --build build --config Release`
 
 


### PR DESCRIPTION
The windows-2019 runner image is being deprecated, consider switching to windows-2022(windows-latest) or windows-2025 instead. For more details see https://github.com/actions/runner-images/issues/12045.