### PR TITLE
Fix broken doxygen when using 2 layer macro for deprecation warning.

### DIFF
--- a/Packet++/header/TcpLayer.h
+++ b/Packet++/header/TcpLayer.h
@@ -5,8 +5,8 @@
 #include "TLVData.h"
 #include <string.h>
 
-#define PCPP_DEPRECATED_TCP_OPTION_TYPE                                                                                \
-	PCPP_DEPRECATED("enum TcpOptionType is deprecated; Use enum class TcpOptionEnumType instead")
+#define PCPP_INTERNAL_DEPRECATE_TCP_OPTION_TYPE_MSG                                                                    \
+	"enum TcpOptionType is deprecated; Use enum class TcpOptionEnumType instead"
 
 /// @file
 
@@ -364,7 +364,7 @@ namespace pcpp
 		};
 
 		/// @deprecated This method is deprecated, please use constructor with TcpOptionEnumType
-		PCPP_DEPRECATED_TCP_OPTION_TYPE
+		PCPP_DEPRECATED(PCPP_INTERNAL_DEPRECATE_TCP_OPTION_TYPE_MSG)
 		TcpOptionBuilder(TcpOptionType optionType, const uint8_t* optionValue, uint8_t optionValueLen)
 		    : TLVRecordBuilder(static_cast<uint8_t>(optionType), optionValue, optionValueLen)
 		{}
@@ -380,7 +380,7 @@ namespace pcpp
 		{}
 
 		/// @deprecated This method is deprecated, please use constructor with TcpOptionEnumType
-		PCPP_DEPRECATED_TCP_OPTION_TYPE
+		PCPP_DEPRECATED(PCPP_INTERNAL_DEPRECATE_TCP_OPTION_TYPE_MSG)
 		TcpOptionBuilder(TcpOptionType optionType, uint8_t optionValue)
 		    : TLVRecordBuilder(static_cast<uint8_t>(optionType), optionValue)
 		{}
@@ -394,7 +394,7 @@ namespace pcpp
 		{}
 
 		/// @deprecated This method is deprecated, please use constructor with TcpOptionEnumType
-		PCPP_DEPRECATED_TCP_OPTION_TYPE
+		PCPP_DEPRECATED(PCPP_INTERNAL_DEPRECATE_TCP_OPTION_TYPE_MSG)
 		TcpOptionBuilder(TcpOptionType optionType, uint16_t optionValue)
 		    : TLVRecordBuilder(static_cast<uint8_t>(optionType), optionValue)
 		{}
@@ -408,7 +408,7 @@ namespace pcpp
 		{}
 
 		/// @deprecated This method is deprecated, please use constructor with TcpOptionEnumType
-		PCPP_DEPRECATED_TCP_OPTION_TYPE
+		PCPP_DEPRECATED(PCPP_INTERNAL_DEPRECATE_TCP_OPTION_TYPE_MSG)
 		TcpOptionBuilder(TcpOptionType optionType, uint32_t optionValue)
 		    : TLVRecordBuilder(static_cast<uint8_t>(optionType), optionValue)
 		{}
@@ -480,7 +480,7 @@ namespace pcpp
 		uint16_t getDstPort() const;
 
 		/// @deprecated This method is deprecated, please use getTcpOption(TcpOptionEnumType option)
-		PCPP_DEPRECATED_TCP_OPTION_TYPE
+		PCPP_DEPRECATED(PCPP_INTERNAL_DEPRECATE_TCP_OPTION_TYPE_MSG)
 		TcpOption getTcpOption(TcpOptionType option) const;
 
 		/// Get a TCP option by type
@@ -529,7 +529,7 @@ namespace pcpp
 		                               TcpOptionEnumType prevOptionType = TcpOptionEnumType::Unknown);
 
 		/// @deprecated This method is deprecated, please use removeTcpOption(TcpOptionEnumType)
-		PCPP_DEPRECATED_TCP_OPTION_TYPE
+		PCPP_DEPRECATED(PCPP_INTERNAL_DEPRECATE_TCP_OPTION_TYPE_MSG)
 		bool removeTcpOption(TcpOptionType optionType);
 
 		/// Remove an existing TCP option from the layer. TCP option is found by type
@@ -601,4 +601,4 @@ namespace pcpp
 	}
 }  // namespace pcpp
 
-#undef PCPP_DEPRECATED_TCP_OPTION_TYPE
+#undef PCPP_INTERNAL_DEPRECATE_TCP_OPTION_TYPE_MSG


### PR DESCRIPTION
Doxygen gets confused when a 2 layer macro is used to specify the [[deprecated]] attribute.

See [TcpLayer docs link](https://pcapplusplus.github.io/api-docs/v25.05/classpcpp_1_1_tcp_layer.html#a07903b52fb726291b37db165671142c4) for example.