### PR TITLE
Changes the Logger last error to be thread local.

### DIFF
--- a/Common++/header/Logger.h
+++ b/Common++/header/Logger.h
@@ -311,7 +311,6 @@ namespace pcpp
 		/// @return Get the last error message
 		std::string getLastError() const
 		{
-			std::lock_guard<std::mutex> const lock(m_LastErrorMtx);
 			return m_LastError;
 		}
 
@@ -395,8 +394,7 @@ namespace pcpp
 		std::array<LogLevel, NumOfLogModules> m_LogModulesArray{};
 		LogPrinter m_LogPrinter;
 
-		mutable std::mutex m_LastErrorMtx;
-		std::string m_LastError;
+		static thread_local std::string m_LastError;
 
 		bool m_UseContextPooling = true;
 		// Keep a maximum of 10 LogContext objects in the pool.

--- a/Common++/src/Logger.cpp
+++ b/Common++/src/Logger.cpp
@@ -50,9 +50,14 @@ namespace pcpp
 #endif
 	}
 
+	thread_local std::string Logger::m_LastError = [] {
+		std::string str;
+		str.reserve(200);
+		return str;
+	}();
+
 	Logger::Logger() : m_LogsEnabled(true), m_LogPrinter(&printToCerr)
 	{
-		m_LastError.reserve(200);
 		m_LogModulesArray.fill(LogLevel::Info);
 	}
 
@@ -110,7 +115,6 @@ namespace pcpp
 		// If the log level is an error, save the error to the last error message variable.
 		if (logLevel == LogLevel::Error)
 		{
-			std::lock_guard<std::mutex> const lock(m_LastErrorMtx);
 			m_LastError = message;
 		}
 		if (m_LogsEnabled)


### PR DESCRIPTION
This PR changes the last error string saved in Logger to be with `thread_local` storage duration. This is to mirror common implementations of win32's `GetLastError()` and unix `errno` which are thread storage duration variables, to accomodate multithreaded contexts.

The change removes a possible "Time to Check, Time to Use" condition, where a thread that previously had an error condition may have its error string overridden by another thread that encounters an error condition prior to the first thread fetching its error string. Due to the aforementioned bug, the original implementation may be considered unreliable in heavily multithreaded environments.

The change may be considered as breaking as it notably removes the ability of a thread to fetch the last error condition from another thread. This will not affect public API signature, but it might affect behaviour. 