### PR TITLE
Remove EndianPortable dependency on winsock2 as it isn't used.

### DIFF
--- a/3rdParty/EndianPortable/include/EndianPortable.h
+++ b/3rdParty/EndianPortable/include/EndianPortable.h
@@ -64,8 +64,9 @@
 #elif defined __CYGWIN__
  #include <endian.h>
 #elif defined(_WIN32) && !defined(_MSC_VER)
-  // MinGW32
- #include <winsock2.h>
+// MinGW32
+// TODO: Windows does not actually provide BYTE_ORDER...
+// This works because both are undefined, and Windows is predominantly little-endian.
  #if(BYTE_ORDER == LITTLE_ENDIAN)
   #define htobe16(x) __builtin_bswap16(x)
   #define htole16(x) (x)
@@ -99,7 +100,8 @@
  #endif
 #elif defined(_WIN32) && defined(_MSC_VER)
 // Visual Studio
- #include <winsock2.h>
+// TODO: Windows does not actually provide BYTE_ORDER...
+// This works because both are undefined, and Windows is predominantly little-endian.
  #if(BYTE_ORDER == LITTLE_ENDIAN)
   #define htobe16(x) _byteswap_ushort(x)
   #define htole16(x) (x)

--- a/Common++/src/SystemUtils.cpp
+++ b/Common++/src/SystemUtils.cpp
@@ -19,14 +19,11 @@
 #endif
 
 #if defined(_WIN32)
+#	include <Windows.h>
 #	define POPEN _popen
-#else
-#	define POPEN popen
-#endif
-
-#if defined(_WIN32)
 #	define PCLOSE _pclose
 #else
+#	define POPEN popen
 #	define PCLOSE pclose
 #endif
 


### PR DESCRIPTION
The code previously used winsock2's `htohs` and `ntohl` defined in winsock2.h but those were removed in 64d727a91b0e019b55dd6c8d0ade64e6bca5a0ad. The `winsock2.h` include is therefor unnecessary and only pollutes every downstream header with a transitive `Windows.h` include.

Further note: Windows does not actually have BYTE_ORDER defined, so that comparison mostly works because both BYTE_ORDER and LITTLE_ENDIAN are undefined and replaced with "0" for the `if` expression. The code works primarily because it has the little endian as first condition and the vast majority of windows systems are in-fact little endian.