### PR TITLE
PcapSplitter - fix a bug when splitting by UDP connections

### DIFF
--- a/Examples/PcapSplitter/ConnectionSplitters.h
+++ b/Examples/PcapSplitter/ConnectionSplitters.h
@@ -199,8 +199,17 @@ public:
 			if (udpLayer != nullptr)
 			{
 				sstream << "udp_";
-				updateStringStream(sstream, getSrcIPString(packet), udpLayer->getSrcPort(), getDstIPString(packet),
-				                   udpLayer->getDstPort());
+
+				auto srcPort = udpLayer->getSrcPort();
+				auto dstPort = udpLayer->getDstPort();
+
+				uint16_t firstPort = srcPort < dstPort ? srcPort : dstPort;
+				uint16_t secondPort = srcPort < dstPort ? dstPort : srcPort;
+
+				std::string firstIP = (srcPort < dstPort) ? getSrcIPString(packet) : getDstIPString(packet);
+				std::string secondIP = (srcPort < dstPort) ? getDstIPString(packet) : getSrcIPString(packet);
+
+				updateStringStream(sstream, firstIP, firstPort, secondIP, secondPort);
 				return outputPcapBasePath + sstream.str();
 			}
 		}

--- a/Examples/PcapSplitter/ConnectionSplitters.h
+++ b/Examples/PcapSplitter/ConnectionSplitters.h
@@ -203,11 +203,11 @@ public:
 				auto srcPort = udpLayer->getSrcPort();
 				auto dstPort = udpLayer->getDstPort();
 
-				uint16_t firstPort = srcPort < dstPort ? srcPort : dstPort;
-				uint16_t secondPort = srcPort < dstPort ? dstPort : srcPort;
+				uint16_t firstPort = srcPort < dstPort ? dstPort : srcPort;
+				uint16_t secondPort = srcPort < dstPort ? srcPort : dstPort;
 
-				std::string firstIP = (srcPort < dstPort) ? getSrcIPString(packet) : getDstIPString(packet);
-				std::string secondIP = (srcPort < dstPort) ? getDstIPString(packet) : getSrcIPString(packet);
+				std::string firstIP = (srcPort < dstPort) ? getDstIPString(packet) : getSrcIPString(packet);
+				std::string secondIP = (srcPort < dstPort) ? getSrcIPString(packet) : getDstIPString(packet);
 
 				updateStringStream(sstream, firstIP, firstPort, secondIP, secondPort);
 				return outputPcapBasePath + sstream.str();


### PR DESCRIPTION
Fixes https://github.com/seladb/PcapPlusPlus/issues/1870, the issue is:
- PcapSplitter only keeps up to 250 files open to avoid maintaining to many file handlers
- When it reaches the limit it closes the LRU file
- If a packet arrives on a connection whose file is already closed, it will reopen the file in append mode
- In this example, it was a UDP flow, so there are no clear src and dst ports. The file was initially opened with the name of `udp_src_ip_src_port_dst_ip_dst_port.pcap`, then closed, and when a new packet came on this flow, it had the opposite IP/ports, so it tried to reopen a file `udp_dst_ip_dst_port_src_ip_src_port.pcap` which didn't exist
- The fix is to always open/reopen the files with a name that has the highest port first and the lowest port later