### PR TITLE
Update pre-commit to use venv python for clang format verison checker hook.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,8 @@ repos:
     hooks:
       - id: check-clang-format-version
         name: Check clang-format version
-        entry: python3 ./ci/check-clang-format-version.py
-        language: system
+        entry: python ./ci/check-clang-format-version.py
+        language: python
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:


### PR DESCRIPTION
This PR updates the clang format version check pre-commit hook to use `language: python` instead of `language: system`. This automatically sets up a python virtual environment and ensures that the entry `python` is always available, even if pre-commit is called in an environment where python is not in the Path (e.g when installed in venv and called as `.../venv/Scripts/pre-commit.exe` on Windows).