### PR TITLE
Update cppcheck to use cpp14 standard.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         args: ["--style=file", "-i"]  # Use the .clang-format file for configuration and apply all fixes
         files: ^(Common\+\+|Packet\+\+|Pcap\+\+|Tests|Examples)/.*\.(cpp|h)$
       - id: cppcheck
-        args: ["--std=c++11", "--language=c++", "--suppressions-list=cppcheckSuppressions.txt", "--inline-suppr", "--force"]
+        args: ["--std=c++14", "--language=c++", "--suppressions-list=cppcheckSuppressions.txt", "--inline-suppr", "--force"]
   - repo: https://github.com/BlankSpruce/gersemi
     rev: 0.19.3
     hooks:


### PR DESCRIPTION
Pre-commit cppcheck still used cpp11 when the project uses cpp 14 to compile.