### PR TITLE
Cleanup of `Packet::createFirstLayer`

### DIFF
--- a/Packet++/header/NullLoopbackLayer.h
+++ b/Packet++/header/NullLoopbackLayer.h
@@ -78,5 +78,14 @@ namespace pcpp
 		{
 			return OsiModelDataLinkLayer;
 		}
+
+		/// @brief Check if the data passes minimal validity checks for Null/Loopback layer
+		/// @param data A pointer to the data
+		/// @param dataLen Size of the data in bytes
+		/// @return True if the data can represent a valid Null/Loopback layer, false otherwise
+		bool static isDataValid(const uint8_t* data, size_t dataLen)
+		{
+			return data != nullptr && dataLen >= sizeof(uint32_t);
+		}
 	};
 }  // namespace pcpp

--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -767,8 +767,7 @@ namespace pcpp
 		}
 		case LinkLayerType::LINKTYPE_NULL:
 		{
-			// Check if rawDataLen is too small fit Null/Loopback
-			if (rawDataLen >= sizeof(uint32_t))
+			if (NullLoopbackLayer::isDataValid(rawData, rawDataLen))
 			{
 				return new NullLoopbackLayer(const_cast<uint8_t*>(rawData), rawDataLen, this);
 			}


### PR DESCRIPTION
 - Changes the if-else chain into a switch case for better readability.
 - Removes the duplicated `new PayloadLayer(...)` calls. If all validations for a link layer fail, it exits the case statement and the payload layer is created by the tail call. IMO, that is easier to read than the multiline ternary operator + static casts calls.