### PR TITLE
Add read buffer to SnoopFileReader.

### DIFF
--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -577,6 +577,7 @@ namespace pcpp
 
 		LinkLayerType m_PcapLinkLayerType;
 		std::ifstream m_SnoopFile;
+		std::vector<uint8_t> m_ReadBuffer;
 
 		bool readNextPacket(timespec& packetTimestamp, uint8_t* packetData, uint32_t packetDataLen,
 		                    uint32_t& capturedLength, uint32_t& frameLength);

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -1195,6 +1195,9 @@ namespace pcpp
 		m_SnoopFile = std::move(snoopFile);
 		m_PcapLinkLayerType = snoop_encap[datalink_type];
 
+		constexpr uint32_t maxPacketLength = 15'000;
+		m_ReadBuffer.resize(maxPacketLength);
+
 		PCPP_LOG_DEBUG("Successfully opened file reader device for filename '" << m_FileName << "'");
 		return true;
 	}
@@ -1245,15 +1248,16 @@ namespace pcpp
 			return false;
 		}
 
-		constexpr uint32_t maxPacketLength = 15'000;
 		timespec packetTimestamp{};
 		uint32_t capturedLength = 0, frameLength = 0;
-		auto packetData = std::make_unique<uint8_t[]>(maxPacketLength);
 
-		while (readNextPacket(packetTimestamp, packetData.get(), maxPacketLength, capturedLength, frameLength))
+		while (readNextPacket(packetTimestamp, m_ReadBuffer.data(), m_ReadBuffer.size(), capturedLength, frameLength))
 		{
-			if (m_BpfWrapper.matches(packetData.get(), capturedLength, packetTimestamp, m_PcapLinkLayerType))
+			if (m_BpfWrapper.matches(m_ReadBuffer.data(), capturedLength, packetTimestamp, m_PcapLinkLayerType))
 			{
+				auto packetData = std::make_unique<uint8_t[]>(capturedLength);
+				std::copy(m_ReadBuffer.begin(), m_ReadBuffer.begin() + capturedLength, packetData.get());
+
 				rawPacket.setRawData(capturedLength > 0 ? packetData.release() : nullptr, capturedLength, true,
 				                     packetTimestamp, m_PcapLinkLayerType, frameLength);
 				reportPacketProcessed();


### PR DESCRIPTION
Mirrors the read buffer implementation of `PcapFileReaderDevice` in #2072 to `SnoopFileReaderDevice`.

This defers the allocation of a packet buffer until after the packet has been confirmed to match all filters and needs to be extracted. It also precisely sizes the needed buffer, reducing wasted space.