### PR TITLE
Improve encapsulation of logic relating to Layer attachment to Packet.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -289,12 +289,6 @@ jobs:
           cd Tests/Packet++Test
           Bin/Packet++Test
 
-      - name: Test Pcap++
-        if: env.avx512 == 'true'
-        run: |
-          cd Tests/Pcap++Test
-          Bin/Pcap++Test
-
       - name: Tests skipped (no AVX-512 hardware support)
         if: env.avx512 == 'false'
         run: echo "Skipping tests since AVX-512 is not supported on the current runner"
@@ -501,7 +495,7 @@ jobs:
     name: Determine Windows Pcap Backend Matrix
     runs-on: ubuntu-latest
     outputs:
-        npcap-or-default: ${{ steps.generate-backends.outputs.npcap_or_default}}
+      npcap-or-default: ${{ steps.generate-backends.outputs.npcap_or_default}}
     steps:
       - name: Initialize NPcap backend variable
         run: echo "npcap_available=false" >> $GITHUB_ENV
@@ -705,42 +699,82 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  windivert:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2.0.0
+
+      - name: Install WinPcap
+        run: |
+          ci\install_winpcap.bat
+          echo "PCAP_SDK_DIR=C:\\WpdPack" >> $env:GITHUB_ENV
+      - name: Set WinDivert root
+        run: echo "WINDIVERT_DIR=C:\\WinDivert" >> $env:GITHUB_ENV
+
+      - name: Install WinDivert
+        shell: pwsh
+        run: .\ci\install_windivert.ps1 -Target "$env:WINDIVERT_DIR"
+
+      - name: Configure PcapPlusPlus (WinDivert)
+        run: cmake -A x64 -G "Visual Studio 17 2022" -DPCAP_ROOT=${{ env.PCAP_SDK_DIR }} -DPCAPPP_USE_WINDIVERT=ON -DWinDivert_ROOT=${{ env.WINDIVERT_DIR }} -S . -B "$env:BUILD_DIR"
+
+      - name: Build PcapPlusPlus
+        run: cmake --build $env:BUILD_DIR -j
+
+      - name: Install tcpreplay
+        run: ci\install_tcpreplay.bat
+
+      - name: Test PcapPlusPlus
+        shell: pwsh
+        run: |
+          Copy-Item "${{ env.WINDIVERT_DIR }}\x64\WinDivert.dll" "Tests\Pcap++Test\Bin\WinDivert.dll" -Force
+          Copy-Item "${{ env.WINDIVERT_DIR }}\x64\WinDivert64.sys" "Tests\Pcap++Test\Bin\WinDivert64.sys" -Force
+
+          python -m pip install -r ci\run_tests\requirements.txt
+          python ci\run_tests\run_tests_windows.py --include-tests windivert
+
   freebsd:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         version: ["14.1", "13.4"]
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - name: Test in FreeBSD
-      id: test
-      uses: vmactions/freebsd-vm@8873d98fd1413b5977cb2f7348fe329775159892 # v1.1.9
-      with:
-        release: ${{ matrix.version }}
-        usesh: true
-        prepare: |
-          pkg install -y python bash cmake git gmake gsed libpcap tcpreplay libffi openssl py311-cryptography
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Test in FreeBSD
+        id: test
+        uses: vmactions/freebsd-vm@8873d98fd1413b5977cb2f7348fe329775159892 # v1.1.9
+        with:
+          release: ${{ matrix.version }}
+          usesh: true
+          prepare: |
+            pkg install -y python bash cmake git gmake gsed libpcap tcpreplay libffi openssl py311-cryptography
+            sysctl kern.ipc.maxsockbuf=16777216
+          run: |
+            set -e
 
-        run: |
-          echo "Building PcapPlusPlus"
-          chmod a+rw /dev/bpf*
-          cmake -S . -B Dist
-          cmake --build Dist -j$(sysctl -n hw.ncpu)
+            echo "Building PcapPlusPlus"
+            chmod a+rw /dev/bpf*
+            cmake -S . -B Dist
+            cmake --build Dist -j$(sysctl -n hw.ncpu)
 
-          echo "Setting up the network interface for the tests"
-          # Get the first interface name that is not 'lo'
-          interface_name=$(ifconfig -l | tr ' ' '\n' | grep -v '^lo' | head -n 1)
-          ifconfig "$interface_name" promisc
+            echo "Setting up the network interface for the tests"
+            # Get the first interface name that is not 'lo'
+            interface_name=$(ifconfig -l | tr ' ' '\n' | grep -v '^lo' | head -n 1)
+            ifconfig "$interface_name" promisc
 
-          echo "Testing PcapPlusPlus"
-          python -m ensurepip
-          python -m pip install -r ci/run_tests/requirements.txt
-          python ci/run_tests/run_tests.py --interface "$interface_name"
+            echo "Testing PcapPlusPlus"
+            python -m ensurepip
+            python -m pip install -r ci/run_tests/requirements.txt
+            python ci/run_tests/run_tests.py --interface "$interface_name"
 
-          echo "Testing PcapPlusPlus examples"
-          cd Tests/ExamplesTest
-          python -m pip install -r requirements.txt
-          python -m pytest --interface "$interface_name" --root-path=../../Dist/examples_bin
+            echo "Testing PcapPlusPlus examples"
+            cd Tests/ExamplesTest
+            python -m pip install -r requirements.txt
+            python -m pytest --interface "$interface_name" --root-path=../../Dist/examples_bin
 
   android:
     strategy:

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -35,7 +35,7 @@ jobs:
         dry-run: false
         sanitizer: ${{ matrix.sanitizer }}
     - name: Upload Crash
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.29.5
+      uses: github/codeql-action/init@0499de31b99561a6d14a36a5f662c2a54f91beee # v3.29.5
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -44,4 +44,4 @@ jobs:
         cmake --build build -j
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.29.5
+      uses: github/codeql-action/analyze@0499de31b99561a6d14a36a5f662c2a54f91beee # v3.29.5

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -363,7 +363,7 @@ jobs:
           mkdir -p "android-package"
           mv "${COMBINED_PACKAGE_DIR}" "android-package"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           path: android-package
           name: android-package-${{ matrix.target }}-${{ matrix.api-version }}
@@ -378,7 +378,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           pattern: android-package-*
           merge-multiple: true

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -58,7 +58,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: SARIF file
           path: results.sarif
@@ -66,6 +66,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@3599b3baa15b485a2e49ef411a7a4bb2452e7f93 # v3.29.5
+        uses: github/codeql-action/upload-sarif@0499de31b99561a6d14a36a5f662c2a54f91beee # v3.29.5
         with:
           sarif_file: results.sarif

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         args: ['--fix=lf']
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.2
+    rev: v0.14.7
     hooks:
       - id: ruff # Run the linter.
         types_or: [ python ]
@@ -38,7 +38,7 @@ repos:
       - id: cppcheck
         args: ["--std=c++14", "--language=c++", "--suppressions-list=cppcheckSuppressions.txt", "--inline-suppr", "--force"]
   - repo: https://github.com/BlankSpruce/gersemi
-    rev: 0.22.3
+    rev: 0.23.2
     hooks:
     - id: gersemi
       args: ["-c"]
@@ -54,6 +54,6 @@ repos:
         args: ['--config=typos-config.toml']
         pass_filenames: false
   - repo: https://github.com/lovesegfault/beautysh
-    rev: v6.2.1
+    rev: v6.4.2
     hooks:
       - id: beautysh

--- a/3rdParty/OUIDataset/PCPP_OUIDataset.json
+++ b/3rdParty/OUIDataset/PCPP_OUIDataset.json
@@ -14319,7 +14319,7 @@
         "vendor": "HotLava Systems, Inc."
     },
     "4801": {
-        "vendor": "Check Point Software Technologies"
+        "vendor": "Check Point Software Technologies Ltd."
     },
     "4802": {
         "vendor": "Apex Electronics Factory"
@@ -16746,7 +16746,7 @@
         "vendor": "D-Link Corporation"
     },
     "5610": {
-        "vendor": "Tellumat (Pty) Ltd"
+        "vendor": "Hensoldt South Africa (Pty) Ltd"
     },
     "5611": {
         "vendor": "zte corporation"
@@ -28074,7 +28074,7 @@
         "vendor": "Adolf Thies Gmbh & Co. KG"
     },
     "9390": {
-        "vendor": "Idemia"
+        "vendor": "Idemia France Sas"
     },
     "9391": {
         "vendor": "Dish Technologies Corp"
@@ -28920,7 +28920,7 @@
         "vendor": "Shenzhen Huapu Digital Co., Ltd"
     },
     "9674": {
-        "vendor": "Laird Connectivity"
+        "vendor": "Ezurio, LLC"
     },
     "9675": {
         "vendor": "Reiner SCT"
@@ -33482,6 +33482,9 @@
     "30925": {
         "vendor": "Ignition Design Labs"
     },
+    "31396": {
+        "vendor": "FRITZ! Technology GmbH"
+    },
     "31512": {
         "vendor": "SENTRY Co., LTD."
     },
@@ -34322,6 +34325,9 @@
     "35002": {
         "vendor": "Nc&C"
     },
+    "35273": {
+        "vendor": "Extreme Networks Headquarters"
+    },
     "35413": {
         "vendor": "Huawei Device Co., Ltd."
     },
@@ -35137,6 +35143,9 @@
     },
     "37370": {
         "vendor": "Synapse Product Development"
+    },
+    "37429": {
+        "vendor": "Apple, Inc."
     },
     "37501": {
         "vendor": "Ficosa Internationa(Taicang) C0.,Ltd."
@@ -36289,6 +36298,9 @@
     },
     "48224": {
         "vendor": "Cisco Systems, Inc"
+    },
+    "48281": {
+        "vendor": "Hangzhou Hikvision Digital Technology Co.,Ltd."
     },
     "48423": {
         "vendor": "Exar Corp."
@@ -39170,6 +39182,9 @@
     "267737": {
         "vendor": "Viwone"
     },
+    "268108": {
+        "vendor": "Nanjing SCIYON Wisdom Technology Group Co.,Ltd."
+    },
     "268214": {
         "vendor": "Smart Innovation LLC"
     },
@@ -39199,6 +39214,9 @@
     },
     "269242": {
         "vendor": "Samsung Electronics Co.,Ltd"
+    },
+    "269531": {
+        "vendor": "Siba Service"
     },
     "269584": {
         "vendor": "Dream Ware Inc."
@@ -39238,6 +39256,9 @@
     },
     "271138": {
         "vendor": "Texas Instruments"
+    },
+    "271365": {
+        "vendor": "Guangdong Oppo Mobile Telecommunications Corp.,Ltd"
     },
     "271813": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -39311,6 +39332,9 @@
     "275651": {
         "vendor": "Qingdao Goertek Horizons Tecnology Co.,LTD"
     },
+    "275663": {
+        "vendor": "Apple, Inc."
+    },
     "275702": {
         "vendor": "Motorola (Wuhan) Mobility Technologies Communication Co., Ltd."
     },
@@ -39331,6 +39355,9 @@
     },
     "276774": {
         "vendor": "China Dragon Technology Limited"
+    },
+    "276939": {
+        "vendor": "Qingdao HaierTechnology Co.,Ltd"
     },
     "277005": {
         "vendor": "SM Optics S.r.l."
@@ -39872,6 +39899,9 @@
     "308478": {
         "vendor": "AVM Audiovisuelles Marketing und Computersysteme GmbH"
     },
+    "308658": {
+        "vendor": "Apple, Inc."
+    },
     "308673": {
         "vendor": "Itel Mobile Limited"
     },
@@ -39974,6 +40004,9 @@
     "312740": {
         "vendor": "Cisco Systems, Inc"
     },
+    "312781": {
+        "vendor": "Mellanox Technologies, Inc."
+    },
     "313351": {
         "vendor": "Xiaomi Communications Co Ltd"
     },
@@ -39991,6 +40024,9 @@
     },
     "313817": {
         "vendor": "Dish Technologies Corp"
+    },
+    "313822": {
+        "vendor": "Qingdao HaierTechnology Co.,Ltd"
     },
     "313997": {
         "vendor": "Enfabrica"
@@ -40880,6 +40916,9 @@
     "532467": {
         "vendor": "Cisco Systems, Inc"
     },
+    "532711": {
+        "vendor": "Mellanox Technologies, Inc."
+    },
     "532975": {
         "vendor": "Samsung Electronics Co.,Ltd"
     },
@@ -41507,6 +41546,9 @@
     "570019": {
         "vendor": "Cynny Italia S.r.L."
     },
+    "570169": {
+        "vendor": "Xiaomi Communications Co Ltd"
+    },
     "570287": {
         "vendor": "vivo Mobile Communication Co., Ltd."
     },
@@ -41864,11 +41906,17 @@
     "669212": {
         "vendor": "Smardii"
     },
+    "678139": {
+        "vendor": "Purple WiFi Limited"
+    },
     "689974": {
         "vendor": "IEEE 1901 Working Group"
     },
     "691810": {
         "vendor": "Delta Solutions LLC"
+    },
+    "693030": {
+        "vendor": "Qorvo, Inc."
     },
     "696891": {
         "vendor": "Vitex LLC"
@@ -41929,6 +41977,9 @@
     },
     "790134": {
         "vendor": "D-Link International"
+    },
+    "790219": {
+        "vendor": "Huawei Device Co., Ltd."
     },
     "790789": {
         "vendor": "Akuvox (Xiamen) Networks Co., Ltd"
@@ -42314,6 +42365,9 @@
     "815453": {
         "vendor": "Samsung Electronics Co.,Ltd"
     },
+    "815461": {
+        "vendor": "Motorola Mobility LLC, a Lenovo Company"
+    },
     "815500": {
         "vendor": "TCT mobile ltd"
     },
@@ -42331,6 +42385,9 @@
     },
     "816062": {
         "vendor": "Dongguan Haimai Electronie Technology Co.,Ltd"
+    },
+    "816244": {
+        "vendor": "Fiberhome Telecommunication Technologies Co.,LTD"
     },
     "816322": {
         "vendor": "Apple, Inc."
@@ -42445,6 +42502,9 @@
     },
     "821106": {
         "vendor": "Fujian Star-Net Communication Co.,Ltd"
+    },
+    "821298": {
+        "vendor": "Nokia Solutions and Networks India Private Limited"
     },
     "821520": {
         "vendor": "Samsung Electronics Co.,Ltd"
@@ -42897,7 +42957,7 @@
         "vendor": "Realme Chongqing Mobile Telecommunications Corp.,Ltd."
     },
     "845577": {
-        "vendor": "Fox Crypto B.V."
+        "vendor": "Sentyron B.V"
     },
     "845605": {
         "vendor": "Microsoft Corporation"
@@ -42961,6 +43021,9 @@
     },
     "848052": {
         "vendor": "Globalsat International Technology Ltd"
+    },
+    "848629": {
+        "vendor": "Sichuan AI-Link Technology Co., Ltd."
     },
     "848710": {
         "vendor": "Xiaomi Communications Co Ltd"
@@ -43137,13 +43200,16 @@
         "vendor": "Hangzhou Hikvision Digital Technology Co.,Ltd."
     },
     "1053489": {
-        "vendor": "Technicolor Delivery Technologies Belgium NV"
+        "vendor": "Vantiva Technologies Belgium"
     },
     "1053678": {
         "vendor": "Justec International Technology INC."
     },
     "1054145": {
         "vendor": "Zhanzuo (Beijing) Technology Co., Ltd."
+    },
+    "1054385": {
+        "vendor": "Guangdong Oppo Mobile Telecommunications Corp.,Ltd"
     },
     "1054793": {
         "vendor": "Weifang Goertek Electronics Co.,Ltd"
@@ -43667,6 +43733,9 @@
     "1082071": {
         "vendor": "Realme Chongqing Mobile Telecommunications Corp.,Ltd."
     },
+    "1082145": {
+        "vendor": "Yichip Microelectronics (Hangzhou) Co.,Ltd"
+    },
     "1082292": {
         "vendor": "Sidora Srl"
     },
@@ -43684,6 +43753,9 @@
     },
     "1083598": {
         "vendor": "Fiberhome Telecommunication Technologies Co.,LTD"
+    },
+    "1083603": {
+        "vendor": "Huawei Technologies Co.,Ltd"
     },
     "1083899": {
         "vendor": "Samsung Electronics Co.,Ltd"
@@ -43934,6 +44006,9 @@
     "1096691": {
         "vendor": "Hunan Fn-Link Technology Limited"
     },
+    "1096758": {
+        "vendor": "Huawei Device Co., Ltd."
+    },
     "1096855": {
         "vendor": "vivo Mobile Communication Co., Ltd."
     },
@@ -44183,6 +44258,9 @@
     "1109121": {
         "vendor": "Samsung Electronics Co.,Ltd"
     },
+    "1109448": {
+        "vendor": "NXP Semiconductors Taiwan Ltd."
+    },
     "1109721": {
         "vendor": "Canoga Perkins Corporation"
     },
@@ -44377,6 +44455,9 @@
     },
     "1316650": {
         "vendor": "Fiberhome Telecommunication Technologies Co.,LTD"
+    },
+    "1316902": {
+        "vendor": "Nokia"
     },
     "1316932": {
         "vendor": "Xenon Smart Teknoloji Ltd."
@@ -44633,6 +44714,9 @@
     "1330202": {
         "vendor": "Max Communication GmbH"
     },
+    "1330431": {
+        "vendor": "Grandstream Networks, Inc."
+    },
     "1330535": {
         "vendor": "Zioncom Electronics (Shenzhen) Ltd."
     },
@@ -44722,6 +44806,9 @@
     },
     "1334889": {
         "vendor": "Guangdong Oppo Mobile Telecommunications Corp.,Ltd"
+    },
+    "1334972": {
+        "vendor": "Huawei Technologies Co.,Ltd"
     },
     "1335188": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -45017,6 +45104,9 @@
     "1352727": {
         "vendor": "Shenzhen Belon Technology CO.,LTD"
     },
+    "1352788": {
+        "vendor": "Mist Systems, Inc."
+    },
     "1352986": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
@@ -45226,6 +45316,9 @@
     },
     "1365581": {
         "vendor": "D-Link International"
+    },
+    "1365628": {
+        "vendor": "Uncord Technologies Private Limited"
     },
     "1365797": {
         "vendor": "Barrot Technology Co.,Ltd."
@@ -45514,6 +45607,9 @@
     },
     "1581694": {
         "vendor": "Samsung Electronics Co.,Ltd"
+    },
+    "1582137": {
+        "vendor": "Yippee Electronics Cp.,Limited"
     },
     "1582665": {
         "vendor": "Intel Corporate"
@@ -45818,6 +45914,9 @@
     "1596339": {
         "vendor": "Samsung Electronics Co.,Ltd"
     },
+    "1596577": {
+        "vendor": "Jiangxi Risound Electronics Co.,LTD"
+    },
     "1596783": {
         "vendor": "N3com"
     },
@@ -46097,6 +46196,9 @@
     "1611128": {
         "vendor": "Denso Corporation"
     },
+    "1611383": {
+        "vendor": "Annapurna labs"
+    },
     "1611761": {
         "vendor": "KOSTAL (Shanghai) Management Co., Ltd."
     },
@@ -46190,6 +46292,9 @@
     "1617054": {
         "vendor": "Itel Mobile Limited"
     },
+    "1617090": {
+        "vendor": "TCL King Electrical Appliances(Huizhou)Co.,Ltd"
+    },
     "1617229": {
         "vendor": "Polostar Technology Corporation"
     },
@@ -46228,6 +46333,9 @@
     },
     "1619345": {
         "vendor": "I-Storm"
+    },
+    "1619543": {
+        "vendor": "Huawei Technologies Co.,Ltd"
     },
     "1619660": {
         "vendor": "We Corporation Inc."
@@ -46299,7 +46407,7 @@
         "vendor": "SonicWall"
     },
     "1622675": {
-        "vendor": "Laird Connectivity"
+        "vendor": "Ezurio, LLC"
     },
     "1622719": {
         "vendor": "Buffalo.Inc"
@@ -46329,7 +46437,7 @@
         "vendor": "Philio Technology Corporation"
     },
     "1625224": {
-        "vendor": "Hitachi Air Conditioning Shimizu, Inc."
+        "vendor": "Hitachi Global Life Solutions, Inc."
     },
     "1625748": {
         "vendor": "Samsung Electronics Co.,Ltd"
@@ -46550,6 +46658,9 @@
     "1637535": {
         "vendor": "Changhe Electronics Co., Ltd."
     },
+    "1637632": {
+        "vendor": "Marelli"
+    },
     "1637748": {
         "vendor": "Routerboard.com"
     },
@@ -46582,6 +46693,9 @@
     },
     "1835545": {
         "vendor": "Guangdong Oppo Mobile Telecommunications Corp.,Ltd"
+    },
+    "1836128": {
+        "vendor": "NXP Semiconductors Taiwan Ltd."
     },
     "1836471": {
         "vendor": "Chongqing Trantor Technology Co., Ltd."
@@ -47093,6 +47207,9 @@
     "1863714": {
         "vendor": "Murata Manufacturing Co., Ltd."
     },
+    "1863765": {
+        "vendor": "Huawei Technologies Co.,Ltd"
+    },
     "1863881": {
         "vendor": "Jiangsu Aisida Electronic Co., Ltd"
     },
@@ -47222,11 +47339,17 @@
     "1870831": {
         "vendor": "Beijing Xiaomi Electronics Co.,Ltd"
     },
+    "1871402": {
+        "vendor": "Apple, Inc."
+    },
     "1871452": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
     "1871502": {
         "vendor": "DB Communication & Systems Co., ltd."
+    },
+    "1871590": {
+        "vendor": "Vtech Telecommunications Limited"
     },
     "1871754": {
         "vendor": "Phase Motion Control SpA"
@@ -47278,6 +47401,9 @@
     },
     "1873915": {
         "vendor": "CoolBitX Ltd."
+    },
+    "1873995": {
+        "vendor": "Extreme Networks Headquarters"
     },
     "1874113": {
         "vendor": "Cloud Network Technology Singapore Pte. Ltd."
@@ -47488,6 +47614,9 @@
     },
     "1887825": {
         "vendor": "AzureWave Technology Inc."
+    },
+    "1888130": {
+        "vendor": "Palo Alto Networks"
     },
     "1888519": {
         "vendor": "Realme Chongqing Mobile Telecommunications Corp.,Ltd."
@@ -48477,7 +48606,7 @@
         "vendor": "SteelSeries ApS"
     },
     "2142209": {
-        "vendor": "Technicolor Delivery Technologies Belgium NV"
+        "vendor": "Vantiva Technologies Belgium"
     },
     "2142455": {
         "vendor": "Enclustra GmbH"
@@ -48499,6 +48628,9 @@
     },
     "2144299": {
         "vendor": "Sagemcom Broadband SAS"
+    },
+    "2144317": {
+        "vendor": "Unionman Technology Co.,Ltd"
     },
     "2144360": {
         "vendor": "Motorola Mobility LLC, a Lenovo Company"
@@ -48571,6 +48703,9 @@
     },
     "2148816": {
         "vendor": "Apple, Inc."
+    },
+    "2149324": {
+        "vendor": "GridVisibility, inc."
     },
     "2149415": {
         "vendor": "Cisco Systems, Inc"
@@ -48662,6 +48797,9 @@
     "2154652": {
         "vendor": "Nokia"
     },
+    "2154845": {
+        "vendor": "TP-Link Systems Inc."
+    },
     "2155176": {
         "vendor": "Apple, Inc."
     },
@@ -48676,6 +48814,9 @@
     },
     "2155876": {
         "vendor": "Commscope"
+    },
+    "2155931": {
+        "vendor": "Panasonic Automotive Systems"
     },
     "2156255": {
         "vendor": "eero inc."
@@ -48932,6 +49073,9 @@
     "2365810": {
         "vendor": "Quectel Wireless Solutions Co.,Ltd."
     },
+    "2365861": {
+        "vendor": "New H3C Technologies Co., Ltd"
+    },
     "2366092": {
         "vendor": "Squarehead Technology AS"
     },
@@ -49172,6 +49316,12 @@
     "2380735": {
         "vendor": "Enernet"
     },
+    "2380781": {
+        "vendor": "Dell Inc."
+    },
+    "2381210": {
+        "vendor": "Apple, Inc."
+    },
     "2381934": {
         "vendor": "zte corporation"
     },
@@ -49249,6 +49399,9 @@
     },
     "2384555": {
         "vendor": "Espressif Inc."
+    },
+    "2384582": {
+        "vendor": "Huawei Device Co., Ltd."
     },
     "2384590": {
         "vendor": "Hewlett Packard Enterprise"
@@ -49411,6 +49564,9 @@
     },
     "2392714": {
         "vendor": "Prowave Technologies Ltd."
+    },
+    "2392778": {
+        "vendor": "vivo Mobile Communication Co., Ltd."
     },
     "2393240": {
         "vendor": "Beijing Jiaoda Microunion Tech.Co.,Ltd."
@@ -49757,6 +49913,9 @@
     "2415286": {
         "vendor": "Sistemas de Gestión Energética S.A. de C.V"
     },
+    "2415508": {
+        "vendor": "Juniper Networks"
+    },
     "2415532": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
@@ -49905,7 +50064,7 @@
         "vendor": "Hewlett Packard Enterprise"
     },
     "2421469": {
-        "vendor": "Radiant Zemax LLC"
+        "vendor": "Radiant Vision Systems, LLC"
     },
     "2421510": {
         "vendor": "Itel Mobile Limited"
@@ -50104,6 +50263,9 @@
     },
     "2628897": {
         "vendor": "In One Smart Technology(H,K,)Limited"
+    },
+    "2629034": {
+        "vendor": "ASTI India Private Limited"
     },
     "2629115": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -50768,6 +50930,9 @@
     "2668008": {
         "vendor": "Texas Instruments"
     },
+    "2668156": {
+        "vendor": "KEBODA Intelligent TECHNOLOGY CO., LTD."
+    },
     "2668585": {
         "vendor": "Juniper Networks"
     },
@@ -50782,6 +50947,9 @@
     },
     "2669401": {
         "vendor": "RNET Technologies, Inc."
+    },
+    "2669490": {
+        "vendor": "Infinix mobility limited"
     },
     "2669549": {
         "vendor": "Bouffalo Lab (Nanjing) Co., Ltd."
@@ -51056,6 +51224,9 @@
     "2681389": {
         "vendor": "Apple, Inc."
     },
+    "2681435": {
+        "vendor": "Samsara Networks Inc"
+    },
     "2681610": {
         "vendor": "Rolling Wireless S.a.r.l. Luxembourg"
     },
@@ -51178,6 +51349,9 @@
     },
     "2764675": {
         "vendor": "Uplink"
+    },
+    "2764770": {
+        "vendor": "onway ag"
     },
     "2770889": {
         "vendor": "Code Construct Pty Ltd"
@@ -51406,6 +51580,9 @@
     },
     "2895176": {
         "vendor": "Commend International GmbH"
+    },
+    "2895860": {
+        "vendor": "eero inc."
     },
     "2895898": {
         "vendor": "Technicolor CH USA Inc for Telus"
@@ -52019,6 +52196,9 @@
     "2928171": {
         "vendor": "Samsung Electronics Co.,Ltd"
     },
+    "2928580": {
+        "vendor": "Private"
+    },
     "2928733": {
         "vendor": "Netgear"
     },
@@ -52283,6 +52463,9 @@
     "2943708": {
         "vendor": "Askey Computer Corp"
     },
+    "2943740": {
+        "vendor": "Intel Corporate"
+    },
     "2944166": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
@@ -52432,6 +52615,9 @@
     },
     "3149214": {
         "vendor": "Ruijie Networks Co.,LTD"
+    },
+    "3149379": {
+        "vendor": "Apple, Inc."
     },
     "3149496": {
         "vendor": "LG Electronics"
@@ -52706,6 +52892,9 @@
     "3165310": {
         "vendor": "Panasonic Electric Works Automation Controls Techno Co.,Ltd."
     },
+    "3165471": {
+        "vendor": "Amazon Technologies Inc."
+    },
     "3165723": {
         "vendor": "Huawei Device Co., Ltd."
     },
@@ -52874,6 +53063,9 @@
     "3176047": {
         "vendor": "LG Electronics (Mobile Communications)"
     },
+    "3176181": {
+        "vendor": "Espressif Inc."
+    },
     "3176395": {
         "vendor": "Maike Industry(Shenzhen)CO.,LTD"
     },
@@ -52927,6 +53119,9 @@
     },
     "3179030": {
         "vendor": "Apple, Inc."
+    },
+    "3179371": {
+        "vendor": "SteeRetail Co.,Ltd."
     },
     "3179416": {
         "vendor": "Espressif Inc."
@@ -53007,7 +53202,7 @@
         "vendor": "Skyworth Digital Technology(Shenzhen) Co.,Ltd"
     },
     "3182991": {
-        "vendor": "Technicolor Delivery Technologies Belgium NV"
+        "vendor": "Vantiva Technologies Belgium"
     },
     "3183350": {
         "vendor": "Shanghai Sunmon Communication Technogy Co.,Ltd"
@@ -53183,6 +53378,9 @@
     "3193725": {
         "vendor": "OnePlus Technology (Shenzhen) Co., Ltd"
     },
+    "3193935": {
+        "vendor": "Beijing Jianguo Bite Technology Co., Ltd."
+    },
     "3194131": {
         "vendor": "Zyxel Communications Corporation"
     },
@@ -53245,6 +53443,9 @@
     },
     "3197750": {
         "vendor": "Belden Singapore Pte. Ltd."
+    },
+    "3197833": {
+        "vendor": "OnLogic Inc"
     },
     "3197895": {
         "vendor": "Cambium Networks Limited"
@@ -53402,6 +53603,9 @@
     "3206268": {
         "vendor": "Shenzhen Along Electronics Co., Ltd"
     },
+    "3206307": {
+        "vendor": "Alfatron Electronics INC"
+    },
     "3206550": {
         "vendor": "LS Mecapion"
     },
@@ -53527,6 +53731,9 @@
     },
     "3408539": {
         "vendor": "Plexonics Technologies LImited"
+    },
+    "3408540": {
+        "vendor": "D-Link Corporation"
     },
     "3408862": {
         "vendor": "Texas Instruments"
@@ -53686,6 +53893,9 @@
     },
     "3417606": {
         "vendor": "CarePredict, Inc."
+    },
+    "3417830": {
+        "vendor": "Cig Shanghai Co Ltd"
     },
     "3418002": {
         "vendor": "Freebox Sas"
@@ -53899,6 +54109,9 @@
     },
     "3429780": {
         "vendor": "Fujian Star-Net Communication Co.,Ltd"
+    },
+    "3429861": {
+        "vendor": "SJIT Co., Ltd."
     },
     "3430142": {
         "vendor": "Cisco Meraki"
@@ -55040,6 +55253,9 @@
     "3682732": {
         "vendor": "Weg"
     },
+    "3683269": {
+        "vendor": "Microsoft Corporation"
+    },
     "3683835": {
         "vendor": "Sagemcom Broadband SAS"
     },
@@ -55099,6 +55315,9 @@
     },
     "3687397": {
         "vendor": "Grotech Inc"
+    },
+    "3687614": {
+        "vendor": "Espressif Inc."
     },
     "3687739": {
         "vendor": "Ruckus Wireless"
@@ -55466,6 +55685,9 @@
     "3709686": {
         "vendor": "Samsung Electronics Co.,Ltd"
     },
+    "3709811": {
+        "vendor": "Gsd Viet Nam Technology Company Limited"
+    },
     "3710130": {
         "vendor": "Apple, Inc."
     },
@@ -55805,6 +56027,9 @@
     "3730247": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
+    "3730439": {
+        "vendor": "Motorola Mobility LLC, a Lenovo Company"
+    },
     "3730445": {
         "vendor": "Apple, Inc."
     },
@@ -55918,6 +56143,9 @@
     },
     "3734292": {
         "vendor": "Huawei Technologies Co.,Ltd"
+    },
+    "3734432": {
+        "vendor": "Shenzhen Baseus Technology CoLtd"
     },
     "3734580": {
         "vendor": "Huawei Device Co., Ltd."
@@ -56150,6 +56378,9 @@
     "3938974": {
         "vendor": "VitalThings AS"
     },
+    "3939020": {
+        "vendor": "Quectel Wireless Solutions Co.,Ltd."
+    },
     "3939320": {
         "vendor": "Hangzhou Hikvision Digital Technology Co.,Ltd."
     },
@@ -56202,7 +56433,10 @@
         "vendor": "Google, Inc."
     },
     "3942566": {
-        "vendor": "Alcatel-Lucent Enterprise (China)"
+        "vendor": "ALE International"
+    },
+    "3943091": {
+        "vendor": "Telesystem communications Pte Ltd"
     },
     "3943156": {
         "vendor": "Brother Industries, LTD."
@@ -56356,6 +56590,9 @@
     },
     "3950903": {
         "vendor": "ASSMANN Electronic GmbH"
+    },
+    "3951103": {
+        "vendor": "Unionman Technology Co.,Ltd"
     },
     "3951250": {
         "vendor": "Hewlett Packard"
@@ -56593,6 +56830,9 @@
     },
     "3965098": {
         "vendor": "Ransnet Singapore Pte Ltd"
+    },
+    "3965225": {
+        "vendor": "Inheco Industrial Heating and Cooling GmbH"
     },
     "3965400": {
         "vendor": "Sagemcom Broadband SAS"
@@ -57113,6 +57353,9 @@
     "3993484": {
         "vendor": "Zhejiang Dahua Technology Co., Ltd."
     },
+    "3993509": {
+        "vendor": "Cloud Network Technology Singapore Pte. Ltd."
+    },
     "3993617": {
         "vendor": "Intel Corporate"
     },
@@ -57176,6 +57419,9 @@
     "3996288": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
+    "3996418": {
+        "vendor": "Apple, Inc."
+    },
     "3996508": {
         "vendor": "Fiberhome Telecommunication Technologies Co.,LTD"
     },
@@ -57223,6 +57469,12 @@
     },
     "4196288": {
         "vendor": "Railtec Systems GmbH"
+    },
+    "4196471": {
+        "vendor": "Xiaomi Communications Co Ltd"
+    },
+    "4197095": {
+        "vendor": "BSH Hausgeräte GmbH"
     },
     "4197648": {
         "vendor": "Commscope"
@@ -57412,6 +57664,9 @@
     },
     "4208557": {
         "vendor": "Macro Image Technology, Inc."
+    },
+    "4208642": {
+        "vendor": "Silicon Laboratories"
     },
     "4209531": {
         "vendor": "Huawei Device Co., Ltd."
@@ -57898,6 +58153,9 @@
     },
     "4236236": {
         "vendor": "Intel Corporate"
+    },
+    "4236362": {
+        "vendor": "Google, Inc."
     },
     "4236603": {
         "vendor": "Nokia"
@@ -58451,6 +58709,9 @@
     "4463180": {
         "vendor": "xFusion Digital Technologies Co.,Ltd."
     },
+    "4463196": {
+        "vendor": "Cisco Systems, Inc"
+    },
     "4463236": {
         "vendor": "Quectel Wireless Solutions Co.,Ltd."
     },
@@ -58462,6 +58723,9 @@
     },
     "4463496": {
         "vendor": "Apple, Inc."
+    },
+    "4463606": {
+        "vendor": "Espressif Inc."
     },
     "4463634": {
         "vendor": "Vantiva USA LLC"
@@ -58504,6 +58768,9 @@
     },
     "4465578": {
         "vendor": "Farmage Co., Ltd."
+    },
+    "4465976": {
+        "vendor": "WNC Corporation"
     },
     "4466107": {
         "vendor": "Bamboo Entertainment Corporation"
@@ -58808,6 +59075,9 @@
     "4482431": {
         "vendor": "Calix Inc."
     },
+    "4482442": {
+        "vendor": "Dukelana LLC"
+    },
     "4482528": {
         "vendor": "Merlion Consulting Services (Shenzhen) Co., Ltd"
     },
@@ -59006,6 +59276,9 @@
     "4493787": {
         "vendor": "Shanghai Huaqin Telecom Technology Co.,Ltd"
     },
+    "4494221": {
+        "vendor": "Innolux Corporation"
+    },
     "4494588": {
         "vendor": "Netgear"
     },
@@ -59026,6 +59299,9 @@
     },
     "4496321": {
         "vendor": "Huawei Technologies Co.,Ltd"
+    },
+    "4496326": {
+        "vendor": "EOSS s.r.l."
     },
     "4496565": {
         "vendor": "Alcomp, Inc"
@@ -59479,6 +59755,9 @@
     },
     "4520794": {
         "vendor": "zte corporation"
+    },
+    "4520822": {
+        "vendor": "vivo Mobile Communication Co., Ltd."
     },
     "4521379": {
         "vendor": "Everysight LTD."
@@ -60509,6 +60788,9 @@
     "4776367": {
         "vendor": "Vity"
     },
+    "4776394": {
+        "vendor": "Apple, Inc."
+    },
     "4776425": {
         "vendor": "Chengdu Meross Technology Co., Ltd."
     },
@@ -60640,6 +60922,9 @@
     },
     "4783111": {
         "vendor": "Huawei Device Co., Ltd."
+    },
+    "4783228": {
+        "vendor": "Shenzhen Huidu Technology Co., Ltd."
     },
     "4783286": {
         "vendor": "Lava International(H.K) Limited"
@@ -60976,6 +61261,9 @@
     },
     "4996118": {
         "vendor": "Samsung Electronics Co.,Ltd"
+    },
+    "4996239": {
+        "vendor": "Shenzhen Jingxun Technology Co., Ltd."
     },
     "4997031": {
         "vendor": "uGrid Network Inc."
@@ -61661,6 +61949,9 @@
     "5034927": {
         "vendor": "HMD Global Oy"
     },
+    "5035185": {
+        "vendor": "NXP Semiconductor (Tianjin) LTD."
+    },
     "5035334": {
         "vendor": "Hewlett Packard Enterprise"
     },
@@ -61730,11 +62021,17 @@
     "5038523": {
         "vendor": "Zhuhai HiFocus Technology Co., Ltd."
     },
+    "5038607": {
+        "vendor": "Xiaomi Communications Co Ltd"
+    },
     "5038833": {
         "vendor": "Udino srl"
     },
     "5039534": {
         "vendor": "Tianjin Beebox Intelligent Technology Co.,Ltd."
+    },
+    "5039696": {
+        "vendor": "Apple, Inc."
     },
     "5039710": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -61789,6 +62086,9 @@
     },
     "5042112": {
         "vendor": "Amazon Technologies Inc."
+    },
+    "5042145": {
+        "vendor": "Dynacon Sp. z o.o."
     },
     "5042222": {
         "vendor": "Vifa Denmark A/S"
@@ -62114,6 +62414,9 @@
     "5255412": {
         "vendor": "Exascend, Inc."
     },
+    "5255459": {
+        "vendor": "FN-LINK TECHNOLOGY Ltd."
+    },
     "5255597": {
         "vendor": "ABB Global Industries and Services Private Limited"
     },
@@ -62368,6 +62671,9 @@
     },
     "5267496": {
         "vendor": "Xirrus Inc."
+    },
+    "5267775": {
+        "vendor": "eero inc."
     },
     "5267844": {
         "vendor": "Avaya Inc"
@@ -62720,6 +63026,9 @@
     "5286366": {
         "vendor": "Smartcom - Bulgaria AD"
     },
+    "5286697": {
+        "vendor": "Trackunit ApS"
+    },
     "5286718": {
         "vendor": "Qibixx AG"
     },
@@ -62864,6 +63173,9 @@
     "5296229": {
         "vendor": "ESYLUX GmbH"
     },
+    "5296237": {
+        "vendor": "Bird Buddy"
+    },
     "5296659": {
         "vendor": "CviLux Corporation"
     },
@@ -62938,6 +63250,9 @@
     },
     "5300463": {
         "vendor": "Nokia"
+    },
+    "5300473": {
+        "vendor": "GE Vernova"
     },
     "5300554": {
         "vendor": "Private"
@@ -63374,6 +63689,9 @@
     "5518825": {
         "vendor": "Feitian Technologies Co., Ltd"
     },
+    "5518897": {
+        "vendor": "Intel Corporate"
+    },
     "5519003": {
         "vendor": "1Verge Internet Technology (Beijing) Co., Ltd."
     },
@@ -63382,6 +63700,9 @@
     },
     "5519720": {
         "vendor": "Edgewater Networks Inc"
+    },
+    "5519734": {
+        "vendor": "Groq"
     },
     "5519839": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -63510,6 +63831,9 @@
         "vendor": "Probedigital Co.,Ltd"
     },
     "5526997": {
+        "vendor": "Huawei Device Co., Ltd."
+    },
+    "5527064": {
         "vendor": "Huawei Device Co., Ltd."
     },
     "5527845": {
@@ -63698,6 +64022,9 @@
     "5538618": {
         "vendor": "Zyxel Communications Corporation"
     },
+    "5538747": {
+        "vendor": "Honda Motor Co., Ltd"
+    },
     "5538896": {
         "vendor": "Tiinlab Corporation"
     },
@@ -63757,6 +64084,9 @@
     },
     "5543032": {
         "vendor": "Silvershore Technology Partners"
+    },
+    "5543627": {
+        "vendor": "AMPAK Technology Inc."
     },
     "5544291": {
         "vendor": "Apple, Inc."
@@ -63866,6 +64196,9 @@
     "5549607": {
         "vendor": "Apple, Inc."
     },
+    "5549756": {
+        "vendor": "China Dragon Technology Limited"
+    },
     "5549776": {
         "vendor": "DASAN Networks, Inc."
     },
@@ -63931,6 +64264,9 @@
     },
     "5554296": {
         "vendor": "Infinix mobility limited"
+    },
+    "5554643": {
+        "vendor": "Guangzhou TR Intelligent Manufacturing Technology Co., Ltd"
     },
     "5554768": {
         "vendor": "Iskratel d.o.o."
@@ -64742,6 +65078,9 @@
     "5801954": {
         "vendor": "Shenzhen Coship Electronics Co., Ltd."
     },
+    "5802384": {
+        "vendor": "Starkey Labs Inc."
+    },
     "5802586": {
         "vendor": "Dell Inc."
     },
@@ -64830,7 +65169,7 @@
         "vendor": "Cisco Systems, Inc"
     },
     "5806133": {
-        "vendor": "Technicolor Delivery Technologies Belgium NV"
+        "vendor": "Vantiva Technologies Belgium"
     },
     "5806191": {
         "vendor": "Revolution Display"
@@ -65501,6 +65840,9 @@
     "6042510": {
         "vendor": "Alpha Networks Inc."
     },
+    "6042545": {
+        "vendor": "EM Microelectronic"
+    },
     "6042624": {
         "vendor": "Hisense Electric Co.,Ltd"
     },
@@ -65524,6 +65866,9 @@
     },
     "6043872": {
         "vendor": "Shanghai Super Electronics Technology Co.,LTD"
+    },
+    "6044023": {
+        "vendor": "Juniper Networks"
     },
     "6044221": {
         "vendor": "zte corporation"
@@ -66143,6 +66488,9 @@
     "6079286": {
         "vendor": "ittim"
     },
+    "6079517": {
+        "vendor": "Stone Devices Sdn. Bhd."
+    },
     "6079843": {
         "vendor": "Hunan Fn-Link Technology Limited"
     },
@@ -66376,6 +66724,9 @@
     },
     "6092058": {
         "vendor": "Zhejiang Dahua Technology Co., Ltd."
+    },
+    "6092090": {
+        "vendor": "Zhongge Smart Technology(Shanghai) Co., Ltd"
     },
     "6092250": {
         "vendor": "Apple, Inc."
@@ -66632,6 +66983,9 @@
     "6301995": {
         "vendor": "Tp-Link Technologies Co.,Ltd."
     },
+    "6302066": {
+        "vendor": "Arista Networks"
+    },
     "6302165": {
         "vendor": "DAVOLINK Inc."
     },
@@ -66742,6 +67096,9 @@
     },
     "6307781": {
         "vendor": "Cox Co., Ltd"
+    },
+    "6307835": {
+        "vendor": "Telink Micro LLC"
     },
     "6308479": {
         "vendor": "Shenzhen Chuangwei-Rgb Electronics Co.,Ltd"
@@ -67226,6 +67583,9 @@
     "6334718": {
         "vendor": "Nokia Solutions and Networks GmbH & Co. KG"
     },
+    "6334804": {
+        "vendor": "Cisco Systems, Inc"
+    },
     "6334896": {
         "vendor": "Merchandising Technologies, Inc"
     },
@@ -67279,6 +67639,12 @@
     },
     "6338273": {
         "vendor": "Texas Instruments"
+    },
+    "6338309": {
+        "vendor": "Shenzhen Skyworth Digital Technology CO., Ltd"
+    },
+    "6338403": {
+        "vendor": "Silicon Laboratories"
     },
     "6338414": {
         "vendor": "Google, Inc."
@@ -67442,6 +67808,9 @@
     "6346777": {
         "vendor": "Hon Hai Precision Ind. Co.,Ltd."
     },
+    "6346871": {
+        "vendor": "Phyplus Technology (Shanghai) Co., Ltd"
+    },
     "6346908": {
         "vendor": "HMD Global Oy"
     },
@@ -67483,6 +67852,9 @@
     },
     "6348174": {
         "vendor": "Intel Corporate"
+    },
+    "6348312": {
+        "vendor": "Apple, Inc."
     },
     "6348341": {
         "vendor": "GITSN, Inc."
@@ -68381,6 +68753,9 @@
     "6595321": {
         "vendor": "OnePlus Technology (Shenzhen) Co., Ltd"
     },
+    "6595383": {
+        "vendor": "Garmin International"
+    },
     "6595393": {
         "vendor": "Wonderlan (Beijing) Technology Co., Ltd."
     },
@@ -68750,6 +69125,9 @@
     "6613900": {
         "vendor": "Seiko Epson Corporation"
     },
+    "6613908": {
+        "vendor": "zte corporation"
+    },
     "6614117": {
         "vendor": "vivo Mobile Communication Co., Ltd."
     },
@@ -68776,6 +69154,9 @@
     },
     "6616398": {
         "vendor": "EM Microelectronic"
+    },
+    "6616653": {
+        "vendor": "Celestica Inc."
     },
     "6616733": {
         "vendor": "Cisco Systems, Inc"
@@ -68881,6 +69262,9 @@
     },
     "6820865": {
         "vendor": "Hon Hai Precision Ind. Co.,Ltd."
+    },
+    "6821241": {
+        "vendor": "BrosTrend Technology LLC"
     },
     "6821264": {
         "vendor": "Sagemcom Broadband SAS"
@@ -68989,6 +69373,9 @@
     },
     "6826460": {
         "vendor": "Ficosa Electronics S.L.U."
+    },
+    "6826717": {
+        "vendor": "zte corporation"
     },
     "6827087": {
         "vendor": "leerang corporation"
@@ -69521,6 +69908,9 @@
     "6856298": {
         "vendor": "Huawei Device Co., Ltd."
     },
+    "6856660": {
+        "vendor": "Amazon Technologies Inc."
+    },
     "6856688": {
         "vendor": "zte corporation"
     },
@@ -69589,6 +69979,9 @@
     },
     "6859658": {
         "vendor": "RF IDeas"
+    },
+    "6859689": {
+        "vendor": "Sagemcom Broadband SAS"
     },
     "6859708": {
         "vendor": "Beijing Xiaomi Mobile Software Co., Ltd"
@@ -70070,6 +70463,9 @@
     "7082419": {
         "vendor": "Wu Qi Technologies,Inc."
     },
+    "7082426": {
+        "vendor": "zte corporation"
+    },
     "7082608": {
         "vendor": "Apple, Inc."
     },
@@ -70282,6 +70678,9 @@
     },
     "7093388": {
         "vendor": "Dell Inc."
+    },
+    "7093841": {
+        "vendor": "Mindray North America"
     },
     "7093869": {
         "vendor": "Apple, Inc."
@@ -70562,6 +70961,12 @@
     "7108192": {
         "vendor": "Kyocera Corporation"
     },
+    "7108343": {
+        "vendor": "MainStreaming SpA"
+    },
+    "7108592": {
+        "vendor": "Huawei Device Co., Ltd."
+    },
     "7108801": {
         "vendor": "Juniper Networks"
     },
@@ -70712,6 +71117,9 @@
     "7118460": {
         "vendor": "Fiberhome Telecommunication Technologies Co.,LTD"
     },
+    "7118914": {
+        "vendor": "Silicon Laboratories"
+    },
     "7119028": {
         "vendor": "Sky Uk Limited"
     },
@@ -70804,6 +71212,9 @@
     },
     "7122709": {
         "vendor": "Webasto SE"
+    },
+    "7122859": {
+        "vendor": "UAB \"Teltonika Telematics\""
     },
     "7123063": {
         "vendor": "ALL Winner (Hong Kong) Limited"
@@ -71492,6 +71903,9 @@
     "7359204": {
         "vendor": "Rinstrum Pty Ltd"
     },
+    "7359434": {
+        "vendor": "Espressif Inc."
+    },
     "7359650": {
         "vendor": "Apple, Inc."
     },
@@ -71969,6 +72383,9 @@
     "7383116": {
         "vendor": "MONAD., Inc."
     },
+    "7383205": {
+        "vendor": "Microsoft Corporation"
+    },
     "7383251": {
         "vendor": "Intel Corporate"
     },
@@ -72142,6 +72559,9 @@
     },
     "7393097": {
         "vendor": "Intel Corporate"
+    },
+    "7393406": {
+        "vendor": "Silicon Laboratories"
     },
     "7393409": {
         "vendor": "Beijing Netpower Technologies Inc."
@@ -72389,6 +72809,9 @@
     "7604094": {
         "vendor": "Quectel Wireless Solutions Co.,Ltd."
     },
+    "7604394": {
+        "vendor": "Ruijie Networks Co.,LTD"
+    },
     "7604446": {
         "vendor": "Fujian Landi Commercial Technology Co., Ltd."
     },
@@ -72433,6 +72856,9 @@
     },
     "7607433": {
         "vendor": "SRT Wireless"
+    },
+    "7607504": {
+        "vendor": "Apple, Inc."
     },
     "7607669": {
         "vendor": "Xiaomi Communications Co Ltd"
@@ -72485,6 +72911,9 @@
     "7611277": {
         "vendor": "zte corporation"
     },
+    "7611445": {
+        "vendor": "Huawei Device Co., Ltd."
+    },
     "7611551": {
         "vendor": "TIBRO Corp."
     },
@@ -72514,6 +72943,9 @@
     },
     "7612521": {
         "vendor": "Huawei Device Co., Ltd."
+    },
+    "7612761": {
+        "vendor": "Apple, Inc."
     },
     "7612786": {
         "vendor": "Juniper Networks"
@@ -72643,6 +73075,9 @@
     },
     "7618251": {
         "vendor": "Gentrice tech"
+    },
+    "7618446": {
+        "vendor": "Apple, Inc."
     },
     "7618498": {
         "vendor": "Hangzhou Hikvision Digital Technology Co.,Ltd."
@@ -72799,6 +73234,9 @@
     },
     "7627083": {
         "vendor": "Chongqing Huijiatong Information Technology Co., Ltd."
+    },
+    "7627217": {
+        "vendor": "GOIP Global Services Pvt. Ltd."
     },
     "7627714": {
         "vendor": "Huawei Device Co., Ltd."
@@ -73024,6 +73462,9 @@
     },
     "7638280": {
         "vendor": "Apple, Inc."
+    },
+    "7638442": {
+        "vendor": "Huawei Technologies Co.,Ltd"
     },
     "7638536": {
         "vendor": "Bestek Corp."
@@ -73337,6 +73778,9 @@
     "7655467": {
         "vendor": "ASUSTek COMPUTER INC."
     },
+    "7655554": {
+        "vendor": "Hisense Visual Technology Co.,Ltd"
+    },
     "7655644": {
         "vendor": "Ericsson AB"
     },
@@ -73577,8 +74021,14 @@
     "7665946": {
         "vendor": "Onface"
     },
+    "7665964": {
+        "vendor": "Ubiquiti Inc"
+    },
     "7666122": {
         "vendor": "Nintendo Co.,Ltd"
+    },
+    "7666217": {
+        "vendor": "Ubiquiti Inc"
     },
     "7666455": {
         "vendor": "Qingdao Goertek Horizons Tecnology Co.,LTD"
@@ -74131,6 +74581,9 @@
     },
     "7888748": {
         "vendor": "Arista Networks"
+    },
+    "7888804": {
+        "vendor": "Ciena Corporation"
     },
     "7888987": {
         "vendor": "Tp-Link Technologies Co.,Ltd."
@@ -74903,6 +75356,9 @@
     "7929236": {
         "vendor": "Apple, Inc."
     },
+    "7929329": {
+        "vendor": "Shenzhen Huadian Communication Co., Ltd"
+    },
     "7929405": {
         "vendor": "Juniper Networks"
     },
@@ -74959,6 +75415,9 @@
     },
     "8126730": {
         "vendor": "Texas Instruments"
+    },
+    "8126782": {
+        "vendor": "Gsd Viet Nam Technology Company Limited"
     },
     "8126855": {
         "vendor": "Curtis Instruments, Inc."
@@ -75118,6 +75577,9 @@
     },
     "8135692": {
         "vendor": "Telechips, Inc."
+    },
+    "8135786": {
+        "vendor": "Scita Solutions"
     },
     "8135833": {
         "vendor": "Apple, Inc."
@@ -75674,6 +76136,9 @@
     "8168695": {
         "vendor": "Extreme Networks Headquarters"
     },
+    "8168766": {
+        "vendor": "Motorola Mobility LLC, a Lenovo Company"
+    },
     "8168847": {
         "vendor": "shenzhen Qikai Electronic Co., Ltd."
     },
@@ -75943,6 +76408,9 @@
     },
     "8180813": {
         "vendor": "Shanghai Moorewatt Energy Technology Co.,Ltd"
+    },
+    "8180904": {
+        "vendor": "Sagemcom Broadband SAS"
     },
     "8181094": {
         "vendor": "Amazon Technologies Inc."
@@ -76262,8 +76730,14 @@
     "8393439": {
         "vendor": "Shenzhen SuperElectron Technology Co.,Ltd."
     },
+    "8393494": {
+        "vendor": "Intel Corporate"
+    },
     "8393602": {
         "vendor": "Huawei Technologies Co.,Ltd"
+    },
+    "8393662": {
+        "vendor": "Juniper Networks"
     },
     "8393792": {
         "vendor": "Sunlit System Technology Corp"
@@ -76850,6 +77324,9 @@
     "8425245": {
         "vendor": "Tp-Link Technologies Co.,Ltd."
     },
+    "8425367": {
+        "vendor": "Xiaomi Communications Co Ltd"
+    },
     "8425448": {
         "vendor": "Intelbras"
     },
@@ -76912,6 +77389,9 @@
     },
     "8429483": {
         "vendor": "Fiberhome Telecommunication Technologies Co.,LTD"
+    },
+    "8429540": {
+        "vendor": "Shen Zhen Tenda Technology Co.,Ltd"
     },
     "8429557": {
         "vendor": "Samsung Electronics Co.,Ltd"
@@ -77023,6 +77503,9 @@
     },
     "8435525": {
         "vendor": "The Silk Technologies ILC LTD"
+    },
+    "8435754": {
+        "vendor": "Realme Chongqing Mobile Telecommunications Corp.,Ltd."
     },
     "8436038": {
         "vendor": "Nokia"
@@ -77267,6 +77750,9 @@
     "8450468": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
+    "8450472": {
+        "vendor": "Guangzhou V-Solution Telecommunication Technology Co.,Ltd."
+    },
     "8450482": {
         "vendor": "Espressif Inc."
     },
@@ -77359,6 +77845,9 @@
     },
     "8652740": {
         "vendor": "Walter Kidde Portable Equipment, Inc."
+    },
+    "8652858": {
+        "vendor": "Intel Corporate"
     },
     "8653470": {
         "vendor": "Nexapp Technologies Pvt Ltd"
@@ -77636,6 +78125,9 @@
     "8668335": {
         "vendor": "Zhejiang Tmall Technology Co., Ltd."
     },
+    "8668576": {
+        "vendor": "Tube investments of India Limited"
+    },
     "8668819": {
         "vendor": "Beijing Xiaomi Mobile Software Co., Ltd"
     },
@@ -77710,6 +78202,9 @@
     },
     "8673921": {
         "vendor": "ffly4u"
+    },
+    "8674060": {
+        "vendor": "eFAB P.S.A."
     },
     "8674066": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -77956,6 +78451,9 @@
     },
     "8687626": {
         "vendor": "Arcadyan Corporation"
+    },
+    "8688229": {
+        "vendor": "Intel Corporate"
     },
     "8688357": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -78251,6 +78749,9 @@
     "8704346": {
         "vendor": "TCT mobile ltd"
     },
+    "8704449": {
+        "vendor": "Intel Corporate"
+    },
     "8704808": {
         "vendor": "Apple, Inc."
     },
@@ -78460,6 +78961,9 @@
     },
     "8715075": {
         "vendor": "Central Denshi Seigyo"
+    },
+    "8715284": {
+        "vendor": "Shenzhen Bilian Electronic Co.，Ltd"
     },
     "8715436": {
         "vendor": "Apple, Inc."
@@ -78680,6 +79184,9 @@
     "8923472": {
         "vendor": "Netmoon Technology Co., Ltd"
     },
+    "8923525": {
+        "vendor": "Sz Dji Technology Co.,Ltd"
+    },
     "8923548": {
         "vendor": "Samsung Electronics Co.,Ltd"
     },
@@ -78754,6 +79261,9 @@
     },
     "8928139": {
         "vendor": "Cheering Connection Co. Ltd."
+    },
+    "8928220": {
+        "vendor": "CJ intelligent technology LTD."
     },
     "8928284": {
         "vendor": "Mercury Corporation"
@@ -79643,6 +80153,9 @@
     "8976662": {
         "vendor": "Qingdao Dayu Dance Digital Technology Co.,Ltd"
     },
+    "8976832": {
+        "vendor": "KTS Kommunikationstechnik und Systeme GmbH"
+    },
     "8977501": {
         "vendor": "Cisco Systems, Inc"
     },
@@ -80120,6 +80633,9 @@
     "9198753": {
         "vendor": "d-broad,INC"
     },
+    "9198932": {
+        "vendor": "Kisi"
+    },
     "9198944": {
         "vendor": "UCI Corporation Co.,Ltd."
     },
@@ -80239,6 +80755,9 @@
     },
     "9205526": {
         "vendor": "Longcheer Telecommunication Limited"
+    },
+    "9205625": {
+        "vendor": "Arcadyan Corporation"
     },
     "9205975": {
         "vendor": "Shenzhen Fast Technologies Co.,Ltd"
@@ -80488,6 +81007,9 @@
     },
     "9217025": {
         "vendor": "Shenzhen New Chip Intelligence Co.,LTD"
+    },
+    "9217108": {
+        "vendor": "Private"
     },
     "9217441": {
         "vendor": "Oregano Systems - Design & Consulting GmbH"
@@ -80852,6 +81374,9 @@
     "9239832": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
+    "9239881": {
+        "vendor": "Espressif Inc."
+    },
     "9240030": {
         "vendor": "Sagemcom Broadband SAS"
     },
@@ -81023,6 +81548,9 @@
     "9444110": {
         "vendor": "Fujitsu Technology Solutions GmbH"
     },
+    "9444510": {
+        "vendor": "Alcatel-Lucent Enterprise"
+    },
     "9444647": {
         "vendor": "zte corporation"
     },
@@ -81113,6 +81641,9 @@
     "9449803": {
         "vendor": "AltoBeam Inc."
     },
+    "9449878": {
+        "vendor": "Shenzhen Ip-Com Networks Co.,Ltd."
+    },
     "9449933": {
         "vendor": "Onyx Healthcare Inc."
     },
@@ -81127,6 +81658,9 @@
     },
     "9450862": {
         "vendor": "Vodafone Omnitel N.V."
+    },
+    "9450914": {
+        "vendor": "Apple, Inc."
     },
     "9450986": {
         "vendor": "Silicon Laboratories"
@@ -81196,6 +81730,9 @@
     },
     "9453546": {
         "vendor": "Huawei Technologies Co.,Ltd"
+    },
+    "9454002": {
+        "vendor": "Ubiquiti Inc"
     },
     "9454562": {
         "vendor": "Cornami, Inc"
@@ -81470,6 +82007,9 @@
     "9468504": {
         "vendor": "Zegna-Daidong Limited"
     },
+    "9468606": {
+        "vendor": "Gsd Viet Nam Technology Company Limited"
+    },
     "9468657": {
         "vendor": "Wally"
     },
@@ -81731,8 +82271,14 @@
     "9481755": {
         "vendor": "Tp-Link Technologies Co.,Ltd."
     },
+    "9482073": {
+        "vendor": "Choice IT Global LLC"
+    },
     "9482193": {
         "vendor": "netKTI Co., Ltd"
+    },
+    "9482273": {
+        "vendor": "Intel Corporate"
     },
     "9482477": {
         "vendor": "Apple, Inc."
@@ -81820,6 +82366,9 @@
     },
     "9488344": {
         "vendor": "zte corporation"
+    },
+    "9488722": {
+        "vendor": "Durin, Inc"
     },
     "9488795": {
         "vendor": "Tesorion Nederland B.V."
@@ -82070,6 +82619,9 @@
     "9501533": {
         "vendor": "Beijing Xiaomi Mobile Software Co., Ltd"
     },
+    "9501587": {
+        "vendor": "Renesas Design US Inc."
+    },
     "9501606": {
         "vendor": "Hon Hai Precision Ind. Co.,Ltd."
     },
@@ -82265,6 +82817,9 @@
     "9709085": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
+    "9709326": {
+        "vendor": "Intel Corporate"
+    },
     "9709424": {
         "vendor": "BSH Hausgeräte GmbH"
     },
@@ -82360,6 +82915,9 @@
     },
     "9714416": {
         "vendor": "Nokia Corporation"
+    },
+    "9714466": {
+        "vendor": "Netgear"
     },
     "9714608": {
         "vendor": "New H3C Technologies Co., Ltd"
@@ -82472,6 +83030,9 @@
     "9720624": {
         "vendor": "Hon Hai Precision Ind. Co.,Ltd."
     },
+    "9720831": {
+        "vendor": "Intel Corporate"
+    },
     "9720979": {
         "vendor": "Rigado, LLC"
     },
@@ -82498,6 +83059,9 @@
     },
     "9722157": {
         "vendor": "EKE Building Technology Systems Ltd"
+    },
+    "9722602": {
+        "vendor": "Huawei Technologies Co.,Ltd"
     },
     "9722620": {
         "vendor": "Amazon Technologies Inc."
@@ -83360,6 +83924,9 @@
     "9963983": {
         "vendor": "OnePlus Technology (Shenzhen) Co., Ltd"
     },
+    "9964107": {
+        "vendor": "Nokia Solutions and Networks GmbH & Co. KG"
+    },
     "9964595": {
         "vendor": "Silicon Laboratories"
     },
@@ -83399,8 +83966,14 @@
     "9965800": {
         "vendor": "Apple, Inc."
     },
+    "9966028": {
+        "vendor": "Ciena Corporation"
+    },
     "9966115": {
         "vendor": "Tarmoc Network LTD"
+    },
+    "9966263": {
+        "vendor": "Karst.Ai"
     },
     "9966304": {
         "vendor": "Xiaomi Communications Co Ltd"
@@ -83603,11 +84176,17 @@
     "9977759": {
         "vendor": "China SSJ (Suzhou) Network Technology Inc."
     },
+    "9977764": {
+        "vendor": "zte corporation"
+    },
     "9977832": {
         "vendor": "Samsung Electronics Co.,Ltd"
     },
     "9978043": {
         "vendor": "Dell Inc."
+    },
+    "9978068": {
+        "vendor": "Vantiva Connected Home - Technologies Telco"
     },
     "9978204": {
         "vendor": "Nintendo Co.,Ltd"
@@ -83617,6 +84196,9 @@
     },
     "9978469": {
         "vendor": "Sagemcom Broadband SAS"
+    },
+    "9978539": {
+        "vendor": "GN Hearing A/S"
     },
     "9978842": {
         "vendor": "Intertech"
@@ -83707,6 +84289,9 @@
     },
     "9982641": {
         "vendor": "Samsung Electronics Co.,Ltd"
+    },
+    "9982815": {
+        "vendor": "Huawei Technologies Co.,Ltd"
     },
     "9983003": {
         "vendor": "Intel Corporate"
@@ -84191,6 +84776,9 @@
     "10014547": {
         "vendor": "Bbk Educational Electronics Corp.,Ltd."
     },
+    "10014589": {
+        "vendor": "Apple, Inc."
+    },
     "10015379": {
         "vendor": "Google, Inc."
     },
@@ -84470,6 +85058,9 @@
     "10224755": {
         "vendor": "Tecmobile (International) Ltd."
     },
+    "10224822": {
+        "vendor": "Quectel Wireless Solutions Co.,Ltd."
+    },
     "10224875": {
         "vendor": "Apple, Inc."
     },
@@ -84583,6 +85174,9 @@
     },
     "10232334": {
         "vendor": "TASCAN Systems GmbH"
+    },
+    "10232848": {
+        "vendor": "Bouffalo Lab (Nanjing) Co., Ltd."
     },
     "10232946": {
         "vendor": "Sagemcom Broadband SAS"
@@ -85158,7 +85752,7 @@
         "vendor": "Intel Corporate"
     },
     "10262310": {
-        "vendor": "Technicolor Delivery Technologies Belgium NV"
+        "vendor": "Vantiva Technologies Belgium"
     },
     "10262409": {
         "vendor": "1More"
@@ -85397,6 +85991,9 @@
     "10275971": {
         "vendor": "Juniper Networks"
     },
+    "10276162": {
+        "vendor": "Dongguan Liesheng Electronic Co., Ltd."
+    },
     "10276226": {
         "vendor": "Cheng Uei Precision Industry Co.,Ltd"
     },
@@ -85477,6 +86074,9 @@
     },
     "10280707": {
         "vendor": "Harman/Becker Automotive Systems GmbH"
+    },
+    "10280842": {
+        "vendor": "Huawei Technologies Co.,Ltd"
     },
     "10280881": {
         "vendor": "Shenzhen Crave Communication Co., LTD"
@@ -86024,6 +86624,9 @@
     "10507551": {
         "vendor": "Sagemcom Broadband SAS"
     },
+    "10507566": {
+        "vendor": "zte corporation"
+    },
     "10507599": {
         "vendor": "Cisco Systems, Inc"
     },
@@ -86339,6 +86942,9 @@
     "10525083": {
         "vendor": "Apple, Inc."
     },
+    "10525196": {
+        "vendor": "Honor Device Co., Ltd."
+    },
     "10525266": {
         "vendor": "Shenzhen MoreSense Technology Co., Ltd."
     },
@@ -86487,7 +87093,7 @@
         "vendor": "InfiNet LLC"
     },
     "10532156": {
-        "vendor": "Technicolor Delivery Technologies Belgium NV"
+        "vendor": "Vantiva Technologies Belgium"
     },
     "10532169": {
         "vendor": "Arcadyan Corporation"
@@ -86801,6 +87407,9 @@
     "10550382": {
         "vendor": "Telegrafia a.s."
     },
+    "10550745": {
+        "vendor": "Unionman Technology Co.,Ltd"
+    },
     "10550881": {
         "vendor": "Vivint Wireless Inc."
     },
@@ -87026,6 +87635,9 @@
     "10758583": {
         "vendor": "bluesky"
     },
+    "10758694": {
+        "vendor": "GD Midea Air-Conditioning Equipment Co.,Ltd."
+    },
     "10758769": {
         "vendor": "Sichuan Tianyi Comheart Telecom Co.,LTD"
     },
@@ -87119,6 +87731,9 @@
     "10764136": {
         "vendor": "Arista Network, Inc."
     },
+    "10764199": {
+        "vendor": "Hewlett Packard Enterprise"
+    },
     "10764327": {
         "vendor": "zte corporation"
     },
@@ -87154,6 +87769,9 @@
     },
     "10766074": {
         "vendor": "AmTRAN Video Corporation"
+    },
+    "10766948": {
+        "vendor": "Maverick Mobile LLC"
     },
     "10767059": {
         "vendor": "ST Electronics(Shanghai) Co.,Ltd"
@@ -87459,7 +88077,7 @@
         "vendor": "vivo Mobile Communication Co., Ltd."
     },
     "10785201": {
-        "vendor": "Technicolor Delivery Technologies Belgium NV"
+        "vendor": "Vantiva Technologies Belgium"
     },
     "10785483": {
         "vendor": "Nokia"
@@ -87633,13 +88251,16 @@
         "vendor": "Intel Corporate"
     },
     "10793449": {
-        "vendor": "Technicolor Delivery Technologies Belgium NV"
+        "vendor": "Vantiva Technologies Belgium"
     },
     "10793454": {
         "vendor": "H. ZANDER GmbH & Co. KG"
     },
     "10793529": {
         "vendor": "Cisco Systems, Inc"
+    },
+    "10793558": {
+        "vendor": "Shenzhen Incar Technology Co., Ltd."
     },
     "10793639": {
         "vendor": "Adaxys Solutions AG"
@@ -87695,6 +88316,9 @@
     "10796801": {
         "vendor": "Intel Corporate"
     },
+    "10797232": {
+        "vendor": "Drivenets"
+    },
     "10797255": {
         "vendor": "ShenZhen Hitom Communication Technology Co..LTD"
     },
@@ -87703,6 +88327,9 @@
     },
     "10797368": {
         "vendor": "Telink Semiconductor (Taipei) Co. Ltd."
+    },
+    "10797369": {
+        "vendor": "Dongguan Huayin Electronic Technology Co., Ltd."
     },
     "10797544": {
         "vendor": "Nintendo Co.,Ltd"
@@ -87778,6 +88405,9 @@
     },
     "10800858": {
         "vendor": "Arcadyan Corporation"
+    },
+    "10800899": {
+        "vendor": "Realme Chongqing Mobile Telecommunications Corp.,Ltd."
     },
     "10800914": {
         "vendor": "Espressif Inc."
@@ -87980,6 +88610,9 @@
     "10810562": {
         "vendor": "Vnpt Technology"
     },
+    "10810570": {
+        "vendor": "Private"
+    },
     "10810658": {
         "vendor": "Chofu Seisakusho Co.,Ltd"
     },
@@ -88093,6 +88726,9 @@
     },
     "11015028": {
         "vendor": "Panasonic Corporation AVC Networks Company"
+    },
+    "11015032": {
+        "vendor": "Nokia"
     },
     "11015501": {
         "vendor": "Tp-Link Technologies Co.,Ltd."
@@ -88748,6 +89384,9 @@
     "11051145": {
         "vendor": "Tactical Communications"
     },
+    "11051154": {
+        "vendor": "China Dragon Technology Limited"
+    },
     "11051159": {
         "vendor": "ScioTeq bvba"
     },
@@ -88922,6 +89561,9 @@
     "11062928": {
         "vendor": "Cvc"
     },
+    "11063015": {
+        "vendor": "Fiberhome Telecommunication Technologies Co.,LTD"
+    },
     "11063264": {
         "vendor": "GDN Enterprises Private Limited"
     },
@@ -88975,6 +89617,9 @@
     },
     "11066458": {
         "vendor": "Digital Watchdog"
+    },
+    "11066783": {
+        "vendor": "Quectel Wireless Solutions Co.,Ltd."
     },
     "11066984": {
         "vendor": "Beijing Wide Technology Co.,Ltd"
@@ -89453,6 +90098,9 @@
     "11288011": {
         "vendor": "Intel Corporate"
     },
+    "11288058": {
+        "vendor": "Hangzhou Huacheng Network Technology Co.,Ltd"
+    },
     "11288241": {
         "vendor": "Google, Inc."
     },
@@ -89843,6 +90491,9 @@
     "11307474": {
         "vendor": "Ciena Corporation"
     },
+    "11307719": {
+        "vendor": "Huawei Technologies Co.,Ltd"
+    },
     "11307725": {
         "vendor": "ROGER D.Wensker, G.Wensker sp.j."
     },
@@ -89968,6 +90619,12 @@
     },
     "11314791": {
         "vendor": "Electronic Systems Protection, Inc."
+    },
+    "11314948": {
+        "vendor": "Espressif Inc."
+    },
+    "11315185": {
+        "vendor": "TP-Link Systems Inc."
     },
     "11315342": {
         "vendor": "SHARP Corporation"
@@ -90275,6 +90932,9 @@
     "11331147": {
         "vendor": "Shenzhen Baojia Battery Technology Co., Ltd."
     },
+    "11331259": {
+        "vendor": "Google, Inc."
+    },
     "11331451": {
         "vendor": "Sichuan Tianyi Comheart Telecom Co.,LTD"
     },
@@ -90292,6 +90952,9 @@
     },
     "11332202": {
         "vendor": "Genix Infocomm Co., Ltd."
+    },
+    "11332208": {
+        "vendor": "ZUNDA Inc."
     },
     "11332330": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -90367,6 +91030,9 @@
     },
     "11335884": {
         "vendor": "Commscope"
+    },
+    "11335986": {
+        "vendor": "NXP Semiconductor (Tianjin) LTD."
     },
     "11336048": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -90639,7 +91305,7 @@
         "vendor": "Shenzhen Maxtang Computer Co.,Ltd"
     },
     "11551581": {
-        "vendor": "NuLEDs, Inc."
+        "vendor": "MechoShade"
     },
     "11551764": {
         "vendor": "New H3C Technologies Co., Ltd"
@@ -90922,6 +91588,9 @@
     },
     "11567576": {
         "vendor": "I-sys Corp"
+    },
+    "11567842": {
+        "vendor": "ASUSTek COMPUTER INC."
     },
     "11568086": {
         "vendor": "Commscope"
@@ -91331,6 +92000,9 @@
     "11589580": {
         "vendor": "Tridonic GmbH & Co KG"
     },
+    "11589598": {
+        "vendor": "Hangzhou Linovision Co., Ltd."
+    },
     "11589768": {
         "vendor": "Panasonic Automotive Systems Co.,Ltd"
     },
@@ -91491,7 +92163,7 @@
         "vendor": "Cisco Systems, Inc"
     },
     "11598613": {
-        "vendor": "Laird Connectivity"
+        "vendor": "Ezurio, LLC"
     },
     "11598813": {
         "vendor": "Shenzhen SuperElectron Technology Co.,Ltd."
@@ -91648,6 +92320,9 @@
     },
     "11803947": {
         "vendor": "Shenzhen YOUHUA Technology Co., Ltd"
+    },
+    "11804002": {
+        "vendor": "Nokia Shanghai Bell Co., Ltd."
     },
     "11804100": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -92600,6 +93275,9 @@
     "11858723": {
         "vendor": "Petatel Inc."
     },
+    "11859099": {
+        "vendor": "Huawei Device Co., Ltd."
+    },
     "11859342": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
@@ -92966,6 +93644,9 @@
     "12079840": {
         "vendor": "Beijing Xiaomi Electronics Co.,Ltd"
     },
+    "12080004": {
+        "vendor": "Xiaomi Communications Co Ltd"
+    },
     "12080044": {
         "vendor": "Apple, Inc."
     },
@@ -93064,6 +93745,9 @@
     },
     "12084869": {
         "vendor": "Sagemcom Broadband SAS"
+    },
+    "12085360": {
+        "vendor": "Nintendo Co.,Ltd"
     },
     "12085698": {
         "vendor": "Sunitec Enterprise Co., Ltd."
@@ -93361,6 +94045,9 @@
     },
     "12101470": {
         "vendor": "Wuxi Xinjie Electric Co.,Ltd"
+    },
+    "12101522": {
+        "vendor": "Sichuan Tianyi Comheart Telecom Co.,LTD"
     },
     "12101669": {
         "vendor": "Samsung Electronics Co.,Ltd"
@@ -93719,6 +94406,9 @@
     "12121167": {
         "vendor": "u-blox AG"
     },
+    "12121252": {
+        "vendor": "Google, Inc."
+    },
     "12121296": {
         "vendor": "Herrmann Ultraschalltechnik GmbH & Co. Kg"
     },
@@ -93914,6 +94604,9 @@
     "12324987": {
         "vendor": "Samsung Electronics Co.,Ltd"
     },
+    "12325407": {
+        "vendor": "Accton Technology Corporation"
+    },
     "12325470": {
         "vendor": "Beijing WisVideo INC."
     },
@@ -94030,6 +94723,9 @@
     },
     "12331778": {
         "vendor": "China Dragon Technology Limited"
+    },
+    "12331806": {
+        "vendor": "Cresyn Co., Ltd."
     },
     "12331883": {
         "vendor": "Beijing Haier IC Design Co.,Ltd"
@@ -94658,6 +95354,9 @@
     "12364246": {
         "vendor": "Cyber-Rain, Inc."
     },
+    "12364418": {
+        "vendor": "Fiberhome Telecommunication Technologies Co.,LTD"
+    },
     "12364668": {
         "vendor": "TRnP KOREA Co Ltd"
     },
@@ -94732,6 +95431,9 @@
     },
     "12368966": {
         "vendor": "SKS Welding Systems GmbH"
+    },
+    "12369098": {
+        "vendor": "Huawei Device Co., Ltd."
     },
     "12369284": {
         "vendor": "zte corporation"
@@ -94839,7 +95541,7 @@
         "vendor": "Owl Labs"
     },
     "12375911": {
-        "vendor": "BAE Systems Apllied Intelligence"
+        "vendor": "BAE Systems"
     },
     "12375973": {
         "vendor": "Hewlett Packard Enterprise"
@@ -94852,6 +95554,9 @@
     },
     "12376384": {
         "vendor": "ASR Co,.Ltd."
+    },
+    "12376571": {
+        "vendor": "China Mobile Group Device Co.,Ltd."
     },
     "12376841": {
         "vendor": "Cisco Meraki"
@@ -95086,6 +95791,9 @@
     },
     "12589189": {
         "vendor": "Hon Hai Precision Ind. Co.,Ltd."
+    },
+    "12589196": {
+        "vendor": "Altus Sistemas de Automação S.A."
     },
     "12589380": {
         "vendor": "Juniper Networks"
@@ -95387,6 +96095,9 @@
     "12605155": {
         "vendor": "Hangzhou Hikvision Digital Technology Co.,Ltd."
     },
+    "12605220": {
+        "vendor": "Honor Device Co., Ltd."
+    },
     "12605372": {
         "vendor": "Avaya Inc"
     },
@@ -95467,6 +96178,9 @@
     },
     "12611053": {
         "vendor": "Hangzhou Hikvision Digital Technology Co.,Ltd."
+    },
+    "12611133": {
+        "vendor": "Shenzhen Tecno Technology"
     },
     "12611480": {
         "vendor": "eero inc."
@@ -96021,7 +96735,7 @@
         "vendor": "Guangdong Oppo Mobile Telecommunications Corp.,Ltd"
     },
     "12643904": {
-        "vendor": "Laird Connectivity"
+        "vendor": "Ezurio, LLC"
     },
     "12644021": {
         "vendor": "Enice Network."
@@ -97076,6 +97790,9 @@
     "12897605": {
         "vendor": "Beijing Boomsense Technology CO.,LTD."
     },
+    "12897616": {
+        "vendor": "Shenzhen C-Data Technology Co., Ltd."
+    },
     "12897666": {
         "vendor": "Hangzhou Lowan Information Technology Co., Ltd."
     },
@@ -97209,7 +97926,7 @@
         "vendor": "Tp-Link Technologies Co.,Ltd."
     },
     "12904989": {
-        "vendor": "Technicolor Delivery Technologies Belgium NV"
+        "vendor": "Vantiva Technologies Belgium"
     },
     "12905273": {
         "vendor": "Sagemcom Broadband SAS"
@@ -97538,6 +98255,9 @@
     "13120331": {
         "vendor": "Apple, Inc."
     },
+    "13120372": {
+        "vendor": "Zyxel Communications Corporation"
+    },
     "13120485": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
@@ -97808,6 +98528,9 @@
     "13136676": {
         "vendor": "Sow Cheng Technology Co. Ltd."
     },
+    "13136923": {
+        "vendor": "Fiberhome Telecommunication Technologies Co.,LTD"
+    },
     "13137243": {
         "vendor": "Quantify Technology Pty. Ltd."
     },
@@ -97861,6 +98584,9 @@
     },
     "13139796": {
         "vendor": "ASUSTek COMPUTER INC."
+    },
+    "13140077": {
+        "vendor": "Apple, Inc."
     },
     "13140532": {
         "vendor": "Cisco Systems, Inc"
@@ -97939,6 +98665,9 @@
     },
     "13144311": {
         "vendor": "Huawei Technologies Co.,Ltd"
+    },
+    "13144387": {
+        "vendor": "Nintendo Co.,Ltd"
     },
     "13144569": {
         "vendor": "Sagemcom Broadband SAS"
@@ -98093,6 +98822,9 @@
     "13151285": {
         "vendor": "PiLink Co., Ltd."
     },
+    "13151719": {
+        "vendor": "Shenzhen Shengxi Industrial Co.,Ltd"
+    },
     "13151900": {
         "vendor": "Shanghai TYD Elecronic Technology Co. Ltd"
     },
@@ -98234,6 +98966,9 @@
     "13159352": {
         "vendor": "Hewlett Packard"
     },
+    "13159457": {
+        "vendor": "eero inc."
+    },
     "13159605": {
         "vendor": "Hunter Douglas"
     },
@@ -98368,6 +99103,9 @@
     },
     "13166080": {
         "vendor": "Huawei Technologies Co.,Ltd"
+    },
+    "13166355": {
+        "vendor": "Bouffalo Lab (Nanjing) Co., Ltd."
     },
     "13166454": {
         "vendor": "PTCOM Technology"
@@ -98555,6 +99293,9 @@
     "13369585": {
         "vendor": "Sagemcom Broadband SAS"
     },
+    "13370173": {
+        "vendor": "Beijing Xiaomi Mobile Software Co., Ltd"
+    },
     "13370235": {
         "vendor": "Texas Instruments"
     },
@@ -98741,6 +99482,9 @@
     "13381047": {
         "vendor": "Apple, Inc."
     },
+    "13381074": {
+        "vendor": "Ruckus Wireless"
+    },
     "13381088": {
         "vendor": "Routerboard.com"
     },
@@ -98776,6 +99520,9 @@
     },
     "13383002": {
         "vendor": "SecuGen Corporation"
+    },
+    "13383355": {
+        "vendor": "Silicon Laboratories"
     },
     "13383375": {
         "vendor": "Cisco Systems, Inc"
@@ -99097,6 +99844,9 @@
     },
     "13399610": {
         "vendor": "zte corporation"
+    },
+    "13399621": {
+        "vendor": "Microsoft Corporation"
     },
     "13399657": {
         "vendor": "Seetech"
@@ -99815,6 +100565,9 @@
     "13637482": {
         "vendor": "Samsung Electronics Co.,Ltd"
     },
+    "13637559": {
+        "vendor": "Atios AG"
+    },
     "13637570": {
         "vendor": "ASUSTek COMPUTER INC."
     },
@@ -99974,6 +100727,9 @@
     "13648947": {
         "vendor": "Clourney Semiconductor"
     },
+    "13649293": {
+        "vendor": "Shenzhen Skyworth Digital Technology CO., Ltd"
+    },
     "13649420": {
         "vendor": "Dell Inc."
     },
@@ -100054,6 +100810,9 @@
     },
     "13653695": {
         "vendor": "Amosense"
+    },
+    "13653746": {
+        "vendor": "Buffalo.Inc"
     },
     "13653755": {
         "vendor": "Samsung Electronics Co.,Ltd"
@@ -100378,6 +101137,9 @@
     },
     "13670556": {
         "vendor": "ConMet"
+    },
+    "13670577": {
+        "vendor": "GScoolink Microelectronics (Beijing) Co.,LTD"
     },
     "13670869": {
         "vendor": "Alcatel-Lucent"
@@ -101004,7 +101766,7 @@
         "vendor": "Fike Corporation"
     },
     "13907229": {
-        "vendor": "Technicolor Delivery Technologies Belgium NV"
+        "vendor": "Vantiva Technologies Belgium"
     },
     "13907256": {
         "vendor": "Beijing Xiaomi Mobile Software Co., Ltd"
@@ -101517,7 +102279,7 @@
         "vendor": "NEC Corporation"
     },
     "13931102": {
-        "vendor": "Technicolor Delivery Technologies Belgium NV"
+        "vendor": "Vantiva Technologies Belgium"
     },
     "13931193": {
         "vendor": "Orion Nova, S.L."
@@ -101539,6 +102301,9 @@
     },
     "13931681": {
         "vendor": "Texas Instruments"
+    },
+    "13931689": {
+        "vendor": "Intel Corporate"
     },
     "13931752": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -101611,6 +102376,9 @@
     },
     "13934189": {
         "vendor": "Wuhan Zhongyuan Huadian Science & Technology Co.,"
+    },
+    "13934377": {
+        "vendor": "Fiberhome Telecommunication Technologies Co.,LTD"
     },
     "13934557": {
         "vendor": "Huawei Device Co., Ltd."
@@ -102069,7 +102837,7 @@
         "vendor": "Extreme Networks Headquarters"
     },
     "14156570": {
-        "vendor": "Laird Connectivity"
+        "vendor": "Ezurio, LLC"
     },
     "14156586": {
         "vendor": "Commtact Ltd"
@@ -102346,6 +103114,9 @@
     },
     "14170364": {
         "vendor": "Ruckus Wireless"
+    },
+    "14170678": {
+        "vendor": "AltoBeam Inc."
     },
     "14170845": {
         "vendor": "Raspberry Pi Trading Ltd"
@@ -102655,6 +103426,9 @@
     },
     "14186725": {
         "vendor": "Kuhn Sa"
+    },
+    "14186736": {
+        "vendor": "Silicon Laboratories"
     },
     "14186888": {
         "vendor": "Hon Hai Precision Ind. Co.,Ltd."
@@ -103100,6 +103874,9 @@
     "14210933": {
         "vendor": "Sagemcom Broadband SAS"
     },
+    "14211059": {
+        "vendor": "New H3C Technologies Co., Ltd"
+    },
     "14211174": {
         "vendor": "Shenzhen Tozed Technologies Co.,Ltd."
     },
@@ -103156,6 +103933,9 @@
     },
     "14213982": {
         "vendor": "LG Innotek"
+    },
+    "14214004": {
+        "vendor": "Xiaomi Communications Co Ltd"
     },
     "14214062": {
         "vendor": "Cirtec Medical Systems"
@@ -103330,6 +104110,9 @@
     },
     "14418840": {
         "vendor": "LG Innotek"
+    },
+    "14419034": {
+        "vendor": "Nanjing Qinheng Microelectronics Co., Ltd."
     },
     "14419247": {
         "vendor": "National Products Inc."
@@ -103604,6 +104387,9 @@
     "14435437": {
         "vendor": "Allwinner Technology Co., Ltd"
     },
+    "14435505": {
+        "vendor": "Hilti Corporation"
+    },
     "14435510": {
         "vendor": "Samsung Electronics Co.,Ltd"
     },
@@ -103846,6 +104632,9 @@
     },
     "14451446": {
         "vendor": "iPort"
+    },
+    "14451647": {
+        "vendor": "Seiko Epson Corporation"
     },
     "14451715": {
         "vendor": "shenzhen trolink Technology Co.,Ltd"
@@ -104543,6 +105332,9 @@
     "14686680": {
         "vendor": "Bh Technologies"
     },
+    "14686943": {
+        "vendor": "Google, Inc."
+    },
     "14686954": {
         "vendor": "Allied Telesis, Inc."
     },
@@ -104683,6 +105475,9 @@
     },
     "14692601": {
         "vendor": "Juniper Networks"
+    },
+    "14692701": {
+        "vendor": "EM Microelectronic"
     },
     "14692766": {
         "vendor": "Valve Corporation"
@@ -104951,6 +105746,12 @@
     "14709258": {
         "vendor": "Shenzhen SuperElectron Technology Co.,Ltd."
     },
+    "14709334": {
+        "vendor": "Intel Corporate"
+    },
+    "14709409": {
+        "vendor": "Espressif Inc."
+    },
     "14709599": {
         "vendor": "Nucom"
     },
@@ -105080,6 +105881,9 @@
     "14718463": {
         "vendor": "Infinix mobility limited"
     },
+    "14718696": {
+        "vendor": "Fiberhome Telecommunication Technologies Co.,LTD"
+    },
     "14718870": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
@@ -105142,6 +105946,9 @@
     },
     "14721807": {
         "vendor": "Pevco"
+    },
+    "14721894": {
+        "vendor": "Motorola Mobility LLC, a Lenovo Company"
     },
     "14721964": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -105243,7 +106050,7 @@
         "vendor": "Apple, Inc."
     },
     "14727653": {
-        "vendor": "Technicolor Delivery Technologies Belgium NV"
+        "vendor": "Vantiva Technologies Belgium"
     },
     "14727853": {
         "vendor": "Hangzhou Hikvision Digital Technology Co.,Ltd."
@@ -105316,6 +106123,9 @@
     },
     "14731554": {
         "vendor": "Jireh Energy Tech., Ltd."
+    },
+    "14731570": {
+        "vendor": "Intel Corporate"
     },
     "14731642": {
         "vendor": "Apple, Inc."
@@ -105578,6 +106388,9 @@
     "14743998": {
         "vendor": "Cloudena Corp."
     },
+    "14744155": {
+        "vendor": "Arista Networks"
+    },
     "14744300": {
         "vendor": "Platan sp. z o.o. sp. k."
     },
@@ -105586,6 +106399,9 @@
     },
     "14745591": {
         "vendor": "Softiron Inc."
+    },
+    "14942583": {
+        "vendor": "SafeOwl, Inc."
     },
     "14942875": {
         "vendor": "Intel Corporate"
@@ -105641,6 +106457,9 @@
     "14947830": {
         "vendor": "Texas Instruments"
     },
+    "14947859": {
+        "vendor": "Extreme Networks Headquarters"
+    },
     "14948312": {
         "vendor": "8Bitdo Technology Hk Limited"
     },
@@ -105658,6 +106477,9 @@
     },
     "14948908": {
         "vendor": "ZPE Systems, Inc."
+    },
+    "14949187": {
+        "vendor": "Beijing Xiaomi Mobile Software Co., Ltd"
     },
     "14949451": {
         "vendor": "V2 Technology, Inc."
@@ -106016,6 +106838,9 @@
     "14968164": {
         "vendor": "Shenzhen Ktc Technology Co.,Ltd"
     },
+    "14968166": {
+        "vendor": "Maple IoT Solutions LLC"
+    },
     "14968248": {
         "vendor": "Espressif Inc."
     },
@@ -106072,6 +106897,9 @@
     },
     "14971653": {
         "vendor": "Shenzhen INVT Electric CO.,Ltd"
+    },
+    "14971673": {
+        "vendor": "Huawei Device Co., Ltd."
     },
     "14971984": {
         "vendor": "Shenzhen Grandsun Electronic Co.,Ltd."
@@ -106198,6 +107026,9 @@
     },
     "14978757": {
         "vendor": "Huawei Technologies Co.,Ltd"
+    },
+    "14978825": {
+        "vendor": "ithinx GmbH"
     },
     "14978845": {
         "vendor": "Huawei Device Co., Ltd."
@@ -106477,6 +107308,9 @@
     },
     "14994946": {
         "vendor": "WyreStorm Technologies Ltd"
+    },
+    "14995032": {
+        "vendor": "Anhui Realloong Automotive Electronics Co.,Ltd"
     },
     "14995056": {
         "vendor": "Health & Life co., Ltd."
@@ -107159,6 +107993,9 @@
     "15232570": {
         "vendor": "Sony Interactive Entertainment Inc."
     },
+    "15232574": {
+        "vendor": "Sichuan Tianyi Comheart Telecom Co.,LTD"
+    },
     "15232580": {
         "vendor": "zte corporation"
     },
@@ -107224,6 +108061,9 @@
     },
     "15237336": {
         "vendor": "GNTEK Electronics Co.,Ltd."
+    },
+    "15237351": {
+        "vendor": "Huawei Device Co., Ltd."
     },
     "15237458": {
         "vendor": "Apple, Inc."
@@ -107317,6 +108157,9 @@
     },
     "15242758": {
         "vendor": "testo Instruments (Shenzhen) Co., Ltd."
+    },
+    "15243076": {
+        "vendor": "LCFC(Hefei) Electronics Technology co., ltd"
     },
     "15243162": {
         "vendor": "Quectel Wireless Solutions Co.,Ltd."
@@ -107580,7 +108423,7 @@
         "vendor": "Chipsea Technologies(Shenzhen) Corp."
     },
     "15256565": {
-        "vendor": "Laird Connectivity"
+        "vendor": "Ezurio, LLC"
     },
     "15256600": {
         "vendor": "D-Link International"
@@ -108020,6 +108863,9 @@
     "15473241": {
         "vendor": "Belkin International Inc."
     },
+    "15473347": {
+        "vendor": "Ugreen Group Limited"
+    },
     "15473503": {
         "vendor": "Hewlett Packard Enterprise"
     },
@@ -108323,6 +109169,9 @@
     "15489699": {
         "vendor": "Huawei Device Co., Ltd."
     },
+    "15489905": {
+        "vendor": "Inventec(Chongqing) Corporation"
+    },
     "15489907": {
         "vendor": "Advanced & Wise Technology Corp."
     },
@@ -108439,6 +109288,9 @@
     },
     "15497545": {
         "vendor": "Fujitsu Limited"
+    },
+    "15497664": {
+        "vendor": "zte corporation"
     },
     "15497714": {
         "vendor": "Startel"
@@ -108653,6 +109505,9 @@
     "15509039": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
+    "15509389": {
+        "vendor": "Cisco Systems, Inc"
+    },
     "15509421": {
         "vendor": "Barrot Technology Co.,Ltd."
     },
@@ -108774,7 +109629,7 @@
         "vendor": "PowerChord Group Limited"
     },
     "15515770": {
-        "vendor": "Laird Connectivity"
+        "vendor": "Ezurio, LLC"
     },
     "15516075": {
         "vendor": "Guangzhou Shiyuan Electronic Technology Company Limited"
@@ -108922,6 +109777,9 @@
     },
     "15526165": {
         "vendor": "STI Ltd"
+    },
+    "15526354": {
+        "vendor": "Apple, Inc."
     },
     "15526389": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -109097,6 +109955,9 @@
     "15734201": {
         "vendor": "PlayFusion Limited"
     },
+    "15734301": {
+        "vendor": "Espressif Inc."
+    },
     "15734312": {
         "vendor": "Technicolor (China) Technology Co., Ltd."
     },
@@ -109235,8 +110096,14 @@
     "15740839": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
+    "15740858": {
+        "vendor": "Apple, Inc."
+    },
     "15740888": {
         "vendor": "Bi2-Vision"
+    },
+    "15740946": {
+        "vendor": "Continental Autonomous Mobility Germany"
     },
     "15741466": {
         "vendor": "Mita-Teknik A/S"
@@ -109349,6 +110216,9 @@
     "15748564": {
         "vendor": "Sagemcom Broadband SAS"
     },
+    "15748772": {
+        "vendor": "HP Inc."
+    },
     "15748988": {
         "vendor": "Amazon Technologies Inc."
     },
@@ -109363,6 +110233,9 @@
     },
     "15750401": {
         "vendor": "Huawei Device Co., Ltd."
+    },
+    "15750530": {
+        "vendor": "Arashi Vision Inc."
     },
     "15751053": {
         "vendor": "JetHome LLC"
@@ -109718,6 +110591,9 @@
     "15772659": {
         "vendor": "Fiberhome Telecommunication Technologies Co.,LTD"
     },
+    "15772666": {
+        "vendor": "Shenzhen Rayin Technology Co.,Ltd"
+    },
     "15772836": {
         "vendor": "HBC-radiomatic"
     },
@@ -109799,6 +110675,9 @@
     "15776104": {
         "vendor": "Itel Mobile Limited"
     },
+    "15776848": {
+        "vendor": "Mellanox Technologies, Inc."
+    },
     "15776968": {
         "vendor": "MaxID (Pty) Ltd"
     },
@@ -109859,6 +110738,9 @@
     "15779920": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
+    "15779979": {
+        "vendor": "Wyze Labs Inc"
+    },
     "15779980": {
         "vendor": "LeddarTech Inc."
     },
@@ -109897,6 +110779,9 @@
     },
     "15782687": {
         "vendor": "Apple, Inc."
+    },
+    "15782699": {
+        "vendor": "Juniper Networks"
     },
     "15782823": {
         "vendor": "CobaltRay Co., Ltd"
@@ -110003,6 +110888,9 @@
     "15789342": {
         "vendor": "Bilkon Bilgisayar Kontrollu Cih. Im.Ltd."
     },
+    "15789393": {
+        "vendor": "Qingdao Intelligent&Precise Electronics Co.,Ltd."
+    },
     "15789496": {
         "vendor": "Servercom (India) Private Limited"
     },
@@ -110098,6 +110986,9 @@
     },
     "15792839": {
         "vendor": "Huawei Device Co., Ltd."
+    },
+    "15793023": {
+        "vendor": "Mellanox Technologies, Inc."
     },
     "15793253": {
         "vendor": "SynaXG Technologies Pte. Ltd."
@@ -110239,6 +111130,9 @@
     },
     "15997857": {
         "vendor": "Apple, Inc."
+    },
+    "15997990": {
+        "vendor": "AltoBeam Inc."
     },
     "15998065": {
         "vendor": "Shenzhen Sanmu Communication Technology Co., Ltd"
@@ -110507,6 +111401,9 @@
     "16011846": {
         "vendor": "Askey Computer Corp"
     },
+    "16011867": {
+        "vendor": "Antare Technology Ltd"
+    },
     "16011923": {
         "vendor": "Apple, Inc."
     },
@@ -110593,6 +111490,9 @@
     },
     "16016477": {
         "vendor": "Toshiba"
+    },
+    "16016566": {
+        "vendor": "Sercomm Corporation."
     },
     "16016651": {
         "vendor": "Espressif Inc."
@@ -110683,6 +111583,9 @@
     },
     "16021030": {
         "vendor": "Viltechmeda UAB"
+    },
+    "16021676": {
+        "vendor": "Apple, Inc."
     },
     "16021830": {
         "vendor": "Huawei Technologies Co.,Ltd"
@@ -110800,6 +111703,9 @@
     },
     "16030124": {
         "vendor": "WEBER Schraubautomaten GmbH"
+    },
+    "16030385": {
+        "vendor": "Hewlett Packard Enterprise"
     },
     "16030738": {
         "vendor": "Structab AB"
@@ -111128,6 +112034,9 @@
     "16048644": {
         "vendor": "Coyote System"
     },
+    "16048733": {
+        "vendor": "AltoBeam Inc."
+    },
     "16048838": {
         "vendor": "Ubiquiti Inc"
     },
@@ -111366,7 +112275,7 @@
         "vendor": "Google, Inc."
     },
     "16257079": {
-        "vendor": "Atopia Systems, LP"
+        "vendor": "ENTOUCH Controls"
     },
     "16257171": {
         "vendor": "Apple, Inc."
@@ -111740,6 +112649,9 @@
     "16275968": {
         "vendor": "Sanford LP"
     },
+    "16276251": {
+        "vendor": "Espressif Inc."
+    },
     "16276283": {
         "vendor": "Askey Computer Corp"
     },
@@ -112012,6 +112924,9 @@
     },
     "16290163": {
         "vendor": "Aedle Sas"
+    },
+    "16290293": {
+        "vendor": "Dingtian Technologies Co., Ltd"
     },
     "16290803": {
         "vendor": "Volans"
@@ -112934,6 +113849,9 @@
     "16530835": {
         "vendor": "Longcheer Telecommunication Limited"
     },
+    "16530840": {
+        "vendor": "Accton Technology Corporation"
+    },
     "16530853": {
         "vendor": "Arcadyan Corporation"
     },
@@ -113192,6 +114110,9 @@
     "16544250": {
         "vendor": "Trane Technologies"
     },
+    "16544392": {
+        "vendor": "Cisco Systems, Inc"
+    },
     "16544763": {
         "vendor": "Huawei Technologies Co.,Ltd"
     },
@@ -113257,6 +114178,9 @@
     },
     "16549699": {
         "vendor": "Huawei Technologies Co.,Ltd"
+    },
+    "16549927": {
+        "vendor": "Apple, Inc."
     },
     "16550461": {
         "vendor": "zte corporation"
@@ -113375,6 +114299,9 @@
     "16555480": {
         "vendor": "Beijing TongTongYiLian Science and Technology Ltd."
     },
+    "16555603": {
+        "vendor": "Intel Corporate"
+    },
     "16555818": {
         "vendor": "Zyxel Communications Corporation"
     },
@@ -113401,6 +114328,9 @@
     },
     "16556586": {
         "vendor": "PT. Callysta Multi Engineering"
+    },
+    "16556670": {
+        "vendor": "Huawei Technologies Co.,Ltd"
     },
     "16556934": {
         "vendor": "Shenzhen Chuangwei-Rgb Electronics Co.,Ltd"
@@ -113699,6 +114629,9 @@
     "16574058": {
         "vendor": "Industrial Software Co"
     },
+    "16574150": {
+        "vendor": "China Mobile Group Device Co.,Ltd."
+    },
     "16574470": {
         "vendor": "Edifier International"
     },
@@ -113755,6 +114688,9 @@
     },
     "16578427": {
         "vendor": "Huawei Device Co., Ltd."
+    },
+    "16578657": {
+        "vendor": "Harman/Becker Automotive Systems GmbH"
     },
     "16578734": {
         "vendor": "Intel Corporate"
@@ -114327,6 +115263,31 @@
                     "13770365599744": "Shenzhen Yingmu Technology.,Ltd",
                     "13770366648320": "Beijing Beibianzhida Technology Co.,Ltd",
                     "13770367696896": "Fx Technology Limited"
+                }
+            }
+        ]
+    },
+    "835508": {
+        "vendor": "",
+        "maskedFilters": [
+            {
+                "mask": 28,
+                "vendors": {
+                    "14017498185728": "Acula Technology Corp",
+                    "14017499234304": "Innomotics GmbH",
+                    "14017500282880": "Macnica Technology",
+                    "14017501331456": "ShenZhen XunDun Technology CO.LTD",
+                    "14017502380032": "Shenzhen EN Plus Tech Co.,Ltd.",
+                    "14017503428608": "ICWiser",
+                    "14017504477184": "Prolight Concepts (UK) Ltd",
+                    "14017505525760": "Odyssey Robot LLC",
+                    "14017506574336": "Changzhou Asia Networks Information Technology Co., Ltd",
+                    "14017507622912": "VirtualV Trading Limited",
+                    "14017508671488": "Irteya Llc",
+                    "14017509720064": "대한전력전자",
+                    "14017510768640": "ShenZhen Zeal-All Technology Co.,Ltd",
+                    "14017511817216": "Nanchang si colordisplay Technology Co.,Ltd",
+                    "14017512865792": "Shenzhen PengBrain Technology Co.,Ltd"
                 }
             }
         ]
@@ -115156,6 +116117,31 @@
                     "35227552448512": "sehwa",
                     "35227553497088": "Bently & EL Co. Ltd.",
                     "35227554545664": "HANGZHOU DANGBEI NETWORK TECH.Co.,Ltd"
+                }
+            }
+        ]
+    },
+    "2108378": {
+        "vendor": "",
+        "maskedFilters": [
+            {
+                "mask": 28,
+                "vendors": {
+                    "35372713115648": "Ik Multimedia Production Srl",
+                    "35372714164224": "Enovates NV",
+                    "35372715212800": "Thales Nederland BV",
+                    "35372716261376": "CtrlMovie AG",
+                    "35372717309952": "Teletek Electronics JSC",
+                    "35372718358528": "Plato System Development B.V.",
+                    "35372719407104": "Shenzhen FeiCheng Technology Co.,Ltd",
+                    "35372720455680": "Chongqing Ruishixing Technology Co., Ltd",
+                    "35372721504256": "Brush Electrical Machines Ltd",
+                    "35372722552832": "REDMOUSE Inc.",
+                    "35372723601408": "Industrial Connections & Solutions LLC",
+                    "35372724649984": "Arvind Limited",
+                    "35372725698560": "EV4 Limited",
+                    "35372726747136": "Transit Solutions, LLC.",
+                    "35372727795712": "ZhuoYu Technology"
                 }
             }
         ]
@@ -116750,7 +117736,7 @@
                     "79203142729728": "Technological Application And Production One Member Liability Company (Tecapro Company)",
                     "79203143778304": "Quanta Storage Inc.",
                     "79203144826880": "Hangzhou Jianan Technology Co.,Ltd",
-                    "79203145875456": "Aureka, Inc.",
+                    "79203145875456": "Aria Networks, Inc.",
                     "79203146924032": "Shenzhen Electron Technology Co., LTD.",
                     "79203147972608": "Dspread Technology (Beijing) Inc.",
                     "79203149021184": "Guangzhou Chuangsou Network Technology Co., Ltd.",
@@ -117514,6 +118500,31 @@
             }
         ]
     },
+    "5797383": {
+        "vendor": "",
+        "maskedFilters": [
+            {
+                "mask": 28,
+                "vendors": {
+                    "97263946825728": "HARDWARIO a.s.",
+                    "97263947874304": "Shing Chong International Co., Ltd.",
+                    "97263948922880": "Controlway(Suzhou) Electric Co., Ltd.",
+                    "97263949971456": "Shenzhen HANSWELL Technology Co., Ltd.",
+                    "97263951020032": "Beijing FHZX Science and Technology Co., Ltd.",
+                    "97263952068608": "RealSense Inc.",
+                    "97263953117184": "Shade Innovations",
+                    "97263954165760": "Oceansbio",
+                    "97263955214336": "Olte Climate sp. z o.o.",
+                    "97263956262912": "Suprock Technologies",
+                    "97263957311488": "INP Technologies Ltd",
+                    "97263958360064": "Rwaytech",
+                    "97263959408640": "BOE Technology Group Co., Ltd.",
+                    "97263960457216": "Hubcom Techno System LLP",
+                    "97263961505792": "Shenzhen Gago Electronics Co.,Ltd"
+                }
+            }
+        ]
+    },
     "5805528": {
         "vendor": "",
         "maskedFilters": [
@@ -117636,6 +118647,24 @@
                     "101542904463360": "tarm AG",
                     "101542905511936": "Aeva, Inc.",
                     "101542906560512": "Ai-Rider Corporation"
+                }
+            }
+        ]
+    },
+    "6052981": {
+        "vendor": "",
+        "maskedFilters": [
+            {
+                "mask": 28,
+                "vendors": {
+                    "101552170729472": "Tectoy S.A",
+                    "101552171778048": "youyeetoo",
+                    "101552172826624": "O-cubes Shanghai Microelectronics Technology Co., Ltd",
+                    "101552173875200": "Bkeen International Corporated",
+                    "101552178069504": "hassoun Gulf Industrial Company",
+                    "101552179118080": "Spectrum FiftyNine BV",
+                    "101552182263808": "Siemens Sensors & Communication Ltd.",
+                    "101552183312384": "Shenzhen Jooan Technology Co., Ltd"
                 }
             }
         ]
@@ -118409,6 +119438,31 @@
                     "127704489787392": "Hsptek Jsc",
                     "127704490835968": "Shenzhen smart-core technology co.,ltd.",
                     "127704491884544": "WDJ Hi-Tech Inc."
+                }
+            }
+        ]
+    },
+    "7615286": {
+        "vendor": "",
+        "maskedFilters": [
+            {
+                "mask": 28,
+                "vendors": {
+                    "127763298123776": "Huzhou Luxshare Precision Industry Co.LTD",
+                    "127763299172352": "Shengzhen Gongjin Electronics",
+                    "127763300220928": "Zoller + Fröhlich GmbH",
+                    "127763301269504": "Shenzhen DBG Innovation Tech Limited",
+                    "127763302318080": "Elide Interfaces Inc",
+                    "127763303366656": "Seclab Fr",
+                    "127763304415232": "Baumer Inspection GmbH",
+                    "127763305463808": "Venture International Pte Ltd",
+                    "127763306512384": "Moultrie Mobile",
+                    "127763307560960": "Lyno Dynamics LLC",
+                    "127763308609536": "Shenzhen Jooan Technology Co., Ltd",
+                    "127763309658112": "Annapurna labs",
+                    "127763310706688": "Shenzhen Handheld-Wireless Technology Co., Ltd.",
+                    "127763311755264": "ACTECK TECHNOLOGY Co., Ltd",
+                    "127763312803840": "Ramon Space"
                 }
             }
         ]
@@ -122977,6 +124031,31 @@
             }
         ]
     },
+    "15267543": {
+        "vendor": "",
+        "maskedFilters": [
+            {
+                "mask": 28,
+                "vendors": {
+                    "256146866700288": "Mono Technologies Inc.",
+                    "256146867748864": "Precision Fukuhara Works,Ltd.",
+                    "256146868797440": "Jinan Ruolin Video Technology Co., Ltd",
+                    "256146869846016": "Ziehl-Abegg Se",
+                    "256146870894592": "Xiphos Systems Corp.",
+                    "256146871943168": "emicrotec",
+                    "256146872991744": "Massive Beams GmbH",
+                    "256146874040320": "CowManager",
+                    "256146875088896": "INTEGRA Metering AG",
+                    "256146876137472": "Hefei BOE Vision-electronic Technology Co.,Ltd.",
+                    "256146877186048": "Ivostud GmbH",
+                    "256146878234624": "Guangzhou Panyu Juda Car Audio Equipment Co.,Ltd",
+                    "256146879283200": "clover Co,.Ltd",
+                    "256146880331776": "ZhuoPuCheng (Shenzhen) Technology.Co.,Ltd.",
+                    "256146881380352": "Emergent Solutions Inc."
+                }
+            }
+        ]
+    },
     "15269662": {
         "vendor": "",
         "maskedFilters": [
@@ -124460,7 +125539,7 @@
                     "346853752832": "H M Computing Limited",
                     "346853756928": "Optical Wireless Link Inc.",
                     "346853761024": "Pantec Engineering AG",
-                    "346853765120": "Cyan Technology Ltd",
+                    "346853765120": "CyanConnode",
                     "346853769216": "dresden-elektronik",
                     "346853773312": "CC Systems AB",
                     "346853777408": "Basler Electric Company",
@@ -128693,7 +129772,7 @@
                     "123917675110400": "Cubro Acronet GesmbH",
                     "123917675114496": "Audi Ag",
                     "123917675118592": "Kumu Networks",
-                    "123917675122688": "Weigl Elektronik & Mediaprojekte",
+                    "123917675122688": "Weigl GmbH & Co KG",
                     "123917675126784": "ePOINT Embedded Computing Limited",
                     "123917675130880": "SPX Flow Technology BV",
                     "123917675134976": "Micro Debug, Y.K.",
@@ -129135,7 +130214,7 @@
                     "123917676920832": "Brinkmann Audio GmbH",
                     "123917676924928": "MIVO Technology AB",
                     "123917676929024": "MacGray Services",
-                    "123917676933120": "BAE Systems Apllied Intelligence",
+                    "123917676933120": "BAE Systems",
                     "123917676937216": "Blue Skies Global LLC",
                     "123917676941312": "MondeF",
                     "123917676945408": "Promess Inc.",
@@ -132289,7 +133368,7 @@
                     "123917689856000": "CONTES, spol. s r.o.",
                     "123917689860096": "Guan Show Technologe Co., Ltd.",
                     "123917689864192": "Fourth Frontier Technologies Private Limited",
-                    "123917689868288": "BAE Systems Apllied Intelligence",
+                    "123917689868288": "BAE Systems",
                     "123917689872384": "Merz s.r.o.",
                     "123917689876480": "Flextronics International Kft",
                     "123917689880576": "Quiss Ag",
@@ -132791,6 +133870,8 @@
                     "154066449747968": "SMITEC S.p.A.",
                     "154066449760256": "eyrise B.V.",
                     "154066449764352": "Hunan Shengyun Photoelectric Technology Co.,LTD",
+                    "154066449768448": "DEUTA Werke GmbH",
+                    "154066449780736": "Shenzhen Tezesk Energy Technology Co.,LTD",
                     "154066449788928": "SOLIDpower SpA",
                     "154066449797120": "Ektos A/S",
                     "154066449805312": "IQ Home Kft.",
@@ -132876,6 +133957,7 @@
                     "154066450305024": "E2 Nova Corporation",
                     "154066450313216": "Forsee Power",
                     "154066450317312": "Bunka Shutter Co., Ltd.",
+                    "154066450337792": "SMC Gateway",
                     "154066450341888": "Luke Granger-Brown",
                     "154066450345984": "Tiama",
                     "154066450350080": "Signatrol Ltd",
@@ -132885,6 +133967,7 @@
                     "154066450374656": "Bnb",
                     "154066450378752": "Aurora Communication Technologies Corp.",
                     "154066450382848": "Active Research Limited",
+                    "154066450386944": "Opal Camera Inc.",
                     "154066450395136": "Eurek srl",
                     "154066450403328": "TechnipFMC",
                     "154066450415616": "EA Elektro-Automatik GmbH",
@@ -132917,6 +134000,7 @@
                     "154066450608128": "Combilent",
                     "154066450616320": "ikan International LLC",
                     "154066450620416": "Nautel LTD",
+                    "154066450632704": "CEI Ptd Ltd",
                     "154066450636800": "Indra Heera Technology LLP",
                     "154066450640896": "Pneumax Spa",
                     "154066450644992": "Beijing Zhenlong Technology Co.,Ltd.",
@@ -132989,6 +134073,7 @@
                     "154066451124224": "Wuhan YiValley Opto-electric technology Co.,Ltd",
                     "154066451128320": "Leidos Inc",
                     "154066451132416": "Emcom Systems",
+                    "154066451136512": "Attack do Brasil Ind Com Apar de Som LTDA",
                     "154066451140608": "Agrowtek Inc.",
                     "154066451144704": "Sichuan ZhikongLingxin Technology Co., Ltd.",
                     "154066451148800": "Bavaria Digital Technik GmbH",
@@ -133015,6 +134100,7 @@
                     "154066451329024": "aelettronica group srl",
                     "154066451333120": "Private",
                     "154066451353600": "Nexxto Servicos Em Tecnologia da Informacao SA",
+                    "154066451357696": "Bounce Imaging",
                     "154066451361792": "EnviroNode IoT Solutions",
                     "154066451369984": "person-AIz AS",
                     "154066451374080": "Rapid-e-Engineering Steffen Kramer",
@@ -133051,6 +134137,7 @@
                     "154066451587072": "Radian Research, Inc.",
                     "154066451591168": "Canon Electron Tubes & Devices Co., Ltd.",
                     "154066451595264": "Haptech Defense Systems",
+                    "154066451603456": "Asteelflash Design Solutions Hamburg GmbH",
                     "154066451615744": "Lichtwart GmbH",
                     "154066451623936": "Tantronic AG",
                     "154066451628032": "AVCOMM Technologies Inc",
@@ -133079,6 +134166,7 @@
                     "154066451816448": "The Bionetics Corporation",
                     "154066451828736": "Yuansiang Optoelectronics Co.,Ltd.",
                     "154066451841024": "PHB Eletronica Ltda.",
+                    "154066451849216": "Colossus Computing, Inc.",
                     "154066451853312": "Digilens",
                     "154066451857408": "Shenzhen Chuanxin Micro Technology Co., Ltd",
                     "154066451877888": "Kaysons Electricals Private Limited",
@@ -133134,6 +134222,7 @@
                     "154066452213760": "Whizz Systems Inc.",
                     "154066452217856": "Heitec Ag",
                     "154066452221952": "Nvp Teco Ltd",
+                    "154066452238336": "Smart Tech Inc",
                     "154066452242432": "i2s",
                     "154066452250624": "Vision Systems Safety Tech",
                     "154066452254720": "Craft4 Digital GmbH",
@@ -133141,6 +134230,7 @@
                     "154066452262912": "Power Electronics Espana, S.L.",
                     "154066452267008": "Sakura Seiki Co.,Ltd.",
                     "154066452271104": "AVA Monitoring AB",
+                    "154066452283392": "Ubiq Technologies International Ltd",
                     "154066452287488": "Jiangsu Ruidong Electric Power Technology Co.,Ltd",
                     "154066452291584": "Gogo Business Aviation",
                     "154066452295680": "Landis+Gyr Equipamentos de Medição Ltda",
@@ -133152,6 +134242,7 @@
                     "154066452320256": "Integer.pl S.A.",
                     "154066452324352": "Power Electronics Espana, S.L.",
                     "154066452328448": "TT electronics integrated manufacturing services (Suzhou) Limited",
+                    "154066452332544": "Thales Nederland BV",
                     "154066452336640": "Automata GmbH & Co. KG",
                     "154066452340736": "AD Parts, S.L.",
                     "154066452344832": "Nagtech Llc",
@@ -133188,6 +134279,7 @@
                     "154066452537344": "E2 Nova Corporation",
                     "154066452545536": "Cambridge Research Systems Ltd",
                     "154066452566016": "J&J Philippines Corporation",
+                    "154066452570112": "Techtuit Co.,Ltd.",
                     "154066452578304": "CONTROL SYSTEMS Srl",
                     "154066452594688": "TimeMachines Inc.",
                     "154066452598784": "Flextronics International Kft",
@@ -133317,6 +134409,7 @@
                     "154066453372928": "Golding Audio Ltd",
                     "154066453377024": "Deviceworx Technologies Inc.",
                     "154066453389312": "Abbott Diagnostics Technologies AS",
+                    "154066453393408": "Guangzhou Beizeng Information Technology Co.,Ltd",
                     "154066453405696": "Kron Medidores",
                     "154066453409792": "Lumentum",
                     "154066453413888": "QLM Technology Ltd",
@@ -133339,6 +134432,7 @@
                     "154066453544960": "NavSys Technology Inc.",
                     "154066453549056": "Stratis IOT",
                     "154066453553152": "Wavestream Corp",
+                    "154066453557248": "Resmed Pty Ltd",
                     "154066453561344": "BTG Instruments AB",
                     "154066453565440": "TECHPLUS-LINK Technology Co.,Ltd",
                     "154066453581824": "Sejong security system Cor.",
@@ -133348,6 +134442,7 @@
                     "154066453602304": "UVIRCO Technologies",
                     "154066453610496": "e.p.g. Elettronica s.r.l.",
                     "154066453614592": "FRAKO Kondensatoren- und Anlagenbau GmbH",
+                    "154066453618688": "Kyowakiden Industry Co.,Ltd.",
                     "154066453622784": "Eiden Co.,Ltd.",
                     "154066453630976": "Unlimited Bandwidth LLC",
                     "154066453639168": "BRS Sistemas Eletrônicos",
@@ -133366,6 +134461,7 @@
                     "154066453733376": "Surya Electronics",
                     "154066453737472": "Cambrian Works, Inc.",
                     "154066453741568": "Actelser S.L.",
+                    "154066453749760": "Antara Technologies",
                     "154066453753856": "Mitsubishi Electric India Pvt. Ltd.",
                     "154066453762048": "Yu Yan System Technology Co., Ltd.",
                     "154066453774336": "STV Electronic GmbH",
@@ -133405,18 +134501,22 @@
                     "154066454024192": "Bornico",
                     "154066454028288": "Spacelite Inc",
                     "154066454040576": "Solid State Supplies Ltd",
+                    "154066454044672": "Syrma SGS Technology",
                     "154066454048768": "beespace Technologies Limited",
                     "154066454052864": "MB connect line GmbH Fernwartungssysteme",
                     "154066454056960": "Novanta IMS",
                     "154066454061056": "Potter Electric Signal Co. LLC",
                     "154066454069248": "Contrive Srl",
                     "154066454073344": "Figment Design Laboratories",
+                    "154066454081536": "Marvaus Technologies Private Limited",
+                    "154066454085632": "Förster-Technik GmbH",
                     "154066454093824": "Onbitel",
                     "154066454106112": "Design and Manufacturing Vista Electronics Pvt.Ltd.",
                     "154066454110208": "GVA Lighting, Inc.",
                     "154066454114304": "RealD, Inc.",
                     "154066454122496": "Guan Show Technologe Co., Ltd.",
                     "154066454134784": "KJ Klimateknik A/S",
+                    "154066454138880": "Weigl GmbH & Co KG",
                     "154066454147072": "Shanghai Angwei Information Technology Co.,Ltd.",
                     "154066454155264": "GreenTally LLC",
                     "154066454159360": "Inspur Digital Enterprise Technology Co., Ltd.",
@@ -133466,6 +134566,7 @@
                     "154066454446080": "Tantec A/S",
                     "154066454450176": "Breas Medical AB",
                     "154066454454272": "Bludigit SpA",
+                    "154066454458368": "ID Quantique SA",
                     "154066454462464": "Potter Electric Signal Co. LLC",
                     "154066454470656": "Alaire Technologies Inc",
                     "154066454474752": "Potter Electric Signal Co. LLC",
@@ -133477,6 +134578,7 @@
                     "154066454507520": "miniDSP",
                     "154066454511616": "U -Mei-Dah Int'L Enterprise Co.,Ltd.",
                     "154066454519808": "GV Technology Co.,Ltd.",
+                    "154066454523904": "XYZ Digital Private Limited",
                     "154066454528000": "Point One Navigation",
                     "154066454544384": "astTECS Communications Private Limited",
                     "154066454556672": "IWS Global Pty Ltd",
@@ -133487,6 +134589,7 @@
                     "154066454605824": "SBS SpA",
                     "154066454614016": "Apantac LLC",
                     "154066454618112": "North Building Technologies Limited",
+                    "154066454626304": "Carestream Healthcare International Company Limited",
                     "154066454630400": "Guan Show Technologe Co., Ltd.",
                     "154066454638592": "Sicon srl",
                     "154066454642688": "SunSonic LLC",
@@ -133523,6 +134626,7 @@
                     "154066454851584": "Tualcom Elektronik A.S.",
                     "154066454855680": "EA Elektroautomatik GmbH & Co. KG",
                     "154066454863872": "UrbanChain Group Co., Ltd",
+                    "154066454867968": "Idneo Technologies,S.A.U.",
                     "154066454872064": "Kite Rise Technologies GmbH",
                     "154066454876160": "Season Electronics Ltd",
                     "154066454880256": "Bellco Trading Company (Pvt) Ltd",
@@ -133534,6 +134638,7 @@
                     "154066454908928": "Control Aut Tecnologia em Automação LTDA",
                     "154066454913024": "Blik Sensing B.V.",
                     "154066454921216": "iOpt",
+                    "154066454925312": "Daniele Saladino",
                     "154066454929408": "Tcl Operations Polska Sp. Z O.O.",
                     "154066454933504": "Smart Radar System, Inc",
                     "154066454937600": "Wagner Group GmbH",
@@ -133612,6 +134717,7 @@
                     "154066455461888": "Tirasoft Technology",
                     "154066455470080": "Primalucelab isrl",
                     "154066455478272": "Private",
+                    "154066455482368": "CommBox Pty Ltd",
                     "154066455490560": "Delta Computers LLC.",
                     "154066455494656": "Seongwon Eng Co.,Ltd",
                     "154066455498752": "Breas Medical AB",
@@ -133644,6 +134750,7 @@
                     "154066455674880": "Alpes recherche et développement",
                     "154066455678976": "Mahindr & Mahindra",
                     "154066455683072": "Packetalk LLC",
+                    "154066455687168": "YUYAMA MFG Co.,Ltd",
                     "154066455691264": "Image Engineering",
                     "154066455695360": "Twin Development",
                     "154066455703552": "Eloy Water",
@@ -133672,6 +134779,7 @@
                     "154066455863296": "PolCam Systems Sp. z o.o.",
                     "154066455867392": "Recom Llc.",
                     "154066455871488": "Lance Design LLC",
+                    "154066455883776": "Dave Srl",
                     "154066455887872": "Anhui Chaokun Testing Equipment Co., Ltd",
                     "154066455891968": "Camius",
                     "154066455900160": "Fuku Energy Technology Co., Ltd.",
@@ -133679,7 +134787,9 @@
                     "154066455916544": "Nanjing Aotong Intelligent Technology Co.,Ltd",
                     "154066455920640": "Cong Ty Co Phan Ky Thuat Moi Truong Viet An",
                     "154066455928832": "Rfengine Co., Ltd.",
+                    "154066455932928": "eumig industrie-TV GmbH.",
                     "154066455945216": "ICT International",
+                    "154066455949312": "Sael Srl",
                     "154066455953408": "Beijing Zhongzhi Huida Technology Co., Ltd",
                     "154066455957504": "Siemens Industry Software Inc.",
                     "154066455977984": "DEUTA Werke GmbH",
@@ -133699,6 +134809,7 @@
                     "154066456068096": "Hangzhou EasyXR Advanced Technology Co., Ltd.",
                     "154066456072192": "Embeddded Plus Plus",
                     "154066456076288": "ViewSonic Corp",
+                    "154066456080384": "Pro Design Electronic GmbH",
                     "154066456088576": "Haiyang Olix Co.,Ltd.",
                     "154066456100864": "Aml",
                     "154066456109056": "Europe Trade",
@@ -133712,13 +134823,16 @@
                     "154066456166400": "Dave Srl",
                     "154066456178688": "Senior Group LLC",
                     "154066456182784": "Gridpulse c.o.o.",
+                    "154066456203264": "Newone Co.,Ltd.",
                     "154066456207360": "Nilfisk Food",
                     "154066456215552": "L tec Co.,Ltd",
                     "154066456219648": "Teledyne Cetac",
+                    "154066456223744": "Tokyo Interphone Co.,Ltd.",
                     "154066456227840": "P5",
                     "154066456236032": "S.E.I. Co.,Ltd.",
                     "154066456240128": "Optotune Switzerland AG",
                     "154066456244224": "Bright Solutions PTE LTD",
+                    "154066456256512": "YUYAMA MFG Co.,Ltd",
                     "154066456260608": "SUS Corporation",
                     "154066456268800": "Action Streamer LLC",
                     "154066456276992": "Astrometric Instruments, Inc.",
@@ -133768,6 +134882,7 @@
                     "154066456555520": "Becton Dickinson",
                     "154066456559616": "Automata Spa",
                     "154066456567808": "Q (Cue), Inc.",
+                    "154066456571904": "MobileMustHave",
                     "154066456576000": "Bulwark",
                     "154066456588288": "Toho System Co., Ltd.",
                     "154066456596480": "Potter Electric Signal Co. LLC",
@@ -133799,10 +134914,12 @@
                     "154066456764416": "Argosdyne Co., Ltd",
                     "154066456768512": "Leopard Imaging Inc",
                     "154066456776704": "Khimo",
+                    "154066456780800": "浙江红谱科技有限公司",
                     "154066456788992": "Intrinsic Innovation, LLC",
                     "154066456793088": "ViewSonic Corp",
                     "154066456797184": "SUN･TECTRO,Ltd.",
                     "154066456801280": "ALPHI Technology Corporation",
+                    "154066456805376": "KMtronic LTD",
                     "154066456813568": "SCU Co., Ltd.",
                     "154066456817664": "ViewSonic International Corporation",
                     "154066456821760": "RAB Microfluidics R&D Company Ltd",
@@ -133828,6 +134945,7 @@
                     "154066456981504": "Onicon",
                     "154066456985600": "Broyce Control Ltd",
                     "154066456993792": "OvercomTech",
+                    "154066457001984": "Zengar Institute Inc",
                     "154066457010176": "Nexion Data Systems P/L",
                     "154066457014272": "Nstek Co., Ltd.",
                     "154066457022464": "Internet Protocolo Logica Sl",
@@ -133874,6 +134992,7 @@
                     "154066457284608": "Flextronics International Kft",
                     "154066457288704": "Star Systems International Limited",
                     "154066457300992": "Systel Inc",
+                    "154066457309184": "Meiji Electric Industry",
                     "154066457313280": "American Energy Storage Innovations",
                     "154066457321472": "Yonnet Bilisim Yaz. Egt. Ve Dan. Hiz. Tic. A.S.",
                     "154066457325568": "ASTRACOM Co. Ltd",
@@ -133905,6 +135024,8 @@
                     "154066457460736": "HME Co.,ltd",
                     "154066457464832": "Druck Ltd.",
                     "154066457468928": "Atm Llc",
+                    "154066457473024": "VMA GmbH",
+                    "154066457477120": "Maysun Corporation",
                     "154066457489408": "Tabology",
                     "154066457497600": "DEUTA Werke GmbH",
                     "154066457505792": "Senso2Me Nv",
@@ -133943,6 +135064,7 @@
                     "154066457747456": "Flextronics International Kft",
                     "154066457751552": "Ascon Tecnologic S.r.l.",
                     "154066457755648": "Jacquet Dechaume",
+                    "154066457772032": "Kuntu Technology Limited Liability Compant",
                     "154066457776128": "Fugro Technology B.V.",
                     "154066457780224": "Shanghai smartlogic technology Co.,Ltd.",
                     "154066457784320": "Transdigital Pty Ltd",
@@ -133974,6 +135096,7 @@
                     "154066457927680": "AT-Automation Technology GmbH",
                     "154066457931776": "Videosys Broadcast Ltd",
                     "154066457935872": "G.M. International srl",
+                    "154066457944064": "Abbott Diagnostics Technologies AS",
                     "154066457952256": "FleetSafe India Private Limited",
                     "154066457956352": "Copelion International Inc",
                     "154066457968640": "Mitsubishi Electric Klimat Transportation Systems S.p.A.",
@@ -133998,6 +135121,7 @@
                     "154066458091520": "Gemini Electronics B.V.",
                     "154066458095616": "Potter Electric Signal Co. LLC",
                     "154066458103808": "Gogo BA",
+                    "154066458107904": "37130",
                     "154066458112000": "ViewSonic Corp",
                     "154066458116096": "Tiama",
                     "154066458124288": "IP Devices",
@@ -134015,6 +135139,7 @@
                     "154066458230784": "Xtend Technologies Pvt Ltd",
                     "154066458234880": "L-signature",
                     "154066458238976": "Sicon srl",
+                    "154066458247168": "InfoMac Sp. z o.o. Sp.k.",
                     "154066458255360": "Potter Electric Signal Co. LLC",
                     "154066458259456": "Image Soft Oy",
                     "154066458271744": "Fo Xie Optoelectronics Technology Co., Ltd",
@@ -134093,6 +135218,7 @@
                     "154066458779648": "Cirrus Systems, Inc.",
                     "154066458787840": "Hermes Network Inc",
                     "154066458791936": "NextT Microwave Inc",
+                    "154066458804224": "Potter Electric Signal Co. LLC",
                     "154066458812416": "YUYAMA MFG Co.,Ltd",
                     "154066458816512": "Chromaviso A/S",
                     "154066458824704": "Guan Show Technologe Co., Ltd.",
@@ -134165,6 +135291,7 @@
                     "154066459258880": "H2Ok Innovations",
                     "154066459267072": "SPIT Technology, Inc",
                     "154066459271168": "Rejås of Sweden AB",
+                    "154066459291648": "Temcoline",
                     "154066459299840": "Lorenz GmbH & Co. KG",
                     "154066459308032": "Autark GmbH",
                     "154066459312128": "BRS Sistemas Eletrônicos",
@@ -134193,6 +135320,7 @@
                     "154066459459584": "Iav Engineering Sarl",
                     "154066459467776": "EA Elektro-Automatik GmbH",
                     "154066459471872": "Vantageo Private Limited",
+                    "154066459488256": "Vortix Networks",
                     "154066459492352": "Potter Electric Signal Co. LLC",
                     "154066459496448": "Infrasafe/ Advantor Systems",
                     "154066459504640": "Dorsett Technologies Inc",
@@ -134202,6 +135330,7 @@
                     "154066459545600": "KSE GmbH",
                     "154066459549696": "Sona Networks Private Limited",
                     "154066459553792": "Talleres de Escoriaza SA",
+                    "154066459570176": "Baker Hughes EMEA",
                     "154066459574272": "Abacus Peripherals Pvt Ltd",
                     "154066459586560": "Peter Huber Kaeltemaschinenbau SE",
                     "154066459594752": "Phe-nX B.V.",
@@ -134240,6 +135369,8 @@
                     "154066459820032": "Header Rhyme",
                     "154066459824128": "RealWear",
                     "154066459832320": "Camozzi Automation SpA",
+                    "154066459836416": "Indra Heera Network Private Limited",
+                    "154066459840512": "Pacton Technologies Pty Ltd",
                     "154066459844608": "Golding Audio Ltd",
                     "154066459860992": "EDC Acoustics",
                     "154066459865088": "Shanghai Sizhong Information Technology Co., Ltd",
@@ -134247,6 +135378,7 @@
                     "154066459877376": "Exi Flow Measurement Ltd",
                     "154066459881472": "ASAP Electronics GmbH",
                     "154066459885568": "Saline Lectronics, Inc.",
+                    "154066459889664": "Televic Rail GmbH",
                     "154066459897856": "EA Elektro-Automatik GmbH",
                     "154066459901952": "Wolfspyre Labs",
                     "154066459918336": "Integer.pl S.A.",
@@ -134284,6 +135416,7 @@
                     "154066460135424": "Lumiplan Duhamel",
                     "154066460139520": "Elac Americas Inc.",
                     "154066460143616": "Dorlet Sau",
+                    "154066460147712": "ZJU-Hangzhou Global Scientific and Technological Innovation Center",
                     "154066460155904": "FUJIHENSOKUKI Co., Ltd.",
                     "154066460160000": "INVENTIA Sp. z o.o.",
                     "154066460164096": "Uplusit",
@@ -134342,6 +135475,7 @@
                     "154066460536832": "Cardinal Scales Manufacturing Co",
                     "154066460540928": "V-teknik Elektronik AB",
                     "154066460545024": "Martec S.p.A.",
+                    "154066460557312": "Hiwin Mikrosystem Corp.",
                     "154066460561408": "Procon Electronics Pty Ltd",
                     "154066460565504": "DEUTA-WERKE GmbH",
                     "154066460569600": "Rax-Tech International",
@@ -134359,6 +135493,7 @@
                     "154066460676096": "Infinitive Group Limited",
                     "154066460680192": "Agrology, PBC",
                     "154066460688384": "Future wave ultra tech Company",
+                    "154066460692480": "Sentek Pty Ltd",
                     "154066460700672": "Integer.pl S.A.",
                     "154066460704768": "Jacobs Technology, Inc.",
                     "154066460712960": "Signasystems Elektronik San. ve Tic. Ltd. Sti.",
@@ -134375,6 +135510,7 @@
                     "154066460770304": "axelife",
                     "154066460778496": "Leder Elektronik Design GmbH",
                     "154066460782592": "BlueSword Intelligent Technology Co., Ltd.",
+                    "154066460803072": "Etm Co Ltd",
                     "154066460815360": "Velvu Technologies Private Limited",
                     "154066460819456": "Beijing Zhongchen Microelectronics Co.,Ltd",
                     "154066460823552": "Justmorph Pte. Ltd.",
@@ -134439,6 +135575,7 @@
                     "154066461237248": "Panoramic Power",
                     "154066461241344": "Nov'in",
                     "154066461249536": "Tocho Marking Systems America, Inc",
+                    "154066461253632": "Aidhom",
                     "154066461257728": "wincker international enterprise co., ltd",
                     "154066461261824": "Lechpol Electronics Spółka z o.o. Sp.k.",
                     "154066461270016": "Blighter Surveillance Systems Ltd",
@@ -134453,6 +135590,7 @@
                     "154066461315072": "wonder meditec",
                     "154066461323264": "Mtechnology - Gamma Commerciale Srl",
                     "154066461327360": "Fujian ONETHING Technology Co.,Ltd.",
+                    "154066461331456": "Rsc",
                     "154066461335552": "Plug Power",
                     "154066461347840": "RADA Electronics Industries Ltd.",
                     "154066461351936": "Pneumax Spa",
@@ -134463,6 +135601,7 @@
                     "154066461380608": "RealD, Inc.",
                     "154066461388800": "Fell Technology AS",
                     "154066461396992": "State Grid Intelligence Technology Co.,Ltd.",
+                    "154066461409280": "Samkyung MS",
                     "154066461417472": "Phygitall Soluções Em Internet Das Coisas",
                     "154066461421568": "Lineage Power Pvt Ltd.,",
                     "154066461442048": "Picocom Technology Ltd",
@@ -134521,6 +135660,7 @@
                     "154066461786112": "Jmv Lps Ltd",
                     "154066461794304": "BESO sp. z o.o.",
                     "154066461798400": "DEUTA-WERKE GmbH",
+                    "154066461802496": "Buckeye Mountain",
                     "154066461810688": "FMC Technologies Measurement Solutions Inc",
                     "154066461814784": "iLensys Technologies PVT LTD",
                     "154066461818880": "AvMap srlu",
@@ -134567,6 +135707,7 @@
                     "154066462052352": "Geolux",
                     "154066462060544": "Reo Ag",
                     "154066462081024": "Technologies Bacmove Inc.",
+                    "154066462089216": "Microchip Technologies Inc",
                     "154066462101504": "Genius Sports SS LLC",
                     "154066462105600": "Sirius LLC",
                     "154066462109696": "Triumph SEC",
@@ -134615,6 +135756,7 @@
                     "154066462363648": "iENSO Inc.",
                     "154066462371840": "Power Electronics Espana, S.L.",
                     "154066462380032": "Ambarella Inc.",
+                    "154066462392320": "Chengdu Xinyuandi Technology Co., Ltd.",
                     "154066462396416": "Peter Huber Kaeltemaschinenbau SE",
                     "154066462400512": "ODTech Co., Ltd.",
                     "154066462408704": "Eco-Adapt",
@@ -134653,6 +135795,7 @@
                     "154066462625792": "EA Elektro-Automatik GmbH",
                     "154066462629888": "Safe Instruments",
                     "154066462633984": "Luneau Technology Operations",
+                    "154066462638080": "Invixium Access Inc",
                     "154066462642176": "Yaviar LLC",
                     "154066462654464": "Nippon Techno Lab Inc",
                     "154066462658560": "Abbott Diagnostics Technologies AS",
@@ -134721,6 +135864,7 @@
                     "154066463109120": "Pixel Design & Manufacturing Sdn. Bhd.",
                     "154066463113216": "Sl Usa, Llc",
                     "154066463117312": "Private",
+                    "154066463133696": "Landis+Gyr Equipamentos de Medição Ltda",
                     "154066463141888": "Eureka For Smart Properties Co. W.L.L",
                     "154066463145984": "Zhuhai Huaya machinery Technology Co., LTD",
                     "154066463150080": "Nha Trang Hitech Company, Ltd",
@@ -134779,6 +135923,7 @@
                     "154066463498240": "YUYAMA MFG Co.,Ltd",
                     "154066463506432": "Monarch Instrument",
                     "154066463514624": "End 2 End Technologies",
+                    "154066463522816": "Private",
                     "154066463526912": "Future Life Technology",
                     "154066463531008": "Caproc Oy",
                     "154066463543296": "Liburdi Dimetrics Corp.",
@@ -134788,6 +135933,7 @@
                     "154066463563776": "Critical Software SA",
                     "154066463567872": "Gridnt",
                     "154066463571968": "Grupo Epelsa S.L.",
+                    "154066463576064": "Fairwinds Technologies",
                     "154066463580160": "Wisdom Audio",
                     "154066463588352": "Zumbach Electronic AG",
                     "154066463596544": "Realtek Semiconductor Corp.",
@@ -134839,6 +135985,7 @@
                     "154066463940608": "Mainco automotion s.l.",
                     "154066463944704": "Zhuhai Lonl electric Co.,Ltd",
                     "154066463952896": "Shanghai Yamato Scale Co., Ltd",
+                    "154066463965184": "MB connect line GmbH",
                     "154066463969280": "victtron",
                     "154066463977472": "Lambda Systems Inc.",
                     "154066463981568": "Beijing Dangong Technology Co., Ltd",
@@ -134848,6 +135995,7 @@
                     "154066464002048": "Giordano Controls Spa",
                     "154066464010240": "Rugged Controls",
                     "154066464014336": "Pigs Can Fly Labs LLC",
+                    "154066464018432": "SEGRON Automation, s.r.o.",
                     "154066464022528": "Procon Electronics Pty Ltd",
                     "154066464026624": "Packet Digital, LLC",
                     "154066464030720": "Amazon Robotics MTAC Matrix NPI",
@@ -134865,6 +136013,7 @@
                     "154066464108544": "KST technology",
                     "154066464116736": "Abbott Diagnostics Technologies AS",
                     "154066464124928": "Efficient Residential Heating GmbH",
+                    "154066464133120": "Irmos Technologies AG",
                     "154066464137216": "Jemac Sweden AB",
                     "154066464145408": "BorgWarner Engineering Services AG",
                     "154066464149504": "Franke Aquarotter GmbH",
@@ -134882,6 +136031,7 @@
                     "154066464251904": "Atse Llc",
                     "154066464256000": "Bobeesc Co.",
                     "154066464260096": "Meiko Electronics Co.,Ltd.",
+                    "154066464264192": "Novanta IMS",
                     "154066464268288": "Nuvation Energy",
                     "154066464272384": "Vingloop Technology Ltd",
                     "154066464276480": "Dvb-Tech S.R.L.",
@@ -134917,6 +136067,7 @@
                     "154066464485376": "Amiad Water Systems",
                     "154066464493568": "Horcery LLC",
                     "154066464497664": "Metabuild",
+                    "154066464501760": "RADA Electronics Industries Ltd.",
                     "154066464514048": "AITEC Corporation",
                     "154066464518144": "Neways Technologies B.V.",
                     "154066464522240": "Finotex Electronic Solutions PVT LTD",
@@ -134971,6 +136122,7 @@
                     "154066464854016": "Plura",
                     "154066464862208": "JieChuang HeYi(Beijing) Technology Co., Ltd.",
                     "154066464866304": "MHE Electronics",
+                    "154066464870400": "RADIC Technologies, Inc.",
                     "154066464874496": "EA Elektro-Automatik GmbH",
                     "154066464882688": "Zin Technologies",
                     "154066464899072": "Luxshare Electronic Technology (Kunshan) LTD",
@@ -134988,6 +136140,7 @@
                     "154066465005568": "Aqua Broadcast Ltd",
                     "154066465017856": "Meiryo Denshi Corp.",
                     "154066465026048": "Delta Solutions LLC",
+                    "154066465030144": "Power Electronics Espana, S.L.",
                     "154066465034240": "KxS Technologies Oy",
                     "154066465038336": "Hyve Solutions",
                     "154066465042432": "Potter Electric Signal Co. LLC",
@@ -135009,6 +136162,7 @@
                     "154066465161216": "Mcs Innovation Pvt Ltd",
                     "154066465165312": "Netgen Hitech Solutions Llp",
                     "154066465169408": "DEUTA-WERKE GmbH",
+                    "154066465177600": "Infosoft Digital Design and Services P L",
                     "154066465181696": "OnDis Solutions Ltd",
                     "154066465189888": "Xlera Solutions, LLC",
                     "154066465193984": "Private",
@@ -135044,6 +136198,7 @@
                     "154066465439744": "Rigel Engineering, LLC",
                     "154066465443840": "MB connect line GmbH Fernwartungssysteme",
                     "154066465456128": "Thermaco Incorporated",
+                    "154066465460224": "nanoTRONIX Computing Inc.",
                     "154066465464320": "Voyage Audio LLC",
                     "154066465468416": "IDEX India Pvt Ltd",
                     "154066465472512": "Albotronic",
@@ -135056,6 +136211,7 @@
                     "154066465525760": "International Water Treatment Maritime AS",
                     "154066465529856": "Shenzhen INVT Electric Co.,Ltd",
                     "154066465533952": "Sicon srl",
+                    "154066465550336": "Polarity Inc",
                     "154066465558528": "Weinan Wins Future Technology Co.,Ltd",
                     "154066465562624": "intersaar GmbH",
                     "154066465566720": "Beijing REMANG Technology Co., Ltd.",
@@ -135066,6 +136222,7 @@
                     "154066465599488": "wtec GmbH",
                     "154066465607680": "Jbf",
                     "154066465611776": "Broadcast Tools, Inc.",
+                    "154066465619968": "Fibernet Ltd",
                     "154066465624064": "CenterClick LLC",
                     "154066465628160": "In-lite Design BV",
                     "154066465632256": "Jorex Lorex India Private Limited",
@@ -135118,6 +136275,7 @@
                     "154066465939456": "SACO Controls Inc.",
                     "154066465943552": "Dentalhitec",
                     "154066465947648": "Xps Eletronica Ltda",
+                    "154066465951744": "Sysinno Technology Inc.",
                     "154066465959936": "Elsist Srl",
                     "154066465964032": "Beijing Tong Cybsec Technology Co.,LTD",
                     "154066465972224": "DREAMSWELL Technology CO.,Ltd",
@@ -135146,6 +136304,7 @@
                     "154066466127872": "Dorlet Sau",
                     "154066466131968": "Sumico",
                     "154066466136064": "Invertek Drives Ltd",
+                    "154066466152448": "Elektrotechnik & Elektronik Oltmann GmbH",
                     "154066466160640": "Gredmann Taiwan Ltd.",
                     "154066466164736": "elbit systems - EW and sigint - Elisra",
                     "154066466177024": "Near Earth Autonomy",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ cmake_dependent_option(
 )
 option(PCAPPP_USE_PF_RING "Setup PcapPlusPlus with PF_RING. In this case you must also set PF_RING_ROOT")
 option(PCAPPP_USE_XDP "Setup PcapPlusPlus with XDP")
+option(PCAPPP_USE_WINDIVERT "Setup PcapPlusPlus with WinDivert")
 option(PCAPPP_INSTALL "Install Pcap++" ${PCAPPP_MAIN_PROJECT})
 option(PCAPPP_PACKAGE "Package Pcap++ could require a recent version of CMake" OFF)
 
@@ -283,6 +284,11 @@ if(PCAPPP_BUILD_PCAPPP)
       message(FATAL_ERROR "libbpf not found!")
     endif()
     add_definitions(-DUSE_XDP)
+  endif()
+
+  if(PCAPPP_USE_WINDIVERT)
+    find_package(WinDivert REQUIRED)
+    add_definitions(-DUSE_WINDIVERT)
   endif()
 endif()
 

--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -320,6 +320,12 @@ namespace pcpp
 			return m_Vector.at(index);
 		}
 
+		/// @return A pointer to the underlying array serving as the vector’s storage
+		T** data()
+		{
+			return m_Vector.data();
+		}
+
 	private:
 		/// Performs a copy of the vector along with its elements.
 		/// The caller is responsible of freeing the copied elements.

--- a/Pcap++/CMakeLists.txt
+++ b/Pcap++/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   $<$<BOOL:${PCAPPP_USE_XDP}>:src/XdpDevice.cpp>
   src/RawSocketDevice.cpp
   $<$<BOOL:${WIN32}>:src/WinPcapLiveDevice.cpp>
+  $<$<BOOL:${PCAPPP_USE_WINDIVERT}>:src/WinDivertDevice.cpp>
   # Force light pcapng to be link fully static
   $<TARGET_OBJECTS:light_pcapng>
 )
@@ -52,6 +53,10 @@ endif()
 
 if(PCAPPP_USE_XDP)
   list(APPEND public_headers header/XdpDevice.h)
+endif()
+
+if(PCAPPP_USE_WINDIVERT)
+  list(APPEND public_headers header/WinDivertDevice.h)
 endif()
 
 if(LINUX)
@@ -97,6 +102,7 @@ target_link_libraries(
     $<$<BOOL:${PCAPPP_USE_PF_RING}>:PF_RING::PF_RING>
     $<$<BOOL:${PCAPPP_USE_DPDK}>:DPDK::DPDK>
     $<$<BOOL:${PCAPPP_USE_XDP}>:BPF::BPF>
+    $<$<BOOL:${PCAPPP_USE_WINDIVERT}>:WinDivert::WinDivert>
     PCAP::PCAP
     Threads::Threads
 )

--- a/Pcap++/header/Device.h
+++ b/Pcap++/header/Device.h
@@ -40,7 +40,7 @@ namespace pcpp
 	/// An abstract interface representing all devices that have BPF (Berkeley Packet Filter) filtering capabilities,
 	/// meaning devices that can filter packets based on the BPF filtering syntax.
 	/// This is an abstract class that cannot be instantiated
-	class IFilterableDevice
+	class IFilterableDevice : public IDevice
 	{
 	protected:
 		// c'tor should not be public
@@ -53,22 +53,39 @@ namespace pcpp
 		/// received
 		/// @param[in] filter The filter to be set in PcapPlusPlus' GeneralFilter format
 		/// @return True if filter set successfully, false otherwise
-		virtual bool setFilter(GeneralFilter& filter)
+		bool setFilter(GeneralFilter& filter)
 		{
 			std::string filterAsString;
 			filter.parseToString(filterAsString);
-			return setFilter(filterAsString);
+			return doUpdateFilter(&filterAsString);
 		}
 
 		/// Set a filter for the device. When implemented by the device, only packets that match the filter will be
-		/// received
+		/// processed.
 		/// @param[in] filterAsString The filter to be set in Berkeley Packet Filter (BPF) syntax
 		/// (http://biot.com/capstats/bpf.html)
 		/// @return True if filter set successfully, false otherwise
-		virtual bool setFilter(std::string filterAsString) = 0;
+		bool setFilter(std::string const& filterAsString)
+		{
+			return doUpdateFilter(&filterAsString);
+		}
 
 		/// Clear the filter currently set on the device
 		/// @return True if filter was removed successfully or if no filter was set, false otherwise
-		virtual bool clearFilter() = 0;
+		bool clearFilter()
+		{
+			return doUpdateFilter(nullptr);
+		}
+
+	protected:
+		/// @brief Updates the filter on the device with a BPF string.
+		///
+		/// Only packets that match the filter should be processed by the device after this method is called.
+		/// A nullptr should disable any existing filter on the device.
+		///
+		/// @param filterAsString A pointer to a string representing the filter in BPF syntax
+		/// (http://biot.com/capstats/bpf.html).
+		/// @return True if the operation was successful, false otherwise.
+		virtual bool doUpdateFilter(std::string const* filterAsString) = 0;
 	};
 }  // namespace pcpp

--- a/Pcap++/header/DpdkDevice.h
+++ b/Pcap++/header/DpdkDevice.h
@@ -344,7 +344,7 @@ namespace pcpp
 			/// Total number of erroneous packets
 			uint64_t rxErroneousPackets;
 			/// Total number of RX mbuf allocation failures
-			uint64_t rxMbufAlocFailed;
+			uint64_t rxMbufAllocFailed;
 		};
 
 		virtual ~DpdkDevice();

--- a/Pcap++/header/KniDevice.h
+++ b/Pcap++/header/KniDevice.h
@@ -232,10 +232,10 @@ namespace pcpp
 	private:
 		/// All instances of this class MUST be produced by KniDeviceList class
 		KniDevice(const KniDeviceConfiguration& conf, size_t mempoolSize, int unique);
-		/// This class is not copyable
-		KniDevice(const KniDevice&);
-		/// This class is not copyable
-		KniDevice& operator=(const KniDevice&);
+
+		KniDevice(const KniDevice&) = delete;
+		KniDevice& operator=(const KniDevice&) = delete;
+
 		/// All instances of this class MUST be destroyed by KniDeviceList class
 		~KniDevice();
 

--- a/Pcap++/header/LinuxNicInformationSocket.h
+++ b/Pcap++/header/LinuxNicInformationSocket.h
@@ -29,6 +29,10 @@ namespace pcpp
 		/// Tries to open handled socket on construction.
 		/// If fails prints the debug message
 		LinuxNicInformationSocket();
+
+		LinuxNicInformationSocket(const LinuxNicInformationSocket&) = delete;
+		LinuxNicInformationSocket operator=(const LinuxNicInformationSocket&) = delete;
+
 		/// Closes handled socket on destruction.
 		/// If no socket was opened prints the debug message
 		~LinuxNicInformationSocket();
@@ -50,10 +54,6 @@ namespace pcpp
 		bool makeRequest(const char* nicName, const IoctlType ioctlType, ifreq* request);
 
 	private:
-		/// Hidden copy constructor. This structure is not copyable
-		LinuxNicInformationSocket(const LinuxNicInformationSocket&);
-		/// Hidden copy assignment operator. This structure is not copyable
-		LinuxNicInformationSocket operator=(const LinuxNicInformationSocket&);
 		LinuxSocket m_Socket;
 	};
 }  // namespace pcpp

--- a/Pcap++/header/PcapDevice.h
+++ b/Pcap++/header/PcapDevice.h
@@ -138,14 +138,13 @@ namespace pcpp
 	/// @class IPcapDevice
 	/// An abstract class representing all libpcap-based packet capturing devices: files, libPcap, WinPcap/Npcap and
 	/// RemoteCapture. This class is abstract and cannot be instantiated
-	class IPcapDevice : public IDevice, public IFilterableDevice, public IPcapStatisticsProvider
+	class IPcapDevice : public IFilterableDevice, public IPcapStatisticsProvider
 	{
 	protected:
 		internal::PcapHandle m_PcapDescriptor;
 
 		// c'tor should not be public
-		IPcapDevice() : IDevice()
-		{}
+		IPcapDevice() = default;
 
 	public:
 		virtual ~IPcapDevice() = default;
@@ -164,20 +163,7 @@ namespace pcpp
 		PCPP_DEPRECATED("Prefer GeneralFilter::matches(...) method directly.")
 		static bool matchPacketWithFilter(GeneralFilter& filter, RawPacket* rawPacket);
 
-		// implement abstract methods
-
-		using IFilterableDevice::setFilter;
-
-		/// Set a filter for the device. When implemented by the device, only packets that match the filter will be
-		/// received. Please note that when the device is closed the filter is reset so when reopening the device you
-		/// need to call this method again in order to reactivate the filter
-		/// @param[in] filterAsString The filter to be set in Berkeley Packet Filter (BPF) syntax
-		/// (http://biot.com/capstats/bpf.html)
-		/// @return True if filter set successfully, false otherwise
-		bool setFilter(std::string filterAsString) override;
-
-		/// Clear the filter currently set on device
-		/// @return True if filter was removed successfully or if no filter was set, false otherwise
-		bool clearFilter() override;
+	protected:
+		bool doUpdateFilter(std::string const* filterAsString) override;
 	};
 }  // namespace pcpp

--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -363,21 +363,18 @@ namespace pcpp
 		/// @param[out] rawPacket A reference for an empty RawPacket where the packet will be written
 		/// @return True if a packet was read successfully. False will be returned if the file isn't opened (also, an
 		/// error log will be printed) or if reached end-of-file
-		bool getNextPacket(RawPacket& rawPacket);
+		bool getNextPacket(RawPacket& rawPacket) override;
 
 		/// Open the file name which path was specified in the constructor in a read-only mode
 		/// @return True if file was opened successfully or if file is already opened. False if opening the file failed
 		/// for some reason (for example: file path does not exist)
-		bool open();
-
-		/// Set a filter for PcapNG reader device. Only packets that match the filter will be received
-		/// @param[in] filterAsString The filter to be set in Berkeley Packet Filter (BPF) syntax
-		/// (http://biot.com/capstats/bpf.html)
-		/// @return True if filter set successfully, false otherwise
-		bool setFilter(std::string filterAsString);
+		bool open() override;
 
 		/// Close the pacp-ng file
-		void close();
+		void close() override;
+
+	protected:
+		bool doUpdateFilter(std::string const* filter) override;
 	};
 
 	/// @class PcapNgFileWriterDevice
@@ -476,11 +473,8 @@ namespace pcpp
 		/// Flush and close the pcap-ng file
 		void close() override;
 
-		/// Set a filter for PcapNG writer device. Only packets that match the filter will be persisted
-		/// @param[in] filterAsString The filter to be set in Berkeley Packet Filter (BPF) syntax
-		/// (http://biot.com/capstats/bpf.html)
-		/// @return True if filter set successfully, false otherwise
-		bool setFilter(std::string filterAsString) override;
+	protected:
+		bool doUpdateFilter(std::string const* filterAsString) override;
 
 	private:
 		/// @struct PcapNgMetadata

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -103,12 +103,8 @@ namespace pcpp
 		// Should be set to true by the Callee for the Caller
 		std::atomic<bool> m_CaptureThreadStarted;
 
-		OnPacketArrivesCallback m_cbOnPacketArrives;
-		void* m_cbOnPacketArrivesUserCookie;
 		OnPacketArrivesStopBlocking m_cbOnPacketArrivesBlockingMode;
 		void* m_cbOnPacketArrivesBlockingModeUserCookie;
-		RawPacketVector* m_CapturedPackets;
-		bool m_CaptureCallbackMode;
 		LinkLayerType m_LinkType;
 		bool m_UsePoll;
 
@@ -124,11 +120,6 @@ namespace pcpp
 		void setDeviceMacAddress();
 		void setDefaultGateway();
 
-		// threads
-		void captureThreadMain();
-
-		static void onPacketArrives(uint8_t* user, const struct pcap_pkthdr* pkthdr, const uint8_t* packet);
-		static void onPacketArrivesNoCallback(uint8_t* user, const struct pcap_pkthdr* pkthdr, const uint8_t* packet);
 		static void onPacketArrivesBlockingMode(uint8_t* user, const struct pcap_pkthdr* pkthdr, const uint8_t* packet);
 
 	public:

--- a/Pcap++/header/PfRingDevice.h
+++ b/Pcap++/header/PfRingDevice.h
@@ -31,7 +31,7 @@ namespace pcpp
 
 	/// @class PfRingDevice
 	/// A class representing a PF_RING port
-	class PfRingDevice : public IDevice, public IFilterableDevice
+	class PfRingDevice : public IFilterableDevice
 	{
 		friend class PfRingDeviceList;
 
@@ -315,15 +315,12 @@ namespace pcpp
 			return m_DeviceOpened;
 		}
 
-		using IFilterableDevice::setFilter;
+	protected:
+		bool doUpdateFilter(std::string const* filterAsString) override;
 
-		/// Sets a BPF filter to the device
-		/// @param[in] filterAsString The BPF filter in string format
-		bool setFilter(std::string filterAsString);
-
-		/// Remove a filter if currently set
-		/// @return True if filter was removed successfully or if no filter was set, false otherwise
-		bool clearFilter();
+	private:
+		bool removeFilterForAllChannels();
+		bool setFilterForAllChannels(std::string const& filterAsString);
 	};
 
 }  // namespace pcpp

--- a/Pcap++/header/WinDivertDevice.h
+++ b/Pcap++/header/WinDivertDevice.h
@@ -1,0 +1,477 @@
+#pragma once
+
+#include <functional>
+#include <tuple>
+#include <unordered_map>
+#include <atomic>
+#include "Device.h"
+
+/// @file
+/// @brief WinDivert-based device (Windows-only) for capturing and sending packets at the network layer.
+///
+/// This header exposes a device wrapper around the WinDivert driver that lets applications:
+/// - Open a WinDivert handle with a filter
+/// - Capture inbound/outbound IPv4/IPv6 packets in batches or via a callback
+/// - Send batches of raw packets
+/// - Inspect and configure queue parameters (length, time, size)
+/// - Query WinDivert runtime version and available network interfaces
+///
+/// For filter syntax and semantics please refer to the WinDivert documentation.
+///
+/// @namespace pcpp
+/// @brief The main namespace for the PcapPlusPlus library
+namespace pcpp
+{
+	namespace internal
+	{
+		/// @brief Abstract helper that wraps Windows OVERLAPPED I/O used by WinDivert operations.
+		///
+		/// Implementations provide waiting/resetting primitives and a way to fetch
+		/// the result of an asynchronous I/O tied to a specific WinDivert handle.
+		class IOverlappedWrapper
+		{
+		public:
+			/// @brief Result of waiting on an OVERLAPPED I/O operation.
+			///
+			/// Indicates whether the asynchronous operation completed, timed out or failed,
+			/// and carries an optional Windows error code.
+			struct WaitResult
+			{
+				/// @enum Status
+				/// @brief Status codes for wait result.
+				enum class Status
+				{
+					Completed,  ///< The wait completed successfully
+					Timeout,    ///< The wait timed out before completion
+					Failed      ///< The wait failed; see errorCode
+				};
+
+				Status status;           ///< Final wait status
+				uint32_t errorCode = 0;  ///< Windows error code (when relevant)
+			};
+
+			/// @brief Result of completing an OVERLAPPED I/O operation.
+			///
+			/// Contains the final status, the number of bytes/packet length produced by the
+			/// operation (when applicable), and a Windows error code on failure.
+			struct OverlappedResult
+			{
+				/// @enum Status
+				/// @brief Status codes for overlapped result.
+				enum class Status
+				{
+					Success,  ///< Operation completed successfully
+					Failed    ///< Operation failed; see errorCode
+				};
+
+				Status status;           ///< Completion status
+				uint32_t packetLen = 0;  ///< Number of bytes read/written (when applicable)
+				uint32_t errorCode = 0;  ///< Windows error code (when relevant)
+			};
+
+			virtual WaitResult wait(uint32_t timeout) = 0;
+			virtual void reset() = 0;
+			virtual OverlappedResult getOverlappedResult() = 0;
+			virtual ~IOverlappedWrapper() = default;
+		};
+
+		/// @brief Minimal address/metadata returned by WinDivert for a captured packet.
+		///
+		/// This structure mirrors the subset of fields PcapPlusPlus needs from WinDivert's
+		/// WINDIVERT_ADDRESS: whether the packet is IPv6, the Windows interface index and
+		/// the original WinDivert timestamp.
+		struct WinDivertAddress
+		{
+			bool isIPv6;              ///< True if the packet is IPv6, false for IPv4
+			uint32_t interfaceIndex;  ///< Windows network interface index
+			uint64_t timestamp;       ///< WinDivert timestamp associated with the packet
+		};
+
+		/// @class IWinDivertHandle
+		/// @brief An abstract handle for interacting with the WinDivert device.
+		///
+		/// This interface represents an opened WinDivert handle and provides the minimal
+		/// set of operations used by WinDivertDevice: asynchronous receive, batched send,
+		/// querying/setting queue parameters and handle closure. Concrete implementations
+		/// wrap the corresponding WinDivert C APIs and Windows OVERLAPPED I/O.
+		class IWinDivertHandle
+		{
+		public:
+			/// @brief WinDivert runtime parameters that can be queried or configured.
+			enum class WinDivertParam
+			{
+				QueueLength = 0,   ///< Maximum number of packets in the queue
+				QueueTime = 1,     ///< Maximum time (ms) a packet may stay in the queue
+				QueueSize = 2,     ///< Maximum total queue size (bytes)
+				VersionMajor = 3,  ///< WinDivert major version
+				VersionMinor = 4   ///< WinDivert minor version
+			};
+
+			/// @brief Generic success code returned by most operations.
+			static constexpr uint32_t SuccessResult = 0;
+			/// @brief Windows ERROR_IO_PENDING (997) reported when an async operation is in flight.
+			static constexpr uint32_t ErrorIoPending = 997;
+
+			virtual ~IWinDivertHandle() = default;
+
+			/// @brief Close the underlying WinDivert handle.
+			/// @return Windows error code-style result. 0 indicates success.
+			virtual uint32_t close() = 0;
+
+			/// @brief Begin or perform an overlapped receive of raw packet data.
+			///
+			/// If an overlapped object is provided, the call initiates an asynchronous read
+			/// and typically returns ErrorIoPending. Completion status and size should be
+			/// obtained via the provided IOverlappedWrapper.
+			///
+			/// @param[in] buffer          Destination buffer for packet data.
+			/// @param[in] bufferLen       Size of the destination buffer in bytes.
+			/// @param[in] addressesSize   Number of address entries the implementation may capture for a batch.
+			/// @param[in] overlapped      Wrapper around Windows OVERLAPPED used for async I/O. Must not be null for
+			/// async.
+			/// @return 0 on success, ErrorIoPending if async operation started, or a Windows error code on failure.
+			virtual uint32_t recvEx(uint8_t* buffer, uint32_t bufferLen, size_t addressesSize,
+			                        IOverlappedWrapper* overlapped) = 0;
+
+			/// @brief Finalize a previous overlapped receive and fetch per-packet address metadata.
+			/// @return A vector of WinDivertAddress entries, one per packet captured in the last receive.
+			virtual std::vector<WinDivertAddress> recvExComplete() = 0;
+
+			/// @brief Send a batch of raw packets.
+			/// @param[in] buffer        Buffer containing one or more consecutive packets.
+			/// @param[in] bufferLen     Total size in bytes of the packets contained in buffer.
+			/// @param[in] addressesSize Number of address entries accompanying the send batch.
+			/// @return 0 on success, otherwise a Windows error code.
+			virtual uint32_t sendEx(uint8_t* buffer, uint32_t bufferLen, size_t addressesSize) = 0;
+
+			/// @brief Create a new overlapped wrapper bound to this handle.
+			/// @return A unique_ptr to a fresh IOverlappedWrapper for async operations.
+			virtual std::unique_ptr<IOverlappedWrapper> createOverlapped() = 0;
+
+			/// @brief Query a WinDivert runtime/queue parameter.
+			/// @param[in]  param The parameter to query.
+			/// @param[out] value The retrieved value.
+			/// @return True on success, false on failure.
+			virtual bool getParam(WinDivertParam param, uint64_t& value) = 0;
+
+			/// @brief Set a WinDivert runtime/queue parameter.
+			/// @param[in] param The parameter to set.
+			/// @param[in] value The value to set.
+			/// @return True on success, false on failure.
+			virtual bool setParam(WinDivertParam param, uint64_t value) = 0;
+		};
+
+		/// @class IWinDivertDriver
+		/// @brief Factory and system-query abstraction used by WinDivertDevice.
+		///
+		/// The sole responsibilities of this interface are:
+		/// - Creating IWinDivertHandle instances (which expose the WinDivert API surface).
+		/// - Enumerating relevant Windows network interfaces.
+		/// Keeping these responsibilities here keeps WinDivertDevice decoupled from concrete
+		/// system/driver calls and enables unit testing and alternative implementations.
+		class IWinDivertDriver
+		{
+		public:
+			/// @brief Information about a Windows network interface as reported by WinDivert/Windows APIs.
+			struct NetworkInterface
+			{
+				uint32_t index;            ///< Interface index as provided by Windows
+				std::wstring name;         ///< Interface name (GUID or friendly/system name)
+				std::wstring description;  ///< Human-readable description from the OS
+				bool isLoopback;           ///< True if the interface type is software loopback
+				bool isUp;                 ///< True when the interface operational status is up
+			};
+
+			/// @brief Open a WinDivert handle with the given filter and settings.
+			/// @param[in] filter   WinDivert filter string (see WinDivert documentation).
+			/// @param[in] layer    WinDivert layer value (typically WINDIVERT_LAYER_NETWORK).
+			/// @param[in] priority Injection/capture priority (lower is higher priority).
+			/// @param[in] flags    WinDivert open flags (sniff mode, fragments, etc.).
+			/// @return A unique_ptr to an IWinDivertHandle on success, or nullptr on failure.
+			virtual std::unique_ptr<IWinDivertHandle> open(const std::string& filter, int layer, int16_t priority,
+			                                               uint64_t flags) = 0;
+
+			/// @brief Enumerate Windows network interfaces relevant to WinDivert.
+			/// @return A vector of NetworkInterface objects with index, name, description and status.
+			virtual std::vector<NetworkInterface> getNetworkInterfaces() const = 0;
+
+			virtual ~IWinDivertDriver() = default;
+		};
+	}  // namespace internal
+
+	/// @class WinDivertRawPacket
+	/// @brief A RawPacket specialization used by WinDivertDevice.
+	///
+	/// In addition to the base RawPacket data (raw buffer, timestamp and link-layer type),
+	/// WinDivert also provides the Windows network interface index and the original
+	/// WinDivert timestamp. These can be retrieved with getInterfaceIndex() and
+	/// getWinDivertTimestamp() respectively.
+	class WinDivertRawPacket : public RawPacket
+	{
+	public:
+		WinDivertRawPacket(const uint8_t* pRawData, int rawDataLen, timespec timestamp, bool deleteRawDataAtDestructor,
+		                   LinkLayerType layerType, uint32_t interfaceIndex, uint64_t winDivertTimestamp)
+		    : RawPacket(pRawData, rawDataLen, timestamp, deleteRawDataAtDestructor, layerType),
+		      m_InterfaceIndex(interfaceIndex), m_WinDivertTimestamp(winDivertTimestamp)
+		{}
+
+		~WinDivertRawPacket() override = default;
+
+		/// @brief Get the Windows interface index the packet was captured on.
+		/// @return The interface index as reported by WinDivert.
+		uint32_t getInterfaceIndex() const
+		{
+			return m_InterfaceIndex;
+		}
+
+		/// @brief Get the original WinDivert timestamp captured for this packet.
+		/// @return A 64-bit timestamp value as returned by WinDivert (see WinDivert docs for units and origin).
+		uint64_t getWinDivertTimestamp() const
+		{
+			return m_WinDivertTimestamp;
+		}
+
+	private:
+		uint32_t m_InterfaceIndex;
+		uint64_t m_WinDivertTimestamp;
+	};
+
+	/// @class WinDivertDevice
+	/// @brief A device wrapper around the WinDivert driver for Windows.
+	///
+	/// WinDivert is a kernel driver for packet interception and injection on Windows.
+	/// WinDivertDevice opens a WinDivert handle on the WINDIVERT_LAYER_NETWORK layer using a filter
+	/// and provides methods to receive and send packets in batches, query/set queue parameters,
+	/// retrieve the WinDivert runtime version, and enumerate Windows network interfaces.
+	///
+	/// Notes:
+	/// - The default open() uses the filter "true", capturing both directions.
+	/// - The device is opened in sniffing mode and supports fragmented packets.
+	/// - Receive can be done into a user-provided vector or via a callback loop that can be stopped with stopReceive().
+	/// - Send batches multiple packets at once for efficiency.
+	/// - Queue parameters map to WinDivert queue configuration (length in packets, time in milliseconds, size in
+	/// bytes).
+	///
+	/// For WinDivert filter syntax, layer semantics, timestamps and error codes please refer to the WinDivert
+	/// documentation.
+	class WinDivertDevice : public IDevice
+	{
+	public:
+		/// @struct ReceiveResult
+		/// @brief Result object returned by receive operations.
+		struct ReceiveResult
+		{
+			/// @enum Status
+			/// @brief Status codes for receive operations.
+			enum class Status
+			{
+				Completed,  ///< Receive completed successfully
+				Timeout,    ///< Receive timed out before completing the requested operation
+				Failed      ///< Receive failed due to an error (see error and errorCode)
+			};
+
+			Status status;           ///< Operation status (Completed/Timeout/Failed)
+			std::string error;       ///< Error message when status is Failed; empty otherwise
+			uint32_t errorCode = 0;  ///< Platform-specific error code associated with the failure (0 if none)
+		};
+
+		/// @struct SendResult
+		/// @brief Result object returned by send operations.
+		struct SendResult
+		{
+			/// @enum Status
+			/// @brief Status codes for send operations.
+			enum class Status
+			{
+				Completed,  ///< Send operation completed successfully
+				Failed      ///< Send operation failed (see error and errorCode)
+			};
+
+			Status status;           ///< Operation status (Completed/Failed)
+			size_t packetsSent;      ///< Number of packets successfully sent when status is Completed
+			std::string error;       ///< Error message when status is Failed; empty otherwise
+			uint32_t errorCode = 0;  ///< Platform-specific error code associated with the failure (0 if none)
+		};
+
+		/// @struct WinDivertVersion
+		/// @brief The WinDivert runtime version as reported by the driver.
+		struct WinDivertVersion
+		{
+			uint64_t major;  ///< Major version number reported by WinDivert
+			uint64_t minor;  ///< Minor version number reported by WinDivert
+
+			/// @brief Convert to "major.minor" string representation.
+			std::string toString() const
+			{
+				return std::to_string(major) + "." + std::to_string(minor);
+			}
+		};
+
+		/// @struct NetworkInterface
+		/// @brief A Windows network interface entry returned by getNetworkInterfaces().
+		struct NetworkInterface
+		{
+			uint32_t index;            ///< Interface index as provided by Windows
+			std::wstring name;         ///< Interface name (GUID or friendly/system name)
+			std::wstring description;  ///< Human-readable description from the OS
+			bool isLoopback;           ///< True if the interface type is software loopback
+			bool isUp;                 ///< True when the interface operational status is up
+		};
+
+		/// @enum QueueParam
+		/// @brief Queue tuning parameters supported by WinDivert.
+		///
+		/// These map to WinDivert queue configuration parameters:
+		/// - QueueLength – maximum number of packets in the internal queue (packets)
+		/// - QueueTime – maximum time packets may sit in the internal queue (milliseconds)
+		/// - QueueSize – maximum memory size for the internal queue (bytes)
+		enum class QueueParam
+		{
+			QueueLength,  ///< Maximum number of packets in the packet queue (packets)
+			QueueTime,    ///< Maximum residence time of packets in the queue (milliseconds)
+			QueueSize     ///< Maximum memory allocated for the queue (bytes)
+		};
+
+		/// @typedef WinDivertRawPacketVector
+		/// @brief Convenience alias for a vector of WinDivertRawPacket pointers with ownership semantics.
+		using WinDivertRawPacketVector = PointerVector<WinDivertRawPacket>;
+
+		/// @struct WinDivertReceiveCallbackContext
+		/// @brief Context object passed to ReceivePacketCallback.
+		struct WinDivertReceiveCallbackContext
+		{
+			WinDivertDevice* device = nullptr;  ///< The device that owns the receive loop (may be null)
+		};
+
+		/// @brief Callback invoked with a batch of received packets when using the callback receive API.
+		/// The callback is called from the receiving loop until stopReceive() is invoked or an error/timeout occurs.
+		///
+		/// @param[in] packetVec A list of the currently received batch of WinDivertRawPacket objects.
+		/// @param[in] context   A context object providing the calling device and, potentially, other metadata.
+		using ReceivePacketCallback = std::function<void(const WinDivertRawPacketVector& packetVec,
+		                                                 const WinDivertReceiveCallbackContext& context)>;
+		/// @typedef QueueParams
+		/// @brief A map of QueueParam keys to their values. Units are per QueueParam description above.
+		using QueueParams = std::unordered_map<QueueParam, uint64_t>;
+
+		/// @brief Construct a WinDivertDevice.
+		///
+		/// @param[in] driver Optional WinDivert driver implementation.
+		/// Ownership is transferred to WinDivertDevice. Pass nullptr (the default)
+		/// to use the built-in default driver implementation.
+		WinDivertDevice(std::unique_ptr<internal::IWinDivertDriver> driver = nullptr);
+
+		/// @brief Open the device with a default filter capturing both directions.
+		/// @return true on success, false on failure (see logs for details).
+		/// @note This calls open("true") on WINDIVERT_LAYER_NETWORK with sniffing/fragments flags.
+		bool open() override;
+
+		/// @brief Open the device with a custom WinDivert filter.
+		/// @param[in] filter A WinDivert filter string (e.g. "ip and tcp.DstPort == 80").
+		/// @return true on success, false on failure (see logs for details).
+		/// @note The device is opened on WINDIVERT_LAYER_NETWORK with sniffing and fragment support.
+		bool open(const std::string& filter);
+
+		/// @brief Close the device and release the underlying WinDivert handle.
+		void close() override;
+
+		bool isOpened() const override
+		{
+			return m_DeviceOpened;
+		}
+
+		/// @brief Receive packets into a vector owned by the caller.
+		///
+		/// This method receives up to maxPackets packets (0 means unlimited) in batches of batchSize.
+		/// It returns when either enough packets were captured or timeout milliseconds elapsed without completion.
+		///
+		/// @param[out] packetVec Destination vector for received packets. Each entry is a WinDivertRawPacket that owns
+		/// its data.
+		/// @param[in] timeout Receive timeout in milliseconds. Use 0 with a positive maxPackets to wait until quota is
+		/// reached.
+		/// @param[in] maxPackets Maximum packets to receive before returning. Use 0 for no limit (subject to timeout).
+		/// @param[in] batchSize Number of packets to read per WinDivert call (must be > 0). Default is 64.
+		/// @return A ReceiveResult describing the outcome. On failure, see error and errorCode.
+		ReceiveResult receivePackets(WinDivertRawPacketVector& packetVec, uint32_t timeout = 5000,
+		                             uint32_t maxPackets = 0, uint8_t batchSize = 64);
+
+		/// @brief Receive packets using a callback invoked for each received batch.
+		///
+		/// The method runs a receive loop and invokes callback with each batch. The loop ends when stopReceive()
+		/// is called from another thread, on timeout, or if an error occurs. Packet memory is valid during the callback
+		/// and is released when the callback returns.
+		///
+		/// @param[in] callback A callback receiving a vector view of the current batch.
+		/// @param[in] timeout Receive timeout in milliseconds per wait cycle. Default is 5000ms.
+		/// @param[in] batchSize Number of packets to read per WinDivert call (must be > 0). Default is 64.
+		/// @return A ReceiveResult describing the final outcome.
+		ReceiveResult receivePackets(const ReceivePacketCallback& callback, uint32_t timeout = 5000,
+		                             uint8_t batchSize = 64);
+
+		/// @brief Request to stop an ongoing receivePackets(callback, ...) loop.
+		/// @note This is thread-safe and can be called from a thread other than the receiving thread.
+		void stopReceive();
+
+		/// @brief Send a vector of raw packets in batches.
+		///
+		/// The method copies packet data into an internal buffer and calls WinDivert send in batches of batchSize.
+		///
+		/// @param[in] packetVec A vector of raw packets to send.
+		/// @param[in] batchSize Number of packets to send per WinDivert call (must be > 0). Default is 64.
+		/// @return A SendResult describing the outcome and number of packets sent.
+		SendResult sendPackets(const RawPacketVector& packetVec, uint8_t batchSize = 64) const;
+
+		/// @brief Get the current WinDivert queue parameters.
+		/// @return A map from QueueParam to the configured value.
+		QueueParams getPacketQueueParams() const;
+
+		/// @brief Set WinDivert queue parameters.
+		/// @param[in] params A map of queue parameters to set. Absent keys are left unchanged.
+		/// @note Values units are: length (packets), time (milliseconds), size (bytes).
+		void setPacketQueueParams(const QueueParams& params) const;
+
+		/// @brief Get the WinDivert runtime version loaded on the system.
+		/// @return A WinDivertVersion with major and minor components.
+		WinDivertVersion getVersion() const;
+
+		/// @brief Get a pointer to a specific Windows network interface by index.
+		/// @param[in] interfaceIndex The Windows interface index.
+		/// @return A pointer to an internal NetworkInterface entry or nullptr if not found.
+		/// @warning The returned pointer may become invalid after subsequent calls that refresh interfaces.
+		const NetworkInterface* getNetworkInterface(uint32_t interfaceIndex) const;
+
+		/// @brief Enumerate Windows network interfaces.
+		/// @return A vector of NetworkInterface entries.
+		std::vector<NetworkInterface> getNetworkInterfaces() const;
+
+	private:
+		std::unique_ptr<internal::IWinDivertDriver> m_Driver;
+		std::unique_ptr<internal::IWinDivertHandle> m_Handle;
+		std::atomic<bool> m_IsReceiving{ false };
+		mutable std::unordered_map<uint32_t, NetworkInterface> m_NetworkInterfaces;
+		mutable bool m_NetworkInterfacesInitialized = false;
+		bool m_DeviceOpened = false;
+
+		struct ReceiveResultInternal : ReceiveResult
+		{
+			uint32_t capturedDataLength = 0;
+			std::vector<internal::WinDivertAddress> addresses;
+
+			ReceiveResultInternal(Status status, const std::string& error = "", uint32_t errorCode = 0)
+			    : ReceiveResult{ status, error, errorCode }
+			{}
+
+			ReceiveResultInternal(uint32_t capturedDataLength, const std::vector<internal::WinDivertAddress>& addresses)
+			    : ReceiveResult{ Status::Completed, "", 0 }, capturedDataLength(capturedDataLength),
+			      addresses(addresses)
+			{}
+		};
+
+		ReceiveResultInternal receivePacketsInternal(uint32_t timeout, uint8_t batchSize, std::vector<uint8_t>& buffer,
+		                                             internal::IOverlappedWrapper* overlapped);
+		static std::tuple<LinkLayerType, uint16_t, timespec> getPacketInfo(uint8_t* buffer, uint32_t bufferLen,
+		                                                                   const internal::WinDivertAddress& address);
+		void setNetworkInterfaces() const;
+		static std::string getErrorString(uint32_t errorCode);
+	};
+}  // namespace pcpp

--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -829,7 +829,7 @@ namespace pcpp
 		stats.devId = m_Id;
 		stats.timestamp = timestamp;
 		stats.rxErroneousPackets = rteStats.ierrors;
-		stats.rxMbufAlocFailed = rteStats.rx_nombuf;
+		stats.rxMbufAllocFailed = rteStats.rx_nombuf;
 		stats.rxPacketsDroppedByHW = rteStats.imissed;
 		stats.aggregatedRxStats.packets = rteStats.ipackets;
 		stats.aggregatedRxStats.bytes = rteStats.ibytes;

--- a/Pcap++/src/PcapDevice.cpp
+++ b/Pcap++/src/PcapDevice.cpp
@@ -133,7 +133,7 @@ namespace pcpp
 		return stats;
 	}
 
-	bool IPcapDevice::setFilter(std::string filterAsString)
+	bool IPcapDevice::doUpdateFilter(std::string const* filterAsString)
 	{
 		PCPP_LOG_DEBUG("Filter to be set: '" << filterAsString << "'");
 		if (!isOpened())
@@ -142,12 +142,14 @@ namespace pcpp
 			return false;
 		}
 
-		return m_PcapDescriptor.setFilter(filterAsString);
-	}
-
-	bool IPcapDevice::clearFilter()
-	{
-		return m_PcapDescriptor.clearFilter();
+		if (filterAsString == nullptr || filterAsString->empty())
+		{
+			return m_PcapDescriptor.clearFilter();
+		}
+		else
+		{
+			return m_PcapDescriptor.setFilter(*filterAsString);
+		}
 	}
 
 	bool IPcapDevice::matchPacketWithFilter(GeneralFilter& filter, RawPacket* rawPacket)

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -624,9 +624,14 @@ namespace pcpp
 		return getNextPacket(rawPacket, temp);
 	}
 
-	bool PcapNgFileReaderDevice::setFilter(std::string filterAsString)
+	bool PcapNgFileReaderDevice::doUpdateFilter(std::string const* filterAsString)
 	{
-		return m_BpfWrapper.setFilter(filterAsString);
+		if (filterAsString == nullptr)
+		{
+			return m_BpfWrapper.setFilter("");
+		}
+
+		return m_BpfWrapper.setFilter(*filterAsString);
 	}
 
 	void PcapNgFileReaderDevice::close()
@@ -876,9 +881,14 @@ namespace pcpp
 		PCPP_LOG_DEBUG("File writer closed for file '" << m_FileName << "'");
 	}
 
-	bool PcapNgFileWriterDevice::setFilter(std::string filterAsString)
+	bool PcapNgFileWriterDevice::doUpdateFilter(std::string const* filterAsString)
 	{
-		return m_BpfWrapper.setFilter(filterAsString);
+		if (filterAsString == nullptr)
+		{
+			return m_BpfWrapper.setFilter("");
+		}
+
+		return m_BpfWrapper.setFilter(*filterAsString);
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -272,6 +272,126 @@ namespace pcpp
 			}
 			PCPP_LOG_DEBUG("Ended periodic statistics update procedure");
 		}
+
+		struct CaptureContext
+		{
+			PcapLiveDevice* device = nullptr;
+			OnPacketArrivesCallback callback;
+			void* userCookie = nullptr;
+		};
+
+		struct AccumulatorCaptureContext
+		{
+			PcapLiveDevice* device = nullptr;
+			RawPacketVector* capturedPackets = nullptr;
+		};
+
+		// A noop function to be used when no callback is set
+		void onPacketArrivesNoop(uint8_t* user, const pcap_pkthdr* pkthdr, const uint8_t* packet)
+		{}
+
+		// @brief Wraps the raw packet data into a RawPacket instance and calls the user callback
+		// @param user A pointer to a CaptureContext instance
+		// @param pkthdr A pointer to the pcap_pkthdr struct
+		// @param packet A pointer to the raw packet data
+		void onPacketArrivesCallback(uint8_t* user, const pcap_pkthdr* pkthdr, const uint8_t* packet)
+		{
+			auto* context = reinterpret_cast<CaptureContext*>(user);
+			if (context == nullptr || context->device == nullptr || context->callback == nullptr)
+			{
+				PCPP_LOG_ERROR("Unable to extract PcapLiveDevice instance or callback");
+				return;
+			}
+
+			// TODO: Add exception handling to tunnel the exceptions from here to the capture thread
+			// through the C code boundary
+
+			RawPacket rawPacket(packet, pkthdr->caplen, pkthdr->ts, false, context->device->getLinkType());
+			context->callback(&rawPacket, context->device, context->userCookie);
+		}
+
+		/// @brief Wraps the raw packet data into a RawPacket instance and adds it to the captured packets vector
+		/// @param user A pointer to an AccumulatorCaptureContext instance
+		/// @param pkthdr A pointer to the pcap_pkthdr struct
+		/// @param packet A pointer to the raw packet data
+		void onPacketArrivesAccumulator(uint8_t* user, const pcap_pkthdr* pkthdr, const uint8_t* packet)
+		{
+			auto* context = reinterpret_cast<AccumulatorCaptureContext*>(user);
+			if (context == nullptr || context->device == nullptr || context->capturedPackets == nullptr)
+			{
+				PCPP_LOG_ERROR("Unable to extract PcapLiveDevice instance or captured packets vector");
+				return;
+			}
+
+			// TODO: Add exception handling to tunnel the exceptions from here to the capture thread
+			// through the C code boundary
+
+			uint8_t* packetData = new uint8_t[pkthdr->caplen];
+			std::memcpy(packetData, packet, pkthdr->caplen);
+			auto rawPacket = std::make_unique<RawPacket>(packetData, pkthdr->caplen, pkthdr->ts, true,
+			                                             context->device->getLinkType());
+			context->capturedPackets->pushBack(std::move(rawPacket));
+		}
+
+		/// @brief A procedure that dispatches packets to a user-defined callback function whenever a packet arrives.
+		///
+		/// The procedure runs in a loop until the `stopFlag` is set to true.
+		/// The procedure will set the `hasStarted` flag to true at the start of the procedure.
+		///
+		/// @param stopFlag A reference to an atomic boolean that indicates when to stop capturing packets
+		/// @param hasStarted A reference to an atomic boolean that indicates when the capture thread has started
+		/// @param pcapDescriptor A reference to the pcap handle on which to call pcap_dispatch
+		/// @param context A CaptureContext instance that holds the device, callback and user cookie.
+		void captureThreadMain(std::atomic_bool& stopFlag, std::atomic_bool& hasStarted,
+		                       internal::PcapHandle const& pcapDescriptor, CaptureContext context)
+		{
+			PCPP_LOG_DEBUG("Started capture thread for device '" << context.device->getName() << "'");
+			hasStarted.store(true);
+
+			// If the callback is null, we use a no-op handler to avoid unnecessary overhead
+			// Statistics only capture still requires pcap_dispatch to be called, but we don't need to process
+			// packets.
+			pcap_handler callbackHandler = context.callback ? onPacketArrivesCallback : onPacketArrivesNoop;
+
+			while (!stopFlag.load())
+			{
+				if (pcap_dispatch(pcapDescriptor.get(), -1, callbackHandler, reinterpret_cast<uint8_t*>(&context)) ==
+				    -1)
+				{
+					PCPP_LOG_ERROR("pcap_dispatch returned an error: " << pcapDescriptor.getLastError());
+					stopFlag.store(true);
+				}
+			}
+
+			PCPP_LOG_DEBUG("Ended capture thread for device '" << context.device->getName() << "'");
+		}
+
+		/// @brief A procedure that accumulates captured packets into a vector.
+		///
+		/// The procedure runs in a loop until the `stopFlag` is set to true.
+		/// The procedure will set the `hasStarted` flag to true at the start of the procedure.
+		///
+		/// @param stopFlag A reference to an atomic boolean that indicates when to stop capturing packets
+		/// @param hasStarted A reference to an atomic boolean that indicates when the capture thread has started
+		/// @param pcapDescriptor A reference to the pcap handle on which to call pcap_dispatch
+		/// @param context An AccumulatorCaptureContext instance that holds the device and the captured packets vector.
+		void captureThreadMainAccumulator(std::atomic_bool& stopFlag, std::atomic_bool& hasStarted,
+		                                  internal::PcapHandle const& pcapDescriptor, AccumulatorCaptureContext context)
+		{
+			PCPP_LOG_DEBUG("Started capture thread for device '" << context.device->getName() << "'");
+			hasStarted.store(true);
+			while (!stopFlag.load())
+			{
+				if (pcap_dispatch(pcapDescriptor.get(), 100, onPacketArrivesAccumulator,
+				                  reinterpret_cast<uint8_t*>(&context)) == -1)
+				{
+					PCPP_LOG_ERROR("pcap_dispatch returned an error: " << pcapDescriptor.getLastError());
+					stopFlag.store(true);
+				}
+			}
+
+			PCPP_LOG_DEBUG("Ended capture thread for device '" << context.device->getName() << "'");
+		}
 	}  // namespace
 
 	PcapLiveDevice::PcapLiveDevice(DeviceInterfaceDetails interfaceDetails, bool calculateMTU, bool calculateMacAddress,
@@ -309,48 +429,13 @@ namespace pcpp
 		m_CaptureThreadStarted = false;
 		m_StopThread = false;
 		m_CaptureThread = {};
-		m_cbOnPacketArrives = nullptr;
 		m_cbOnPacketArrivesBlockingMode = nullptr;
 		m_cbOnPacketArrivesBlockingModeUserCookie = nullptr;
-		m_cbOnPacketArrivesUserCookie = nullptr;
-		m_CaptureCallbackMode = true;
-		m_CapturedPackets = nullptr;
 		if (calculateMacAddress)
 		{
 			setDeviceMacAddress();
 			PCPP_LOG_DEBUG("   MAC addr: " << m_MacAddress);
 		}
-	}
-
-	void PcapLiveDevice::onPacketArrives(uint8_t* user, const struct pcap_pkthdr* pkthdr, const uint8_t* packet)
-	{
-		PcapLiveDevice* pThis = reinterpret_cast<PcapLiveDevice*>(user);
-		if (pThis == nullptr)
-		{
-			PCPP_LOG_ERROR("Unable to extract PcapLiveDevice instance");
-			return;
-		}
-
-		RawPacket rawPacket(packet, pkthdr->caplen, pkthdr->ts, false, pThis->getLinkType());
-
-		if (pThis->m_cbOnPacketArrives != nullptr)
-			pThis->m_cbOnPacketArrives(&rawPacket, pThis, pThis->m_cbOnPacketArrivesUserCookie);
-	}
-
-	void PcapLiveDevice::onPacketArrivesNoCallback(uint8_t* user, const struct pcap_pkthdr* pkthdr,
-	                                               const uint8_t* packet)
-	{
-		PcapLiveDevice* pThis = reinterpret_cast<PcapLiveDevice*>(user);
-		if (pThis == nullptr)
-		{
-			PCPP_LOG_ERROR("Unable to extract PcapLiveDevice instance");
-			return;
-		}
-
-		uint8_t* packetData = new uint8_t[pkthdr->caplen];
-		memcpy(packetData, packet, pkthdr->caplen);
-		RawPacket* rawPacketPtr = new RawPacket(packetData, pkthdr->caplen, pkthdr->ts, true, pThis->getLinkType());
-		pThis->m_CapturedPackets->pushBack(rawPacketPtr);
 	}
 
 	void PcapLiveDevice::onPacketArrivesBlockingMode(uint8_t* user, const struct pcap_pkthdr* pkthdr,
@@ -369,37 +454,6 @@ namespace pcpp
 			if (pThis->m_cbOnPacketArrivesBlockingMode(&rawPacket, pThis,
 			                                           pThis->m_cbOnPacketArrivesBlockingModeUserCookie))
 				pThis->m_StopThread = true;
-	}
-
-	void PcapLiveDevice::captureThreadMain()
-	{
-		PCPP_LOG_DEBUG("Started capture thread for device '" << m_InterfaceDetails.name << "'");
-		m_CaptureThreadStarted = true;
-
-		if (m_CaptureCallbackMode)
-		{
-			while (!m_StopThread)
-			{
-				if (pcap_dispatch(m_PcapDescriptor.get(), -1, onPacketArrives, reinterpret_cast<uint8_t*>(this)) == -1)
-				{
-					PCPP_LOG_ERROR("pcap_dispatch returned an error: " << m_PcapDescriptor.getLastError());
-					m_StopThread = true;
-				}
-			}
-		}
-		else
-		{
-			while (!m_StopThread)
-			{
-				if (pcap_dispatch(m_PcapDescriptor.get(), 100, onPacketArrivesNoCallback,
-				                  reinterpret_cast<uint8_t*>(this)) == -1)
-				{
-					PCPP_LOG_ERROR("pcap_dispatch returned an error: " << m_PcapDescriptor.getLastError());
-					m_StopThread = true;
-				}
-			}
-		}
-		PCPP_LOG_DEBUG("Ended capture thread for device '" << m_InterfaceDetails.name << "'");
 	}
 
 	internal::PcapHandle PcapLiveDevice::doOpen(const DeviceConfiguration& config)
@@ -487,14 +541,17 @@ namespace pcpp
 		case PCPP_IN:
 		{
 			PCPP_LOG_DEBUG("Only incoming traffics will be captured");
+			break;
 		}
 		case PCPP_OUT:
 		{
 			PCPP_LOG_DEBUG("Only outgoing traffics will be captured");
+			break;
 		}
 		default:
 		{
 			PCPP_LOG_DEBUG("Both incoming and outgoing traffics will be captured");
+			break;
 		}
 		}
 
@@ -651,11 +708,13 @@ namespace pcpp
 			return false;
 		}
 
-		m_CaptureCallbackMode = true;
-		m_cbOnPacketArrives = std::move(onPacketArrives);
-		m_cbOnPacketArrivesUserCookie = onPacketArrivesUserCookie;
+		CaptureContext context;
+		context.device = this;
+		context.callback = std::move(onPacketArrives);
+		context.userCookie = onPacketArrivesUserCookie;
 
-		m_CaptureThread = std::thread(&pcpp::PcapLiveDevice::captureThreadMain, this);
+		m_CaptureThread = std::thread(&captureThreadMain, std::ref(m_StopThread), std::ref(m_CaptureThreadStarted),
+		                              std::ref(m_PcapDescriptor), std::move(context));
 
 		// Wait thread to be start
 		// C++20 = m_CaptureThreadStarted.wait(true);
@@ -707,11 +766,15 @@ namespace pcpp
 			return false;
 		}
 
-		m_CapturedPackets = &capturedPacketsVector;
-		m_CapturedPackets->clear();
+		capturedPacketsVector.clear();
 
-		m_CaptureCallbackMode = false;
-		m_CaptureThread = std::thread(&pcpp::PcapLiveDevice::captureThreadMain, this);
+		AccumulatorCaptureContext context;
+		context.device = this;
+		context.capturedPackets = &capturedPacketsVector;
+
+		m_CaptureThread = std::thread(&captureThreadMainAccumulator, std::ref(m_StopThread),
+		                              std::ref(m_CaptureThreadStarted), std::ref(m_PcapDescriptor), std::move(context));
+
 		// Wait thread to be start
 		// C++20 = m_CaptureThreadStarted.wait(true);
 		while (m_CaptureThreadStarted != true)
@@ -749,8 +812,6 @@ namespace pcpp
 			PCPP_LOG_ERROR("Failed to prepare capture: " << ex.what());
 			return 0;
 		}
-		m_cbOnPacketArrives = nullptr;
-		m_cbOnPacketArrivesUserCookie = nullptr;
 
 		m_cbOnPacketArrivesBlockingMode = std::move(onPacketArrives);
 		m_cbOnPacketArrivesBlockingModeUserCookie = userCookie;

--- a/Pcap++/src/PfRingDevice.cpp
+++ b/Pcap++/src/PfRingDevice.cpp
@@ -366,7 +366,7 @@ namespace pcpp
 		return SystemCores::IdToSystemCore[sched_getcpu()];
 	}
 
-	bool PfRingDevice::setFilter(std::string filterAsString)
+	bool PfRingDevice::doUpdateFilter(std::string const* filterAsString)
 	{
 		if (!m_DeviceOpened)
 		{
@@ -374,6 +374,18 @@ namespace pcpp
 			return false;
 		}
 
+		if (filterAsString == nullptr || filterAsString->empty())
+		{
+			return removeFilterForAllChannels();
+		}
+		else
+		{
+			return setFilterForAllChannels(*filterAsString);
+		}
+	}
+
+	bool PfRingDevice::setFilterForAllChannels(std::string const& filterAsString)
+	{
 		for (pfring* rxChannel : m_PfRingDescriptors)
 		{
 			int res = pfring_set_bpf_filter(rxChannel, (char*)filterAsString.c_str());
@@ -394,7 +406,7 @@ namespace pcpp
 		return true;
 	}
 
-	bool PfRingDevice::clearFilter()
+	bool PfRingDevice::removeFilterForAllChannels()
 	{
 		if (!m_IsFilterCurrentlySet)
 			return true;

--- a/Pcap++/src/WinDivertDevice.cpp
+++ b/Pcap++/src/WinDivertDevice.cpp
@@ -1,0 +1,713 @@
+#include "WinDivertDevice.h"
+#include "Logger.h"
+#include "Packet.h"
+#include "windivert.h"
+#include "IPv4Layer.h"
+#include "IPv6Layer.h"
+#include "EndianPortable.h"
+#include <iostream>
+#include <windows.h>
+#include <iphlpapi.h>
+#include <winsock2.h>
+#include <chrono>
+
+namespace pcpp
+{
+	namespace internal
+	{
+		class WinDivertOverlappedWrapper : public IOverlappedWrapper
+		{
+		public:
+			explicit WinDivertOverlappedWrapper(const HANDLE handle) : m_Handle(handle)
+			{
+				ZeroMemory(&m_Overlapped, sizeof(m_Overlapped));
+
+				m_Event = CreateEvent(nullptr, TRUE, FALSE, nullptr);
+				if (!m_Event)
+				{
+					throw std::runtime_error("Failed to create event");
+				}
+				m_Overlapped.hEvent = m_Event;
+			}
+
+			// Non-copyable or movable
+			WinDivertOverlappedWrapper(const WinDivertOverlappedWrapper&) = delete;
+			WinDivertOverlappedWrapper& operator=(const WinDivertOverlappedWrapper&) = delete;
+			WinDivertOverlappedWrapper& operator=(WinDivertOverlappedWrapper&&) = delete;
+			WinDivertOverlappedWrapper(WinDivertOverlappedWrapper&&) = delete;
+
+			~WinDivertOverlappedWrapper() override
+			{
+				if (CancelIoEx(m_Handle, &m_Overlapped))
+				{
+					WaitForSingleObject(m_Event, INFINITE);
+				}
+				else
+				{
+					DWORD error = GetLastError();
+					if (error != ERROR_NOT_FOUND)
+					{
+						PCPP_LOG_ERROR("CancelIoEx failed with unexpected error: " << error);
+						// May still want to wait with a timeout for safety
+						WaitForSingleObject(m_Event, 1000);
+					}
+				}
+				CloseHandle(m_Event);
+			}
+
+			LPOVERLAPPED get()
+			{
+				return &m_Overlapped;
+			}
+
+			WaitResult wait(uint32_t timeout) override
+			{
+				auto waitResult = WaitForSingleObject(m_Overlapped.hEvent, timeout);
+				if (waitResult == WAIT_OBJECT_0)
+				{
+					return { WaitResult::Status::Completed, 0 };
+				}
+
+				if (waitResult == WAIT_TIMEOUT)
+				{
+					return { WaitResult::Status::Timeout, 0 };
+				}
+
+				return { WaitResult::Status::Failed, static_cast<uint32_t>(GetLastError()) };
+			}
+
+			void reset() override
+			{
+				if (!ResetEvent(m_Event))
+				{
+					throw std::runtime_error("Failed to reset overlapped event");
+				}
+
+				// Zero everything except hEvent
+				auto event = m_Overlapped.hEvent;
+				ZeroMemory(&m_Overlapped, sizeof(m_Overlapped));
+				m_Overlapped.hEvent = event;
+			}
+
+			OverlappedResult getOverlappedResult() override
+			{
+				DWORD packetLen = 0;
+				if (GetOverlappedResult(m_Handle, &m_Overlapped, &packetLen, FALSE))
+				{
+					return { OverlappedResult::Status::Success, static_cast<uint32_t>(packetLen), 0 };
+				}
+
+				return { OverlappedResult::Status::Failed, 0, static_cast<uint32_t>(GetLastError()) };
+			}
+
+		private:
+			HANDLE m_Event;
+			HANDLE m_Handle;
+			OVERLAPPED m_Overlapped = {};
+		};
+
+		class WinDivertHandle : public IWinDivertHandle
+		{
+		public:
+			explicit WinDivertHandle(const HANDLE handle) : m_Handle(handle)
+			{}
+
+			~WinDivertHandle() override
+			{
+				if (m_IsOpened)
+				{
+					WinDivertHandle::close();
+				}
+			}
+
+			uint32_t close() override
+			{
+				auto result = WinDivertClose(m_Handle);
+				m_IsOpened = false;
+				if (!result)
+				{
+					return GetLastError();
+				}
+				return SuccessResult;
+			}
+
+			uint32_t recvEx(uint8_t* buffer, uint32_t bufferLen, size_t addressesSize,
+			                IOverlappedWrapper* overlapped) override
+			{
+				auto winDivertOverlapped = dynamic_cast<WinDivertOverlappedWrapper*>(overlapped);
+				if (winDivertOverlapped == nullptr)
+				{
+					throw std::runtime_error("Failed to get WinDivertOverlapped");
+				}
+
+				m_WinDivertAddresses.resize(addressesSize);
+				m_WinDivertAddressesSize = sizeof(WINDIVERT_ADDRESS) * addressesSize;
+
+				uint32_t recvLen;
+				auto result = WinDivertRecvEx(m_Handle, buffer, bufferLen, &recvLen, 0, m_WinDivertAddresses.data(),
+				                              &m_WinDivertAddressesSize, winDivertOverlapped->get());
+
+				if (!result)
+				{
+					return GetLastError();
+				}
+
+				return SuccessResult;
+			}
+
+			std::vector<WinDivertAddress> recvExComplete() override
+			{
+				uint32_t numOfAddressesReceived = m_WinDivertAddressesSize / sizeof(WINDIVERT_ADDRESS);
+				std::vector<WinDivertAddress> result(numOfAddressesReceived);
+
+				for (uint32_t i = 0; i < numOfAddressesReceived; i++)
+				{
+					result[i].isIPv6 = m_WinDivertAddresses[i].IPv6 == 1;
+					result[i].interfaceIndex = m_WinDivertAddresses[i].Network.IfIdx;
+					result[i].timestamp = m_WinDivertAddresses[i].Timestamp;
+				}
+
+				return result;
+			}
+
+			uint32_t sendEx(uint8_t* buffer, uint32_t bufferLen, size_t addressesSize) override
+			{
+				std::vector<WINDIVERT_ADDRESS> winDivertAddresses;
+				for (size_t i = 0; i < addressesSize; i++)
+				{
+					WINDIVERT_ADDRESS addr = {};
+					addr.Outbound = 1;
+					winDivertAddresses.push_back(addr);
+				}
+
+				auto result = WinDivertSendEx(m_Handle, buffer, bufferLen, nullptr, 0, winDivertAddresses.data(),
+				                              addressesSize * sizeof(WINDIVERT_ADDRESS), nullptr);
+				if (!result)
+				{
+					return GetLastError();
+				}
+
+				return SuccessResult;
+			}
+
+			std::unique_ptr<IOverlappedWrapper> createOverlapped() override
+			{
+				return std::make_unique<WinDivertOverlappedWrapper>(m_Handle);
+			}
+
+			bool getParam(WinDivertParam param, uint64_t& value) override
+			{
+				return WinDivertGetParam(m_Handle, static_cast<WINDIVERT_PARAM>(param), &value);
+			}
+
+			bool setParam(WinDivertParam param, uint64_t value) override
+			{
+				return WinDivertSetParam(m_Handle, static_cast<WINDIVERT_PARAM>(param), value);
+			}
+
+		private:
+			HANDLE m_Handle;
+			bool m_IsOpened = true;
+			std::vector<WINDIVERT_ADDRESS> m_WinDivertAddresses;
+			uint32_t m_WinDivertAddressesSize = 0;
+		};
+
+		class WinDivertDriver : public IWinDivertDriver
+		{
+		public:
+			std::unique_ptr<IWinDivertHandle> open(const std::string& filter, int layer, int16_t priority,
+			                                       uint64_t flags) override
+			{
+				auto handle = WinDivertOpen(filter.c_str(), static_cast<WINDIVERT_LAYER>(layer), priority, flags);
+				if (handle == INVALID_HANDLE_VALUE)
+				{
+					PCPP_LOG_ERROR("Failed to open WinDivertHandle, error was: " << GetLastError());
+					return nullptr;
+				}
+				return std::make_unique<WinDivertHandle>(handle);
+			}
+
+			std::vector<NetworkInterface> getNetworkInterfaces() const override
+			{
+				std::vector<NetworkInterface> networkInterfaces;
+
+				ULONG bufferSize = 15000;
+				std::vector<BYTE> buffer(bufferSize);
+
+				auto result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr,
+				                                   reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data()), &bufferSize);
+
+				if (result == ERROR_BUFFER_OVERFLOW)
+				{
+					buffer.resize(bufferSize);
+					result = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, nullptr,
+					                              reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data()), &bufferSize);
+				}
+
+				if (result != NO_ERROR)
+				{
+					throw std::runtime_error("Error while getting network interfaces");
+				}
+
+				auto adapter = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(buffer.data());
+
+				while (adapter)
+				{
+					NetworkInterface networkInterface;
+					networkInterface.index = adapter->IfIndex;
+					networkInterface.name = adapter->FriendlyName;
+					networkInterface.description = adapter->Description;
+					networkInterface.isLoopback = (adapter->IfType == IF_TYPE_SOFTWARE_LOOPBACK);
+					networkInterface.isUp = (adapter->OperStatus == IfOperStatusUp);
+
+					networkInterfaces.push_back(networkInterface);
+					adapter = adapter->Next;
+				}
+
+				return networkInterfaces;
+			}
+		};
+
+	}  // namespace internal
+
+	constexpr uint32_t WinDivertBufferLength = 65536;
+
+	WinDivertDevice::WinDivertDevice(std::unique_ptr<internal::IWinDivertDriver> driver)
+	    : m_Driver(driver != nullptr ? std::move(driver) : std::make_unique<internal::WinDivertDriver>())
+	{}
+
+	bool WinDivertDevice::open()
+	{
+		return open("true");
+	}
+
+	bool WinDivertDevice::open(const std::string& filter)
+	{
+		m_Handle = m_Driver->open(filter, WINDIVERT_LAYER_NETWORK, 0, WINDIVERT_FLAG_SNIFF | WINDIVERT_FLAG_FRAGMENTS);
+		if (!m_Handle)
+		{
+			return false;
+		}
+
+		setNetworkInterfaces();
+
+		m_DeviceOpened = true;
+		return true;
+	}
+
+	void WinDivertDevice::close()
+	{
+		auto result = m_Handle->close();
+		if (result != internal::IWinDivertHandle::SuccessResult)
+		{
+			PCPP_LOG_ERROR("Couldn't receive packet, status: " << getErrorString(static_cast<uint16_t>(result)) << "("
+			                                                   << static_cast<int>(result) << ")");
+		}
+	}
+
+	WinDivertDevice::ReceiveResult WinDivertDevice::receivePackets(WinDivertRawPacketVector& packetVec,
+	                                                               uint32_t timeout, uint32_t maxPackets,
+	                                                               uint8_t batchSize)
+	{
+		if (!isOpened())
+		{
+			return { ReceiveResult::Status::Failed, "Device is not open" };
+		}
+
+		if (m_IsReceiving)
+		{
+			return { ReceiveResult::Status::Failed, "Already receiving packets, please call stopReceive() first" };
+		}
+
+		if (batchSize == 0)
+		{
+			return { ReceiveResult::Status::Failed, "Batch size has to be a positive number" };
+		}
+
+		if (timeout == 0 && maxPackets == 0)
+		{
+			return { ReceiveResult::Status::Failed,
+				     "At least one of timeout and maxPackets must be a positive number" };
+		}
+
+		auto overlapped = m_Handle->createOverlapped();
+		uint32_t bufferSize = WinDivertBufferLength * batchSize;
+		std::vector<uint8_t> buffer(bufferSize);
+
+		uint32_t receivedPacketCount = 0;
+		while (maxPackets == 0 || receivedPacketCount < maxPackets)
+		{
+			auto result = receivePacketsInternal(timeout, batchSize, buffer, overlapped.get());
+
+			if (result.status != ReceiveResult::Status::Completed)
+			{
+				return { result.status, result.error, result.errorCode };
+			}
+
+			uint32_t packetCountInCurrentBatch = receivedPacketCount + result.addresses.size() > maxPackets
+			                                         ? maxPackets - receivedPacketCount
+			                                         : result.addresses.size();
+			receivedPacketCount += packetCountInCurrentBatch;
+
+			uint8_t* curPacketPtr = buffer.data();
+			size_t remainingBytes = result.capturedDataLength;
+
+			for (uint32_t i = 0; i < packetCountInCurrentBatch; i++)
+			{
+				auto packetInfo = getPacketInfo(curPacketPtr, remainingBytes, result.addresses[i]);
+
+				auto linkType = std::get<0>(packetInfo);
+				if (linkType == LINKTYPE_INVALID)
+				{
+					continue;
+				}
+
+				auto packetLength = std::get<1>(packetInfo);
+				auto packetData = std::make_unique<uint8_t[]>(packetLength);
+				memcpy(packetData.get(), curPacketPtr, packetLength);
+				packetVec.pushBack(new WinDivertRawPacket(
+				    packetData.release(), static_cast<int>(packetLength), std::get<2>(packetInfo), true, linkType,
+				    result.addresses[i].interfaceIndex, result.addresses[i].timestamp));
+				curPacketPtr += packetLength;
+				remainingBytes -= packetLength;
+			}
+
+			overlapped->reset();
+		}
+
+		return { ReceiveResult::Status::Completed };
+	}
+
+	WinDivertDevice::ReceiveResult WinDivertDevice::receivePackets(const ReceivePacketCallback& callback,
+	                                                               uint32_t timeout, uint8_t batchSize)
+	{
+		if (!isOpened())
+		{
+			return { ReceiveResult::Status::Failed, "Device is not open" };
+		}
+
+		if (m_IsReceiving)
+		{
+			return { ReceiveResult::Status::Failed, "Already receiving packets, please call stopReceive() first" };
+		}
+
+		if (batchSize == 0)
+		{
+			return { ReceiveResult::Status::Failed, "Batch size has to be a positive number" };
+		}
+
+		if (!callback)
+		{
+			return { ReceiveResult::Status::Failed, "Callback was not provided" };
+		}
+
+		auto overlapped = m_Handle->createOverlapped();
+		uint32_t bufferSize = WinDivertBufferLength * batchSize;
+		std::vector<uint8_t> buffer(bufferSize);
+
+		WinDivertRawPacketVector receivedPackets;
+		m_IsReceiving = true;
+		while (m_IsReceiving)
+		{
+			auto result = receivePacketsInternal(timeout, batchSize, buffer, overlapped.get());
+
+			if (result.status != ReceiveResult::Status::Completed)
+			{
+				m_IsReceiving = false;
+				return { result.status, result.error, result.errorCode };
+			}
+
+			uint8_t* curPacketPtr = buffer.data();
+			size_t remainingBytes = result.capturedDataLength;
+
+			receivedPackets.clear();
+			for (auto& address : result.addresses)
+			{
+				auto packetInfo = getPacketInfo(curPacketPtr, remainingBytes, address);
+
+				auto linkType = std::get<0>(packetInfo);
+				if (linkType == LINKTYPE_INVALID)
+				{
+					continue;
+				}
+
+				auto packetLength = std::get<1>(packetInfo);
+				receivedPackets.pushBack(new WinDivertRawPacket(curPacketPtr, static_cast<int>(packetLength),
+				                                                std::get<2>(packetInfo), false, linkType,
+				                                                address.interfaceIndex, address.timestamp));
+				curPacketPtr += packetLength;
+				remainingBytes -= packetLength;
+			}
+
+			WinDivertReceiveCallbackContext context{ this };
+			callback(receivedPackets, context);
+
+			overlapped->reset();
+		}
+
+		return { ReceiveResult::Status::Completed };
+	}
+
+	void WinDivertDevice::stopReceive()
+	{
+		m_IsReceiving = false;
+	}
+
+	WinDivertDevice::SendResult WinDivertDevice::sendPackets(const RawPacketVector& packetVec, uint8_t batchSize) const
+	{
+		if (!m_DeviceOpened)
+		{
+			return { SendResult::Status::Failed, 0, "Device is not open" };
+		}
+
+		if (batchSize == 0)
+		{
+			return { SendResult::Status::Failed, 0, "Batch size has to be a positive number" };
+		}
+
+		std::array<uint8_t, WinDivertBufferLength> buffer{};
+		auto curBufferPtr = buffer.data();
+
+		uint8_t packetsInCurrentBatch = 0;
+		size_t packetsSent = 0;
+		size_t packetsToSend = packetVec.size();
+		for (auto packetIndex = 0; packetIndex < packetVec.size(); packetIndex++)
+		{
+			memcpy(curBufferPtr, packetVec.at(packetIndex)->getRawData(), packetVec.at(packetIndex)->getRawDataLen());
+			curBufferPtr += packetVec.at(packetIndex)->getRawDataLen();
+			packetsInCurrentBatch++;
+
+			if (packetsInCurrentBatch >= batchSize || packetIndex >= packetsToSend - 1)
+			{
+				auto result = m_Handle->sendEx(buffer.data(), WinDivertBufferLength, packetsInCurrentBatch);
+				if (result != internal::IWinDivertHandle::SuccessResult)
+				{
+					return { SendResult::Status::Failed, packetsSent,
+						     "Sending packets failed: " + getErrorString(result), result };
+				}
+				packetsSent += packetsInCurrentBatch;
+
+				packetsInCurrentBatch = 0;
+				memset(buffer.data(), 0, sizeof(buffer));
+				curBufferPtr = buffer.data();
+			}
+		}
+
+		return { SendResult::Status::Completed, packetsSent };
+	}
+
+	WinDivertDevice::QueueParams WinDivertDevice::getPacketQueueParams() const
+	{
+		if (!m_DeviceOpened)
+		{
+			throw std::runtime_error("Device is not open");
+		}
+
+		uint64_t queueLength, queueTime, queueSize;
+
+		auto getParamResult = true;
+		getParamResult |= m_Handle->getParam(internal::IWinDivertHandle::WinDivertParam::QueueLength, queueLength);
+		getParamResult |= m_Handle->getParam(internal::IWinDivertHandle::WinDivertParam::QueueTime, queueTime);
+		getParamResult |= m_Handle->getParam(internal::IWinDivertHandle::WinDivertParam::QueueSize, queueSize);
+
+		if (!getParamResult)
+		{
+			throw std::runtime_error("Failed to retrieve queue parameters");
+		}
+
+		return {
+			{ QueueParam::QueueLength, queueLength },
+			{ QueueParam::QueueTime,   queueTime   },
+			{ QueueParam::QueueSize,   queueSize   }
+		};
+	}
+
+	void WinDivertDevice::setPacketQueueParams(const QueueParams& params) const
+	{
+		if (!m_DeviceOpened)
+		{
+			throw std::runtime_error("Device is not open");
+		}
+
+		for (auto& param : params)
+		{
+			switch (param.first)
+			{
+			case QueueParam::QueueLength:
+			{
+				m_Handle->setParam(internal::IWinDivertHandle::WinDivertParam::QueueLength, param.second);
+				break;
+			}
+			case QueueParam::QueueTime:
+			{
+				m_Handle->setParam(internal::IWinDivertHandle::WinDivertParam::QueueTime, param.second);
+				break;
+			}
+			case QueueParam::QueueSize:
+			{
+				m_Handle->setParam(internal::IWinDivertHandle::WinDivertParam::QueueSize, param.second);
+				break;
+			}
+			}
+		}
+	}
+
+	WinDivertDevice::WinDivertVersion WinDivertDevice::getVersion() const
+	{
+		if (!m_DeviceOpened)
+		{
+			throw std::runtime_error("Device is not open");
+		}
+
+		uint64_t versionMajor, versionMinor;
+
+		auto getParamResult = true;
+		getParamResult |= m_Handle->getParam(internal::IWinDivertHandle::WinDivertParam::VersionMajor, versionMajor);
+		getParamResult |= m_Handle->getParam(internal::IWinDivertHandle::WinDivertParam::VersionMajor, versionMinor);
+
+		if (!getParamResult)
+		{
+			throw std::runtime_error("Failed to retrieve WinDivert version");
+		}
+
+		return { versionMajor, versionMinor };
+	}
+
+	const WinDivertDevice::NetworkInterface* WinDivertDevice::getNetworkInterface(uint32_t interfaceIndex) const
+	{
+		auto it = m_NetworkInterfaces.find(interfaceIndex);
+		if (it != m_NetworkInterfaces.end())
+		{
+			return &it->second;
+		}
+
+		return nullptr;
+	}
+
+	std::vector<WinDivertDevice::NetworkInterface> WinDivertDevice::getNetworkInterfaces() const
+	{
+		setNetworkInterfaces();
+
+		std::vector<NetworkInterface> interfaces;
+		interfaces.reserve(m_NetworkInterfaces.size());
+
+		for (const auto& entry : m_NetworkInterfaces)
+		{
+			interfaces.push_back(entry.second);
+		}
+
+		return interfaces;
+	}
+
+	WinDivertDevice::ReceiveResultInternal WinDivertDevice::receivePacketsInternal(
+	    uint32_t timeout, uint8_t batchSize, std::vector<uint8_t>& buffer, internal::IOverlappedWrapper* overlapped)
+	{
+		auto result = m_Handle->recvEx(buffer.data(), buffer.size(), batchSize, overlapped);
+		if (result != internal::IWinDivertHandle::ErrorIoPending && result != internal::IWinDivertHandle::SuccessResult)
+		{
+			return { ReceiveResult::Status::Failed, "Error receiving packets: " + getErrorString(result), result };
+		}
+
+		if (timeout == 0)
+		{
+			timeout = INFINITE;
+		}
+		auto waitResult = overlapped->wait(timeout);
+
+		switch (waitResult.status)
+		{
+		case internal::IOverlappedWrapper::WaitResult::Status::Completed:
+		{
+			auto overlappedResult = overlapped->getOverlappedResult();
+			if (overlappedResult.status != internal::IOverlappedWrapper::OverlappedResult::Status::Success)
+			{
+				return { ReceiveResult::Status::Failed,
+					     "Error fetching overlapped result: " + getErrorString(overlappedResult.errorCode),
+					     overlappedResult.errorCode };
+			}
+
+			return { overlappedResult.packetLen, m_Handle->recvExComplete() };
+		}
+		case internal::IOverlappedWrapper::WaitResult::Status::Timeout:
+		{
+			return { ReceiveResult::Status::Timeout };
+		}
+		default:
+		{
+			return { ReceiveResult::Status::Failed,
+				     "Error while waiting for packets: " + getErrorString(waitResult.errorCode), waitResult.errorCode };
+		}
+		}
+	}
+
+	std::tuple<LinkLayerType, uint16_t, timespec> WinDivertDevice::getPacketInfo(
+	    uint8_t* buffer, uint32_t bufferLen, const internal::WinDivertAddress& address)
+	{
+		uint16_t packetLength = 0;
+		LinkLayerType linkType = LINKTYPE_INVALID;
+		if (address.isIPv6 && IPv6Layer::isDataValid(buffer, bufferLen))
+		{
+			packetLength = sizeof(ip6_hdr) + be16toh(reinterpret_cast<ip6_hdr*>(buffer)->payloadLength);
+			linkType = LINKTYPE_IPV6;
+		}
+		else if (IPv4Layer::isDataValid(buffer, bufferLen))
+		{
+			packetLength = be16toh(reinterpret_cast<iphdr*>(buffer)->totalLength);
+			linkType = LINKTYPE_IPV4;
+		}
+		else
+		{
+			return { linkType, 0, {} };
+		}
+
+		auto now = std::chrono::system_clock::now();
+		auto duration = now.time_since_epoch();
+		auto nanoSecs = std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count();
+		timespec ts = { nanoSecs / 1'000'000'000, nanoSecs % 1'000'000'000 };
+
+		return { linkType, packetLength, ts };
+	}
+
+	void WinDivertDevice::setNetworkInterfaces() const
+	{
+		if (m_NetworkInterfacesInitialized)
+		{
+			return;
+		}
+
+		auto networkInterfaces = m_Driver->getNetworkInterfaces();
+		for (const auto& networkInterface : networkInterfaces)
+		{
+			m_NetworkInterfaces[networkInterface.index] = { networkInterface.index, networkInterface.name,
+				                                            networkInterface.description, networkInterface.isLoopback,
+				                                            networkInterface.isUp };
+		}
+
+		m_NetworkInterfacesInitialized = true;
+	}
+
+	std::string WinDivertDevice::getErrorString(uint32_t errorCode)
+	{
+		LPSTR messageBuffer = nullptr;
+		DWORD size = FormatMessageA(
+		    FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, nullptr,
+		    errorCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), reinterpret_cast<LPSTR>(&messageBuffer), 0, nullptr);
+
+		if (size == 0)
+		{
+			return "Unknown error";
+		}
+
+		std::string message(messageBuffer, size);
+
+		// Remove trailing newlines
+		while (!message.empty() && (message.back() == '\n' || message.back() == '\r'))
+		{
+			message.pop_back();
+		}
+
+		LocalFree(messageBuffer);
+
+		return message;
+	}
+}  // namespace pcpp

--- a/Pcap++/src/XdpDevice.cpp
+++ b/Pcap++/src/XdpDevice.cpp
@@ -403,8 +403,8 @@ namespace pcpp
 		auto umemInfo = static_cast<xsk_umem_info*>(m_Umem->getInfo());
 
 		struct xsk_socket_config xskConfig;
-		xskConfig.rx_size = m_Config->txSize;
-		xskConfig.tx_size = m_Config->rxSize;
+		xskConfig.rx_size = m_Config->rxSize;
+		xskConfig.tx_size = m_Config->txSize;
 		xskConfig.libbpf_flags = 0;
 		xskConfig.xdp_flags = 0;
 		xskConfig.bind_flags = 0;

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 [PcapPlusPlus](https://pcapplusplus.github.io/) is a multiplatform C++ library for capturing, parsing and crafting of network packets. It is designed to be efficient, powerful and easy to use.
 
-PcapPlusPlus enables decoding and forging capabilities for a large variety of network protocols. It also provides easy to use C++ wrappers for the most popular packet processing engines such as [libpcap](https://www.tcpdump.org/), [WinPcap](https://www.winpcap.org/), [Npcap](https://nmap.org/npcap/), [DPDK](https://www.dpdk.org/), [eBPF AF_XDP](https://www.kernel.org/doc/html/next/networking/af_xdp.html) and [PF_RING](https://www.ntop.org/products/packet-capture/pf_ring/).
+PcapPlusPlus enables decoding and forging capabilities for a large variety of network protocols. It also provides easy to use C++ wrappers for the most popular packet processing engines such as [libpcap](https://www.tcpdump.org/), [WinPcap](https://www.winpcap.org/), [Npcap](https://nmap.org/npcap/), [DPDK](https://www.dpdk.org/), [eBPF AF_XDP](https://www.kernel.org/doc/html/next/networking/af_xdp.html), [WinDivert](https://reqrypt.org/windivert.html) and [PF_RING](https://www.ntop.org/products/packet-capture/pf_ring/).
 
 Translations: English · [正體中文](./translation/README-zh-tw.md) · [한국어](./translation/README-kor.md)
 
@@ -115,7 +115,7 @@ and you should see the following output in your terminal:
 
 ## Feature Overview
 
-- __Packet capture__ through an easy to use C++ wrapper for popular packet capture engines such as [libpcap](https://www.tcpdump.org/), [WinPcap](https://www.winpcap.org/), [Npcap](https://nmap.org/npcap/), [Intel DPDK](https://www.dpdk.org/), [eBPF AF_XDP](https://www.kernel.org/doc/html/next/networking/af_xdp.html), [ntop’s PF_RING](https://www.ntop.org/products/packet-capture/pf_ring/) and [raw sockets](https://en.wikipedia.org/wiki/Network_socket#Raw_socket) [[Learn more](https://pcapplusplus.github.io/docs/features#packet-capture)]
+- __Packet capture__ through an easy to use C++ wrapper for popular packet capture engines such as [libpcap](https://www.tcpdump.org/), [WinPcap](https://www.winpcap.org/), [Npcap](https://nmap.org/npcap/), [Intel DPDK](https://www.dpdk.org/), [eBPF AF_XDP](https://www.kernel.org/doc/html/next/networking/af_xdp.html), [WinDivert](https://reqrypt.org/windivert.html), [ntop’s PF_RING](https://www.ntop.org/products/packet-capture/pf_ring/) and [raw sockets](https://en.wikipedia.org/wiki/Network_socket#Raw_socket) [[Learn more](https://pcapplusplus.github.io/docs/features#packet-capture)]
 - __Packet parsing and crafting__ including detailed analysis of protocols and layers, packet generation and packet edit for a large variety of [network protocols](https://pcapplusplus.github.io/docs/features#supported-network-protocols) [[Learn more](https://pcapplusplus.github.io/docs/features#packet-parsing-and-crafting)]
 - __Read and write packets from/to files__ in both __PCAP__ and __PCAPNG__ formats [[Learn more](https://pcapplusplus.github.io/docs/features#read-and-write-packets-fromto-files)]
 - __Packet processing in line rate__ through an efficient and easy to use C++ wrapper for [DPDK](https://www.dpdk.org/), [eBPF AF_XDP](https://www.kernel.org/doc/html/next/networking/af_xdp.html) and [PF_RING](https://www.ntop.org/products/packet-capture/pf_ring/) [[Learn more](https://pcapplusplus.github.io/docs/features#dpdk-support)]
@@ -180,7 +180,7 @@ You can find much more information in the [Getting Started](https://pcapplusplus
 PcapPlusPlus consists of 3 libraries:
 
 1. __Packet++__ - a library for parsing, creating and editing network packets
-2. __Pcap++__ - a library for intercepting and sending packets, providing network and NIC info, stats, etc. It is actually a C++ wrapper for packet capturing engines such as libpcap, WinPcap, Npcap, DPDK and PF_RING
+2. __Pcap++__ - a library for intercepting and sending packets, providing network and NIC info, stats, etc. It is actually a C++ wrapper for packet capturing engines such as libpcap, WinPcap, Npcap, DPDK, AF_XDP, WinDivert and PF_RING
 3. __Common++__ - a library with some common code utilities used by both Packet++ and Pcap++
 
 You can find an extensive API documentation in the [API documentation section](https://pcapplusplus.github.io/docs/api) in PcapPlusPlus web-site.

--- a/Tests/Pcap++Test/CMakeLists.txt
+++ b/Tests/Pcap++Test/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   Tests/RawSocketTests.cpp
   Tests/SystemUtilsTests.cpp
   Tests/TcpReassemblyTests.cpp
+  Tests/WinDivertTests.cpp
   Tests/XdpTests.cpp
 )
 

--- a/Tests/Pcap++Test/TestDefinition.h
+++ b/Tests/Pcap++Test/TestDefinition.h
@@ -128,3 +128,9 @@ PTF_TEST_CASE(TestXdpDeviceReceivePackets);
 PTF_TEST_CASE(TestXdpDeviceSendPackets);
 PTF_TEST_CASE(TestXdpDeviceNonDefaultConfig);
 PTF_TEST_CASE(TestXdpDeviceInvalidConfig);
+
+// Implemented in WinDivertTests.cpp
+PTF_TEST_CASE(TestWinDivertReceivePackets);
+PTF_TEST_CASE(TestWinDivertSendPackets);
+PTF_TEST_CASE(TestWinDivertParams);
+PTF_TEST_CASE(TestWinDivertNetworkInterfaces);

--- a/Tests/Pcap++Test/Tests/FilterTests.cpp
+++ b/Tests/Pcap++Test/Tests/FilterTests.cpp
@@ -106,9 +106,9 @@ PTF_TEST_CASE(TestPcapFiltersLive)
 	andFilter.parseToString(filterAsString);
 	PTF_ASSERT_TRUE(liveDev->setFilter(andFilter));
 	PTF_ASSERT_TRUE(liveDev->startCapture(capturedPackets));
-	PTF_ASSERT_TRUE(sendURLRequest("www.walla.co.il"));
+	PTF_ASSERT_TRUE(sendURLRequest("www.google.com"));
 	// let the capture work for couple of seconds
-	totalSleepTime = incSleep(capturedPackets, 2, 7);
+	totalSleepTime = incSleep(capturedPackets, 2, 20);
 	PTF_PRINT_VERBOSE("Total sleep time: " << totalSleepTime);
 	liveDev->stopCapture();
 	PTF_ASSERT_GREATER_OR_EQUAL_THAN(capturedPackets.size(), 2);

--- a/Tests/Pcap++Test/Tests/WinDivertTests.cpp
+++ b/Tests/Pcap++Test/Tests/WinDivertTests.cpp
@@ -1,0 +1,457 @@
+#include <IPLayer.h>
+
+#include "../TestDefinition.h"
+#include "../Common/GlobalTestArgs.h"
+#include "../Common/TestUtils.h"
+#include "WinDivertDevice.h"
+#include "PcapFileDevice.h"
+#include "Packet.h"
+
+extern PcapTestArgs PcapTestGlobalArgs;
+
+pcpp::WinDivertDevice::ReceivePacketCallback noOpCallback =
+    [](const pcpp::WinDivertDevice::WinDivertRawPacketVector&,
+       const pcpp::WinDivertDevice::WinDivertReceiveCallbackContext&) {};
+
+PTF_TEST_CASE(TestWinDivertReceivePackets)
+{
+#ifdef USE_WINDIVERT
+	// Receive with packet vector
+	{
+		pcpp::WinDivertDevice device;
+		PTF_ASSERT_TRUE(device.open());
+
+		DeviceTeardown devTeardown(&device);
+
+		pcpp::WinDivertDevice::WinDivertRawPacketVector rawPackets;
+		uint32_t expectedPacketCount = 10;
+		auto result = device.receivePackets(rawPackets, 10000, expectedPacketCount);
+		PTF_ASSERT_EQUAL(result.status, pcpp::WinDivertDevice::ReceiveResult::Status::Completed, enumclass);
+		PTF_ASSERT_EQUAL(result.error, "");
+		PTF_ASSERT_EQUAL(result.errorCode, 0);
+
+		PTF_ASSERT_EQUAL(rawPackets.size(), expectedPacketCount);
+
+		for (const auto& rawPacket : rawPackets)
+		{
+			PTF_ASSERT_NOT_NULL(device.getNetworkInterface(rawPacket->getInterfaceIndex()));
+			pcpp::Packet packet(rawPacket);
+			PTF_ASSERT_TRUE(packet.getFirstLayer()->isMemberOfProtocolFamily(pcpp::IP));
+		}
+	}
+
+	// Receive with callback
+	{
+		pcpp::WinDivertDevice device;
+		PTF_ASSERT_TRUE(device.open());
+
+		DeviceTeardown devTeardown(&device);
+
+		uint32_t expectedPacketCount = 10;
+		uint16_t packetCounter = 0;
+		bool allPacketsHaveInterface = true;
+		bool allPacketsOfTypeIP = true;
+		bool isTimestampIncreasing = true;
+		bool deviceInContextMatch = false;
+		uint64_t currentTimestamp = 0;
+
+		auto result = device.receivePackets([&](const pcpp::WinDivertDevice::WinDivertRawPacketVector& packetVec,
+		                                        const pcpp::WinDivertDevice::WinDivertReceiveCallbackContext& context) {
+			if (context.device == &device)
+			{
+				deviceInContextMatch = true;
+			}
+
+			for (auto& rawPacket : packetVec)
+			{
+				allPacketsHaveInterface &= device.getNetworkInterface(rawPacket->getInterfaceIndex()) != nullptr;
+				pcpp::Packet packet(rawPacket);
+				allPacketsOfTypeIP &= packet.getFirstLayer()->isMemberOfProtocolFamily(pcpp::IP);
+				isTimestampIncreasing &= (rawPacket->getWinDivertTimestamp() >= currentTimestamp);
+				currentTimestamp = rawPacket->getWinDivertTimestamp();
+			}
+
+			packetCounter += packetVec.size();
+			if (packetCounter >= expectedPacketCount)
+			{
+				device.stopReceive();
+			}
+		});
+
+		PTF_ASSERT_EQUAL(result.status, pcpp::WinDivertDevice::ReceiveResult::Status::Completed, enumclass);
+		PTF_ASSERT_EQUAL(result.error, "");
+		PTF_ASSERT_EQUAL(result.errorCode, 0);
+		PTF_ASSERT_GREATER_OR_EQUAL_THAN(packetCounter, expectedPacketCount);
+		PTF_ASSERT_TRUE(allPacketsHaveInterface);
+		PTF_ASSERT_TRUE(allPacketsOfTypeIP);
+		PTF_ASSERT_TRUE(isTimestampIncreasing);
+		PTF_ASSERT_TRUE(deviceInContextMatch);
+	}
+
+	// Receive timeout
+	{
+		pcpp::WinDivertDevice device;
+
+		auto networkInterfaces = device.getNetworkInterfaces();
+		uint32_t invalidInterfaceIndex = 0;
+		while (true)
+		{
+			auto it = std::find_if(networkInterfaces.begin(), networkInterfaces.end(),
+			                       [&](const auto& item) { return item.index == invalidInterfaceIndex; });
+
+			if (it == networkInterfaces.end())
+			{
+				break;
+			}
+
+			invalidInterfaceIndex++;
+		}
+
+		PTF_ASSERT_TRUE(device.open("ifIdx == " + std::to_string(invalidInterfaceIndex)));
+
+		DeviceTeardown devTeardown(&device);
+
+		pcpp::WinDivertDevice::WinDivertRawPacketVector rawPackets;
+		auto result = device.receivePackets(rawPackets, 500);
+
+		PTF_ASSERT_EQUAL(result.status, pcpp::WinDivertDevice::ReceiveResult::Status::Timeout, enumclass);
+	}
+
+	// TODO: consider adding stats for number of batches
+
+	// Receive with non-default batch size
+	{
+		pcpp::WinDivertDevice device;
+		PTF_ASSERT_TRUE(device.open());
+
+		DeviceTeardown devTeardown(&device);
+
+		pcpp::WinDivertDevice::WinDivertRawPacketVector rawPackets;
+		uint32_t expectedPacketCount = 13;
+		auto result = device.receivePackets(rawPackets, 10000, expectedPacketCount, 3);
+		PTF_ASSERT_EQUAL(result.status, pcpp::WinDivertDevice::ReceiveResult::Status::Completed, enumclass);
+
+		PTF_ASSERT_EQUAL(rawPackets.size(), expectedPacketCount);
+	}
+
+	// Receive with a filter
+	{
+		pcpp::WinDivertDevice device;
+		pcpp::IPAddress ipAddress(PcapTestGlobalArgs.ipToSendReceivePackets);
+		std::string filter;
+		if (ipAddress.isIPv4())
+		{
+			filter = "ip.SrcAddr == " + ipAddress.toString();
+		}
+		else
+		{
+			filter = "ipv6.SrcAddr == " + ipAddress.toString();
+		}
+		PTF_ASSERT_TRUE(device.open(filter));
+
+		pcpp::WinDivertDevice::WinDivertRawPacketVector rawPackets;
+		auto result = device.receivePackets(rawPackets, 10000, 10);
+		PTF_ASSERT_EQUAL(result.status, pcpp::WinDivertDevice::ReceiveResult::Status::Completed, enumclass);
+
+		for (const auto& rawPacket : rawPackets)
+		{
+			pcpp::Packet packet(rawPacket);
+			PTF_ASSERT_EQUAL(packet.getLayerOfType<pcpp::IPLayer>()->getSrcIPAddress(), ipAddress);
+		}
+	}
+
+	// Receive when device not open
+	{
+		pcpp::WinDivertDevice device;
+
+		pcpp::WinDivertDevice::WinDivertRawPacketVector rawPackets;
+		auto result1 = device.receivePackets(rawPackets);
+		auto result2 = device.receivePackets(noOpCallback);
+
+		for (const auto& result : { result1, result2 })
+		{
+			PTF_ASSERT_EQUAL(result.status, pcpp::WinDivertDevice::ReceiveResult::Status::Failed, enumclass);
+			PTF_ASSERT_EQUAL(result.error, "Device is not open");
+			PTF_ASSERT_EQUAL(result.errorCode, 0);
+		}
+	}
+
+	// Receive when batch size is 0
+	{
+		pcpp::WinDivertDevice device;
+		PTF_ASSERT_TRUE(device.open());
+
+		DeviceTeardown devTeardown(&device);
+
+		pcpp::WinDivertDevice::WinDivertRawPacketVector rawPackets;
+		auto result1 = device.receivePackets(rawPackets, 5000, 0, 0);
+		auto result2 = device.receivePackets(noOpCallback, 5000, 0);
+
+		for (const auto& result : { result1, result2 })
+		{
+			PTF_ASSERT_EQUAL(result.status, pcpp::WinDivertDevice::ReceiveResult::Status::Failed, enumclass);
+			PTF_ASSERT_EQUAL(result.error, "Batch size has to be a positive number");
+			PTF_ASSERT_EQUAL(result.errorCode, 0);
+		}
+	}
+
+	// Receive when timeout and maxPackets are 0
+	{
+		pcpp::WinDivertDevice device;
+		PTF_ASSERT_TRUE(device.open());
+
+		DeviceTeardown devTeardown(&device);
+
+		pcpp::WinDivertDevice::WinDivertRawPacketVector rawPackets;
+		auto result = device.receivePackets(rawPackets, 0, 0);
+
+		PTF_ASSERT_EQUAL(result.status, pcpp::WinDivertDevice::ReceiveResult::Status::Failed, enumclass);
+		PTF_ASSERT_EQUAL(result.error, "At least one of timeout and maxPackets must be a positive number");
+		PTF_ASSERT_EQUAL(result.errorCode, 0);
+	}
+
+	// Receive when already receiving
+	{
+		pcpp::WinDivertDevice device;
+		PTF_ASSERT_TRUE(device.open());
+
+		DeviceTeardown devTeardown(&device);
+
+		bool failedReceiveWhileReceiving = false;
+
+		device.receivePackets([&](const pcpp::WinDivertDevice::WinDivertRawPacketVector&,
+		                          const pcpp::WinDivertDevice::WinDivertReceiveCallbackContext&) {
+			auto result1 = device.receivePackets(noOpCallback);
+			pcpp::WinDivertDevice::WinDivertRawPacketVector rawPackets;
+			auto result2 = device.receivePackets(rawPackets);
+
+			auto expectedStatus = pcpp::WinDivertDevice::ReceiveResult::Status::Failed;
+			auto expectedError = "Already receiving packets, please call stopReceive() first";
+			if (result1.status == expectedStatus && result2.status == expectedStatus &&
+			    result1.error == expectedError && result2.error == expectedError)
+			{
+				failedReceiveWhileReceiving = true;
+			}
+
+			device.stopReceive();
+		});
+
+		PTF_ASSERT_TRUE(failedReceiveWhileReceiving);
+	}
+
+	// Receive with no callback
+	{
+		pcpp::WinDivertDevice device;
+		PTF_ASSERT_TRUE(device.open());
+
+		DeviceTeardown devTeardown(&device);
+
+		auto result = device.receivePackets(nullptr);
+
+		PTF_ASSERT_EQUAL(result.status, pcpp::WinDivertDevice::ReceiveResult::Status::Failed, enumclass);
+		PTF_ASSERT_EQUAL(result.error, "Callback was not provided");
+	}
+#else
+	PTF_SKIP_TEST("WinDivert is not configured");
+#endif
+}  // TestWinDivertReceivePackets
+
+PTF_TEST_CASE(TestWinDivertSendPackets)
+{
+#ifdef USE_WINDIVERT
+	// Send packets
+	{
+		pcpp::RawPacketVector packetVec;
+
+		pcpp::PcapFileReaderDevice ipv4Reader("PcapExamples/linktype_ipv4.pcap");
+		PTF_ASSERT_TRUE(ipv4Reader.open());
+		PTF_ASSERT_EQUAL(ipv4Reader.getNextPackets(packetVec, 2), 2);
+
+		pcpp::PcapFileReaderDevice ipv6Reader("PcapExamples/linktype_ipv6.pcap");
+		PTF_ASSERT_TRUE(ipv6Reader.open());
+		PTF_ASSERT_EQUAL(ipv6Reader.getNextPackets(packetVec, 1), 1);
+
+		pcpp::WinDivertDevice device;
+		PTF_ASSERT_TRUE(device.open());
+
+		DeviceTeardown devTeardown(&device);
+
+		auto sendResult = device.sendPackets(packetVec);
+		PTF_ASSERT_EQUAL(sendResult.status, pcpp::WinDivertDevice::SendResult::Status::Completed, enumclass);
+		PTF_ASSERT_EQUAL(sendResult.error, "");
+		PTF_ASSERT_EQUAL(sendResult.packetsSent, 3);
+	}
+
+	// Send packets with batch size
+	{
+		pcpp::RawPacketVector packetVec;
+
+		for (int i = 0; i < 10; i++)
+		{
+			pcpp::PcapFileReaderDevice ipv4Reader("PcapExamples/linktype_ipv4.pcap");
+			PTF_ASSERT_TRUE(ipv4Reader.open());
+			PTF_ASSERT_EQUAL(ipv4Reader.getNextPackets(packetVec, 2), 2);
+		}
+
+		pcpp::WinDivertDevice device;
+		PTF_ASSERT_TRUE(device.open());
+
+		DeviceTeardown devTeardown(&device);
+
+		auto sendResult = device.sendPackets(packetVec, 6);
+		PTF_ASSERT_EQUAL(sendResult.status, pcpp::WinDivertDevice::SendResult::Status::Completed, enumclass);
+		PTF_ASSERT_EQUAL(sendResult.error, "");
+		PTF_ASSERT_EQUAL(sendResult.packetsSent, 20);
+	}
+
+	// Send packets with link layer which is not IPv4/6
+	{
+		pcpp::RawPacketVector packetVec;
+
+		pcpp::PcapFileReaderDevice ethReader("PcapExamples/one_tcp_stream.pcap");
+		PTF_ASSERT_TRUE(ethReader.open());
+		PTF_ASSERT_EQUAL(ethReader.getNextPackets(packetVec, 2), 2);
+
+		pcpp::WinDivertDevice device;
+		PTF_ASSERT_TRUE(device.open());
+
+		DeviceTeardown devTeardown(&device);
+
+		auto sendResult = device.sendPackets(packetVec);
+		PTF_ASSERT_EQUAL(sendResult.status, pcpp::WinDivertDevice::SendResult::Status::Failed, enumclass);
+		PTF_ASSERT_EQUAL(sendResult.errorCode, 87);
+		PTF_ASSERT_EQUAL(sendResult.error, "Sending packets failed: The parameter is incorrect.");
+		PTF_ASSERT_EQUAL(sendResult.packetsSent, 0);
+	}
+
+	// Send partially succeeds
+	{
+		pcpp::RawPacketVector packetVec;
+
+		pcpp::PcapFileReaderDevice ipv4Reader("PcapExamples/linktype_ipv4.pcap");
+		PTF_ASSERT_TRUE(ipv4Reader.open());
+		PTF_ASSERT_EQUAL(ipv4Reader.getNextPackets(packetVec, 2), 2);
+
+		pcpp::PcapFileReaderDevice ethReader("PcapExamples/one_tcp_stream.pcap");
+		PTF_ASSERT_TRUE(ethReader.open());
+		PTF_ASSERT_EQUAL(ethReader.getNextPackets(packetVec, 2), 2);
+
+		pcpp::WinDivertDevice device;
+		PTF_ASSERT_TRUE(device.open());
+
+		DeviceTeardown devTeardown(&device);
+
+		auto sendResult = device.sendPackets(packetVec, 1);
+		PTF_ASSERT_EQUAL(sendResult.status, pcpp::WinDivertDevice::SendResult::Status::Failed, enumclass);
+		PTF_ASSERT_EQUAL(sendResult.errorCode, 87);
+		PTF_ASSERT_EQUAL(sendResult.error, "Sending packets failed: The parameter is incorrect.");
+		PTF_ASSERT_EQUAL(sendResult.packetsSent, 2);
+	}
+
+	// Send when device not open
+	{
+		pcpp::RawPacketVector packetVec;
+
+		pcpp::PcapFileReaderDevice ipv4Reader("PcapExamples/linktype_ipv4.pcap");
+		PTF_ASSERT_TRUE(ipv4Reader.open());
+		PTF_ASSERT_EQUAL(ipv4Reader.getNextPackets(packetVec, 2), 2);
+
+		pcpp::WinDivertDevice device;
+		auto sendResult = device.sendPackets(packetVec);
+
+		PTF_ASSERT_EQUAL(sendResult.status, pcpp::WinDivertDevice::SendResult::Status::Failed, enumclass);
+		PTF_ASSERT_EQUAL(sendResult.error, "Device is not open");
+		PTF_ASSERT_EQUAL(sendResult.errorCode, 0);
+		PTF_ASSERT_EQUAL(sendResult.packetsSent, 0);
+	}
+
+	// Send when batch size is 0
+	{
+		pcpp::RawPacketVector packetVec;
+
+		pcpp::PcapFileReaderDevice ipv4Reader("PcapExamples/linktype_ipv4.pcap");
+		PTF_ASSERT_TRUE(ipv4Reader.open());
+		PTF_ASSERT_EQUAL(ipv4Reader.getNextPackets(packetVec, 2), 2);
+
+		pcpp::WinDivertDevice device;
+		PTF_ASSERT_TRUE(device.open());
+
+		DeviceTeardown devTeardown(&device);
+
+		pcpp::WinDivertDevice::WinDivertRawPacketVector rawPackets;
+		auto sendResult = device.sendPackets(packetVec, 0);
+
+		PTF_ASSERT_EQUAL(sendResult.status, pcpp::WinDivertDevice::SendResult::Status::Failed, enumclass);
+		PTF_ASSERT_EQUAL(sendResult.error, "Batch size has to be a positive number");
+		PTF_ASSERT_EQUAL(sendResult.errorCode, 0);
+		PTF_ASSERT_EQUAL(sendResult.packetsSent, 0);
+	}
+#else
+	PTF_SKIP_TEST("WinDivert is not configured");
+#endif
+}  // TestWinDivertSendPackets
+
+PTF_TEST_CASE(TestWinDivertParams)
+{
+#ifdef USE_WINDIVERT
+	{
+		pcpp::WinDivertDevice device;
+		PTF_ASSERT_TRUE(device.open());
+
+		DeviceTeardown devTeardown(&device);
+
+		PTF_ASSERT_EQUAL(device.getVersion().toString(), "2.2");
+
+		auto queueParams = device.getPacketQueueParams();
+		for (const auto& keyValuePair : queueParams)
+		{
+			PTF_ASSERT_GREATER_THAN(keyValuePair.second, 0);
+		}
+
+		pcpp::WinDivertDevice::QueueParams clonedQueueParams(queueParams);
+		for (const auto& keyValuePair : clonedQueueParams)
+		{
+			clonedQueueParams[keyValuePair.first] = keyValuePair.second + 1;
+		}
+		device.setPacketQueueParams(clonedQueueParams);
+
+		queueParams = device.getPacketQueueParams();
+		PTF_ASSERT_TRUE(queueParams == clonedQueueParams);
+	}
+
+	// Device is not open
+	{
+		pcpp::WinDivertDevice device;
+
+		PTF_ASSERT_RAISES(device.getVersion(), std::runtime_error, "Device is not open");
+		PTF_ASSERT_RAISES(device.getPacketQueueParams(), std::runtime_error, "Device is not open");
+		PTF_ASSERT_RAISES(device.setPacketQueueParams({}), std::runtime_error, "Device is not open");
+	}
+#else
+	PTF_SKIP_TEST("WinDivert is not configured");
+#endif
+}  // TestWinDivertParams
+
+PTF_TEST_CASE(TestWinDivertNetworkInterfaces)
+{
+#ifdef USE_WINDIVERT
+	pcpp::WinDivertDevice device;
+
+	auto networkInterfaces = device.getNetworkInterfaces();
+	bool atLeastOneInterfaceIsUp = false;
+	bool atLeastOneLoopbackInterface = false;
+	for (const auto& networkInterface : networkInterfaces)
+	{
+		PTF_ASSERT_GREATER_THAN(networkInterface.index, 0);
+		PTF_ASSERT_FALSE(networkInterface.name.empty());
+		PTF_ASSERT_FALSE(networkInterface.description.empty());
+		atLeastOneInterfaceIsUp |= networkInterface.isUp;
+		atLeastOneLoopbackInterface |= networkInterface.isLoopback;
+	}
+
+	PTF_ASSERT_TRUE(atLeastOneInterfaceIsUp);
+	PTF_ASSERT_TRUE(atLeastOneLoopbackInterface);
+#else
+	PTF_SKIP_TEST("WinDivert is not configured");
+#endif
+}  // TestWinDivertNetworkInterfaces

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -313,6 +313,11 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(TestXdpDeviceNonDefaultConfig, "xdp");
 	PTF_RUN_TEST(TestXdpDeviceInvalidConfig, "xdp");
 
+	PTF_RUN_TEST(TestWinDivertReceivePackets, "windivert");
+	PTF_RUN_TEST(TestWinDivertSendPackets, "windivert");
+	PTF_RUN_TEST(TestWinDivertParams, "windivert");
+	PTF_RUN_TEST(TestWinDivertNetworkInterfaces, "windivert");
+
 	PTF_END_RUNNING_TESTS;
 }
 

--- a/ci/clang-tidy-all.sh
+++ b/ci/clang-tidy-all.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-IGNORE_LIST=".*dirent.* .*DpdkDevice* .*KniDevice* .*MBufRawPacket* .*PfRingDevice* .*RemoteDevice* .*XdpDevice* .*WinPcap*"
+IGNORE_LIST=".*dirent.* .*DpdkDevice* .*KniDevice* .*MBufRawPacket* .*PfRingDevice* .*RemoteDevice* .*XdpDevice* .*WinPcap* .*WinDivert*"
 
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "${SCRIPT}")

--- a/ci/install_windivert.ps1
+++ b/ci/install_windivert.ps1
@@ -1,0 +1,35 @@
+param([string]$Target = "C:\WinDivert")
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $tmp = @($env:RUNNER_TEMP, $env:TEMP) | Where-Object { $_ } | Select-Object -First 1
+    $zip  = Join-Path $tmp "WinDivert.zip"
+    $dest = Join-Path $tmp "WinDivertTmp"
+
+    Invoke-WebRequest "https://github.com/basil00/Divert/releases/download/v2.2.0/WinDivert-2.2.0-A.zip" -OutFile $zip
+
+    Remove-Item $dest -Recurse -Force -ErrorAction SilentlyContinue
+    Expand-Archive $zip $dest -Force
+
+    $root = (Get-ChildItem $dest -Directory | Select-Object -First 1).FullName
+    if (-not $root) { throw "Extraction failed - WinDivert root not found." }
+
+    Remove-Item $Target -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item -ItemType Directory -Path $Target -Force | Out-Null
+
+    foreach ($d in "include", "x64", "x86") {
+        $path = Join-Path $root $d
+        if (Test-Path $path) { Copy-Item $path $Target -Recurse -Force }
+    }
+
+    if ($env:GITHUB_ENV)  { "WinDivert_ROOT=$Target" | Out-File $env:GITHUB_ENV  -Append -Encoding utf8 }
+    if ($env:GITHUB_PATH) { Join-Path $Target "x64"   | Out-File $env:GITHUB_PATH -Append -Encoding utf8 }
+
+    Write-Host "WinDivert installation completed."
+    exit 0
+}
+catch {
+    Write-Error "Failed to install WinDivert: $($_.Exception.Message)"
+    exit 1
+}

--- a/ci/run_tests/run_tests_windows.py
+++ b/ci/run_tests/run_tests_windows.py
@@ -73,6 +73,14 @@ def main():
         help="Pcap++ tests to skip",
     )
     parser.add_argument(
+        "--include-tests",
+        "-t",
+        type=str,
+        nargs="+",
+        default=[],
+        help="Pcap++ tests to include",
+    )
+    parser.add_argument(
         "--coverage",
         "-c",
         action="store_true",
@@ -125,6 +133,9 @@ def main():
             exit(completed_process.returncode)
 
         skip_tests = ["TestRemoteCapture"] + args.skip_tests
+        include_tests = (
+            ["-t", ";".join(args.include_tests)] if args.include_tests else []
+        )
         if args.coverage:
             completed_process = subprocess.run(
                 [
@@ -146,6 +157,7 @@ def main():
                     ip_address,
                     "-x",
                     ";".join(skip_tests),
+                    *include_tests,
                 ],
                 cwd=os.path.join("Tests", "Pcap++Test"),
                 shell=True,
@@ -158,6 +170,7 @@ def main():
                     ip_address,
                     "-x",
                     ";".join(skip_tests),
+                    *include_tests,
                 ],
                 cwd=os.path.join("Tests", "Pcap++Test"),
                 shell=True,

--- a/cmake/modules/FindDPDK.cmake
+++ b/cmake/modules/FindDPDK.cmake
@@ -77,8 +77,7 @@ else()
 
   # Get all the libraries regarding the version
   list(
-    APPEND
-    _DPDK_LOOK_FOR_LIBS
+    APPEND _DPDK_LOOK_FOR_LIBS
     net
     kni
     ethdev
@@ -97,8 +96,7 @@ else()
 
   if(DPDK_VERSION VERSION_LESS "20.11")
     list(
-      APPEND
-      _DPDK_LOOK_FOR_LIBS
+      APPEND _DPDK_LOOK_FOR_LIBS
       pmd_bond
       pmd_vmxnet3
       pmd_virtio

--- a/cmake/modules/FindWinDivert.cmake
+++ b/cmake/modules/FindWinDivert.cmake
@@ -1,0 +1,120 @@
+# FindWinDivert.cmake
+#
+# Module to locate the WinDivert library, header, and driver files.
+#
+# This module defines the following variables:
+#
+#   WinDivert_FOUND           - TRUE if both the library and header were found
+#   WinDivert_INCLUDE_DIR     - Directory containing windivert.h
+#   WinDivert_INCLUDE_DIRS    - Same as above (for compatibility with other modules)
+#   WinDivert_LIBRARY         - Path to WinDivert.lib
+#   WinDivert_LIBRARIES       - Same as above (for compatibility with target_link_libraries)
+#   WinDivert_SYS_FILE        - (Optional) Path to the WinDivertXX.sys driver file
+#   WinDivert_DLL_FILE        - (Optional) Path to WinDivert.dll (for dynamic linking or redistribution)
+#
+# You can provide a hint to the search location using either:
+#   - The CMake variable WinDivert_ROOT
+#   - The environment variable WinDivert_ROOT
+#
+# Expected directory structure:
+#
+#   WinDivert/
+#   ├── include/
+#   │   └── windivert.h
+#   ├── x64/
+#   │   ├── WinDivert.lib
+#   │   ├── WinDivert.dll
+#   │   └── WinDivert64.sys
+#   └── x86/
+#       ├── WinDivert.lib
+#       ├── WinDivert.dll
+#       └── WinDivert32.sys
+
+if(NOT WIN32)
+  if(NOT WinDivert_FIND_QUIETLY)
+    message(FATAL_ERROR "WinDivert is only available on Windows")
+  endif()
+  return()
+endif()
+
+# Detect 64-bit vs 32-bit
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(_WinDivert_ARCH_DIR "x64")
+  set(_WinDivert_SYS_NAME "WinDivert64.sys")
+else()
+  set(_WinDivert_ARCH_DIR "x86")
+  set(_WinDivert_SYS_NAME "WinDivert32.sys")
+endif()
+
+# Normalize user-provided root path
+if(DEFINED WinDivert_ROOT)
+  file(TO_CMAKE_PATH "${WinDivert_ROOT}" _WinDivert_ROOT_HINT)
+elseif(DEFINED ENV{WinDivert_ROOT})
+  file(TO_CMAKE_PATH "$ENV{WinDivert_ROOT}" _WinDivert_ROOT_HINT)
+else()
+  set(_WinDivert_ROOT_HINT "")
+endif()
+
+if(NOT WinDivert_FIND_QUIETLY)
+  message(STATUS "WinDivert root hint: ${_WinDivert_ROOT_HINT}")
+  message(STATUS "Looking in arch dir: ${_WinDivert_ARCH_DIR}")
+endif()
+
+# Look for header
+find_path(
+  WinDivert_INCLUDE_DIR
+  NAMES windivert.h
+  PATHS "${_WinDivert_ROOT_HINT}" "C:/Program Files/WinDivert" "C:/WinDivert"
+  PATH_SUFFIXES include
+)
+
+# Look for library
+find_library(
+  WinDivert_LIBRARY
+  NAMES WinDivert
+  PATHS "${_WinDivert_ROOT_HINT}" "C:/Program Files/WinDivert" "C:/WinDivert"
+  PATH_SUFFIXES ${_WinDivert_ARCH_DIR}
+)
+
+# Look for .sys file (optional)
+find_file(
+  WinDivert_SYS
+  NAMES ${_WinDivert_SYS_NAME}
+  PATHS "${_WinDivert_ROOT_HINT}" "C:/Program Files/WinDivert" "C:/WinDivert"
+  PATH_SUFFIXES ${_WinDivert_ARCH_DIR}
+)
+
+# Look for .dll file (optional)
+find_file(
+  WinDivert_DLL
+  NAMES WinDivert.dll
+  PATHS "${_WinDivert_ROOT_HINT}" "C:/Program Files/WinDivert" "C:/WinDivert"
+  PATH_SUFFIXES ${_WinDivert_ARCH_DIR}
+)
+
+# Handle REQUIRED + FOUND logic
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WinDivert REQUIRED_VARS WinDivert_INCLUDE_DIR WinDivert_LIBRARY)
+
+# Print results if not quiet
+if(NOT WinDivert_FIND_QUIETLY)
+  message(STATUS "WinDivert_INCLUDE_DIR: ${WinDivert_INCLUDE_DIR}")
+  message(STATUS "WinDivert_LIBRARY: ${WinDivert_LIBRARY}")
+  message(STATUS "WinDivert_SYS: ${WinDivert_SYS}")
+  message(STATUS "WinDivert_DLL: ${WinDivert_DLL}")
+endif()
+
+# Compatibility variables (set AFTER discovery)
+set(WinDivert_INCLUDE_DIRS ${WinDivert_INCLUDE_DIR})
+set(WinDivert_LIBRARIES ${WinDivert_LIBRARY})
+set(WinDivert_SYS_FILE ${WinDivert_SYS})
+set(WinDivert_DLL_FILE ${WinDivert_DLL})
+
+# Create imported target
+if(WinDivert_FOUND AND NOT TARGET WinDivert::WinDivert)
+  add_library(WinDivert::WinDivert STATIC IMPORTED)
+  set_target_properties(
+    WinDivert::WinDivert
+    PROPERTIES IMPORTED_LOCATION "${WinDivert_LIBRARY}" INTERFACE_INCLUDE_DIRECTORIES "${WinDivert_INCLUDE_DIR}"
+  )
+endif()


### PR DESCRIPTION
## Summary
This PR intended to improve the encapsulation and clarity of Layer field data. As per the C++ core guidelines `protected` data fields are generally undesired as they represent difficulty in maintaining base class invariants across derived classes.

The main object of this PR is the introduction of a new helper struct `LayerAllocationInfo` in the internal namespace, to hold allocation information for Layer objects and provide behavior helper methods. The helper structure replaces is contained as a field in a `Layer` to represent its current allocation state.

### `LayerAllocationInfo` and chosen fields.
The information structure contains 2 members:
- `Packet* attachedPacket`, replacing `m_Packet` pointer inside `Layer`.
- `bool managedByPacket`, replacing `m_isAllocatedInPacket` flag inside `Layer`.

The replacements were chosen due to their relevancy to the allocation behaviour of `Layer` and little else. Those fields were previously intermixed with other fields in the `Layer` object causing confusion when determining their use and scope.

- `attachedPacket` (previously `m_Packet`) is exclusively used for indication if the layer's data is owned by a packet and to forward requests for structural data changes to the underlying packet buffer, if available. The new name was chosen to better represent that use.
- `managedByPacket` (previously `m_IsAllocatedInPacket`) is exclusively used as flag to determine if the `Layer` object's lifecycle is managed by the `Packet` instance it is attached to. The field intricately tied to the state of `attachedPacket` and as such is included to the helper structure.

The new fields include extensive documentation regarding their use, improving the maintainability of the code. ( Think about the you in 5 months reading it 🙂 )

### Behaviour methods instead of direct field mutation
The new helper structure adds two behavior methods:
- `attachPacket(Packet* packet, bool managed, bool force = false)`: This method encapsulates the behavior of attaching a layer to a Packet instance. It allows a `Packet` instance attaching a `Layer` to itself to update the information in one step instead of manually having to directly update `private` fields to the `Layer` instance. The method also provides integrated sanity checks if a `Layer` is being attached to a `Packet` instance twice.
- `detach()`: Encapsulates the behaviour of detaching a `Layer` from `Packet`. It allows a `Packet` instance detaching a `Layer` to inform it of its new state in one step.

### Protected data accessors and private fields
The new `LayerAllocationInfo` structure is held as a private field inside `Layer`. The change improves data integrity as the allocation information (packet or managed flag) is unavailable for accidental modification by derived classes.

To keep existing behaviour of a `Layer` instance forwarding its attachment to any other instance it constructs during parsing, a new protected accessor `getAttachedPacket()` has been added and instances of direct use of `m_Packet` are replaced by it.

### Bug Fixes
- Fixed bug due to lack of zeroing of `m_IsAllocatedInPacket` flag when detaching a layer. If said layer is attached to a new packet instance, the old implementation disregarded the ownership flag and considered the layer instance as owned by the packet, due to the layer flag being set from the previous packet.