### PR TITLE
Added `deprecated` to documentation to output a warning in the docs.

### DIFF
--- a/Pcap++/header/PcapLiveDeviceList.h
+++ b/Pcap++/header/PcapLiveDeviceList.h
@@ -57,6 +57,7 @@ namespace pcpp
 		/// Get a pointer to the live device by its IP address. IP address can be both IPv4 or IPv6
 		/// @param[in] ipAddr The IP address defined for the device
 		/// @return A pointer to the live device if this IP address exists. nullptr otherwise
+		/// @deprecated Use `getDeviceByIp` instead.
 		PCPP_DEPRECATED("Use `getDeviceByIp`")
 		PcapLiveDevice* getPcapLiveDeviceByIp(const IPAddress& ipAddr) const;
 
@@ -68,6 +69,7 @@ namespace pcpp
 		/// Get a pointer to the live device by its IPv4 address
 		/// @param[in] ipAddr The IPv4 address defined for the device
 		/// @return A pointer to the live device if this IPv4 address exists. nullptr otherwise
+		/// @deprecated Use `getDeviceByIp` instead.
 		PCPP_DEPRECATED("Use `getDeviceByIp`")
 		PcapLiveDevice* getPcapLiveDeviceByIp(const IPv4Address& ipAddr) const;
 
@@ -79,6 +81,7 @@ namespace pcpp
 		/// Get a pointer to the live device by its IPv6 address
 		/// @param[in] ip6Addr The IPv6 address defined for the device
 		/// @return A pointer to the live device if this IPv6 address exists. nullptr otherwise
+		/// @deprecated Use `getDeviceByIp` instead.
 		PCPP_DEPRECATED("Use `getDeviceByIp`")
 		PcapLiveDevice* getPcapLiveDeviceByIp(const IPv6Address& ip6Addr) const;
 
@@ -91,6 +94,7 @@ namespace pcpp
 		/// IPv6
 		/// @param[in] ipAddrAsString The IP address defined for the device as string
 		/// @return A pointer to the live device if this IP address is valid and exists. nullptr otherwise
+		/// @deprecated Use `getDeviceByIp` instead.
 		PCPP_DEPRECATED("Use `getDeviceByIp`")
 		PcapLiveDevice* getPcapLiveDeviceByIp(const std::string& ipAddrAsString) const;
 
@@ -103,6 +107,7 @@ namespace pcpp
 		/// Get a pointer to the live device by its name
 		/// @param[in] name The name of the interface (e.g eth0)
 		/// @return A pointer to the live device if this name exists. nullptr otherwise
+		/// @deprecated Use `getDeviceByName` instead.
 		PCPP_DEPRECATED("Use `getDeviceByName`")
 		PcapLiveDevice* getPcapLiveDeviceByName(const std::string& name) const;
 
@@ -114,6 +119,7 @@ namespace pcpp
 		/// Get a pointer to the live device by its IP address or name
 		/// @param[in] ipOrName An IP address or name of the interface
 		/// @return A pointer to the live device if exists, nullptr otherwise
+		/// @deprecated Use `getDeviceByIpOrName` instead.
 		PCPP_DEPRECATED("Use `getDeviceByIpOrName`")
 		PcapLiveDevice* getPcapLiveDeviceByIpOrName(const std::string& ipOrName) const;
 

--- a/Pcap++/header/PcapRemoteDeviceList.h
+++ b/Pcap++/header/PcapRemoteDeviceList.h
@@ -140,6 +140,7 @@ namespace pcpp
 		/// Search a PcapRemoteDevice in the list by its IPv4 address
 		/// @param[in] ip4Addr The IPv4 address
 		/// @return The PcapRemoteDevice if found, nullptr otherwise
+		/// @deprecated Use `getDeviceByIp` instead.
 		PCPP_DEPRECATED("Use `getDeviceByIp`")
 		PcapRemoteDevice* getRemoteDeviceByIP(const IPv4Address& ip4Addr) const;
 
@@ -151,6 +152,7 @@ namespace pcpp
 		/// Search a PcapRemoteDevice in the list by its IPv6 address
 		/// @param[in] ip6Addr The IPv6 address
 		/// @return The PcapRemoteDevice if found, nullptr otherwise
+		/// @deprecated Use `getDeviceByIp` instead.
 		PCPP_DEPRECATED("Use `getDeviceByIp`")
 		PcapRemoteDevice* getRemoteDeviceByIP(const IPv6Address& ip6Addr) const;
 
@@ -162,6 +164,7 @@ namespace pcpp
 		/// Search a PcapRemoteDevice in the list by its IP address (IPv4 or IPv6)
 		/// @param[in] ipAddr The IP address
 		/// @return The PcapRemoteDevice if found, nullptr otherwise
+		/// @deprecated Use `getDeviceByIp` instead.
 		PCPP_DEPRECATED("Use `getDeviceByIp`")
 		PcapRemoteDevice* getRemoteDeviceByIP(const IPAddress& ipAddr) const;
 
@@ -173,6 +176,7 @@ namespace pcpp
 		/// Search a PcapRemoteDevice in the list by its IP address
 		/// @param[in] ipAddrAsString The IP address in string format
 		/// @return The PcapRemoteDevice if found, nullptr otherwise
+		/// @deprecated Use `getDeviceByIP` instead.
 		PCPP_DEPRECATED("Use `getDeviceByIp`")
 		PcapRemoteDevice* getRemoteDeviceByIP(const std::string& ipAddrAsString) const;
 

--- a/Pcap++/header/PfRingDeviceList.h
+++ b/Pcap++/header/PfRingDeviceList.h
@@ -48,6 +48,7 @@ namespace pcpp
 		/// Get a PF_RING device by name. The name is the Linux interface name which appears in ifconfig
 		/// (e.g eth0, eth1, etc.)
 		/// @return A pointer to the PF_RING device
+		/// @deprecated Use `getDeviceByName` instead.
 		PCPP_DEPRECATED("Use `getDeviceByName`")
 		PfRingDevice* getPfRingDeviceByName(const std::string& devName) const;
 


### PR DESCRIPTION
Added 'deprecated' notes to the documentation as doxygen does not automatically generate deprecation notes from [[deprecated]] attribute.