### PR TITLE
Updated Logger to use `std::function`

### DIFF
--- a/Common++/header/Logger.h
+++ b/Common++/header/Logger.h
@@ -246,9 +246,8 @@ namespace pcpp
 		/// @param[in] method The method in PcapPlusPlus code the log message is coming from
 		/// @param[in] line The line in PcapPlusPlus code the log message is coming from
 		/// @remarks The printer callback should support being called from multiple threads simultaneously.
-		using LogPrinter =
-		    std::function<void(LogLevel logLevel, const std::string& logMessage, const std::string& file,
-		                       const std::string& method, const int line)>;
+		using LogPrinter = std::function<void(LogLevel logLevel, const std::string& logMessage, const std::string& file,
+		                                      const std::string& method, const int line)>;
 
 		/// A static method for converting the log level enum to a string.
 		/// @param[in] logLevel A log level enum

--- a/Common++/header/Logger.h
+++ b/Common++/header/Logger.h
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <ostream>
 #include <sstream>
+#include <functional>
 #include "DeprecationUtils.h"
 #include "ObjectPool.h"
 
@@ -245,9 +246,8 @@ namespace pcpp
 		/// @param[in] method The method in PcapPlusPlus code the log message is coming from
 		/// @param[in] line The line in PcapPlusPlus code the log message is coming from
 		/// @remarks The printer callback should support being called from multiple threads simultaneously.
-		using LogPrinter =
-		    std::add_pointer<void(LogLevel logLevel, const std::string& logMessage, const std::string& file,
-		                          const std::string& method, const int line)>::type;
+		using LogPrinter = std::function<void(LogLevel logLevel, const std::string& logMessage, const std::string& file,
+		                                      const std::string& method, const int line)>;
 
 		/// A static method for converting the log level enum to a string.
 		/// @param[in] logLevel A log level enum


### PR DESCRIPTION
This PR updates `pcpp::Logger::LogPrinter` to alias to `std::function<void(...)>` from `std::add_pointer_t<void(...)>`.

Micro benchmarking found no noticeable performance drop from the change.

In the benchmarks the print function was replaced with an int accumulator function to avoid variance due to console IO.
```cpp
volatile int dummy = 0;

static void printer(pcpp::LogLevel logLevel, const std::string& logMessage, const std::string& file,
                    const std::string& method, int line)
{
	benchmark::DoNotOptimize(logLevel);
	dummy++;
}
```

Run on (16 X 4700 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 1024 KiB (x8)
  L3 Unified 98304 KiB (x1)
Windows 11 x64, MSVC Release Build

| Test Run | Time | CPU Time | Iterations |
| ------------- | ------------- | ------------- | ------------- |
| Func Pointer N1 | 223 ns | 220 ns | 2986667 |
| Func Pointer N2 | 225 ns | 225 ns | 3200000 |
| Func Pointer N3 | 226 ns | 220 ns | 3200000 |
| Func Pointer N4 | 223 ns | 225 ns | 3200000 |
| std::function N1 | 225 ns | 225 ns | 3200000 |
| std::function N2 | 224 ns | 225 ns | 2986667 |
| std::function N3 | 224 ns | 220 ns | 3200000 |
| std::function N4 | 226 ns | 225 ns | 2986667 |

