### PR TITLE
Fix inclusive `parseUntil` condition in the main packet parse loop.

### DIFF
--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -106,51 +106,6 @@ namespace pcpp
 			m_LastLayer->m_NextLayer = nullptr;
 		}
 
-		/*
-		while (curLayer != nullptr &&
-		       // Check the parse until condition
-		       (parseUntil == UnknownProtocol || !curLayer->isMemberOfProtocolFamily(parseUntil)) &&
-		       // Check the parse until OSI condition
-		       curLayer->getOsiModelLayer() <= parseUntilLayer)
-		{
-		    // Parse layer, allocate it
-		    curLayer->parseNextLayer();
-		    curLayer->m_IsAllocatedInPacket = true;
-
-		    // Move to next layer.
-		    curLayer = curLayer->getNextLayer();
-
-		    // If a next layer exists, update last layer.
-		    if (curLayer != nullptr)
-		        m_LastLayer = curLayer;
-		}
-		*/
-
-		/*
-		// The loop ends with curLayer being either nullptr or one past the last parsed layer
-		if (curLayer != nullptr && curLayer->isMemberOfProtocolFamily(parseUntil))
-		{
-		    curLayer->m_IsAllocatedInPacket = true;
-		}
-
-		// If the target OSI layer is exceeded, roll back the last layer (why?)
-		if (curLayer != nullptr && curLayer->getOsiModelLayer() > parseUntilLayer)
-		{
-		    // don't delete the first layer. If already past the target layer, treat the same as if the layer was found.
-		    if (curLayer == m_FirstLayer)
-		    {
-		        curLayer->m_IsAllocatedInPacket = true;
-		    }
-		    else
-		    {
-		        // Rolls back last layer if it exceeded the target OSI layer
-		        m_LastLayer = curLayer->getPrevLayer();
-		        delete curLayer;
-		        m_LastLayer->m_NextLayer = nullptr;
-		    }
-		}
-		*/
-
 		// If there is data left in the raw packet that doesn't belong to any layer, create a PacketTrailerLayer
 		if (m_LastLayer != nullptr && parseUntil == UnknownProtocol && parseUntilLayer == OsiModelLayerUnknown)
 		{

--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -66,7 +66,7 @@ namespace pcpp
 		// As the stop conditions are inclusive, the parse must go one layer further and then roll back if needed
 		bool rollbackLastLayer = false;
 		bool foundTargetProtocol = false;
-		for (Layer* curLayer = m_FirstLayer; curLayer != nullptr; curLayer = curLayer->getNextLayer())
+		for (auto* curLayer = m_FirstLayer; curLayer != nullptr; curLayer = curLayer->getNextLayer())
 		{
 			// Mark the current layer as allocated in the packet
 			curLayer->m_IsAllocatedInPacket = true;

--- a/Tests/Packet++Test/TestDefinition.h
+++ b/Tests/Packet++Test/TestDefinition.h
@@ -60,6 +60,7 @@ PTF_TEST_CASE(ResizeLayerTest);
 PTF_TEST_CASE(PrintPacketAndLayersTest);
 PTF_TEST_CASE(ProtocolFamilyMembershipTest);
 PTF_TEST_CASE(PacketParseLayerLimitTest);
+PTF_TEST_CASE(PacketParseMultiLayerTest);
 
 // Implemented in HttpTests.cpp
 PTF_TEST_CASE(HttpRequestParseMethodTest);

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -169,6 +169,7 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(PrintPacketAndLayersTest, "packet;print");
 	PTF_RUN_TEST(ProtocolFamilyMembershipTest, "packet");
 	PTF_RUN_TEST(PacketParseLayerLimitTest, "packet");
+	PTF_RUN_TEST(PacketParseMultiLayerTest, "packet");
 
 	PTF_RUN_TEST(HttpRequestParseMethodTest, "http");
 	PTF_RUN_TEST(HttpRequestLayerParsingTest, "http");

--- a/Tests/PcppTestUtilities/Resources.h
+++ b/Tests/PcppTestUtilities/Resources.h
@@ -29,7 +29,8 @@ namespace pcpp_tests
 		public:
 			/// @brief Constructs a ResourceProvider with a specified data root directory.
 			/// @param dataRoot The root directory from which resources will be loaded.
-			explicit ResourceProvider(std::string dataRoot);
+			/// @param frozen If true, the provider is read-only and does not allow saving resources.
+			explicit ResourceProvider(std::string dataRoot, bool frozen = true);
 
 			/// @brief Loads a resource from resource provider.
 			/// @param filename The name of the resource file to load.
@@ -43,8 +44,18 @@ namespace pcpp_tests
 			/// @return A vector containing the loaded data.
 			std::vector<uint8_t> loadResourceToVector(const char* filename, ResourceType resourceType) const;
 
+			/// @brief Saves a resource to the resource provider.
+			/// @param resourceType The type of the resource being saved.
+			/// @param filename The name of the file to save the resource to.
+			/// @param data Pointer to the data to be saved.
+			/// @param length The length of the data in bytes.
+			/// @throw std::runtime_error if the provider is frozen and does not allow saving.
+			void saveResource(ResourceType resourceType, const char* filename, const uint8_t* data,
+			                  size_t length) const;
+
 		private:
 			std::string m_DataRoot;  ///< The root directory for test data files
+			bool m_Frozen = true;    ///< Indicates if the provider is frozen (no modifications allowed)
 		};
 
 	}  // namespace utils


### PR DESCRIPTION
The `parseUntil` is now fully inclusive and parses until it exhausts a sequence of target protocol types. This allows specifying target protocols that allow chaining of the same protocol types.

Simplified the rollback mechanism.