### PR TITLE
Disabled concurrency cancellation for master and dev branch.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,7 +18,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !(github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev') }}
 
 jobs:
   pre-commit:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !(github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev') }}
 
 jobs:
   Fuzzing:

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !(github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev') }}
 
 jobs:
   doxygen:


### PR DESCRIPTION
This PR updates the `cancel-in-progress` token to evaluate to false on the `master` and `dev` branches to allow full CI coverage when multiple PRs are merged in short succession.