### PR TITLE
Reorder filter definitions.

### DIFF
--- a/Pcap++/header/PcapFilter.h
+++ b/Pcap++/header/PcapFilter.h
@@ -195,7 +195,7 @@ namespace pcpp
 		}
 
 		/// @brief Get the direction of the filter (source or destination)
-		Direction getDir() const
+		Direction getDirection() const
 		{
 			return m_Dir;
 		}

--- a/Pcap++/header/PcapFilter.h
+++ b/Pcap++/header/PcapFilter.h
@@ -226,6 +226,7 @@ namespace pcpp
 			m_Operator = op;
 		}
 
+		/// @brief Get the operator of the filter
 		FilterOperator getOperator() const
 		{
 			return m_Operator;

--- a/Pcap++/header/PcapFilter.h
+++ b/Pcap++/header/PcapFilter.h
@@ -194,6 +194,7 @@ namespace pcpp
 			m_Dir = dir;
 		}
 
+		/// @brief Get the direction of the filter (source or destination)
 		Direction getDir() const
 		{
 			return m_Dir;

--- a/Pcap++/src/PcapFilter.cpp
+++ b/Pcap++/src/PcapFilter.cpp
@@ -229,7 +229,7 @@ namespace pcpp
 
 	void MacAddressFilter::parseToString(std::string& result)
 	{
-		if (getDir() != SRC_OR_DST)
+		if (getDirection() != SRC_OR_DST)
 		{
 			std::string dir;
 			parseDirection(dir);

--- a/Pcap++/src/PcapFilter.cpp
+++ b/Pcap++/src/PcapFilter.cpp
@@ -18,17 +18,6 @@ namespace pcpp
 
 	static const int DEFAULT_SNAPLEN = 9000;
 
-	bool GeneralFilter::matchPacketWithFilter(RawPacket* rawPacket)
-	{
-		std::string filterStr;
-		parseToString(filterStr);
-
-		if (!m_BpfWrapper.setFilter(filterStr))
-			return false;
-
-		return m_BpfWrapper.matchPacketWithFilter(rawPacket);
-	}
-
 	namespace internal
 	{
 		void BpfProgramDeleter::operator()(bpf_program* ptr) const noexcept
@@ -85,12 +74,6 @@ namespace pcpp
 		return true;
 	}
 
-	void BpfFilterWrapper::freeProgram()
-	{
-		m_Program = nullptr;
-		m_FilterStr.clear();
-	}
-
 	bool BpfFilterWrapper::matchPacketWithFilter(const RawPacket* rawPacket)
 	{
 		return matchPacketWithFilter(rawPacket->getRawData(), rawPacket->getRawDataLen(),
@@ -114,6 +97,23 @@ namespace pcpp
 		pktHdr.ts = internal::toTimeval(packetTimestamp);
 
 		return (pcap_offline_filter(m_Program.get(), &pktHdr, packetData) != 0);
+	}
+
+	void BpfFilterWrapper::freeProgram()
+	{
+		m_Program = nullptr;
+		m_FilterStr.clear();
+	}
+
+	bool GeneralFilter::matchPacketWithFilter(RawPacket* rawPacket)
+	{
+		std::string filterStr;
+		parseToString(filterStr);
+
+		if (!m_BpfWrapper.setFilter(filterStr))
+			return false;
+
+		return m_BpfWrapper.matchPacketWithFilter(rawPacket);
 	}
 
 	void BPFStringFilter::parseToString(std::string& result)


### PR DESCRIPTION
Split of #1957.

The PR reorders the filter definitions in the order `public / protected / private`, allowing external behaviour (public methods) to be at the top of the class for easy reference. Notable exception are constructors, which are placed at the top of the class.

Additional changes:
- Exposed `getOperator` in the public API of `IFilterWithOperator`.
- Exposed `getDir` as `getDirection` in the public API of `IFilterWithDirection`.