### PR TITLE
Reorder of PcapFileDevice.h to improve grouping.

### DIFF
--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -92,6 +92,30 @@ namespace pcpp
 		static IFileReaderDevice* getReader(const std::string& fileName);
 	};
 
+	/// @class IFileWriterDevice
+	/// An abstract class (cannot be instantiated, has a private c'tor) which is the parent class for file writer
+	/// devices
+	class IFileWriterDevice : public IFileDevice
+	{
+	protected:
+		uint32_t m_NumOfPacketsWritten;
+		uint32_t m_NumOfPacketsNotWritten;
+
+		IFileWriterDevice(const std::string& fileName);
+
+	public:
+		/// A destructor for this class
+		virtual ~IFileWriterDevice()
+		{}
+
+		virtual bool writePacket(RawPacket const& packet) = 0;
+
+		virtual bool writePackets(const RawPacketVector& packets) = 0;
+
+		using IFileDevice::open;
+		virtual bool open(bool appendMode) = 0;
+	};
+
 	/// @class PcapFileReaderDevice
 	/// A class for opening a pcap file in read-only mode. This class enable to open the file and read all packets,
 	/// packet-by-packet
@@ -152,188 +176,6 @@ namespace pcpp
 		/// rest of the members will contain 0
 		/// @param[out] stats The stats struct where stats are returned
 		void getStatistics(PcapStats& stats) const;
-	};
-
-	/// @class SnoopFileReaderDevice
-	/// A class for opening a snoop file in read-only mode. This class enable to open the file and read all packets,
-	/// packet-by-packet
-	class SnoopFileReaderDevice : public IFileReaderDevice
-	{
-	private:
-#pragma pack(1)
-		/// File format header.
-		typedef struct
-		{
-			uint64_t identification_pattern;
-			uint32_t version_number;
-			uint32_t datalink_type;
-		} snoop_file_header_t;
-
-		/// Packet record header.
-		typedef struct
-		{
-			uint32_t original_length;       ///< original packet length
-			uint32_t included_length;       ///< saved packet length
-			uint32_t packet_record_length;  ///< total record length
-			uint32_t ndrops_cumulative;     ///< cumulative drops
-			uint32_t time_sec;              ///< timestamp
-			uint32_t time_usec;             ///< microsecond timestamp
-		} snoop_packet_header_t;
-#pragma pack()
-
-		LinkLayerType m_PcapLinkLayerType;
-		std::ifstream m_snoopFile;
-
-		// private copy c'tor
-		SnoopFileReaderDevice(const PcapFileReaderDevice& other);
-		SnoopFileReaderDevice& operator=(const PcapFileReaderDevice& other);
-
-	public:
-		/// A constructor for this class that gets the snoop full path file name to open. Notice that after calling this
-		/// constructor the file isn't opened yet, so reading packets will fail. For opening the file call open()
-		/// @param[in] fileName The full path of the file to read
-		SnoopFileReaderDevice(const std::string& fileName)
-		    : IFileReaderDevice(fileName), m_PcapLinkLayerType(LINKTYPE_ETHERNET)
-		{}
-
-		/// A destructor for this class
-		virtual ~SnoopFileReaderDevice();
-
-		/// @return The link layer type of this file
-		LinkLayerType getLinkLayerType() const
-		{
-			return m_PcapLinkLayerType;
-		}
-
-		// overridden methods
-
-		/// Read the next packet from the file. Before using this method please verify the file is opened using open()
-		/// @param[out] rawPacket A reference for an empty RawPacket where the packet will be written
-		/// @return True if a packet was read successfully. False will be returned if the file isn't opened (also, an
-		/// error log will be printed) or if reached end-of-file
-		bool getNextPacket(RawPacket& rawPacket);
-
-		/// Open the file name which path was specified in the constructor in a read-only mode
-		/// @return True if file was opened successfully or if file is already opened. False if opening the file failed
-		/// for some reason (for example: file path does not exist)
-		bool open();
-
-		/// Get statistics of packets read so far. In the PcapStats struct, only the packetsRecv member is relevant. The
-		/// rest of the members will contain 0
-		/// @param[out] stats The stats struct where stats are returned
-		void getStatistics(PcapStats& stats) const;
-
-		/// Close the snoop file
-		void close();
-	};
-
-	/// @class PcapNgFileReaderDevice
-	/// A class for opening a pcap-ng file in read-only mode. This class enable to open the file and read all packets,
-	/// packet-by-packet
-	class PcapNgFileReaderDevice : public IFileReaderDevice
-	{
-	private:
-		internal::LightPcapNgHandle* m_LightPcapNg;
-		BpfFilterWrapper m_BpfWrapper;
-
-		// private copy c'tor
-		PcapNgFileReaderDevice(const PcapNgFileReaderDevice& other);
-		PcapNgFileReaderDevice& operator=(const PcapNgFileReaderDevice& other);
-
-	public:
-		/// A constructor for this class that gets the pcap-ng full path file name to open. Notice that after calling
-		/// this constructor the file isn't opened yet, so reading packets will fail. For opening the file call open()
-		/// @param[in] fileName The full path of the file to read
-		PcapNgFileReaderDevice(const std::string& fileName);
-
-		/// A destructor for this class
-		virtual ~PcapNgFileReaderDevice()
-		{
-			close();
-		}
-
-		/// The pcap-ng format allows storing metadata at the header of the file. Part of this metadata is a string
-		/// specifying the operating system that was used for capturing the packets. This method reads this string from
-		/// the metadata (if exists) and returns it
-		/// @return The operating system string if exists, or an empty string otherwise
-		std::string getOS() const;
-
-		/// The pcap-ng format allows storing metadata at the header of the file. Part of this metadata is a string
-		/// specifying the hardware that was used for capturing the packets. This method reads this string from the
-		/// metadata (if exists) and returns it
-		/// @return The hardware string if exists, or an empty string otherwise
-		std::string getHardware() const;
-
-		/// The pcap-ng format allows storing metadata at the header of the file. Part of this metadata is a string
-		/// specifying the capture application that was used for capturing the packets. This method reads this string
-		/// from the metadata (if exists) and returns it
-		/// @return The capture application string if exists, or an empty string otherwise
-		std::string getCaptureApplication() const;
-
-		/// The pcap-ng format allows storing metadata at the header of the file. Part of this metadata is a string
-		/// containing a user-defined comment (can be any string). This method reads this string from the metadata (if
-		/// exists) and returns it
-		/// @return The comment written inside the file if exists, or an empty string otherwise
-		std::string getCaptureFileComment() const;
-
-		/// The pcap-ng format allows storing a user-defined comment for every packet (besides the comment per-file).
-		/// This method reads the next packet and the comment attached to it (if such comment exists), and returns them
-		/// both
-		/// @param[out] rawPacket A reference for an empty RawPacket where the packet will be written
-		/// @param[out] packetComment The comment attached to the packet or an empty string if no comment exists
-		/// @return True if a packet was read successfully. False will be returned if the file isn't opened (also, an
-		/// error log will be printed) or if reached end-of-file
-		bool getNextPacket(RawPacket& rawPacket, std::string& packetComment);
-
-		// overridden methods
-
-		/// Read the next packet from the file. Before using this method please verify the file is opened using open()
-		/// @param[out] rawPacket A reference for an empty RawPacket where the packet will be written
-		/// @return True if a packet was read successfully. False will be returned if the file isn't opened (also, an
-		/// error log will be printed) or if reached end-of-file
-		bool getNextPacket(RawPacket& rawPacket);
-
-		/// Open the file name which path was specified in the constructor in a read-only mode
-		/// @return True if file was opened successfully or if file is already opened. False if opening the file failed
-		/// for some reason (for example: file path does not exist)
-		bool open();
-
-		/// Get statistics of packets read so far.
-		/// @param[out] stats The stats struct where stats are returned
-		void getStatistics(PcapStats& stats) const;
-
-		/// Set a filter for PcapNG reader device. Only packets that match the filter will be received
-		/// @param[in] filterAsString The filter to be set in Berkeley Packet Filter (BPF) syntax
-		/// (http://biot.com/capstats/bpf.html)
-		/// @return True if filter set successfully, false otherwise
-		bool setFilter(std::string filterAsString);
-
-		/// Close the pacp-ng file
-		void close();
-	};
-
-	/// @class IFileWriterDevice
-	/// An abstract class (cannot be instantiated, has a private c'tor) which is the parent class for file writer
-	/// devices
-	class IFileWriterDevice : public IFileDevice
-	{
-	protected:
-		uint32_t m_NumOfPacketsWritten;
-		uint32_t m_NumOfPacketsNotWritten;
-
-		IFileWriterDevice(const std::string& fileName);
-
-	public:
-		/// A destructor for this class
-		virtual ~IFileWriterDevice()
-		{}
-
-		virtual bool writePacket(RawPacket const& packet) = 0;
-
-		virtual bool writePackets(const RawPacketVector& packets) = 0;
-
-		using IFileDevice::open;
-		virtual bool open(bool appendMode) = 0;
 	};
 
 	/// @class PcapFileWriterDevice
@@ -431,6 +273,91 @@ namespace pcpp
 	private:
 		bool openWrite();
 		bool openAppend();
+	};
+
+	/// @class PcapNgFileReaderDevice
+	/// A class for opening a pcap-ng file in read-only mode. This class enable to open the file and read all packets,
+	/// packet-by-packet
+	class PcapNgFileReaderDevice : public IFileReaderDevice
+	{
+	private:
+		internal::LightPcapNgHandle* m_LightPcapNg;
+		BpfFilterWrapper m_BpfWrapper;
+
+		// private copy c'tor
+		PcapNgFileReaderDevice(const PcapNgFileReaderDevice& other);
+		PcapNgFileReaderDevice& operator=(const PcapNgFileReaderDevice& other);
+
+	public:
+		/// A constructor for this class that gets the pcap-ng full path file name to open. Notice that after calling
+		/// this constructor the file isn't opened yet, so reading packets will fail. For opening the file call open()
+		/// @param[in] fileName The full path of the file to read
+		PcapNgFileReaderDevice(const std::string& fileName);
+
+		/// A destructor for this class
+		virtual ~PcapNgFileReaderDevice()
+		{
+			close();
+		}
+
+		/// The pcap-ng format allows storing metadata at the header of the file. Part of this metadata is a string
+		/// specifying the operating system that was used for capturing the packets. This method reads this string from
+		/// the metadata (if exists) and returns it
+		/// @return The operating system string if exists, or an empty string otherwise
+		std::string getOS() const;
+
+		/// The pcap-ng format allows storing metadata at the header of the file. Part of this metadata is a string
+		/// specifying the hardware that was used for capturing the packets. This method reads this string from the
+		/// metadata (if exists) and returns it
+		/// @return The hardware string if exists, or an empty string otherwise
+		std::string getHardware() const;
+
+		/// The pcap-ng format allows storing metadata at the header of the file. Part of this metadata is a string
+		/// specifying the capture application that was used for capturing the packets. This method reads this string
+		/// from the metadata (if exists) and returns it
+		/// @return The capture application string if exists, or an empty string otherwise
+		std::string getCaptureApplication() const;
+
+		/// The pcap-ng format allows storing metadata at the header of the file. Part of this metadata is a string
+		/// containing a user-defined comment (can be any string). This method reads this string from the metadata (if
+		/// exists) and returns it
+		/// @return The comment written inside the file if exists, or an empty string otherwise
+		std::string getCaptureFileComment() const;
+
+		/// The pcap-ng format allows storing a user-defined comment for every packet (besides the comment per-file).
+		/// This method reads the next packet and the comment attached to it (if such comment exists), and returns them
+		/// both
+		/// @param[out] rawPacket A reference for an empty RawPacket where the packet will be written
+		/// @param[out] packetComment The comment attached to the packet or an empty string if no comment exists
+		/// @return True if a packet was read successfully. False will be returned if the file isn't opened (also, an
+		/// error log will be printed) or if reached end-of-file
+		bool getNextPacket(RawPacket& rawPacket, std::string& packetComment);
+
+		// overridden methods
+
+		/// Read the next packet from the file. Before using this method please verify the file is opened using open()
+		/// @param[out] rawPacket A reference for an empty RawPacket where the packet will be written
+		/// @return True if a packet was read successfully. False will be returned if the file isn't opened (also, an
+		/// error log will be printed) or if reached end-of-file
+		bool getNextPacket(RawPacket& rawPacket);
+
+		/// Open the file name which path was specified in the constructor in a read-only mode
+		/// @return True if file was opened successfully or if file is already opened. False if opening the file failed
+		/// for some reason (for example: file path does not exist)
+		bool open();
+
+		/// Get statistics of packets read so far.
+		/// @param[out] stats The stats struct where stats are returned
+		void getStatistics(PcapStats& stats) const;
+
+		/// Set a filter for PcapNG reader device. Only packets that match the filter will be received
+		/// @param[in] filterAsString The filter to be set in Berkeley Packet Filter (BPF) syntax
+		/// (http://biot.com/capstats/bpf.html)
+		/// @return True if filter set successfully, false otherwise
+		bool setFilter(std::string filterAsString);
+
+		/// Close the pacp-ng file
+		void close();
 	};
 
 	/// @class PcapNgFileWriterDevice
@@ -557,6 +484,79 @@ namespace pcpp
 
 		bool openWrite(PcapNgMetadata const* metadata = nullptr);
 		bool openAppend();
+	};
+
+	/// @class SnoopFileReaderDevice
+	/// A class for opening a snoop file in read-only mode. This class enable to open the file and read all packets,
+	/// packet-by-packet
+	class SnoopFileReaderDevice : public IFileReaderDevice
+	{
+	private:
+#pragma pack(1)
+		/// File format header.
+		typedef struct
+		{
+			uint64_t identification_pattern;
+			uint32_t version_number;
+			uint32_t datalink_type;
+		} snoop_file_header_t;
+
+		/// Packet record header.
+		typedef struct
+		{
+			uint32_t original_length;       ///< original packet length
+			uint32_t included_length;       ///< saved packet length
+			uint32_t packet_record_length;  ///< total record length
+			uint32_t ndrops_cumulative;     ///< cumulative drops
+			uint32_t time_sec;              ///< timestamp
+			uint32_t time_usec;             ///< microsecond timestamp
+		} snoop_packet_header_t;
+#pragma pack()
+
+		LinkLayerType m_PcapLinkLayerType;
+		std::ifstream m_snoopFile;
+
+		// private copy c'tor
+		SnoopFileReaderDevice(const PcapFileReaderDevice& other);
+		SnoopFileReaderDevice& operator=(const PcapFileReaderDevice& other);
+
+	public:
+		/// A constructor for this class that gets the snoop full path file name to open. Notice that after calling this
+		/// constructor the file isn't opened yet, so reading packets will fail. For opening the file call open()
+		/// @param[in] fileName The full path of the file to read
+		SnoopFileReaderDevice(const std::string& fileName)
+		    : IFileReaderDevice(fileName), m_PcapLinkLayerType(LINKTYPE_ETHERNET)
+		{}
+
+		/// A destructor for this class
+		virtual ~SnoopFileReaderDevice();
+
+		/// @return The link layer type of this file
+		LinkLayerType getLinkLayerType() const
+		{
+			return m_PcapLinkLayerType;
+		}
+
+		// overridden methods
+
+		/// Read the next packet from the file. Before using this method please verify the file is opened using open()
+		/// @param[out] rawPacket A reference for an empty RawPacket where the packet will be written
+		/// @return True if a packet was read successfully. False will be returned if the file isn't opened (also, an
+		/// error log will be printed) or if reached end-of-file
+		bool getNextPacket(RawPacket& rawPacket);
+
+		/// Open the file name which path was specified in the constructor in a read-only mode
+		/// @return True if file was opened successfully or if file is already opened. False if opening the file failed
+		/// for some reason (for example: file path does not exist)
+		bool open();
+
+		/// Get statistics of packets read so far. In the PcapStats struct, only the packetsRecv member is relevant. The
+		/// rest of the members will contain 0
+		/// @param[out] stats The stats struct where stats are returned
+		void getStatistics(PcapStats& stats) const;
+
+		/// Close the snoop file
+		void close();
 	};
 
 }  // namespace pcpp


### PR DESCRIPTION
Reordered the `PcapFileDevice.h` header to improve the grouping between the classes.
The new grouping groups the classes by the specific type of file they operate on, instead of on the type of device they are.
IMO, this improves the cohesion, as the concrete reader / writers of a type are much more relevant to each other as a pair than to the different writer classes of unrelated file type.

Old order:
- `IFileDevice`
- `IFileReaderDevice`
- File Readers...
- `IFileWriterDevice`
- File Writers...

New order:
- File Interfaces - `IFileDevice`, `IFileReaderDevice`, `IFileWriterDevice`
- `Pcap` reader / writer
- `PcapNG` reader / writer
- `Snoop` reader.