### PR TITLE
Added documentation comment for protocol type and protocol type family.

### DIFF
--- a/Packet++/header/ProtocolType.h
+++ b/Packet++/header/ProtocolType.h
@@ -8,6 +8,28 @@
 /// @brief The main namespace for the PcapPlusPlus lib
 namespace pcpp
 {
+	/// @defgroup ProtocolTypes ProtocolType and ProtocolTypeFamily
+	/// In the PcapPlusPlus library, specific protocols are identified by a `ProtocolType` value, which is an 8-bit
+	/// unsigned integer. Each Layer class has a ProtocolType that can be used to identify the protocol of that layer.
+	///
+	/// As there are some situations where multiple protocols can be grouped together (e.g. IPv4 and IPv6 into IP),
+	/// PcapPlusPlus also defines ProtocolTypeFamily, which is a group of multiple protocol types. In functions where a
+	/// ProtocolTypeFamily parameter is expected, a single ProtocolType value can be passed instead. The library will
+	/// treat it as a family containing only that single protocol.
+	///
+	/// @internal
+	/// 
+	/// A ProtocolTypeFamily pack is represented as a 32-bit unsigned integer. Each octet in the 32-bit value is a
+	/// ProtocolType, allowing for up to 4 protocols to be packed into a single ProtocolTypeFamily value. For example,
+	/// the ProtocolTypeFamily for IP is represented as 0x203, which contains both IPv4 (0x02) and IPv6 (0x03)
+	/// protocols. A single ProtocolType casted to ProtocolTypeFamily will result the value '0x000000xx' where 'xx' is
+	/// the value of the ProtocolType.
+	/// 
+	/// @endinternal
+
+	/// @addtogroup ProtocolTypes
+	/// @{
+
 	/// @typedef ProtocolType
 	/// Representing all protocols supported by PcapPlusPlus
 	typedef uint8_t ProtocolType;
@@ -223,6 +245,8 @@ namespace pcpp
 	/// Diagnostic over IP protocol (DOIP)
 	const ProtocolType DOIP = 59;
 
+	/// @}
+
 	/// An enum representing OSI model layers
 	enum OsiModelLayer
 	{
@@ -250,6 +274,7 @@ namespace pcpp
 		/// @param family A protocol type family value.
 		/// @param protocol A protocol type value to check against the family.
 		/// @return True if the protocol is part of the family, false otherwise.
+		/// @ingroup ProtocolTypes
 		constexpr bool protoFamilyContainsProtocol(ProtocolTypeFamily family, ProtocolType protocol)
 		{
 			auto const protocolToFamily = static_cast<ProtocolTypeFamily>(protocol);

--- a/Packet++/header/ProtocolType.h
+++ b/Packet++/header/ProtocolType.h
@@ -18,13 +18,13 @@ namespace pcpp
 	/// treat it as a family containing only that single protocol.
 	///
 	/// @internal
-	/// 
+	///
 	/// A ProtocolTypeFamily pack is represented as a 32-bit unsigned integer. Each octet in the 32-bit value is a
 	/// ProtocolType, allowing for up to 4 protocols to be packed into a single ProtocolTypeFamily value. For example,
 	/// the ProtocolTypeFamily for IP is represented as 0x203, which contains both IPv4 (0x02) and IPv6 (0x03)
 	/// protocols. A single ProtocolType casted to ProtocolTypeFamily will result the value '0x000000xx' where 'xx' is
 	/// the value of the ProtocolType.
-	/// 
+	///
 	/// @endinternal
 
 	/// @addtogroup ProtocolTypes


### PR DESCRIPTION
In relation to https://github.com/seladb/PcapPlusPlus/pull/1916#discussion_r2270700810.

This PR adds a short description on `ProtocolType` and `ProtocolTypeFamily` usage in a separate doxygen "topic" page.

Note: The paragraphs enclosed inside the `@internal` and `@endinternal` scope, will not generate any documentation unless doxygen is ran with `INTERNAL_DOCS=YES`. As the section there relates to the internal mechanics and can be subject to change, I decided it is best not to specify it directly in public documentation, to avoid users of the library relying on the information.