### PR TITLE
Update Npcap-0.96 location

### DIFF
--- a/ci/install_npcap.bat
+++ b/ci/install_npcap.bat
@@ -3,7 +3,7 @@ if defined NPCAP_USERNAME set /A NPCAP_OEM_CREDENTIALS_DEFINED=NPCAP_OEM_CREDENT
 if defined NPCAP_PASSWORD set /A NPCAP_OEM_CREDENTIALS_DEFINED=NPCAP_OEM_CREDENTIALS_DEFINED+1
 
 if "%NPCAP_OEM_CREDENTIALS_DEFINED%"=="2" (
-	set NPCAP_FILE=npcap-1.60-oem.exe
+	set NPCAP_FILE=npcap-0.96.exe
 ) else (
 	:: Silent mode is disabled for newer non-oem version
 	set NPCAP_FILE=npcap-0.96.exe
@@ -11,10 +11,10 @@ if "%NPCAP_OEM_CREDENTIALS_DEFINED%"=="2" (
 
 if "%NPCAP_OEM_CREDENTIALS_DEFINED%"=="2" (
 	echo Using Npcap OEM version %NPCAP_FILE%
-	curl -L --digest --user %NPCAP_USERNAME%:%NPCAP_PASSWORD% https://npcap.com/oem/dist/%NPCAP_FILE% --output %NPCAP_FILE%
+	curl -L https://raw.githubusercontent.com/seladb/PcapPlusPlus-Deploy/refs/heads/master/Packages/%NPCAP_FILE% --output %NPCAP_FILE%
 ) else (
 	echo Using Npcap free version %NPCAP_FILE%
-	curl -L https://npcap.com/dist/%NPCAP_FILE% --output %NPCAP_FILE%
+	curl -L https://raw.githubusercontent.com/seladb/PcapPlusPlus-Deploy/refs/heads/master/Packages/%NPCAP_FILE% --output %NPCAP_FILE%
 )
 
 %NPCAP_FILE% /S /winpcap_mode

--- a/ci/install_npcap.bat
+++ b/ci/install_npcap.bat
@@ -3,7 +3,7 @@ if defined NPCAP_USERNAME set /A NPCAP_OEM_CREDENTIALS_DEFINED=NPCAP_OEM_CREDENT
 if defined NPCAP_PASSWORD set /A NPCAP_OEM_CREDENTIALS_DEFINED=NPCAP_OEM_CREDENTIALS_DEFINED+1
 
 if "%NPCAP_OEM_CREDENTIALS_DEFINED%"=="2" (
-	set NPCAP_FILE=npcap-0.96.exe
+	set NPCAP_FILE=npcap-1.60-oem.exe
 ) else (
 	:: Silent mode is disabled for newer non-oem version
 	set NPCAP_FILE=npcap-0.96.exe
@@ -11,7 +11,7 @@ if "%NPCAP_OEM_CREDENTIALS_DEFINED%"=="2" (
 
 if "%NPCAP_OEM_CREDENTIALS_DEFINED%"=="2" (
 	echo Using Npcap OEM version %NPCAP_FILE%
-	curl -L https://raw.githubusercontent.com/seladb/PcapPlusPlus-Deploy/refs/heads/master/Packages/%NPCAP_FILE% --output %NPCAP_FILE%
+	curl -L --digest --user %NPCAP_USERNAME%:%NPCAP_PASSWORD% https://npcap.com/oem/dist/%NPCAP_FILE%
 ) else (
 	echo Using Npcap free version %NPCAP_FILE%
 	curl -L https://raw.githubusercontent.com/seladb/PcapPlusPlus-Deploy/refs/heads/master/Packages/%NPCAP_FILE% --output %NPCAP_FILE%

--- a/ci/install_npcap.bat
+++ b/ci/install_npcap.bat
@@ -11,7 +11,7 @@ if "%NPCAP_OEM_CREDENTIALS_DEFINED%"=="2" (
 
 if "%NPCAP_OEM_CREDENTIALS_DEFINED%"=="2" (
 	echo Using Npcap OEM version %NPCAP_FILE%
-	curl -L --digest --user %NPCAP_USERNAME%:%NPCAP_PASSWORD% https://npcap.com/oem/dist/%NPCAP_FILE%
+	curl -L --digest --user %NPCAP_USERNAME%:%NPCAP_PASSWORD% https://npcap.com/oem/dist/%NPCAP_FILE% --output %NPCAP_FILE%
 ) else (
 	echo Using Npcap free version %NPCAP_FILE%
 	curl -L https://raw.githubusercontent.com/seladb/PcapPlusPlus-Deploy/refs/heads/master/Packages/%NPCAP_FILE% --output %NPCAP_FILE%


### PR DESCRIPTION
Npcap 0.96 is the last non-OEM version that had a silent installer. This version is used in CI for forked repos who don't have access to the repo's secret and can't download Npcap OEM version.

Npcap 0.96 was recently removed from Npcap website, so we now host it ourselves: https://github.com/seladb/PcapPlusPlus-Deploy/blob/master/Packages/npcap-0.96.exe