### PR TITLE
Added public headers as private target sources.

### DIFF
--- a/Common++/CMakeLists.txt
+++ b/Common++/CMakeLists.txt
@@ -35,6 +35,8 @@ set(
 # Set the public header that will be installed
 set_property(TARGET Common++ PROPERTY PUBLIC_HEADER ${public_headers})
 
+target_sources(Common++ PRIVATE ${public_headers})
+
 target_compile_features(Common++ PUBLIC cxx_std_14)
 
 target_include_directories(

--- a/Packet++/CMakeLists.txt
+++ b/Packet++/CMakeLists.txt
@@ -157,6 +157,8 @@ set(
 # Don't use set_target_properties CMake limit to 50 elements
 set_property(TARGET Packet++ PROPERTY PUBLIC_HEADER ${public_headers})
 
+target_sources(Packet++ PRIVATE ${public_headers})
+
 target_compile_features(Packet++ PUBLIC cxx_std_14)
 
 target_include_directories(

--- a/Pcap++/CMakeLists.txt
+++ b/Pcap++/CMakeLists.txt
@@ -64,6 +64,8 @@ endif()
 
 set_property(TARGET Pcap++ PROPERTY PUBLIC_HEADER ${public_headers})
 
+target_sources(Pcap++ PRIVATE ${public_headers})
+
 target_compile_features(Pcap++ PUBLIC cxx_std_14)
 
 if(APPLE)


### PR DESCRIPTION
The change does not affect the build process as header files are not compiled, but it helps IDEs recognize that the headers are part of the project and to treat them accordingly. (e.g. VS Rename tooling)