### PR TITLE
Suppress checkers report as it floods local runs.

### DIFF
--- a/cppcheckSuppressions.txt
+++ b/cppcheckSuppressions.txt
@@ -1,5 +1,6 @@
 *:3rdParty/*
 
+checkersReport:*
 ConfigurationNotChecked:*
 ctuOneDefinitionRuleViolation:Examples/*
 missingInclude:*


### PR DESCRIPTION
This PR suppresses the checkers report log of cppcheck as it floods the pre-commit log on local runs when running on newer cppcheck versions.