### PR TITLE
Added a warning log level.

### DIFF
--- a/Common++/header/Logger.h
+++ b/Common++/header/Logger.h
@@ -27,8 +27,9 @@
 // Allows for conditional removal of unwanted log calls at compile time.
 #define PCPP_LOG_LEVEL_OFF 0
 #define PCPP_LOG_LEVEL_ERROR 1
-#define PCPP_LOG_LEVEL_INFO 2
-#define PCPP_LOG_LEVEL_DEBUG 3
+#define PCPP_LOG_LEVEL_WARN 2
+#define PCPP_LOG_LEVEL_INFO 3
+#define PCPP_LOG_LEVEL_DEBUG 4
 
 // All log messages built via a PCPP_LOG_* macro below the PCPP_ACTIVE_LOG_LEVEL will be removed at compile time.
 // Uses the PCPP_ACTIVE_LOG_LEVEL if it is defined, otherwise defaults to PCAP_LOG_LEVEL_DEBUG
@@ -146,6 +147,7 @@ namespace pcpp
 	{
 		Off = PCPP_LOG_LEVEL_OFF,      ///< No log messages are emitted.
 		Error = PCPP_LOG_LEVEL_ERROR,  ///< Error level logs are emitted.
+		Warn = PCPP_LOG_LEVEL_WARN,    ///< Warning level logs and above are emitted.
 		Info = PCPP_LOG_LEVEL_INFO,    ///< Info level logs and above are emitted.
 		Debug = PCPP_LOG_LEVEL_DEBUG   ///< Debug level logs and above are emitted.
 	};
@@ -428,6 +430,12 @@ namespace pcpp
 #	define PCPP_LOG_DEBUG(message) PCPP_LOG(pcpp::LogLevel::Debug, message)
 #else
 #	define PCPP_LOG_DEBUG(message) (void)0
+#endif
+
+#if PCPP_ACTIVE_LOG_LEVEL >= PCPP_LOG_LEVEL_WARN
+#	define PCPP_LOG_WARN(message) PCPP_LOG(pcpp::LogLevel::Warn, message)
+#else
+#	define PCPP_LOG_WARN(message) (void)0
 #endif
 
 #if PCPP_ACTIVE_LOG_LEVEL >= PCPP_LOG_LEVEL_INFO

--- a/Tests/Pcap++Test/Tests/LoggerTests.cpp
+++ b/Tests/Pcap++Test/Tests/LoggerTests.cpp
@@ -11,9 +11,18 @@
 
 namespace pcpp
 {
+#define PCPP_TEST_EXPECTED_DEBUG_LOG_LINE 20
+#define PCPP_TEST_EXPECTED_WARN_LOG_LINE 25
+#define PCPP_TEST_EXPECTED_ERROR_LOG_LINE 30
+
 	void invokeDebugLog()
 	{
 		PCPP_LOG_DEBUG("debug log");
+	}
+
+	void invokeWarnLog(const std::string& message = "")
+	{
+		PCPP_LOG_WARN("warn log" << message);
 	}
 
 	void invokeErrorLog(const std::string& message = "")
@@ -208,6 +217,7 @@ PTF_TEST_CASE(TestLogger)
 		PTF_ASSERT_FALSE(logger.isDebugEnabled(moduleEnum));
 
 		PTF_ASSERT_TRUE(logger.shouldLog(LogLevel::Error, moduleEnum));
+		PTF_ASSERT_TRUE(logger.shouldLog(LogLevel::Warn, moduleEnum));
 		PTF_ASSERT_TRUE(logger.shouldLog(LogLevel::Info, moduleEnum));
 		PTF_ASSERT_FALSE(logger.shouldLog(LogLevel::Debug, moduleEnum));
 		PTF_ASSERT_FALSE(logger.shouldLog(LogLevel::Off, moduleEnum));
@@ -224,31 +234,38 @@ PTF_TEST_CASE(TestLogger)
 	PTF_ASSERT_NULL(LogPrinter::lastMethodSeen);
 
 	pcpp::invokeErrorLog();
-	PTF_ASSERT_EQUAL(LogPrinter::lastLogLevelSeen, (int)pcpp::Logger::Error);
+	PTF_ASSERT_EQUAL(LogPrinter::lastLogLevelSeen, (int)LogLevel::Error);
 	PTF_ASSERT_EQUAL(*LogPrinter::lastLogMessageSeen, "error log");
 	PTF_ASSERT_EQUAL(getLowerCaseFileName(*LogPrinter::lastFilenameSeen), "loggertests.cpp");
 	PTF_ASSERT_EQUAL(getMethodWithoutNamespace(*LogPrinter::lastMethodSeen), "invokeErrorLog");
-	PTF_ASSERT_EQUAL(LogPrinter::lastLineSeen, 21);
+	PTF_ASSERT_EQUAL(LogPrinter::lastLineSeen, PCPP_TEST_EXPECTED_ERROR_LOG_LINE);
 
 	// change one module log level
-	logger.setLogLevel(pcpp::PacketLogModuleArpLayer, pcpp::Logger::Debug);
+	logger.setLogLevel(pcpp::PacketLogModuleArpLayer, LogLevel::Debug);
 	PTF_ASSERT_EQUAL(logger.getLogLevel(pcpp::PacketLogModuleArpLayer), pcpp::LogLevel::Debug, enum);
 	PTF_ASSERT_TRUE(logger.isDebugEnabled(pcpp::PacketLogModuleArpLayer));
 
-	// invoke debug and error logs - expect to see both
+	// invoke debug, warn and error logs - expect to see all
 	pcpp::invokeDebugLog();
-	PTF_ASSERT_EQUAL(LogPrinter::lastLogLevelSeen, (int)pcpp::Logger::Debug);
+	PTF_ASSERT_EQUAL(LogPrinter::lastLogLevelSeen, (int)LogLevel::Debug);
 	PTF_ASSERT_EQUAL(*LogPrinter::lastLogMessageSeen, "debug log");
 	PTF_ASSERT_EQUAL(getLowerCaseFileName(*LogPrinter::lastFilenameSeen), "loggertests.cpp");
 	PTF_ASSERT_EQUAL(getMethodWithoutNamespace(*LogPrinter::lastMethodSeen), "invokeDebugLog");
-	PTF_ASSERT_EQUAL(LogPrinter::lastLineSeen, 16);
+	PTF_ASSERT_EQUAL(LogPrinter::lastLineSeen, PCPP_TEST_EXPECTED_DEBUG_LOG_LINE);
+
+	pcpp::invokeWarnLog();
+	PTF_ASSERT_EQUAL(LogPrinter::lastLogLevelSeen, (int)LogLevel::Warn);
+	PTF_ASSERT_EQUAL(*LogPrinter::lastLogMessageSeen, "warn log");
+	PTF_ASSERT_EQUAL(getLowerCaseFileName(*LogPrinter::lastFilenameSeen), "loggertests.cpp");
+	PTF_ASSERT_EQUAL(getMethodWithoutNamespace(*LogPrinter::lastMethodSeen), "invokeWarnLog");
+	PTF_ASSERT_EQUAL(LogPrinter::lastLineSeen, PCPP_TEST_EXPECTED_WARN_LOG_LINE);
 
 	pcpp::invokeErrorLog();
-	PTF_ASSERT_EQUAL(LogPrinter::lastLogLevelSeen, (int)pcpp::Logger::Error);
+	PTF_ASSERT_EQUAL(LogPrinter::lastLogLevelSeen, (int)LogLevel::Error);
 	PTF_ASSERT_EQUAL(*LogPrinter::lastLogMessageSeen, "error log");
 	PTF_ASSERT_EQUAL(getLowerCaseFileName(*LogPrinter::lastFilenameSeen), "loggertests.cpp");
 	PTF_ASSERT_EQUAL(getMethodWithoutNamespace(*LogPrinter::lastMethodSeen), "invokeErrorLog");
-	PTF_ASSERT_EQUAL(LogPrinter::lastLineSeen, 21);
+	PTF_ASSERT_EQUAL(LogPrinter::lastLineSeen, PCPP_TEST_EXPECTED_ERROR_LOG_LINE);
 
 	// verify the last error message
 	PTF_ASSERT_EQUAL(logger.getLastError(), "error log");
@@ -263,6 +280,7 @@ PTF_TEST_CASE(TestLogger)
 		PTF_ASSERT_TRUE(logger.isDebugEnabled(static_cast<LogModule>(moduleEnum)));
 
 		PTF_ASSERT_TRUE(logger.shouldLog(LogLevel::Error, moduleEnum));
+		PTF_ASSERT_TRUE(logger.shouldLog(LogLevel::Warn, moduleEnum));
 		PTF_ASSERT_TRUE(logger.shouldLog(LogLevel::Info, moduleEnum));
 		PTF_ASSERT_TRUE(logger.shouldLog(LogLevel::Debug, moduleEnum));
 		PTF_ASSERT_FALSE(logger.shouldLog(LogLevel::Off, moduleEnum));
@@ -274,7 +292,7 @@ PTF_TEST_CASE(TestLogger)
 	PTF_ASSERT_EQUAL(*LogPrinter::lastLogMessageSeen, "debug log");
 	PTF_ASSERT_EQUAL(getLowerCaseFileName(*LogPrinter::lastFilenameSeen), "loggertests.cpp");
 	PTF_ASSERT_EQUAL(getMethodWithoutNamespace(*LogPrinter::lastMethodSeen), "invokeDebugLog");
-	PTF_ASSERT_EQUAL(LogPrinter::lastLineSeen, 16);
+	PTF_ASSERT_EQUAL(LogPrinter::lastLineSeen, PCPP_TEST_EXPECTED_DEBUG_LOG_LINE);
 
 	// suppress logs
 	PTF_ASSERT_TRUE(logger.logsEnabled())
@@ -305,7 +323,7 @@ PTF_TEST_CASE(TestLogger)
 	PTF_ASSERT_EQUAL(getLowerCaseFileName(*LogPrinter::lastFilenameSeen), "loggertests.cpp");
 	PTF_ASSERT_EQUAL(getMethodWithoutNamespace(*LogPrinter::lastMethodSeen), "invokeErrorLog");
 	PTF_ASSERT_EQUAL(logger.getLastError(), "error log");
-	PTF_ASSERT_EQUAL(LogPrinter::lastLineSeen, 21);
+	PTF_ASSERT_EQUAL(LogPrinter::lastLineSeen, PCPP_TEST_EXPECTED_ERROR_LOG_LINE);
 
 	// reset LogPrinter
 	LogPrinter::clean();


### PR DESCRIPTION
Split of #1845

This PR adds a Warn log level that sits between ERROR and INFO and can be used to signalize non-critical issues in the runtime.