### PR TITLE
Add `RawPacketBase` as common base class between raw packet implementations.

### DIFF
--- a/Packet++/header/RawPacket.h
+++ b/Packet++/header/RawPacket.h
@@ -264,11 +264,11 @@ namespace pcpp
 			/// @brief A constructor that initializes the timestamp and link layer type.
 			/// @param[in] timestamp The timestamp packet was received by the NIC (in nsec precision)
 			/// @param[in] linkLayerType The link layer type of the packet, defaulting to Ethernet.
-			RawPacketBase(timespec timestamp, LinkLayerType linkLayerType = LinkLayerType::LINKTYPE_ETHERNET);
+			explicit RawPacketBase(timespec timestamp, LinkLayerType linkLayerType = LinkLayerType::LINKTYPE_ETHERNET);
 			/// @brief A constructor that initializes the timestamp and link layer type.
 			/// @param[in] timestamp The timestamp packet was received by the NIC (in usec precision)
 			/// @param[in] linkLayerType The link layer type of the packet, defaulting to Ethernet.
-			RawPacketBase(timeval timestamp, LinkLayerType linkLayerType = LinkLayerType::LINKTYPE_ETHERNET);
+			explicit RawPacketBase(timeval timestamp, LinkLayerType linkLayerType = LinkLayerType::LINKTYPE_ETHERNET);
 
 			// Copy and move constructors and assignment operators are protected to prevent slicing
 			RawPacketBase(const RawPacketBase&) = default;

--- a/Pcap++/src/MBufRawPacket.cpp
+++ b/Pcap++/src/MBufRawPacket.cpp
@@ -217,10 +217,10 @@ namespace pcpp
 		m_RawDataLen = rte_pktmbuf_pkt_len(m_MBuf);
 		memcpy(m_RawData, pRawData, m_RawDataLen);
 		delete[] pRawData;
-		m_TimeStamp = timestamp;
+		setPacketTimeStamp(timestamp);
 		m_RawPacketSet = true;
 		m_FrameLength = frameLength;
-		m_LinkLayerType = layerType;
+		setLinkLayerType(layerType);
 
 		return true;
 	}

--- a/Pcap++/src/MBufRawPacket.cpp
+++ b/Pcap++/src/MBufRawPacket.cpp
@@ -131,7 +131,7 @@ namespace pcpp
 			return;
 		}
 
-		setMBuf(newMbuf, other.m_TimeStamp);
+		setMBuf(newMbuf, other.getPacketTimeStamp());
 
 		m_RawPacketSet = false;
 


### PR DESCRIPTION
Part of #1899

This PR adds a class `RawPacketBase` that is to work as a common base class between `RawPacket` and `MBufRawPacket`.
The current iteration only takes over the management for `timestamp` and `linkLayer` as a minimal example, without defining common API yet.

The class is defined in the `internal` namespace while in development, with the eventual goal to be "published" to the main namespace when complete.