### PR TITLE
Improve benchmarks to support benching with PcapNG and Snoop files.

### DIFF
--- a/Examples/PcapPlusPlus-benchmark/README.md
+++ b/Examples/PcapPlusPlus-benchmark/README.md
@@ -11,10 +11,15 @@ A benchmark application used for measuring PcapPlusPlus performance can be found
 
 Another application integrates with the Google Benchmark library and can be found in `benchmark-google.cpp`. This application currently consists of five different benchmarks, and each benchmark can be influenced by various factors. These benchmarks aim to utilize different influence factors to provide accurate results for different scenarios. You can check the table below for more information. For performance-critical applications using PcapPlusPlus, it is recommended to run benchmarks in your specific environment for more accurate results. Using larger pcap files and those with diverse protocols and sessions can provide better insights into PcapPlusPlus performance in your setup.
 
-|     Benchmark        |   Operation   |  Influencing factors |
-|:-----------------:   |:-------------:|:--------------------:|
-| BM_PcapFileRead      |     Read      |  CPU + Disk (Read)   |
-| BM_PcapFileWrite     |     Write     |  CPU + Disk (Write)  |
-| BM_PacketParsing     | Read + Parse  |  CPU + Disk (Read)   |
-| BM_PacketPureParsing |     Parse     |        CPU           |
-| BM_PacketCrafting    |     Craft     |        CPU           |
+### Benchmarks and their influencing factors
+
+Supported files denote the file formats that can be used as a data source for the benchmark.
+
+
+|     Benchmark        |   Supported files   |   Operation   |  Influencing factors |
+|:--------------------:|:-------------------:|:-------------:|:--------------------:|
+| BM_FileRead          | pcap, pcapng, snoop |     Read      |  CPU + Disk (Read)   |
+| BM_FileWrite         |       N/A           |     Write     |  CPU + Disk (Write)  |
+| BM_PacketParsing     | pcap, pcapng, snoop | Read + Parse  |  CPU + Disk (Read)   |
+| BM_PacketPureParsing | pcap, pcapng, snoop |     Parse     |        CPU           |
+| BM_PacketCrafting    |       N/A           |     Craft     |        CPU           |

--- a/Examples/PcapPlusPlus-benchmark/README.md
+++ b/Examples/PcapPlusPlus-benchmark/README.md
@@ -13,13 +13,15 @@ Another application integrates with the Google Benchmark library and can be foun
 
 ### Benchmarks and their influencing factors
 
-Supported files denote the file formats that can be used as a data source for the benchmark.
+The supported files column indicates the file formats that can be used for the benchmark.
+For Read operations benchmarks that denotes the filetypes that can be used as a data source.
+For Write operation benchmarks that denotes the filetypes that will be generated as output.
 
 
 |     Benchmark        |   Supported files   |   Operation   |  Influencing factors |
 |:--------------------:|:-------------------:|:-------------:|:--------------------:|
 | BM_FileRead          | pcap, pcapng, snoop |     Read      |  CPU + Disk (Read)   |
-| BM_FileWrite         |       N/A           |     Write     |  CPU + Disk (Write)  |
+| BM_FileWrite         |     pcap, pcapng    |     Write     |  CPU + Disk (Write)  |
 | BM_PacketParsing     | pcap, pcapng, snoop | Read + Parse  |  CPU + Disk (Read)   |
 | BM_PacketPureParsing | pcap, pcapng, snoop |     Parse     |        CPU           |
 | BM_PacketCrafting    |       N/A           |     Craft     |        CPU           |

--- a/Examples/PcapPlusPlus-benchmark/benchmark-google.cpp
+++ b/Examples/PcapPlusPlus-benchmark/benchmark-google.cpp
@@ -12,10 +12,6 @@
 
 #include <iostream>
 
-static std::string pcapFileName = "";
-static std::string pcapNgFileName = "";
-static std::string snoopFileName = "";
-
 static void BM_FileRead(benchmark::State& state, std::string const& filepath)
 {
 	if (filepath.empty())
@@ -67,10 +63,6 @@ static void BM_FileRead(benchmark::State& state, std::string const& filepath)
 	state.SetItemsProcessed(totalPackets);
 }
 
-BENCHMARK_CAPTURE(BM_FileRead, Pcap, pcapFileName);
-BENCHMARK_CAPTURE(BM_FileRead, PcapNg, pcapNgFileName);
-BENCHMARK_CAPTURE(BM_FileRead, Snoop, snoopFileName);
-
 static bool startsWith(std::string const& str, std::string const& prefix)
 {
 	if (str.length() < prefix.length())
@@ -83,6 +75,14 @@ static bool endsWith(std::string const& str, std::string const& suffix)
 	if (str.length() < suffix.length())
 		return false;
 	return str.compare(str.length() - suffix.length(), suffix.length(), suffix) == 0;
+}
+
+static std::string getFileName(std::string const& filepath)
+{
+	size_t lastSlashPos = filepath.find_last_of("/\\");
+	if (lastSlashPos == std::string::npos)
+		return filepath;
+	return filepath.substr(lastSlashPos + 1);
 }
 
 static void BM_FileWrite(benchmark::State& state, std::string const& filepath)
@@ -205,9 +205,6 @@ static void BM_PacketParsing(benchmark::State& state, std::string const& filenam
 	state.SetBytesProcessed(totalBytes);
 	state.SetItemsProcessed(totalPackets);
 }
-BENCHMARK_CAPTURE(BM_PacketParsing, Pcap, pcapFileName);
-BENCHMARK_CAPTURE(BM_PacketParsing, PcapNg, pcapNgFileName);
-BENCHMARK_CAPTURE(BM_PacketParsing, Snoop, snoopFileName);
 
 static void BM_PacketPureParsing(benchmark::State& state, std::string const& filename)
 {
@@ -265,9 +262,6 @@ static void BM_PacketPureParsing(benchmark::State& state, std::string const& fil
 	state.SetBytesProcessed(totalProcessedBytes);
 	state.SetItemsProcessed(totalProcessedItems);
 }
-BENCHMARK_CAPTURE(BM_PacketPureParsing, Pcap, pcapFileName);
-BENCHMARK_CAPTURE(BM_PacketPureParsing, PcapNG, pcapNgFileName);
-BENCHMARK_CAPTURE(BM_PacketPureParsing, Snoop, snoopFileName);
 
 static void BM_PacketCrafting(benchmark::State& state)
 {
@@ -326,8 +320,8 @@ BENCHMARK(BM_PacketCrafting);
 
 void printHelp()
 {
-	std::cout
-	    << "Usage: benchmark-google [--pcap-file <file.pcap>] [--pcapng-file <file.pcapng>] [--snoop-file <file.snoop>]\n\n";
+	std::cout << "Usage: benchmark-google [--pcap-file <file.pcap>]... \n"
+	          << "  --pcap-file can be specified multiple times\n\n";
 
 	std::cout << "Google Benchmark options:\n";
 	benchmark::PrintDefaultHelp();
@@ -337,6 +331,8 @@ int main(int argc, char** argv)
 {
 	// Initialize the benchmark
 	benchmark::Initialize(&argc, argv, &printHelp);
+
+	std::vector<std::string> files;
 
 	// Parse command line arguments to find the pcap file name
 	for (int idx = 1; idx < argc; ++idx)
@@ -357,52 +353,29 @@ int main(int argc, char** argv)
 				return 1;
 			}
 
-			pcapFileName = argv[idx + 1];
-		}
-
-		if (strcmp(argv[idx], "--pcapng-file") == 0)
-		{
-			if (idx == argc - 1)
-			{
-				std::cerr << "Please provide a file path after --pcapng-file" << std::endl;
-				return 1;
-			}
-
-			std::string argValue = argv[idx + 1];
-			if (startsWith(argValue, "-"))
-			{
-				std::cerr << "Please provide a file path after --pcapng-file, but got another option: " << argValue
-				          << std::endl;
-				return 1;
-			}
-
-			pcapNgFileName = argv[idx + 1];
-		}
-
-		if (strcmp(argv[idx], "--snoop-file") == 0)
-		{
-			if (idx == argc - 1)
-			{
-				std::cerr << "Please provide a file path after --snoop-file" << std::endl;
-				return 1;
-			}
-
-			std::string argValue = argv[idx + 1];
-			if (startsWith(argValue, "-"))
-			{
-				std::cerr << "Please provide a file path after --snoop-file, but got another option: " << argValue
-				          << std::endl;
-				return 1;
-			}
-
-			snoopFileName = argv[idx + 1];
+			files.push_back(std::move(argValue));
 		}
 	}
 
 	benchmark::AddCustomContext("PcapPlusPlus version", pcpp::getPcapPlusPlusVersionFull());
 	benchmark::AddCustomContext("Build info", pcpp::getBuildDateTime());
 	benchmark::AddCustomContext("Git info", pcpp::getGitInfo());
-	benchmark::AddCustomContext("Pcap file", pcapFileName);
+
+	// Individual loops to register benchmarks in order.
+	for (const auto& file : files)
+	{
+		benchmark::RegisterBenchmark(("BM_FileRead/" + getFileName(file)), BM_FileRead, file);
+	}
+
+	for (const auto& file : files)
+	{
+		benchmark::RegisterBenchmark(("BM_PacketParsing/" + getFileName(file)), BM_PacketParsing, file);
+	}
+
+	for (const auto& file : files)
+	{
+		benchmark::RegisterBenchmark(("BM_PacketPureParsing/" + getFileName(file)), BM_PacketPureParsing, file);
+	}
 
 	// Run the benchmarks
 	benchmark::RunSpecifiedBenchmarks();

--- a/Examples/PcapPlusPlus-benchmark/benchmark-google.cpp
+++ b/Examples/PcapPlusPlus-benchmark/benchmark-google.cpp
@@ -332,7 +332,8 @@ BENCHMARK(BM_PacketCrafting);
 
 void printHelp()
 {
-	std::cout << "Usage: benchmark-google [--pcap-file <file.pcap>] [--pcapng-file <file.pcapng>] [--snoop-file <file.snoop>]\n\n";
+	std::cout
+	    << "Usage: benchmark-google [--pcap-file <file.pcap>] [--pcapng-file <file.pcapng>] [--snoop-file <file.snoop>]\n\n";
 
 	std::cout << "Google Benchmark options:\n";
 	benchmark::PrintDefaultHelp();
@@ -358,7 +359,7 @@ int main(int argc, char** argv)
 			if (startsWith(argValue, "-"))
 			{
 				std::cerr << "Please provide a file path after --pcap-file, but got another option: " << argValue
-						  << std::endl;
+				          << std::endl;
 				return 1;
 			}
 

--- a/Examples/PcapPlusPlus-benchmark/benchmark-google.cpp
+++ b/Examples/PcapPlusPlus-benchmark/benchmark-google.cpp
@@ -20,7 +20,7 @@ static void BM_FileRead(benchmark::State& state, std::string const& filepath)
 {
 	if (filepath.empty())
 	{
-		state.SkipWithError("File path is not set");
+		state.SkipWithMessage("File path is not set");
 		return;
 	}
 
@@ -71,6 +71,13 @@ BENCHMARK_CAPTURE(BM_FileRead, Pcap, pcapFileName);
 BENCHMARK_CAPTURE(BM_FileRead, PcapNg, pcapNgFileName);
 BENCHMARK_CAPTURE(BM_FileRead, Snoop, snoopFileName);
 
+static bool startsWith(std::string const& str, std::string const& prefix)
+{
+	if (str.length() < prefix.length())
+		return false;
+	return str.compare(0, prefix.length(), prefix) == 0;
+}
+
 static bool endsWith(std::string const& str, std::string const& suffix)
 {
 	if (str.length() < suffix.length())
@@ -82,7 +89,7 @@ static void BM_FileWrite(benchmark::State& state, std::string const& filepath)
 {
 	if (filepath.empty())
 	{
-		state.SkipWithError("File path is not set");
+		state.SkipWithMessage("File path is not set");
 		return;
 	}
 
@@ -145,28 +152,34 @@ BENCHMARK_CAPTURE(BM_FileWrite, Pcap, "benchmark-output.pcap");
 BENCHMARK_CAPTURE(BM_FileWrite, PcapNg, "benchmark-output.pcapng");
 // BENCHMARK_CAPTURE(BM_FileWrite, Snoop, "benchmark-output.snoop"); // Snoop file writing is not supported
 
-static void BM_PacketParsing(benchmark::State& state)
+static void BM_PacketParsing(benchmark::State& state, std::string const& filename)
 {
-	if (pcapFileName.empty())
+	if (filename.empty())
 	{
-		state.SkipWithError("Pcap file name is not set");
+		state.SkipWithMessage("File name is not set");
 		return;
 	}
 
 	// Open the pcap file for reading
-	size_t totalBytes = 0;
-	size_t totalPackets = 0;
-	pcpp::PcapFileReaderDevice reader(pcapFileName);
-	if (!reader.open())
+	auto reader = std::unique_ptr<pcpp::IFileReaderDevice>(pcpp::IFileReaderDevice::getReader(filename));
+	if (reader == nullptr)
 	{
-		state.SkipWithError("Cannot open pcap file for reading");
+		state.SkipWithError("Cannot create file reader for file: " + filename);
 		return;
 	}
 
+	if (!reader->open())
+	{
+		state.SkipWithError("Cannot open file for reading");
+		return;
+	}
+
+	size_t totalBytes = 0;
+	size_t totalPackets = 0;
 	pcpp::RawPacket rawPacket;
 	for (auto _ : state)
 	{
-		if (!reader.getNextPacket(rawPacket))
+		if (!reader->getNextPacket(rawPacket))
 		{
 			// If the rawPacket is empty there should be an error
 			if (totalBytes == 0)
@@ -177,8 +190,8 @@ static void BM_PacketParsing(benchmark::State& state)
 
 			// Rewind the file if it reached the end
 			state.PauseTiming();
-			reader.close();
-			reader.open();
+			reader->close();
+			reader->open();
 			state.ResumeTiming();
 			continue;
 		}
@@ -187,7 +200,7 @@ static void BM_PacketParsing(benchmark::State& state)
 		pcpp::Packet parsedPacket(&rawPacket);
 
 		// Use parsedPacket to prevent compiler optimizations
-		assert(parsedPacket.getFirstLayer());
+		benchmark::DoNotOptimize(parsedPacket.getFirstLayer());
 
 		// Count total bytes and packets
 		++totalPackets;
@@ -198,26 +211,35 @@ static void BM_PacketParsing(benchmark::State& state)
 	state.SetBytesProcessed(totalBytes);
 	state.SetItemsProcessed(totalPackets);
 }
-BENCHMARK(BM_PacketParsing);
+BENCHMARK_CAPTURE(BM_PacketParsing, Pcap, pcapFileName);
+BENCHMARK_CAPTURE(BM_PacketParsing, PcapNg, pcapNgFileName);
+BENCHMARK_CAPTURE(BM_PacketParsing, Snoop, snoopFileName);
 
-static void BM_PacketPureParsing(benchmark::State& state)
+static void BM_PacketPureParsing(benchmark::State& state, std::string const& filename)
 {
-	if (pcapFileName.empty())
+	if (filename.empty())
 	{
-		state.SkipWithError("Pcap file name is not set");
+		state.SkipWithMessage("File name is not set");
 		return;
 	}
 
-	pcpp::PcapFileReaderDevice reader(pcapFileName);
-	if (!reader.open())
+	// Open the pcap file for reading
+	auto reader = std::unique_ptr<pcpp::IFileReaderDevice>(pcpp::IFileReaderDevice::getReader(filename));
+	if (reader == nullptr)
 	{
-		state.SkipWithError("Cannot open pcap file for reading");
+		state.SkipWithError("Cannot create file reader for file: " + filename);
+		return;
+	}
+
+	if (!reader->open())
+	{
+		state.SkipWithError("Cannot open file for reading");
 		return;
 	}
 
 	// Preloads all packets into memory
 	pcpp::RawPacketVector rawPackets;
-	reader.getNextPackets(rawPackets);
+	reader->getNextPackets(rawPackets);
 
 	if (rawPackets.size() == 0)
 	{
@@ -249,7 +271,9 @@ static void BM_PacketPureParsing(benchmark::State& state)
 	state.SetBytesProcessed(totalProcessedBytes);
 	state.SetItemsProcessed(totalProcessedItems);
 }
-BENCHMARK(BM_PacketPureParsing);
+BENCHMARK_CAPTURE(BM_PacketPureParsing, Pcap, pcapFileName);
+BENCHMARK_CAPTURE(BM_PacketPureParsing, PcapNG, pcapNgFileName);
+BENCHMARK_CAPTURE(BM_PacketPureParsing, Snoop, snoopFileName);
 
 static void BM_PacketCrafting(benchmark::State& state)
 {
@@ -306,10 +330,18 @@ static void BM_PacketCrafting(benchmark::State& state)
 }
 BENCHMARK(BM_PacketCrafting);
 
+void printHelp()
+{
+	std::cout << "Usage: benchmark-google [--pcap-file <file.pcap>] [--pcapng-file <file.pcapng>] [--snoop-file <file.snoop>]\n\n";
+
+	std::cout << "Google Benchmark options:\n";
+	benchmark::PrintDefaultHelp();
+}
+
 int main(int argc, char** argv)
 {
 	// Initialize the benchmark
-	benchmark::Initialize(&argc, argv);
+	benchmark::Initialize(&argc, argv, &printHelp);
 
 	// Parse command line arguments to find the pcap file name
 	for (int idx = 1; idx < argc; ++idx)
@@ -318,19 +350,58 @@ int main(int argc, char** argv)
 		{
 			if (idx == argc - 1)
 			{
-				std::cerr << "Please provide a pcap file name after --pcap-file" << std::endl;
+				std::cerr << "Please provide a file path after --pcap-file" << std::endl;
+				return 1;
+			}
+
+			std::string argValue = argv[idx + 1];
+			if (startsWith(argValue, "-"))
+			{
+				std::cerr << "Please provide a file path after --pcap-file, but got another option: " << argValue
+						  << std::endl;
 				return 1;
 			}
 
 			pcapFileName = argv[idx + 1];
-			break;
 		}
-	}
 
-	if (pcapFileName.empty())
-	{
-		std::cerr << "Please provide a pcap file name using --pcap-file" << std::endl;
-		return 1;
+		if (strcmp(argv[idx], "--pcapng-file") == 0)
+		{
+			if (idx == argc - 1)
+			{
+				std::cerr << "Please provide a file path after --pcapng-file" << std::endl;
+				return 1;
+			}
+
+			std::string argValue = argv[idx + 1];
+			if (startsWith(argValue, "-"))
+			{
+				std::cerr << "Please provide a file path after --pcapng-file, but got another option: " << argValue
+				          << std::endl;
+				return 1;
+			}
+
+			pcapNgFileName = argv[idx + 1];
+		}
+
+		if (strcmp(argv[idx], "--snoop-file") == 0)
+		{
+			if (idx == argc - 1)
+			{
+				std::cerr << "Please provide a file path after --snoop-file" << std::endl;
+				return 1;
+			}
+
+			std::string argValue = argv[idx + 1];
+			if (startsWith(argValue, "-"))
+			{
+				std::cerr << "Please provide a file path after --snoop-file, but got another option: " << argValue
+				          << std::endl;
+				return 1;
+			}
+
+			snoopFileName = argv[idx + 1];
+		}
 	}
 
 	benchmark::AddCustomContext("PcapPlusPlus version", pcpp::getPcapPlusPlusVersionFull());

--- a/Examples/PcapPlusPlus-benchmark/benchmark-google.cpp
+++ b/Examples/PcapPlusPlus-benchmark/benchmark-google.cpp
@@ -13,14 +13,27 @@
 #include <iostream>
 
 static std::string pcapFileName = "";
+static std::string pcapNgFileName = "";
+static std::string snoopFileName = "";
 
-static void BM_PcapFileRead(benchmark::State& state)
+static void BM_FileRead(benchmark::State& state, std::string const& filepath)
 {
-	// Open the pcap file for reading
-	pcpp::PcapFileReaderDevice reader(pcapFileName);
-	if (!reader.open())
+	if (filepath.empty())
 	{
-		state.SkipWithError("Cannot open pcap file for reading");
+		state.SkipWithError("File path is not set");
+		return;
+	}
+
+	auto reader = std::unique_ptr<pcpp::IFileReaderDevice>(pcpp::IFileReaderDevice::getReader(filepath));
+	if (reader == nullptr)
+	{
+		state.SkipWithError("Cannot create file reader for file: " + filepath);
+		return;
+	}
+
+	if (!reader->open())
+	{
+		state.SkipWithError("Cannot open file for reading: " + filepath);
 		return;
 	}
 
@@ -29,7 +42,7 @@ static void BM_PcapFileRead(benchmark::State& state)
 	pcpp::RawPacket rawPacket;
 	for (auto _ : state)
 	{
-		if (!reader.getNextPacket(rawPacket))
+		if (!reader->getNextPacket(rawPacket))
 		{
 			// If the rawPacket is empty there should be an error
 			if (totalBytes == 0)
@@ -40,8 +53,8 @@ static void BM_PcapFileRead(benchmark::State& state)
 
 			// Rewind the file if it reached the end
 			state.PauseTiming();
-			reader.close();
-			reader.open();
+			reader->close();
+			reader->open();
 			state.ResumeTiming();
 			continue;
 		}
@@ -53,18 +66,54 @@ static void BM_PcapFileRead(benchmark::State& state)
 	state.SetBytesProcessed(totalBytes);
 	state.SetItemsProcessed(totalPackets);
 }
-BENCHMARK(BM_PcapFileRead);
 
-static void BM_PcapFileWrite(benchmark::State& state)
+BENCHMARK_CAPTURE(BM_FileRead, Pcap, pcapFileName);
+BENCHMARK_CAPTURE(BM_FileRead, PcapNg, pcapNgFileName);
+BENCHMARK_CAPTURE(BM_FileRead, Snoop, snoopFileName);
+
+static bool endsWith(std::string const& str, std::string const& suffix)
 {
-	// Open the pcap file for writing
-	pcpp::PcapFileWriterDevice writer("benchmark-output.pcap");
-	if (!writer.open())
+	if (str.length() < suffix.length())
+		return false;
+	return str.compare(str.length() - suffix.length(), suffix.length(), suffix) == 0;
+}
+
+static void BM_FileWrite(benchmark::State& state, std::string const& filepath)
+{
+	if (filepath.empty())
 	{
-		state.SkipWithError("Cannot open pcap file for writing");
+		state.SkipWithError("File path is not set");
 		return;
 	}
 
+	// Select device type based on file extension
+	std::unique_ptr<pcpp::IFileWriterDevice> writer;
+	if (endsWith(filepath, ".pcap"))
+	{
+		writer = std::make_unique<pcpp::PcapFileWriterDevice>(filepath);
+	}
+	else if (endsWith(filepath, ".pcapng"))
+	{
+		writer = std::make_unique<pcpp::PcapNgFileWriterDevice>(filepath);
+	}
+	else if (endsWith(filepath, ".snoop"))
+	{
+		state.SkipWithError("Snoop file writing is not supported");
+		return;
+	}
+	else
+	{
+		state.SkipWithError("Unsupported file extension for writing: " + filepath);
+		return;
+	}
+
+	if (!writer->open())
+	{
+		state.SkipWithError("Cannot open file device for writing");
+		return;
+	}
+
+	// Setup a sample packet to write
 	pcpp::Packet packet;
 	pcpp::EthLayer ethLayer(pcpp::MacAddress("00:00:00:00:00:00"), pcpp::MacAddress("00:00:00:00:00:00"));
 	pcpp::IPv4Layer ip4Layer(pcpp::IPv4Address("192.168.0.1"), pcpp::IPv4Address("192.168.0.2"));
@@ -80,7 +129,7 @@ static void BM_PcapFileWrite(benchmark::State& state)
 	for (auto _ : state)
 	{
 		// Write packet to file
-		writer.writePacket(*(packet.getRawPacket()));
+		writer->writePacket(*(packet.getRawPacket()));
 
 		// Count total bytes and packets
 		++totalPackets;
@@ -91,10 +140,19 @@ static void BM_PcapFileWrite(benchmark::State& state)
 	state.SetBytesProcessed(totalBytes);
 	state.SetItemsProcessed(totalPackets);
 }
-BENCHMARK(BM_PcapFileWrite);
+
+BENCHMARK_CAPTURE(BM_FileWrite, Pcap, "benchmark-output.pcap");
+BENCHMARK_CAPTURE(BM_FileWrite, PcapNg, "benchmark-output.pcapng");
+// BENCHMARK_CAPTURE(BM_FileWrite, Snoop, "benchmark-output.snoop"); // Snoop file writing is not supported
 
 static void BM_PacketParsing(benchmark::State& state)
 {
+	if (pcapFileName.empty())
+	{
+		state.SkipWithError("Pcap file name is not set");
+		return;
+	}
+
 	// Open the pcap file for reading
 	size_t totalBytes = 0;
 	size_t totalPackets = 0;
@@ -144,6 +202,12 @@ BENCHMARK(BM_PacketParsing);
 
 static void BM_PacketPureParsing(benchmark::State& state)
 {
+	if (pcapFileName.empty())
+	{
+		state.SkipWithError("Pcap file name is not set");
+		return;
+	}
+
 	pcpp::PcapFileReaderDevice reader(pcapFileName);
 	if (!reader.open())
 	{

--- a/Examples/PcapPlusPlus-benchmark/benchmark-google.cpp
+++ b/Examples/PcapPlusPlus-benchmark/benchmark-google.cpp
@@ -103,11 +103,6 @@ static void BM_FileWrite(benchmark::State& state, std::string const& filepath)
 	{
 		writer = std::make_unique<pcpp::PcapNgFileWriterDevice>(filepath);
 	}
-	else if (endsWith(filepath, ".snoop"))
-	{
-		state.SkipWithError("Snoop file writing is not supported");
-		return;
-	}
 	else
 	{
 		state.SkipWithError("Unsupported file extension for writing: " + filepath);
@@ -150,7 +145,6 @@ static void BM_FileWrite(benchmark::State& state, std::string const& filepath)
 
 BENCHMARK_CAPTURE(BM_FileWrite, Pcap, "benchmark-output.pcap");
 BENCHMARK_CAPTURE(BM_FileWrite, PcapNg, "benchmark-output.pcapng");
-// BENCHMARK_CAPTURE(BM_FileWrite, Snoop, "benchmark-output.snoop"); // Snoop file writing is not supported
 
 static void BM_PacketParsing(benchmark::State& state, std::string const& filename)
 {


### PR DESCRIPTION
The PR adds support to specify `PcapNG` or `Snoop` files to the benchmark-google project to allow benchmarking of the file read/write speeds on those devices.