### PR TITLE
Fix(build): Add out-of-class definitions for static members to fix debug build

### DIFF
--- a/Common++/src/GeneralUtils.cpp
+++ b/Common++/src/GeneralUtils.cpp
@@ -11,6 +11,7 @@
 
 namespace pcpp
 {
+	constexpr char Base64::paddingChar;
 
 	std::string byteArrayToHexString(const uint8_t* byteArr, size_t byteArrSize, int stringSizeLimit)
 	{

--- a/Packet++/src/LdapLayer.cpp
+++ b/Packet++/src/LdapLayer.cpp
@@ -5,6 +5,9 @@
 namespace pcpp
 {
 
+	constexpr uint8_t LdapResponseLayer::referralTagType;
+	constexpr int LdapBindResponseLayer::serverSaslCredentialsTagType;
+
 	// region LdapOperationType
 
 	// clang-format off


### PR DESCRIPTION
This PR fixes a linker error that occurs when compiling the project in Debug mode (`-DCMAKE_BUILD_TYPE=Debug`). It resolves issue #1997 by providing the necessary out-of-class definitions for several `static constexpr` class members.