### PR TITLE
Added Warn level to cmake compile time log level settings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,11 @@ set(
   "2"
   "3"
   "4"
+  "Off"
+  "Error"
+  "Warn"
+  "Info"
+  "Debug"
 )
 set(
   PCAPPP_LOG_LEVEL
@@ -108,7 +113,23 @@ if(NOT PCAPPP_LOG_LEVEL IN_LIST PCAPP_ALLOWED_LOG_LEVELS)
 endif()
 
 if(PCAPPP_LOG_LEVEL)
-  add_compile_definitions("PCPP_ACTIVE_LOG_LEVEL=${PCAPPP_LOG_LEVEL}")
+  if(PCAPPP_LOG_LEVEL STREQUAL "0" OR PCAPPP_LOG_LEVEL STREQUAL "Off")
+    set(PCAPPP_LOG_LEVEL_VALUE "PCPP_LOG_LEVEL_OFF")
+  elseif(PCAPPP_LOG_LEVEL STREQUAL "1" OR PCAPPP_LOG_LEVEL STREQUAL "Error")
+    set(PCAPPP_LOG_LEVEL_VALUE "PCPP_LOG_LEVEL_ERROR")
+  elseif(PCAPPP_LOG_LEVEL STREQUAL "2" OR PCAPPP_LOG_LEVEL STREQUAL "Warn")
+    set(PCAPPP_LOG_LEVEL_VALUE "PCPP_LOG_LEVEL_WARN")
+  elseif(PCAPPP_LOG_LEVEL STREQUAL "3" OR PCAPPP_LOG_LEVEL STREQUAL "Info")
+    set(PCAPPP_LOG_LEVEL_VALUE "PCPP_LOG_LEVEL_INFO")
+  elseif(PCAPPP_LOG_LEVEL STREQUAL "4" OR PCAPPP_LOG_LEVEL STREQUAL "Debug")
+    set(PCAPPP_LOG_LEVEL_VALUE "PCPP_LOG_LEVEL_DEBUG")
+  endif()
+
+  message(
+    STATUS
+    "Compile time logging verbocity has been set to level \"${PCAPPP_LOG_LEVEL_VALUE}\". All messagess below this level will be pruned."
+  )
+  add_compile_definitions("PCPP_ACTIVE_LOG_LEVEL=${PCAPPP_LOG_LEVEL_VALUE}")
 endif()
 
 # Build options (Turn on Examples and Tests if it's the main project)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ if(PCAPPP_LOG_LEVEL)
 
   message(
     STATUS
-    "Compile time logging verbocity has been set to level \"${PCAPPP_LOG_LEVEL_VALUE}\". All messagess below this level will be pruned."
+    "Compile time logging verbocity has been set to level \"${PCAPPP_LOG_LEVEL_VALUE}\". All messages below this level will be pruned."
   )
   add_compile_definitions("PCPP_ACTIVE_LOG_LEVEL=${PCAPPP_LOG_LEVEL_VALUE}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,12 +93,13 @@ set(
   "1"
   "2"
   "3"
+  "4"
 )
 set(
   PCAPPP_LOG_LEVEL
   ""
   CACHE STRING
-  "Compile time log level (0 - Off, 1 - Error, 2 - Info, 3 - Debug) Default(empty): Debug"
+  "Compile time log level (0 - Off, 1 - Error, 2 - Warn, 3 - Info, 4 - Debug) Default(empty): Debug"
 )
 set_property(CACHE PCAPPP_LOG_LEVEL PROPERTY STRINGS ${PCAPP_ALLOWED_LOG_LEVELS})
 


### PR DESCRIPTION
This PR fixes the mismatch between cmake option for compile time log level and the actual preprocessor define.