### PR TITLE
Add vcpkg.json manifest to project.

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,10 +9,6 @@
     "license": null,
     "dependencies": [
         {
-            "name": "libpcap",
-            "platform": "!windows"
-        },
-        {
             "name": "vcpkg-cmake",
             "host": true
         },
@@ -25,9 +21,18 @@
         {
             "name": "winpcap",
             "platform": "windows"
+        },
+        {
+            "name": "libpcap",
+            "platform": "!windows"
         }
     ],
     "features": {
+        "libpcap": {
+            "description": "PcapPlusPlus with libpcap backend",
+            "dependencies": [ "libpcap" ],
+            "supports": "!windows"
+        },
         "winpcap": {
             "description": "PcapPlusPlus with WinPcap backend",
             "dependencies": [ "winpcap" ],

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,30 +17,24 @@
       "host": true
     }
   ],
-  "default-features": [
-    {
-      "name": "winpcap",
-      "platform": "windows"
-    },
-    {
-      "name": "libpcap",
-      "platform": "!windows"
+    "default-features": [
+        {
+            "name": "pcap"
+        }
+    ],
+    "features": {
+        "pcap": {
+            "description": "Enable pcap backend support. (libpcap on Linux, winpcap on Windows)",
+            "dependencies": [
+                {
+                    "name": "libpcap",
+                    "platform": "!windows"
+                },
+                {
+                    "name": "winpcap",
+                    "platform": "windows"
+                }
+            ]
+        }
     }
-  ],
-  "features": {
-    "libpcap": {
-      "description": "PcapPlusPlus with libpcap backend",
-      "dependencies": [
-        "libpcap"
-      ],
-      "supports": "!windows"
-    },
-    "winpcap": {
-      "description": "PcapPlusPlus with WinPcap backend",
-      "dependencies": [
-        "winpcap"
-      ],
-      "supports": "windows"
-    }
-  }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,42 +1,46 @@
 {
-    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
-    "builtin-baseline": "533a5fda5c0646d1771345fb572e759283444d5f",
-    "name": "pcapplusplus",
-    "version": "25.5-dev",
-    "description": "PcapPlusPlus is a multi-platform C++ library for capturing, parsing and crafting of network packets",
-    "homepage": "https://github.com/seladb/PcapPlusPlus",
-    "documentation": "https://pcapplusplus.github.io",
-    "license": null,
-    "dependencies": [
-        {
-            "name": "vcpkg-cmake",
-            "host": true
-        },
-        {
-            "name": "vcpkg-cmake-config",
-            "host": true
-        }
-    ],
-    "default-features": [
-        {
-            "name": "winpcap",
-            "platform": "windows"
-        },
-        {
-            "name": "libpcap",
-            "platform": "!windows"
-        }
-    ],
-    "features": {
-        "libpcap": {
-            "description": "PcapPlusPlus with libpcap backend",
-            "dependencies": [ "libpcap" ],
-            "supports": "!windows"
-        },
-        "winpcap": {
-            "description": "PcapPlusPlus with WinPcap backend",
-            "dependencies": [ "winpcap" ],
-            "supports": "windows"
-        }
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "builtin-baseline": "d30fdf55cfca16e12bc3ad99cbc615997014b61b",
+  "name": "pcapplusplus",
+  "version": "25.5-dev",
+  "description": "PcapPlusPlus is a multi-platform C++ library for capturing, parsing and crafting of network packets",
+  "homepage": "https://github.com/seladb/PcapPlusPlus",
+  "documentation": "https://pcapplusplus.github.io",
+  "license": null,
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
     }
+  ],
+  "default-features": [
+    {
+      "name": "winpcap",
+      "platform": "windows"
+    },
+    {
+      "name": "libpcap",
+      "platform": "!windows"
+    }
+  ],
+  "features": {
+    "libpcap": {
+      "description": "PcapPlusPlus with libpcap backend",
+      "dependencies": [
+        "libpcap"
+      ],
+      "supports": "!windows"
+    },
+    "winpcap": {
+      "description": "PcapPlusPlus with WinPcap backend",
+      "dependencies": [
+        "winpcap"
+      ],
+      "supports": "windows"
+    }
+  }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+    "builtin-baseline": "533a5fda5c0646d1771345fb572e759283444d5f",
+    "name": "pcapplusplus",
+    "version": "25.5-dev",
+    "description": "PcapPlusPlus is a multi-platform C++ library for capturing, parsing and crafting of network packets",
+    "homepage": "https://github.com/seladb/PcapPlusPlus",
+    "documentation": "https://pcapplusplus.github.io",
+    "license": null,
+    "dependencies": [
+        {
+            "name": "libpcap",
+            "platform": "!windows"
+        },
+        {
+            "name": "vcpkg-cmake",
+            "host": true
+        },
+        {
+            "name": "vcpkg-cmake-config",
+            "host": true
+        }
+    ],
+    "default-features": [
+        {
+            "name": "winpcap",
+            "platform": "windows"
+        }
+    ],
+    "features": {
+        "winpcap": {
+            "description": "PcapPlusPlus with WinPcap backend",
+            "dependencies": [ "winpcap" ],
+            "supports": "windows"
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a `vcpkg.json` manifest to the root project directory. This allows vcpkg to be used to download the dependencies if needed. Integration with cmake is still not automatic tho, and I am unsure if we want it to be. This config is partly as a draft on updating the vcpkg port manifest to be more modular.

### The manifest differs from the current [port manifest](https://github.com/microsoft/vcpkg/blob/master/ports/pcapplusplus/vcpkg.json) in the following ways:

#### Backends as package features instead of required dependencies.
Libpcap and Winpcap dependecies are moved to "feature" dependencies instead of required all the time. By default, "libpcap" and "winpcap" are included features, to keep legacy compatibility. Modularizing the dependencies allows users to pick and choose if they require certain backends. For example if only "Packet++" is needed, no backend needs to be selected.

If we treat backends as features it might also allow adding dependency configurations for `PF_RING` or `DPDK` as I noticed `vcpkg` also has those as ports, but I haven't done any testing on that.

NB: I am unsure if we want to keep `libpcap` and `winpcap` features separate or combine them under a single `pcap` feature?

#### Schema definition:
Added a `$schema` metafield to specify the schema used by the configuration. Mostly for IDE typehints.

#### Version information
The version in the config has the suffix `-dev`, but I am unsure if we want to keep the version field at all? Any thoughts?
