### PR TITLE
Extracted protocol to protocol family check to standalone function.

### DIFF
--- a/Packet++/header/ProtocolType.h
+++ b/Packet++/header/ProtocolType.h
@@ -240,4 +240,18 @@ namespace pcpp
 		/// Unknown / null layer
 		OsiModelLayerUnknown = 8
 	};
+
+	namespace internal
+	{
+		/// @brief Check if a protocol family contains a specific protocol
+		/// @param family A protocol type family value.
+		/// @param protocol A protocol type value to check against the family.
+		/// @return True if the protocol is part of the family, false otherwise.
+		constexpr bool protoFamilyContainsProtocol(ProtocolTypeFamily family, ProtocolType protocol)
+		{
+			auto const protocolToFamily = static_cast<ProtocolTypeFamily>(protocol);
+			return (protocolToFamily == (family & 0xff) || protocolToFamily << 8 == (family & 0xff00) ||
+			        protocolToFamily << 16 == (family & 0xff0000) || protocolToFamily << 24 == (family & 0xff000000));
+		}
+	}  // namespace internal
 }  // namespace pcpp

--- a/Packet++/src/Layer.cpp
+++ b/Packet++/src/Layer.cpp
@@ -45,11 +45,7 @@ namespace pcpp
 
 	bool Layer::isMemberOfProtocolFamily(ProtocolTypeFamily protocolTypeFamily) const
 	{
-		auto protocolToFamily = static_cast<ProtocolTypeFamily>(m_Protocol);
-		return (m_Protocol != UnknownProtocol && (protocolToFamily == (protocolTypeFamily & 0xff) ||
-		                                          protocolToFamily << 8 == (protocolTypeFamily & 0xff00) ||
-		                                          protocolToFamily << 16 == (protocolTypeFamily & 0xff0000) ||
-		                                          protocolToFamily << 24 == (protocolTypeFamily & 0xff000000)));
+		return m_Protocol != UnknownProtocol && internal::protoFamilyContainsProtocol(protocolTypeFamily, m_Protocol);
 	}
 
 	void Layer::copyData(uint8_t* toArr) const


### PR DESCRIPTION
This PR extracts the logic for matching a ProtocolType against a packet ProtocolTypeFamily value into a separate function to allow reusablity.