### PR TITLE
Removed preemptive cleaning of raw packet.

### DIFF
--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -227,7 +227,6 @@ namespace pcpp
 
 	bool PcapFileReaderDevice::getNextPacket(RawPacket& rawPacket)
 	{
-		rawPacket.clear();
 		if (m_PcapDescriptor == nullptr)
 		{
 			PCPP_LOG_ERROR("File device '" << m_FileName << "' not opened");
@@ -577,9 +576,6 @@ namespace pcpp
 
 	bool PcapNgFileReaderDevice::getNextPacket(RawPacket& rawPacket, std::string& packetComment)
 	{
-		rawPacket.clear();
-		packetComment = "";
-
 		if (m_LightPcapNg == nullptr)
 		{
 			PCPP_LOG_ERROR("Pcapng file device '" << m_FileName << "' not opened");
@@ -621,7 +617,13 @@ namespace pcpp
 		}
 
 		if (pktHeader.comment != nullptr && pktHeader.comment_length > 0)
+		{
 			packetComment = std::string(pktHeader.comment, pktHeader.comment_length);
+		}
+		else
+		{
+			packetComment.clear();
+		}
 
 		m_NumOfPacketsRead++;
 		return true;
@@ -980,7 +982,6 @@ namespace pcpp
 
 	bool SnoopFileReaderDevice::getNextPacket(RawPacket& rawPacket)
 	{
-		rawPacket.clear();
 		if (m_DeviceOpened != true)
 		{
 			PCPP_LOG_ERROR("File device '" << m_FileName << "' not opened");


### PR DESCRIPTION
The previous packet data is safely disposed of inside `RawPacket::setRawData` call. The removal of preemptive cleaning also preserves the old data state, in case of operation failure.