### PR TITLE
Remove protected field `m_DeviceOpened` from `IDevice` interface.

### DIFF
--- a/Pcap++/header/Device.h
+++ b/Pcap++/header/Device.h
@@ -23,8 +23,7 @@ namespace pcpp
 		IDevice() = default;
 
 	public:
-		virtual ~IDevice()
-		{}
+		virtual ~IDevice() = default;
 
 		/// Open the device
 		/// @return True if device was opened successfully, false otherwise

--- a/Pcap++/header/Device.h
+++ b/Pcap++/header/Device.h
@@ -19,11 +19,8 @@ namespace pcpp
 	class IDevice
 	{
 	protected:
-		bool m_DeviceOpened;
-
 		// c'tor should not be public
-		IDevice() : m_DeviceOpened(false)
-		{}
+		IDevice() = default;
 
 	public:
 		virtual ~IDevice()
@@ -37,10 +34,7 @@ namespace pcpp
 		virtual void close() = 0;
 
 		/// @return True if the file is opened, false otherwise
-		inline bool isOpened()
-		{
-			return m_DeviceOpened;
-		}
+		virtual bool isOpened() const = 0;
 	};
 
 	/// @class IFilterableDevice

--- a/Pcap++/header/DpdkDevice.h
+++ b/Pcap++/header/DpdkDevice.h
@@ -731,6 +731,11 @@ namespace pcpp
 		/// Close the DpdkDevice. When device is closed it's not possible work with it
 		void close() override;
 
+		bool isOpened() const override
+		{
+			return m_DeviceOpened;
+		}
+
 	private:
 		struct DpdkCoreConfiguration
 		{
@@ -768,6 +773,8 @@ namespace pcpp
 
 		uint64_t convertRssHfToDpdkRssHf(uint64_t rssHF) const;
 		uint64_t convertDpdkRssHfToRssHf(uint64_t dpdkRssHF) const;
+
+		bool m_DeviceOpened = false;
 
 		std::string m_DeviceName;
 		DpdkPMDType m_PMDType;

--- a/Pcap++/header/KniDevice.h
+++ b/Pcap++/header/KniDevice.h
@@ -524,7 +524,14 @@ namespace pcpp
 		/// Stops asynchronous packet capture if it is running.
 		void close();
 
+		bool isOpened() const override
+		{
+			return m_DeviceOpened;
+		}
+
 	private:
+		bool m_DeviceOpened = false;
+
 		struct rte_kni* m_Device;
 		struct rte_mempool* m_MBufMempool;
 		struct KniDeviceInfo

--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -39,6 +39,7 @@ namespace pcpp
 	class IFileDevice : public IPcapDevice
 	{
 	protected:
+		bool m_DeviceOpened = false;
 		std::string m_FileName;
 
 		explicit IFileDevice(const std::string& fileName);
@@ -52,6 +53,11 @@ namespace pcpp
 
 		/// Close the file
 		void close() override;
+
+		bool isOpened() const override
+		{
+			return m_DeviceOpened;
+		}
 	};
 
 	/// @class IFileReaderDevice

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -120,6 +120,8 @@ namespace pcpp
 			std::thread m_WorkerThread;
 		};
 
+		bool m_DeviceOpened = false;
+
 		// This is a second descriptor for the same device. It is needed because of a bug
 		// that occurs in libpcap on Linux (on Windows using WinPcap/Npcap it works well):
 		// It's impossible to capture packets sent by the same descriptor
@@ -652,6 +654,11 @@ namespace pcpp
 		bool open(const DeviceConfiguration& config);
 
 		void close() override;
+
+		bool isOpened() const override
+		{
+			return m_DeviceOpened;
+		}
 
 		/// Clones the current device class
 		/// @return Pointer to the copied class

--- a/Pcap++/header/PfRingDevice.h
+++ b/Pcap++/header/PfRingDevice.h
@@ -59,6 +59,8 @@ namespace pcpp
 			bool m_Ready = false;
 		};
 
+		bool m_DeviceOpened = false;
+
 		std::vector<pfring*> m_PfRingDescriptors;
 		std::string m_DeviceName;
 		int m_InterfaceIndex;
@@ -307,6 +309,11 @@ namespace pcpp
 
 		/// Closes all RX channels currently opened in device
 		void close();
+
+		bool isOpened() const override
+		{
+			return m_DeviceOpened;
+		}
 
 		using IFilterableDevice::setFilter;
 

--- a/Pcap++/header/RawSocketDevice.h
+++ b/Pcap++/header/RawSocketDevice.h
@@ -124,6 +124,11 @@ namespace pcpp
 		/// Close the raw socket
 		void close() override;
 
+		bool isOpened() const override
+		{
+			return m_DeviceOpened;
+		}
+
 	private:
 		enum SocketFamily
 		{
@@ -131,6 +136,8 @@ namespace pcpp
 			IPv4 = 1,
 			IPv6 = 2
 		};
+
+		bool m_DeviceOpened = false;
 
 		SocketFamily m_SockFamily;
 		void* m_Socket;

--- a/Pcap++/header/XdpDevice.h
+++ b/Pcap++/header/XdpDevice.h
@@ -285,6 +285,8 @@ namespace pcpp
 			uint64_t txCompletedPackets;
 		};
 
+		bool m_DeviceOpened = false;
+
 		std::string m_InterfaceName;
 		XdpDeviceConfiguration* m_Config;
 		bool m_ReceivingPackets;

--- a/Pcap++/header/XdpDevice.h
+++ b/Pcap++/header/XdpDevice.h
@@ -179,6 +179,11 @@ namespace pcpp
 		/// Close the device. This method closes the AF_XDP socket and frees the UMEM that was allocated for it.
 		void close() override;
 
+		bool isOpened() const override
+		{
+			return m_DeviceOpened;
+		}
+
 		/// Start receiving packets. In order to use this method the device should be open. Note that this method is
 		/// blocking and will return if:
 		/// - stopReceivePackets() was called from within the user callback

--- a/Pcap++/src/PcapDevice.cpp
+++ b/Pcap++/src/PcapDevice.cpp
@@ -136,7 +136,7 @@ namespace pcpp
 	bool IPcapDevice::setFilter(std::string filterAsString)
 	{
 		PCPP_LOG_DEBUG("Filter to be set: '" << filterAsString << "'");
-		if (!m_DeviceOpened)
+		if (!isOpened())
 		{
 			PCPP_LOG_ERROR("Device not Opened!! cannot set filter");
 			return false;


### PR DESCRIPTION
The C++ core guidelines recommend against usages of protected fields, due to the maintainability issues in large class hierarchies. 

As `IDevice` is the base interface of every device, it is better to let concrete implementations handle their own state detection than to force a boolean to be used everywhere. For instance a `PcapLiveDevice` can instead use the state of its `PcapHandle` for state detection and avoid needing to have `m_DeviceOpened = true / false` throughout its `open() / close()` implementation.