### PR TITLE
fix(tests): Stabilize TestDpdkMultiThread on high-core-count systems

### DIFF
--- a/Tests/Pcap++Test/Tests/DpdkTests.cpp
+++ b/Tests/Pcap++Test/Tests/DpdkTests.cpp
@@ -402,7 +402,7 @@ PTF_TEST_CASE(TestDpdkMultiThread)
 	if (dev->getTotalNumOfRxQueues() > 1)
 	{
 		pcpp::Logger::getInstance().suppressLogs();
-		PTF_ASSERT_FALSE(dev->openMultiQueues(numOfRxQueuesToOpen + 1, 1));
+		PTF_ASSERT_FALSE(dev->openMultiQueues(dev->getTotalNumOfRxQueues() + 1, 1));
 		pcpp::Logger::getInstance().enableLogs();
 	}
 


### PR DESCRIPTION
This PR addresses a potential test failure in TestDpdkMultiThread when running on systems with a large number of CPU cores (more than 32). #1996

The TestDpdkMultiThread test calculates the number of RX queues to open based on the system's core count using pcpp::getNumOfCores() - 1. On machines with more than 32 cores (e.g., 64-core servers), this logic attempts to initialize a number of queues that exceeds the currently supported maximum of 32. This would cause the test to fail, making it difficult to validate PcapPlusPlus on high-end hardware.