### PR TITLE
Deduplication of pcap header read procedures.

### DIFF
--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -310,40 +310,6 @@ namespace pcpp
 		bool m_NeedsSwap = false;
 		FileTimestampPrecision m_Precision = FileTimestampPrecision::Unknown;
 		std::fstream m_PcapFile;
-
-		struct CheckHeaderResult
-		{
-			enum class Result
-			{
-				HeaderOk,
-				HeaderError,
-				HeaderNeeded
-			};
-
-			Result result;
-			std::string error;
-			bool needsSwap = false;
-
-			static CheckHeaderResult fromOk(bool needsSwap)
-			{
-				return { Result::HeaderOk, "", needsSwap };
-			}
-
-			static CheckHeaderResult fromError(const std::string& error)
-			{
-				return { Result::HeaderError, error };
-			}
-
-			static CheckHeaderResult fromHeaderNeeded()
-			{
-				return { Result::HeaderNeeded };
-			}
-		};
-
-		static bool writeHeader(std::fstream& pcapFile, FileTimestampPrecision precision, uint32_t snaplen,
-		                        LinkLayerType linkType);
-		static CheckHeaderResult checkHeader(std::fstream& pcapFile, FileTimestampPrecision requestedPrecision,
-		                                     LinkLayerType requestedLinkType);
 	};
 
 	/// @class PcapNgFileReaderDevice

--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -306,6 +306,9 @@ namespace pcpp
 		void flush();
 
 	private:
+		static bool writeHeader(std::ostream& outStream, FileTimestampPrecision precision, uint32_t snaplen,
+		                        LinkLayerType linkType);
+
 		LinkLayerType m_PcapLinkLayerType = LINKTYPE_ETHERNET;
 		bool m_NeedsSwap = false;
 		FileTimestampPrecision m_Precision = FileTimestampPrecision::Unknown;

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -281,15 +281,123 @@ namespace pcpp
 	// PcapFileReaderDevice members
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-	static uint16_t swap16(uint16_t value)
+	namespace
 	{
-		return static_cast<uint16_t>((value >> 8) | (value << 8));
-	}
+		uint16_t swap16(uint16_t value)
+		{
+			return static_cast<uint16_t>((value >> 8) | (value << 8));
+		}
 
-	static uint32_t swap32(uint32_t value)
-	{
-		return (value >> 24) | ((value >> 8) & 0x0000FF00) | ((value << 8) & 0x00FF0000) | (value << 24);
-	}
+		uint32_t swap32(uint32_t value)
+		{
+			return (value >> 24) | ((value >> 8) & 0x0000FF00) | ((value << 8) & 0x00FF0000) | (value << 24);
+		}
+
+		enum class PcapReadHeaderStatus
+		{
+			Ok,
+			NoData,
+			MalformedData,
+			UnsupportedFormat
+		};
+
+		/// @brief Reads a pcap file header from the given input stream and fills the provided header structure,
+		/// timestamp precision, and byte swap flag.
+		///
+		/// The function will populate the file header structure and convert it to host byte order.
+		///
+		/// @param inStream The input stream to read from.
+		/// @param header A pcap_file_header structure that will be filled with the header data read from the stream.
+		/// @param precision The precision of the timestamps in the pcap file.
+		/// @param needsSwap If the file contents need to be byte-swapped to match the host's endianness.
+		/// @return The status of the reading operation.
+		PcapReadHeaderStatus readPcapHeader(std::istream& inStream, pcap_file_header& header,
+		                                    FileTimestampPrecision& precision, bool& needsSwap)
+		{
+			inStream.read(reinterpret_cast<char*>(&header), sizeof(header));
+
+			auto readBytes = inStream.gcount();
+
+			// Clear any error flags that may have been set by read() to allow further operations on the stream
+			inStream.clear();
+			if (readBytes == 0)
+			{
+				return PcapReadHeaderStatus::NoData;
+			}
+			else if (readBytes < static_cast<std::streamsize>(sizeof(header)))
+			{
+				return PcapReadHeaderStatus::MalformedData;
+			}
+
+			switch (header.magic)
+			{
+			case TCPDUMP_MAGIC:
+			{
+				precision = FileTimestampPrecision::Microseconds;
+				needsSwap = false;
+				break;
+			}
+			case TCPDUMP_MAGIC_SWAPPED:
+			{
+				precision = FileTimestampPrecision::Microseconds;
+				needsSwap = true;
+				break;
+			}
+			case NSEC_TCPDUMP_MAGIC:
+			{
+				precision = FileTimestampPrecision::Nanoseconds;
+				needsSwap = false;
+				break;
+			}
+			case NSEC_TCPDUMP_MAGIC_SWAPPED:
+			{
+				needsSwap = true;
+				precision = FileTimestampPrecision::Nanoseconds;
+				break;
+			}
+			default:
+			{
+				return PcapReadHeaderStatus::UnsupportedFormat;
+			}
+			}
+
+			if (needsSwap)
+			{
+				header.magic = swap32(header.magic);
+				header.version_major = swap16(header.version_major);
+				header.version_minor = swap16(header.version_minor);
+				header.thiszone = swap32(header.thiszone);
+				header.sigfigs = swap32(header.sigfigs);
+				header.snaplen = swap32(header.snaplen);
+				header.linktype = swap32(header.linktype);
+			}
+
+			return PcapReadHeaderStatus::Ok;
+		}
+
+		bool writePcapHeader(std::ostream& outStream, FileTimestampPrecision precision, uint32_t snaplen,
+		                     LinkLayerType linkType)
+		{
+			pcap_file_header header{ precision == FileTimestampPrecision::Microseconds ? TCPDUMP_MAGIC
+				                                                                       : NSEC_TCPDUMP_MAGIC,
+				                     PCAP_MAJOR_VERSION,
+				                     PCAP_MINOR_VERSION,
+				                     0,
+				                     0,
+				                     snaplen,
+				                     static_cast<uint32_t>(linkType) };
+
+			outStream.write(reinterpret_cast<const char*>(&header), sizeof(header));
+
+			if (!outStream.good())
+			{
+				PCPP_LOG_ERROR("Error writing pcap header");
+				return false;
+			}
+
+			return true;
+		}
+	}  // namespace
 
 	bool PcapFileReaderDevice::open()
 	{
@@ -310,53 +418,24 @@ namespace pcpp
 		}
 
 		pcap_file_header pcapFileHeader{};
-		if (!pcapFile.read(reinterpret_cast<char*>(&pcapFileHeader), sizeof(pcapFileHeader)))
+		auto status = readPcapHeader(pcapFile, pcapFileHeader, m_Precision, m_NeedsSwap);
+		switch (status)
+		{
+		case PcapReadHeaderStatus::Ok:
+			break;
+		case PcapReadHeaderStatus::NoData:
+		case PcapReadHeaderStatus::MalformedData:
 		{
 			PCPP_LOG_ERROR("Cannot read pcap file header");
 			return false;
 		}
-
-		switch (pcapFileHeader.magic)
-		{
-		case TCPDUMP_MAGIC:
-		{
-			m_Precision = FileTimestampPrecision::Microseconds;
-			break;
-		}
-
-		case TCPDUMP_MAGIC_SWAPPED:
-		{
-			m_NeedsSwap = true;
-			m_Precision = FileTimestampPrecision::Microseconds;
-			break;
-		}
-
-		case NSEC_TCPDUMP_MAGIC:
-		{
-			m_Precision = FileTimestampPrecision::Nanoseconds;
-			break;
-		}
-
-		case NSEC_TCPDUMP_MAGIC_SWAPPED:
-		{
-			m_NeedsSwap = true;
-			m_Precision = FileTimestampPrecision::Nanoseconds;
-			break;
-		}
-
-		default:
+		case PcapReadHeaderStatus::UnsupportedFormat:
 		{
 			PCPP_LOG_ERROR("Invalid magic number: 0x" << std::hex << pcapFileHeader.magic);
 			return false;
 		}
-		}
-
-		if (m_NeedsSwap)
-		{
-			pcapFileHeader.version_major = swap16(pcapFileHeader.version_major);
-			pcapFileHeader.version_minor = swap16(pcapFileHeader.version_minor);
-			pcapFileHeader.snaplen = swap32(pcapFileHeader.snaplen);
-			pcapFileHeader.linktype = swap32(pcapFileHeader.linktype);
+		default:
+			throw std::logic_error("Unhandled PcapReadHeaderStatus value");
 		}
 
 		if (pcapFileHeader.version_major != 2 && pcapFileHeader.version_major != 543)
@@ -552,21 +631,83 @@ namespace pcpp
 
 		if (appendMode)
 		{
-			auto checkHeaderResult = checkHeader(pcapFile, m_Precision, m_PcapLinkLayerType);
-
-			if (checkHeaderResult.result == CheckHeaderResult::Result::HeaderError)
+			// Using temporary to avoid modifying member variables in case of failure to read header
+			bool needsSwap = false;
+			FileTimestampPrecision precisionFromHeader;
+			pcap_file_header header;
+			auto status = readPcapHeader(pcapFile, header, precisionFromHeader, needsSwap);
+			switch (status)
 			{
-				PCPP_LOG_ERROR(checkHeaderResult.error);
+			case PcapReadHeaderStatus::Ok:
+			{
+				// We have a valid header
+				shouldWriteHeader = false;
+				break;
+			}
+			case PcapReadHeaderStatus::NoData:
+			{
+				// Empty file - preceed as if we are creating a new file
+				shouldWriteHeader = true;
+				break;
+			}
+			case PcapReadHeaderStatus::MalformedData:
+			{
+				PCPP_LOG_ERROR("Cannot read pcap file header. File may be malformed or not a pcap file");
 				return false;
 			}
+			case PcapReadHeaderStatus::UnsupportedFormat:
+			{
+				PCPP_LOG_ERROR("Cannot read pcap file header. Unsupported format or invalid magic number: 0x"
+				               << std::hex << header.magic);
+				return false;
+			}
+			default:
+				throw std::logic_error("Unexpected PcapReadHeaderStatus value");
+			}
 
-			m_NeedsSwap = checkHeaderResult.needsSwap;
-			shouldWriteHeader = checkHeaderResult.result == CheckHeaderResult::Result::HeaderNeeded;
+			m_NeedsSwap = needsSwap;
 
-			pcapFile.seekg(0, std::ios::end);
+			// If we have a header, validate that the file is compatible.
+			if (!shouldWriteHeader)
+			{
+				if (precisionFromHeader != m_Precision)
+				{
+					auto getPrecisionStr = [](const FileTimestampPrecision precision) -> std::string {
+						switch (precision)
+						{
+						case FileTimestampPrecision::Microseconds:
+							return "Microseconds";
+						case FileTimestampPrecision::Nanoseconds:
+							return "Nanoseconds";
+						default:
+							return "Unknown";
+						}
+					};
+
+					PCPP_LOG_ERROR("Existing file precision (" + getPrecisionStr(precisionFromHeader) +
+					               ") does not match the requested device precision (" + getPrecisionStr(m_Precision) +
+					               ")");
+					return false;
+				}
+
+				if (header.version_major != PCAP_MAJOR_VERSION || header.version_minor != PCAP_MINOR_VERSION)
+				{
+					PCPP_LOG_ERROR("Unsupported pcap file version");
+					return false;
+				}
+
+				if (header.linktype != static_cast<uint32_t>(m_PcapLinkLayerType))
+				{
+					PCPP_LOG_ERROR("Existing file link type does not match the requested device link type");
+					return false;
+				}
+
+				// Move the file pointer to the end of the file for appending new packets
+				pcapFile.seekg(0, std::ios::end);
+			}
 		}
 
-		if (shouldWriteHeader && !writeHeader(pcapFile, m_Precision, PCPP_MAX_PACKET_SIZE, m_PcapLinkLayerType))
+		if (shouldWriteHeader && !writePcapHeader(pcapFile, m_Precision, PCPP_MAX_PACKET_SIZE, m_PcapLinkLayerType))
 		{
 			return false;
 		}
@@ -668,129 +809,6 @@ namespace pcpp
 		}
 
 		m_PcapFile.close();
-	}
-
-	bool PcapFileWriterDevice::writeHeader(std::fstream& pcapFile, FileTimestampPrecision precision, uint32_t snaplen,
-	                                       LinkLayerType linkType)
-	{
-		pcap_file_header header{ precision == FileTimestampPrecision::Microseconds ? TCPDUMP_MAGIC : NSEC_TCPDUMP_MAGIC,
-			                     PCAP_MAJOR_VERSION,
-			                     PCAP_MINOR_VERSION,
-			                     0,
-			                     0,
-			                     snaplen,
-			                     static_cast<uint32_t>(linkType) };
-
-		pcapFile.write(reinterpret_cast<const char*>(&header), sizeof(header));
-
-		if (!pcapFile.good())
-		{
-			PCPP_LOG_ERROR("Error writing pcap header");
-			return false;
-		}
-
-		return true;
-	}
-
-	PcapFileWriterDevice::CheckHeaderResult PcapFileWriterDevice::checkHeader(std::fstream& pcapFile,
-	                                                                          FileTimestampPrecision requestedPrecision,
-	                                                                          LinkLayerType requestedLinkType)
-	{
-		if (!pcapFile.is_open())
-		{
-			return CheckHeaderResult::fromError("Pcap file isn't open");
-		}
-
-		pcapFile.seekg(0, std::ios::end);
-		std::streamsize size = pcapFile.tellg();
-
-		if (size == 0)
-		{
-			return CheckHeaderResult::fromHeaderNeeded();
-		}
-
-		if (size < static_cast<std::streamsize>(sizeof(pcap_file_header)))
-		{
-			return CheckHeaderResult::fromError("Malformed file header or not a pcap file");
-		}
-
-		pcapFile.seekg(0, std::ios::beg);
-
-		pcap_file_header pcapFileHeader{};
-		if (!pcapFile.read(reinterpret_cast<char*>(&pcapFileHeader), sizeof(pcapFileHeader)))
-		{
-			return CheckHeaderResult::fromError("Cannot read file header");
-		}
-
-		FileTimestampPrecision precisionFromHeader = FileTimestampPrecision::Microseconds;
-
-		bool needsSwap = false;
-		switch (pcapFileHeader.magic)
-		{
-		case TCPDUMP_MAGIC:
-		{
-			break;
-		}
-		case TCPDUMP_MAGIC_SWAPPED:
-		{
-			needsSwap = true;
-			break;
-		}
-		case NSEC_TCPDUMP_MAGIC:
-		{
-			precisionFromHeader = FileTimestampPrecision::Nanoseconds;
-			break;
-		}
-		case NSEC_TCPDUMP_MAGIC_SWAPPED:
-		{
-			needsSwap = true;
-			precisionFromHeader = FileTimestampPrecision::Nanoseconds;
-			break;
-		}
-		default:
-		{
-			return CheckHeaderResult::fromError("Unsupported pcap file format");
-		}
-		}
-
-		if (needsSwap)
-		{
-			pcapFileHeader.version_major = swap16(pcapFileHeader.version_major);
-			pcapFileHeader.version_minor = swap16(pcapFileHeader.version_minor);
-			pcapFileHeader.snaplen = swap32(pcapFileHeader.snaplen);
-			pcapFileHeader.linktype = swap32(pcapFileHeader.linktype);
-		}
-
-		if (precisionFromHeader != requestedPrecision)
-		{
-			auto getPrecisionStr = [](const FileTimestampPrecision precision) -> std::string {
-				switch (precision)
-				{
-				case FileTimestampPrecision::Microseconds:
-					return "Microseconds";
-				case FileTimestampPrecision::Nanoseconds:
-					return "Nanoseconds";
-				default:
-					return "Unknown";
-				}
-			};
-			return CheckHeaderResult::fromError("Existing file precision (" + getPrecisionStr(precisionFromHeader) +
-			                                    ") does not match the requested device precision (" +
-			                                    getPrecisionStr(requestedPrecision) + ")");
-		}
-
-		if (pcapFileHeader.version_major != PCAP_MAJOR_VERSION || pcapFileHeader.version_minor != PCAP_MINOR_VERSION)
-		{
-			return CheckHeaderResult::fromError("Unsupported pcap file version");
-		}
-
-		if (pcapFileHeader.linktype != static_cast<uint32_t>(requestedLinkType))
-		{
-			return CheckHeaderResult::fromError(
-			    "Existing file link type does not match the requested device link type");
-		}
-
-		return CheckHeaderResult::fromOk(needsSwap);
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -678,11 +678,11 @@ namespace pcpp
 				throw std::logic_error("Unexpected PcapReadHeaderStatus value");
 			}
 
-			m_NeedsSwap = needsSwap;
-
 			// If we have a header, validate that the file is compatible.
 			if (!shouldWriteHeader)
 			{
+				m_NeedsSwap = needsSwap;
+
 				if (precisionFromHeader != m_Precision)
 				{
 					PCPP_LOG_ERROR("Existing file precision (" + toString(precisionFromHeader) +

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -656,6 +656,7 @@ namespace pcpp
 			case PcapReadHeaderStatus::Ok:
 			{
 				// We have a valid header
+				PCPP_LOG_DEBUG("Read existing pcap header file.");
 				shouldWriteHeader = false;
 				break;
 			}
@@ -669,6 +670,7 @@ namespace pcpp
 					return false;
 				}
 
+				PCPP_LOG_DEBUG("File is empty. A new pcap header will be written.");
 				pcapFile.clear();  // Clear EOF or failbit state to allow writing
 				shouldWriteHeader = true;
 				break;

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -339,7 +339,7 @@ namespace pcpp
 			{
 				return PcapReadHeaderStatus::NoData;
 			}
-			else if (readBytes < static_cast<std::streamsize>(sizeof(header)))
+			if (readBytes < static_cast<std::streamsize>(sizeof(header)))
 			{
 				return PcapReadHeaderStatus::MalformedData;
 			}

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -337,9 +337,13 @@ namespace pcpp
 			inStream.seekg(pos);
 
 			auto remainingBytes = endPos - pos;
-			if(remainingBytes < static_cast<std::streamsize>(sizeof(header)))
+			if(remainingBytes == 0)
 			{
 				return PcapReadHeaderStatus::NoData;
+			}
+			else if (remainingBytes < static_cast<std::streamsize>(sizeof(header)))
+			{
+				return PcapReadHeaderStatus::MalformedData;
 			}
 
 			inStream.read(reinterpret_cast<char*>(&header), sizeof(header));

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -332,26 +332,9 @@ namespace pcpp
 		PcapReadHeaderStatus readPcapHeader(std::istream& inStream, pcap_file_header& header,
 		                                    FileTimestampPrecision& precision, bool& needsSwap)
 		{
-			auto pos = inStream.tellg();
-			auto endPos = inStream.seekg(0, std::ios::end).tellg();
-			inStream.seekg(pos);
-
-			auto remainingBytes = endPos - pos;
-			if(remainingBytes == 0)
-			{
-				return PcapReadHeaderStatus::NoData;
-			}
-			else if (remainingBytes < static_cast<std::streamsize>(sizeof(header)))
-			{
-				return PcapReadHeaderStatus::MalformedData;
-			}
-
 			inStream.read(reinterpret_cast<char*>(&header), sizeof(header));
 
 			auto readBytes = inStream.gcount();
-
-			// Clear any error flags that may have been set by read() to allow further operations on the stream
-			inStream.clear();
 			if (readBytes == 0)
 			{
 				return PcapReadHeaderStatus::NoData;
@@ -679,6 +662,14 @@ namespace pcpp
 			case PcapReadHeaderStatus::NoData:
 			{
 				// Empty file - proceed as if we are creating a new file
+				if(pcapFile.bad())
+				{
+					// badbit errors are generally unrecoverable.
+					PCPP_LOG_ERROR("Error reading pcap file.");
+					return false;
+				}
+
+				pcapFile.clear();  // Clear EOF or failbit state to allow writing
 				shouldWriteHeader = true;
 				break;
 			}

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -650,6 +650,10 @@ namespace pcpp
 			bool needsSwap = false;
 			FileTimestampPrecision precisionFromHeader;
 			pcap_file_header header;
+
+			// Position file pointer at the beginning of the file to read the header.
+			// Apparently there is no guarantee where the read file pointer will be initialized when opening in std::ios::app.
+			pcapFile.seekg(0, std::ios::beg);
 			auto status = readPcapHeader(pcapFile, header, precisionFromHeader, needsSwap);
 			switch (status)
 			{

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -43,6 +43,7 @@ namespace pcpp
 	constexpr uint16_t PCAP_MAJOR_VERSION = 2;
 	constexpr uint16_t PCAP_MINOR_VERSION = 4;
 
+#pragma pack(push, 1)
 	struct pcap_file_header
 	{
 		uint32_t magic;
@@ -54,6 +55,8 @@ namespace pcpp
 		uint32_t linktype;
 	};
 
+	static_assert(sizeof(pcap_file_header) == 24, "pcap_file_header must be 24 bytes long");
+
 	struct packet_header
 	{
 		uint32_t tv_sec;
@@ -61,6 +64,8 @@ namespace pcpp
 		uint32_t caplen;
 		uint32_t len;
 	};
+	static_assert(sizeof(packet_header) == 16, "packet_header must be 16 bytes long");
+#pragma pack(pop)
 
 	LinkLayerType toLinkLayerType(uint32_t value)
 	{

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -332,6 +332,16 @@ namespace pcpp
 		PcapReadHeaderStatus readPcapHeader(std::istream& inStream, pcap_file_header& header,
 		                                    FileTimestampPrecision& precision, bool& needsSwap)
 		{
+			auto pos = inStream.tellg();
+			auto endPos = inStream.seekg(0, std::ios::end).tellg();
+			inStream.seekg(pos);
+
+			auto remainingBytes = endPos - pos;
+			if(remainingBytes < static_cast<std::streamsize>(sizeof(header)))
+			{
+				return PcapReadHeaderStatus::NoData;
+			}
+
 			inStream.read(reinterpret_cast<char*>(&header), sizeof(header));
 
 			auto readBytes = inStream.gcount();

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -659,7 +659,7 @@ namespace pcpp
 			}
 			case PcapReadHeaderStatus::NoData:
 			{
-				// Empty file - preceed as if we are creating a new file
+				// Empty file - proceed as if we are creating a new file
 				shouldWriteHeader = true;
 				break;
 			}

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -184,6 +184,19 @@ namespace pcpp
 		}
 	}
 
+	static std::string toString(FileTimestampPrecision precision)
+	{
+		switch (precision)
+		{
+		case FileTimestampPrecision::Microseconds:
+			return "Microseconds";
+		case FileTimestampPrecision::Nanoseconds:
+			return "Nanoseconds";
+		default:
+			return "Unknown";
+		}
+	}
+
 	// ~~~~~~~~~~~~~~~~~~~
 	// IFileDevice members
 	// ~~~~~~~~~~~~~~~~~~~
@@ -672,21 +685,8 @@ namespace pcpp
 			{
 				if (precisionFromHeader != m_Precision)
 				{
-					auto getPrecisionStr = [](const FileTimestampPrecision precision) -> std::string {
-						switch (precision)
-						{
-						case FileTimestampPrecision::Microseconds:
-							return "Microseconds";
-						case FileTimestampPrecision::Nanoseconds:
-							return "Nanoseconds";
-						default:
-							return "Unknown";
-						}
-					};
-
-					PCPP_LOG_ERROR("Existing file precision (" + getPrecisionStr(precisionFromHeader) +
-					               ") does not match the requested device precision (" + getPrecisionStr(m_Precision) +
-					               ")");
+					PCPP_LOG_ERROR("Existing file precision (" + toString(precisionFromHeader) +
+					               ") does not match the requested device precision (" + toString(m_Precision) + ")");
 					return false;
 				}
 

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -651,8 +651,8 @@ namespace pcpp
 			FileTimestampPrecision precisionFromHeader;
 			pcap_file_header header;
 
-			// Position file pointer at the beginning of the file to read the header.
-			// Apparently there is no guarantee where the read file pointer will be initialized when opening in std::ios::app.
+			// Position file pointer at the beginning of the file to read the header. Apparently there is no guarantee
+			// where the read file pointer will be initialized when opening in std::ios::app.
 			pcapFile.seekg(0, std::ios::beg);
 			auto status = readPcapHeader(pcapFile, header, precisionFromHeader, needsSwap);
 			switch (status)
@@ -667,7 +667,7 @@ namespace pcpp
 			case PcapReadHeaderStatus::NoData:
 			{
 				// Empty file - proceed as if we are creating a new file
-				if(pcapFile.bad())
+				if (pcapFile.bad())
 				{
 					// badbit errors are generally unrecoverable.
 					PCPP_LOG_ERROR("Error reading pcap file.");

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -369,8 +369,8 @@ namespace pcpp
 			}
 			case NSEC_TCPDUMP_MAGIC_SWAPPED:
 			{
-				needsSwap = true;
 				precision = FileTimestampPrecision::Nanoseconds;
+				needsSwap = true;
 				break;
 			}
 			default:

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -389,29 +389,6 @@ namespace pcpp
 
 			return PcapReadHeaderStatus::Ok;
 		}
-
-		bool writePcapHeader(std::ostream& outStream, FileTimestampPrecision precision, uint32_t snaplen,
-		                     LinkLayerType linkType)
-		{
-			pcap_file_header header{ precision == FileTimestampPrecision::Microseconds ? TCPDUMP_MAGIC
-				                                                                       : NSEC_TCPDUMP_MAGIC,
-				                     PCAP_MAJOR_VERSION,
-				                     PCAP_MINOR_VERSION,
-				                     0,
-				                     0,
-				                     snaplen,
-				                     static_cast<uint32_t>(linkType) };
-
-			outStream.write(reinterpret_cast<const char*>(&header), sizeof(header));
-
-			if (!outStream.good())
-			{
-				PCPP_LOG_ERROR("Error writing pcap header");
-				return false;
-			}
-
-			return true;
-		}
 	}  // namespace
 
 	bool PcapFileReaderDevice::open()
@@ -723,7 +700,7 @@ namespace pcpp
 			}
 		}
 
-		if (shouldWriteHeader && !writePcapHeader(pcapFile, m_Precision, PCPP_MAX_PACKET_SIZE, m_PcapLinkLayerType))
+		if (shouldWriteHeader && !writeHeader(pcapFile, m_Precision, PCPP_MAX_PACKET_SIZE, m_PcapLinkLayerType))
 		{
 			return false;
 		}
@@ -825,6 +802,28 @@ namespace pcpp
 		}
 
 		m_PcapFile.close();
+	}
+
+	bool PcapFileWriterDevice::writeHeader(std::ostream& outStream, FileTimestampPrecision precision, uint32_t snaplen,
+	                                       LinkLayerType linkType)
+	{
+		pcap_file_header header{ precision == FileTimestampPrecision::Microseconds ? TCPDUMP_MAGIC : NSEC_TCPDUMP_MAGIC,
+			                     PCAP_MAJOR_VERSION,
+			                     PCAP_MINOR_VERSION,
+			                     0,
+			                     0,
+			                     snaplen,
+			                     static_cast<uint32_t>(linkType) };
+
+		outStream.write(reinterpret_cast<const char*>(&header), sizeof(header));
+
+		if (!outStream.good())
+		{
+			PCPP_LOG_ERROR("Error writing pcap header");
+			return false;
+		}
+
+		return true;
 	}
 
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Tests/Pcap++Test/Tests/FileTests.cpp
+++ b/Tests/Pcap++Test/Tests/FileTests.cpp
@@ -1074,7 +1074,7 @@ PTF_TEST_CASE(TestPcapFileAppend)
 		PTF_ASSERT_TRUE(reader.open());
 		pcpp::RawPacket rawPacket2;
 		PTF_ASSERT_TRUE(reader.getNextPacket(rawPacket2));
-		PTF_ASSERT_BUF_COMPARE(rawPacket2.getRawData(), packetData.data(), packetData.size());
+		PTF_ASSERT_BUF_COMPARE_S(rawPacket2.getRawData(), rawPacket2.getRawDataLen(), packetData.data(), packetData.size());
 		PTF_ASSERT_FALSE(reader.getNextPacket(rawPacket2));
 	}
 

--- a/Tests/Pcap++Test/Tests/FileTests.cpp
+++ b/Tests/Pcap++Test/Tests/FileTests.cpp
@@ -1037,7 +1037,8 @@ PTF_TEST_CASE(TestPcapFileAppend)
 		PTF_ASSERT_TRUE(reader.open());
 		pcpp::RawPacket rawPacket2;
 		PTF_ASSERT_TRUE(reader.getNextPacket(rawPacket2));
-		PTF_ASSERT_BUF_COMPARE(rawPacket2.getRawData(), packetData.data(), packetData.size());
+		PTF_ASSERT_BUF_COMPARE_S(rawPacket2.getRawData(), rawPacket2.getRawDataLen(), packetData.data(),
+		                         packetData.size());
 		PTF_ASSERT_FALSE(reader.getNextPacket(rawPacket2));
 	}
 
@@ -1055,7 +1056,8 @@ PTF_TEST_CASE(TestPcapFileAppend)
 		PTF_ASSERT_TRUE(reader.open());
 		pcpp::RawPacket rawPacket2;
 		PTF_ASSERT_TRUE(reader.getNextPacket(rawPacket2));
-		PTF_ASSERT_BUF_COMPARE(rawPacket2.getRawData(), packetData.data(), packetData.size());
+		PTF_ASSERT_BUF_COMPARE_S(rawPacket2.getRawData(), rawPacket2.getRawDataLen(), packetData.data(),
+		                         packetData.size());
 		PTF_ASSERT_FALSE(reader.getNextPacket(rawPacket2));
 	}
 
@@ -1074,7 +1076,8 @@ PTF_TEST_CASE(TestPcapFileAppend)
 		PTF_ASSERT_TRUE(reader.open());
 		pcpp::RawPacket rawPacket2;
 		PTF_ASSERT_TRUE(reader.getNextPacket(rawPacket2));
-		PTF_ASSERT_BUF_COMPARE_S(rawPacket2.getRawData(), rawPacket2.getRawDataLen(), packetData.data(), packetData.size());
+		PTF_ASSERT_BUF_COMPARE_S(rawPacket2.getRawData(), rawPacket2.getRawDataLen(), packetData.data(),
+		                         packetData.size());
 		PTF_ASSERT_FALSE(reader.getNextPacket(rawPacket2));
 	}
 
@@ -1098,9 +1101,11 @@ PTF_TEST_CASE(TestPcapFileAppend)
 		PTF_ASSERT_TRUE(reader.open());
 		pcpp::RawPacket rawPacket2;
 		PTF_ASSERT_TRUE(reader.getNextPacket(rawPacket2));
-		PTF_ASSERT_BUF_COMPARE(rawPacket2.getRawData(), anotherPacketData.data(), anotherPacketData.size());
+		PTF_ASSERT_BUF_COMPARE_S(rawPacket2.getRawData(), rawPacket2.getRawDataLen(), anotherPacketData.data(),
+		                         anotherPacketData.size());
 		PTF_ASSERT_TRUE(reader.getNextPacket(rawPacket2));
-		PTF_ASSERT_BUF_COMPARE(rawPacket2.getRawData(), packetData.data(), packetData.size());
+		PTF_ASSERT_BUF_COMPARE_S(rawPacket2.getRawData(), rawPacket2.getRawDataLen(), packetData.data(),
+		                         packetData.size());
 		PTF_ASSERT_FALSE(reader.getNextPacket(rawPacket2));
 	}
 
@@ -1218,7 +1223,8 @@ PTF_TEST_CASE(TestPcapFileAppend)
 			PTF_ASSERT_EQUAL(rawPacket2.getPacketTimeStamp().tv_sec, 1);
 			auto expectedNsec = std::get<1>(magicNumberVariation) ? 1234 : 1000;
 			PTF_ASSERT_EQUAL(rawPacket2.getPacketTimeStamp().tv_nsec, expectedNsec);
-			PTF_ASSERT_BUF_COMPARE(rawPacket2.getRawData(), packetData.data(), packetData.size());
+			PTF_ASSERT_BUF_COMPARE_S(rawPacket2.getRawData(), rawPacket2.getRawDataLen(), packetData.data(),
+			                         packetData.size());
 		}
 	}
 }  // TestPcapFileAppend

--- a/Tests/Pcap++Test/Tests/FileTests.cpp
+++ b/Tests/Pcap++Test/Tests/FileTests.cpp
@@ -1114,7 +1114,8 @@ PTF_TEST_CASE(TestPcapFileAppend)
 
 		SuppressLogs logSuppress;
 		PTF_ASSERT_FALSE(writer.open(true));
-		PTF_ASSERT_EQUAL(pcpp::Logger::getInstance().getLastError(), "Malformed file header or not a pcap file");
+		PTF_ASSERT_EQUAL(pcpp::Logger::getInstance().getLastError(),
+		                 "Cannot read pcap file header. File may be malformed or not a pcap file");
 		PTF_ASSERT_FALSE(writer.isOpened());
 	}
 
@@ -1166,7 +1167,8 @@ PTF_TEST_CASE(TestPcapFileAppend)
 
 		SuppressLogs logSuppress;
 		PTF_ASSERT_FALSE(writer.open(true));
-		PTF_ASSERT_EQUAL(pcpp::Logger::getInstance().getLastError(), "Unsupported pcap file format");
+		PTF_ASSERT_EQUAL(pcpp::Logger::getInstance().getLastError(),
+		                 "Cannot read pcap file header. Unsupported format or invalid magic number: 0x4d2");
 	}
 
 	// Unsupported version

--- a/Tests/PcppTestFramework/PcppTestFramework.h
+++ b/Tests/PcppTestFramework/PcppTestFramework.h
@@ -176,15 +176,17 @@
 		}                                                                                                              \
 	}
 
-#define PTF_ASSERT_BUF_COMPARE(buf1, buf2, size)                                                                       \
-	if (memcmp(buf1, buf2, size) != 0)                                                                                 \
+#define PTF_ASSERT_BUF_COMPARE_S(buf1, buf1_size, buf2, buf2_size)                                                     \
+	if (buf1_size != buf2_size || memcmp(buf1, buf2, buf1_size) != 0)                                                  \
 	{                                                                                                                  \
 		PTF_PRINT_ASSERTION("FAILED", "BUFFER COMPARE") << "   Actual   " << std::endl;                                \
-		BUFFER_PRINT(buf1, size) << "   Expected   " << std::endl;                                                     \
-		BUFFER_PRINT(buf2, size);                                                                                      \
+		BUFFER_PRINT(buf1, buf1_size) << "   Expected   " << std::endl;                                                \
+		BUFFER_PRINT(buf2, buf2_size);                                                                                 \
 		ptfResult = PTF_RESULT_FAILED;                                                                                 \
 		return;                                                                                                        \
 	}
+
+#define PTF_ASSERT_BUF_COMPARE(buf1, buf2, size) PTF_ASSERT_BUF_COMPARE_S(buf1, size, buf2, size)
 
 #define PTF_ASSERT_TRUE(exp)                                                                                           \
 	if (!(exp))                                                                                                        \


### PR DESCRIPTION
This PR deduplicates the pcap header read procedures shared between `PcapReaderDevice` and `PcapWriterDevice` in append mode.

The affected procedures have been moved to `readPcapHeader` and a mirror `writePcapHeader` functions inside `PcapFileDevice.cpp` that have internal linkage.
The PR also removes `PcapWriterDevice::checkHeader` as it can be integrated directly into `open()` by using `readPcapHeader`.