### PR TITLE
Added const qualified match methods to BfpFilterWrapper.

### DIFF
--- a/Pcap++/src/PcapFilter.cpp
+++ b/Pcap++/src/PcapFilter.cpp
@@ -38,17 +38,23 @@ namespace pcpp
 		}
 	}  // namespace internal
 
-	BpfFilterWrapper::BpfFilterWrapper() : m_LinkType(LinkLayerType::LINKTYPE_ETHERNET)
-	{}
-
-	BpfFilterWrapper::BpfFilterWrapper(const BpfFilterWrapper& other) : BpfFilterWrapper()
+	BpfFilterWrapper::BpfFilterWrapper(std::string filter, LinkLayerType linkType)
+	    : m_FilterStr(std::move(filter)), m_CachedProgramLinkType(linkType),
+	      m_CachedProgram(compileFilter(m_FilterStr, linkType))
 	{
-		setFilter(other.m_FilterStr, other.m_LinkType);
+		if (!m_FilterStr.empty() && m_CachedProgram == nullptr)
+		{
+			throw std::runtime_error("Couldn't compile BPF filter: '" + m_FilterStr + "'");
+		}
 	}
+
+	BpfFilterWrapper::BpfFilterWrapper(const BpfFilterWrapper& other)
+	    : BpfFilterWrapper(other.m_FilterStr, other.m_CachedProgramLinkType)
+	{}
 
 	BpfFilterWrapper& BpfFilterWrapper::operator=(const BpfFilterWrapper& other)
 	{
-		setFilter(other.m_FilterStr, other.m_LinkType);
+		setFilter(other.m_FilterStr, other.m_CachedProgramLinkType);
 		return *this;
 	}
 
@@ -56,64 +62,117 @@ namespace pcpp
 	{
 		if (filter.empty())
 		{
-			freeProgram();
+			m_CachedProgram = nullptr;
+			m_FilterStr.clear();
 			return true;
 		}
 
-		if (filter != m_FilterStr || linkType != m_LinkType)
+		if (filter != m_FilterStr || linkType != m_CachedProgramLinkType)
 		{
-			auto pcap = std::unique_ptr<pcap_t, internal::PcapCloseDeleter>(pcap_open_dead(linkType, DEFAULT_SNAPLEN));
-			if (pcap == nullptr)
+			auto newProgram = compileFilter(filter, linkType);
+			if (newProgram == nullptr)
 			{
+				PCPP_LOG_ERROR("Couldn't compile BPF filter: '" << filter << "'");
 				return false;
 			}
 
-			auto newProg = std::make_unique<bpf_program>();
-			int ret = pcap_compile(pcap.get(), newProg.get(), filter.c_str(), 1, 0);
-			if (ret < 0)
-			{
-				return false;
-			}
-
-			// Reassigns ownership of the bpf program to a new unique_ptr with a custom deleter as it now requires
-			// specialized cleanup.
-			m_Program = std::unique_ptr<bpf_program, internal::BpfProgramDeleter>(newProg.release());
 			m_FilterStr = filter;
-			m_LinkType = linkType;
+			m_CachedProgram = std::move(newProgram);
+			m_CachedProgramLinkType = linkType;
 		}
 
 		return true;
 	}
 
-	void BpfFilterWrapper::freeProgram()
-	{
-		m_Program = nullptr;
-		m_FilterStr.clear();
-	}
-
 	bool BpfFilterWrapper::matchPacketWithFilter(const RawPacket* rawPacket)
 	{
-		return matchPacketWithFilter(rawPacket->getRawData(), rawPacket->getRawDataLen(),
-		                             rawPacket->getPacketTimeStamp(), rawPacket->getLinkLayerType());
+		if (rawPacket == nullptr)
+		{
+			PCPP_LOG_ERROR("Raw packet pointer is null");
+			return false;
+		}
+
+		return matches(*rawPacket);
 	}
 
 	bool BpfFilterWrapper::matchPacketWithFilter(const uint8_t* packetData, uint32_t packetDataLength,
 	                                             timespec packetTimestamp, uint16_t linkType)
 	{
+		return matches(packetData, packetDataLength, packetTimestamp, linkType);
+	}
+
+	bool BpfFilterWrapper::matches(const RawPacket& rawPacket, LinkMissmatchBehaviour onLinkMissmatch) const
+	{
+		return matches(rawPacket.getRawData(), rawPacket.getRawDataLen(), rawPacket.getPacketTimeStamp(),
+		               rawPacket.getLinkLayerType(), onLinkMissmatch);
+	}
+
+	bool BpfFilterWrapper::matches(const uint8_t* packetData, uint32_t packetDataLength, timespec timestamp,
+	                               uint16_t linkType, LinkMissmatchBehaviour onLinkMissmatch) const
+	{
 		if (m_FilterStr.empty())
 			return true;
 
-		if (!setFilter(std::string(m_FilterStr), static_cast<LinkLayerType>(linkType)))
+		// This should never happen, but just in case
+		if (m_CachedProgram == nullptr)
 		{
-			return false;
+			throw std::runtime_error("No compiled BPF program available");
 		}
 
-		struct pcap_pkthdr pktHdr;
+		// Handle link type mismatch
+		if (linkType != static_cast<uint16_t>(m_CachedProgramLinkType))
+		{
+			switch (onLinkMissmatch)
+			{
+			case LinkMissmatchBehaviour::NoMatch:
+			{
+				return false;  // Do not attempt to recompile, just return false
+			}
+			case LinkMissmatchBehaviour::RecompileFilter:
+			{
+				auto newProgram = compileFilter(m_FilterStr, static_cast<LinkLayerType>(linkType));
+				if (newProgram == nullptr)
+				{
+					PCPP_LOG_ERROR("Couldn't compile BPF filter: '" << m_FilterStr << "' for link type: " << linkType);
+					return false;
+				}
+				m_CachedProgram = std::move(newProgram);
+				m_CachedProgramLinkType = static_cast<LinkLayerType>(linkType);
+				break;
+			}
+			default:
+				throw std::logic_error("Unknown LinkMissmatchBehaviour");
+			}
+		}
+
+		// Test the packet against the filter
+		pcap_pkthdr pktHdr;
 		pktHdr.caplen = packetDataLength;
 		pktHdr.len = packetDataLength;
-		pktHdr.ts = internal::toTimeval(packetTimestamp);
+		pktHdr.ts = internal::toTimeval(timestamp);
+		return (pcap_offline_filter(m_CachedProgram.get(), &pktHdr, packetData) != 0);
+	}
 
-		return (pcap_offline_filter(m_Program.get(), &pktHdr, packetData) != 0);
+	BpfFilterWrapper::BpfProgramUPtr BpfFilterWrapper::compileFilter(std::string const& filter, LinkLayerType linkType)
+	{
+		if (filter.empty())
+			return nullptr;
+
+		auto pcap = std::unique_ptr<pcap_t, internal::PcapCloseDeleter>(pcap_open_dead(linkType, DEFAULT_SNAPLEN));
+		if (pcap == nullptr)
+		{
+			return nullptr;
+		}
+
+		auto newProg = std::make_unique<bpf_program>();
+		int ret = pcap_compile(pcap.get(), newProg.get(), filter.c_str(), 1, 0);
+		if (ret < 0)
+		{
+			return nullptr;
+		}
+
+		// Reassigns ownership to a new unique_ptr with a custom deleter as it now requires specialized cleanup.
+		return BpfProgramUPtr(newProg.release());
 	}
 
 	void BPFStringFilter::parseToString(std::string& result)


### PR DESCRIPTION
This PR updates BpfFilterWrapper to allow matching with a packet while the filter is marked as `const`.