### PR TITLE
Specify queue id as a configuration parameter

### DIFF
--- a/Pcap++/header/XdpDevice.h
+++ b/Pcap++/header/XdpDevice.h
@@ -11,8 +11,6 @@
 /// @
 namespace pcpp
 {
-#define XDP_MAX_RXTX_QUEUES 16
-
 	/// @class XdpDevice
 	/// A class wrapping the main functionality of using AF_XDP (XSK) sockets
 	/// which are optimized for high performance packet processing.
@@ -268,7 +266,7 @@ namespace pcpp
 		/// @param[in] interfaceName The interface name to use to detect hardware queues
 		/// @param[in] tx  If true, return TX queues, otherwise RX. Default is false
 		/// @return The number of hardware queues associated with the device.
-		static uint32_t numQueues(const std::string& interfaceName, bool tx = false);
+		static uint32_t numOfHardwareQueues(const std::string& interfaceName, bool tx = false);
 
 	private:
 		class XdpUmem

--- a/Pcap++/header/XdpDevice.h
+++ b/Pcap++/header/XdpDevice.h
@@ -102,7 +102,8 @@ namespace pcpp
 			explicit XdpDeviceConfiguration(AttachMode attachMode = AutoMode, uint16_t umemNumFrames = 0,
 			                                uint16_t umemFrameSize = 0, uint32_t fillRingSize = 0,
 			                                uint32_t completionRingSize = 0, uint32_t rxSize = 0, uint32_t txSize = 0,
-			                                uint16_t rxTxBatchSize = 0, uint16_t frameHeadroomSize = 0, uint32_t queueId = 0)
+			                                uint16_t rxTxBatchSize = 0, uint16_t frameHeadroomSize = 0,
+			                                uint32_t queueId = 0)
 			{
 				this->attachMode = attachMode;
 				this->umemNumFrames = umemNumFrames;
@@ -255,10 +256,9 @@ namespace pcpp
 		/// @return Return queue identifier for underlying socket
 		uint32_t getQueueId() const
 		{
-			if(m_Config)
+			if (m_Config)
 			{
 				return m_Config->queueId;
-
 			}
 
 			return 0;

--- a/Pcap++/header/XdpDevice.h
+++ b/Pcap++/header/XdpDevice.h
@@ -259,6 +259,7 @@ namespace pcpp
 		}
 
 		/// Get number of RX or TX hardware queues for device
+		/// @param[in] interfaceName The interface name to use to detect hardware queues
 		/// @param[in] tx  If true, return TX queues, otherwise RX. Default is false
 		/// @return The number of hardware queues associated with the device. 
 		static uint32_t getNumQueues(const std::string& iface, bool tx = false);

--- a/Pcap++/header/XdpDevice.h
+++ b/Pcap++/header/XdpDevice.h
@@ -262,7 +262,7 @@ namespace pcpp
 		/// @param[in] interfaceName The interface name to use to detect hardware queues
 		/// @param[in] tx  If true, return TX queues, otherwise RX. Default is false
 		/// @return The number of hardware queues associated with the device. 
-		static uint32_t getNumQueues(const std::string& iface, bool tx = false);
+		static uint32_t getNumQueues(const std::string& interfaceName, bool tx = false);
 
 	private:
 		class XdpUmem

--- a/Pcap++/header/XdpDevice.h
+++ b/Pcap++/header/XdpDevice.h
@@ -78,6 +78,10 @@ namespace pcpp
 			/// The max number of packets to be received or sent in one batch
 			uint16_t rxTxBatchSize;
 
+			/// This parameter specifies the amount of space designated for prepending data to the packet in the frame.
+			/// NOTE: the headroom size should be less than the frame size
+			uint16_t frameHeadroomSize;
+
 			/// The queue identifier for the underlying socket. This value should be less than the number
 			/// of hardware queues supported by the device
 			uint16_t queueId;
@@ -93,15 +97,17 @@ namespace pcpp
 			/// @param[in] txSize The size of the TX ring used by the AF_XDP socket. The default value is 2048
 			/// @param[in] rxTxBatchSize The max number of packets to be received or sent in one batch. The default
 			/// value is 64
+			/// @param[in] frameHeadroomSize Space for prepending to packets. The default value is 0
 			/// @param[in] queueId The hardware queue id of the underlying socket. The default value is 0
 			explicit XdpDeviceConfiguration(AttachMode attachMode = AutoMode, uint16_t umemNumFrames = 0,
 			                                uint16_t umemFrameSize = 0, uint32_t fillRingSize = 0,
 			                                uint32_t completionRingSize = 0, uint32_t rxSize = 0, uint32_t txSize = 0,
-			                                uint16_t rxTxBatchSize = 0, uint32_t queueId = 0)
+			                                uint16_t rxTxBatchSize = 0, uint16_t frameHeadroomSize = 0, uint32_t queueId = 0)
 			{
 				this->attachMode = attachMode;
 				this->umemNumFrames = umemNumFrames;
 				this->umemFrameSize = umemFrameSize;
+				this->frameHeadroomSize = frameHeadroomSize;
 				this->fillRingSize = fillRingSize;
 				this->completionRingSize = completionRingSize;
 				this->rxSize = rxSize;
@@ -268,7 +274,7 @@ namespace pcpp
 		class XdpUmem
 		{
 		public:
-			explicit XdpUmem(uint16_t numFrames, uint16_t frameSize, uint32_t fillRingSize,
+			explicit XdpUmem(uint16_t numFrames, uint16_t frameSize, uint16_t frameHeadroomSize, uint32_t fillRingSize,
 			                 uint32_t completionRingSize);
 
 			virtual ~XdpUmem();

--- a/Pcap++/header/XdpDevice.h
+++ b/Pcap++/header/XdpDevice.h
@@ -249,10 +249,19 @@ namespace pcpp
 		/// @return Return queue identifier for underlying socket
 		uint32_t getQueueId()
 		{
-			if(m_Config) return m_Config->queueId;
+			if(m_Config) 
+			{
+				return m_Config->queueId;
+
+			}
 
 			return 0;
 		}
+
+		/// Get number of RX or TX hardware queues for device
+		/// @param[in] tx  If true, return TX queues, otherwise RX. Default is false
+		/// @return The number of hardware queues associated with the device. 
+		static uint32_t getNumQueues(const std::string& iface, bool tx = false);
 
 	private:
 		class XdpUmem
@@ -328,7 +337,5 @@ namespace pcpp
 		bool initUmem();
 		bool populateConfigDefaults(XdpDeviceConfiguration& config) const;
 		bool getSocketStats();
-		
-		uint32_t getNumQueues(const std::string& iface) const;
 	};
 }  // namespace pcpp

--- a/Pcap++/header/XdpDevice.h
+++ b/Pcap++/header/XdpDevice.h
@@ -249,7 +249,7 @@ namespace pcpp
 		/// @return Return queue identifier for underlying socket
 		uint32_t getQueueId()
 		{
-			if(m_Config) 
+			if(m_Config)
 			{
 				return m_Config->queueId;
 
@@ -261,7 +261,7 @@ namespace pcpp
 		/// Get number of RX or TX hardware queues for device
 		/// @param[in] interfaceName The interface name to use to detect hardware queues
 		/// @param[in] tx  If true, return TX queues, otherwise RX. Default is false
-		/// @return The number of hardware queues associated with the device. 
+		/// @return The number of hardware queues associated with the device.
 		static uint32_t getNumQueues(const std::string& interfaceName, bool tx = false);
 
 	private:

--- a/Pcap++/header/XdpDevice.h
+++ b/Pcap++/header/XdpDevice.h
@@ -247,7 +247,7 @@ namespace pcpp
 		XdpDeviceStats getStatistics();
 
 		/// @return Return queue identifier for underlying socket
-		uint32_t getQueueId()
+		uint32_t getQueueId() const
 		{
 			if(m_Config)
 			{
@@ -262,7 +262,7 @@ namespace pcpp
 		/// @param[in] interfaceName The interface name to use to detect hardware queues
 		/// @param[in] tx  If true, return TX queues, otherwise RX. Default is false
 		/// @return The number of hardware queues associated with the device.
-		static uint32_t getNumQueues(const std::string& interfaceName, bool tx = false);
+		static uint32_t numQueues(const std::string& interfaceName, bool tx = false);
 
 	private:
 		class XdpUmem

--- a/Pcap++/src/XdpDevice.cpp
+++ b/Pcap++/src/XdpDevice.cpp
@@ -405,8 +405,8 @@ namespace pcpp
 		auto umemInfo = static_cast<xsk_umem_info*>(m_Umem->getInfo());
 
 		struct xsk_socket_config xskConfig;
-		xskConfig.rx_size = m_Config->txSize;
-		xskConfig.tx_size = m_Config->rxSize;
+		xskConfig.rx_size = m_Config->rxSize;
+		xskConfig.tx_size = m_Config->txSize;
 		xskConfig.libbpf_flags = 0;
 		xskConfig.xdp_flags = 0;
 		xskConfig.bind_flags = 0;
@@ -431,7 +431,7 @@ namespace pcpp
 		}
 
 		m_SocketInfo = socketInfo;
-		
+
 		return true;
 	}
 

--- a/Pcap++/src/XdpDevice.cpp
+++ b/Pcap++/src/XdpDevice.cpp
@@ -38,6 +38,7 @@ namespace pcpp
 #define DEFAULT_FILL_RING_SIZE (XSK_RING_PROD__DEFAULT_NUM_DESCS * 2)
 #define DEFAULT_COMPLETION_RING_SIZE XSK_RING_PROD__DEFAULT_NUM_DESCS
 #define DEFAULT_BATCH_SIZE 64
+#define DEFAULT_NUM_QUEUES 1
 #define DEFAULT_FRAME_HEADROOM_SIZE XSK_UMEM__DEFAULT_FRAME_HEADROOM
 #define IS_POWER_OF_TWO(num) (num && ((num & (num - 1)) == 0))
 
@@ -511,7 +512,7 @@ namespace pcpp
 			return false;
 		}
 
-		unsigned int nhwqueues = numQueues(m_InterfaceName);
+		unsigned int nhwqueues = numOfHardwareQueues(m_InterfaceName);
 		if (qId >= nhwqueues)
 		{
 			PCPP_LOG_ERROR("Queue Id (" << qId << ") must be less than the number hardware queues (" << nhwqueues
@@ -658,10 +659,10 @@ namespace pcpp
 		return m_Stats;
 	}
 
-	uint32_t XdpDevice::numQueues(const std::string& iface, bool tx)
+	uint32_t XdpDevice::numOfHardwareQueues(const std::string& iface, bool tx)
 	{
 		// returns number of hardware queues associated with the device
-		uint32_t rxtxqueues = 0;
+		uint32_t rxtxqueues = DEFAULT_NUM_QUEUES;
 		std::string prefix = tx ? "tx-" : "rx-";
 		std::string path = "/sys/class/net/" + iface + "/queues/";
 		DIR* dir = opendir(path.c_str());

--- a/Pcap++/src/XdpDevice.cpp
+++ b/Pcap++/src/XdpDevice.cpp
@@ -419,7 +419,7 @@ namespace pcpp
 			xskConfig.xdp_flags = XDP_FLAGS_DRV_MODE;
 		}
 
-		int ret = xsk_socket__create(&socketInfo->xsk, m_InterfaceName.c_str(), 0, umemInfo->umem, &socketInfo->rx,
+		int ret = xsk_socket__create(&socketInfo->xsk, m_InterfaceName.c_str(), m_Config->queueId, umemInfo->umem, &socketInfo->rx,
 		                             &socketInfo->tx, &xskConfig);
 		if (ret)
 		{
@@ -429,6 +429,7 @@ namespace pcpp
 		}
 
 		m_SocketInfo = socketInfo;
+		
 		return true;
 	}
 
@@ -449,6 +450,7 @@ namespace pcpp
 		uint32_t rxSize = config.rxSize ? config.rxSize : XSK_RING_CONS__DEFAULT_NUM_DESCS;
 		uint32_t txSize = config.txSize ? config.txSize : XSK_RING_PROD__DEFAULT_NUM_DESCS;
 		uint32_t batchSize = config.rxTxBatchSize ? config.rxTxBatchSize : DEFAULT_BATCH_SIZE;
+		uint32_t qId = config.queueId; // default is zero
 
 		if (frameSize != getpagesize())
 		{
@@ -499,6 +501,12 @@ namespace pcpp
 			return false;
 		}
 
+		if (qId >= XDP_MAX_RXTX_QUEUES)
+		{
+			PCPP_LOG_ERROR("Queue Id " << qId << " must be lower than the maximum number of hardware queues");
+			return(false);
+		}
+
 		config.umemNumFrames = numFrames;
 		config.umemFrameSize = frameSize;
 		config.fillRingSize = fillRingSize;
@@ -506,6 +514,7 @@ namespace pcpp
 		config.rxSize = rxSize;
 		config.txSize = txSize;
 		config.rxTxBatchSize = batchSize;
+		config.queueId = qId;
 
 		return true;
 	}
@@ -635,5 +644,4 @@ namespace pcpp
 
 		return m_Stats;
 	}
-
 }  // namespace pcpp

--- a/Pcap++/src/XdpDevice.cpp
+++ b/Pcap++/src/XdpDevice.cpp
@@ -41,8 +41,8 @@ namespace pcpp
 #define DEFAULT_FRAME_HEADROOM_SIZE XSK_UMEM__DEFAULT_FRAME_HEADROOM
 #define IS_POWER_OF_TWO(num) (num && ((num & (num - 1)) == 0))
 
-	XdpDevice::XdpUmem::XdpUmem(uint16_t numFrames, uint16_t frameSize, uint16_t frameHeadroomSize, uint32_t fillRingSize,
-	                            uint32_t completionRingSize)
+	XdpDevice::XdpUmem::XdpUmem(uint16_t numFrames, uint16_t frameSize, uint16_t frameHeadroomSize,
+	                            uint32_t fillRingSize, uint32_t completionRingSize)
 	{
 		size_t bufferSize = numFrames * frameSize;
 
@@ -422,8 +422,8 @@ namespace pcpp
 			xskConfig.xdp_flags = XDP_FLAGS_DRV_MODE;
 		}
 
-		int ret = xsk_socket__create(&socketInfo->xsk, m_InterfaceName.c_str(), m_Config->queueId, umemInfo->umem, &socketInfo->rx,
-		                             &socketInfo->tx, &xskConfig);
+		int ret = xsk_socket__create(&socketInfo->xsk, m_InterfaceName.c_str(), m_Config->queueId, umemInfo->umem,
+		                             &socketInfo->rx, &socketInfo->tx, &xskConfig);
 		if (ret)
 		{
 			PCPP_LOG_ERROR("xsk_socket__create returned an error: " << ret);
@@ -438,8 +438,8 @@ namespace pcpp
 
 	bool XdpDevice::initUmem()
 	{
-		m_Umem = new XdpUmem(m_Config->umemNumFrames, m_Config->umemFrameSize, m_Config->frameHeadroomSize, m_Config->fillRingSize,
-		                     m_Config->completionRingSize);
+		m_Umem = new XdpUmem(m_Config->umemNumFrames, m_Config->umemFrameSize, m_Config->frameHeadroomSize,
+		                     m_Config->fillRingSize, m_Config->completionRingSize);
 		return true;
 	}
 
@@ -454,7 +454,7 @@ namespace pcpp
 		uint32_t rxSize = config.rxSize ? config.rxSize : XSK_RING_CONS__DEFAULT_NUM_DESCS;
 		uint32_t txSize = config.txSize ? config.txSize : XSK_RING_PROD__DEFAULT_NUM_DESCS;
 		uint32_t batchSize = config.rxTxBatchSize ? config.rxTxBatchSize : DEFAULT_BATCH_SIZE;
-		uint32_t qId = config.queueId; // default is zero
+		uint32_t qId = config.queueId;  // default is zero
 
 		if (frameSize != getpagesize())
 		{
@@ -469,7 +469,7 @@ namespace pcpp
 			return false;
 		}
 
-		if(frameHeadroomSize > frameSize)
+		if (frameHeadroomSize > frameSize)
 		{
 			PCPP_LOG_ERROR("Frame headroom size must be less than the frame size");
 			return false;
@@ -514,7 +514,8 @@ namespace pcpp
 		unsigned int nhwqueues = numQueues(m_InterfaceName);
 		if (qId >= nhwqueues)
 		{
-			PCPP_LOG_ERROR("Queue Id (" << qId << ") must be less than the number hardware queues (" << nhwqueues << ") of device");
+			PCPP_LOG_ERROR("Queue Id (" << qId << ") must be less than the number hardware queues (" << nhwqueues
+			                            << ") of device");
 			return false;
 		}
 
@@ -663,16 +664,16 @@ namespace pcpp
 		uint32_t rxtxqueues = 0;
 		std::string prefix = tx ? "tx-" : "rx-";
 		std::string path = "/sys/class/net/" + iface + "/queues/";
-		DIR *dir = opendir(path.c_str());
+		DIR* dir = opendir(path.c_str());
 
-		if(dir)
+		if (dir)
 		{
 			std::regex rxtx_regex("^" + prefix + "[0-9]+$");
 
 			struct dirent* entry;
-			while((entry = readdir(dir)) != nullptr)
+			while ((entry = readdir(dir)) != nullptr)
 			{
-				if(std::regex_match(entry->d_name, rxtx_regex))
+				if (std::regex_match(entry->d_name, rxtx_regex))
 				{
 					rxtxqueues++;
 				}

--- a/Pcap++/src/XdpDevice.cpp
+++ b/Pcap++/src/XdpDevice.cpp
@@ -503,7 +503,7 @@ namespace pcpp
 			return false;
 		}
 
-		unsigned int nhwqueues = getNumQueues(m_InterfaceName);
+		unsigned int nhwqueues = numQueues(m_InterfaceName);
 		if (qId >= nhwqueues)
 		{
 			PCPP_LOG_ERROR("Queue Id (" << qId << ") must be less than the number hardware queues (" << nhwqueues << ") of device");
@@ -648,7 +648,7 @@ namespace pcpp
 		return m_Stats;
 	}
 
-	uint32_t XdpDevice::getNumQueues(const std::string& iface, bool tx)
+	uint32_t XdpDevice::numQueues(const std::string& iface, bool tx)
 	{
 		// returns number of hardware queues associated with the device
 		uint32_t rxtxqueues = 0;

--- a/Pcap++/src/XdpDevice.cpp
+++ b/Pcap++/src/XdpDevice.cpp
@@ -38,9 +38,10 @@ namespace pcpp
 #define DEFAULT_FILL_RING_SIZE (XSK_RING_PROD__DEFAULT_NUM_DESCS * 2)
 #define DEFAULT_COMPLETION_RING_SIZE XSK_RING_PROD__DEFAULT_NUM_DESCS
 #define DEFAULT_BATCH_SIZE 64
+#define DEFAULT_FRAME_HEADROOM_SIZE XSK_UMEM__DEFAULT_FRAME_HEADROOM
 #define IS_POWER_OF_TWO(num) (num && ((num & (num - 1)) == 0))
 
-	XdpDevice::XdpUmem::XdpUmem(uint16_t numFrames, uint16_t frameSize, uint32_t fillRingSize,
+	XdpDevice::XdpUmem::XdpUmem(uint16_t numFrames, uint16_t frameSize, uint16_t frameHeadroomSize, uint32_t fillRingSize,
 	                            uint32_t completionRingSize)
 	{
 		size_t bufferSize = numFrames * frameSize;
@@ -53,7 +54,7 @@ namespace pcpp
 		struct xsk_umem_config cfg = { .fill_size = fillRingSize,
 			                           .comp_size = completionRingSize,
 			                           .frame_size = frameSize,
-			                           .frame_headroom = XSK_UMEM__DEFAULT_FRAME_HEADROOM,
+			                           .frame_headroom = frameHeadroomSize,
 			                           .flags = 0 };
 
 		struct xsk_umem_info* umem = new xsk_umem_info;
@@ -437,7 +438,7 @@ namespace pcpp
 
 	bool XdpDevice::initUmem()
 	{
-		m_Umem = new XdpUmem(m_Config->umemNumFrames, m_Config->umemFrameSize, m_Config->fillRingSize,
+		m_Umem = new XdpUmem(m_Config->umemNumFrames, m_Config->umemFrameSize, m_Config->frameHeadroomSize, m_Config->fillRingSize,
 		                     m_Config->completionRingSize);
 		return true;
 	}
@@ -446,6 +447,7 @@ namespace pcpp
 	{
 		uint16_t numFrames = config.umemNumFrames ? config.umemNumFrames : DEFAULT_UMEM_NUM_FRAMES;
 		uint16_t frameSize = config.umemFrameSize ? config.umemFrameSize : getpagesize();
+		uint16_t frameHeadroomSize = config.frameHeadroomSize ? config.frameHeadroomSize : DEFAULT_FRAME_HEADROOM_SIZE;
 		uint32_t fillRingSize = config.fillRingSize ? config.fillRingSize : DEFAULT_FILL_RING_SIZE;
 		uint32_t completionRingSize =
 		    config.completionRingSize ? config.completionRingSize : DEFAULT_COMPLETION_RING_SIZE;
@@ -464,6 +466,12 @@ namespace pcpp
 		      IS_POWER_OF_TWO(txSize)))
 		{
 			PCPP_LOG_ERROR("All ring sizes (fill ring, completion ring, rx ring, tx ring) should be a power of two");
+			return false;
+		}
+
+		if(frameHeadroomSize > frameSize)
+		{
+			PCPP_LOG_ERROR("Frame headroom size must be less than the frame size");
 			return false;
 		}
 
@@ -512,6 +520,7 @@ namespace pcpp
 
 		config.umemNumFrames = numFrames;
 		config.umemFrameSize = frameSize;
+		config.frameHeadroomSize = frameHeadroomSize;
 		config.fillRingSize = fillRingSize;
 		config.completionRingSize = completionRingSize;
 		config.rxSize = rxSize;

--- a/Pcap++/src/XdpDevice.cpp
+++ b/Pcap++/src/XdpDevice.cpp
@@ -503,12 +503,6 @@ namespace pcpp
 			return false;
 		}
 
-		if (qId >= XDP_MAX_RXTX_QUEUES)
-		{
-			PCPP_LOG_ERROR("Queue Id " << qId << " must be lower than the maximum number of hardware queues");
-			return(false);
-		}
-
 		unsigned int nhwqueues = getNumQueues(m_InterfaceName);
 		if (qId >= nhwqueues)
 		{


### PR DESCRIPTION
The queue id can be specified as an additional configuration parameter. It is checked against the maximum queues available by the device using a utility provided as a static function. In the open() function, the configured queue id is used in place of the hardwired zero value that was used before. Added a convenience function to obtain the queue id from device. 

Community may consider renaming the XdpDevice to XdpSocketDevice as each instance of the XdpDevice class pertains to a single queue id / socket. 