### PR TITLE
Improve `PcapLiveDevice::stopCapture` responsiveness for large statistic capture intervals.

### DIFF
--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -1,5 +1,7 @@
 #define LOG_MODULE PcapLogModuleLiveDevice
 
+#define NOMINMAX
+
 #include "IpUtils.h"
 #include "DeviceUtils.h"
 #include "PcapUtils.h"
@@ -370,9 +372,16 @@ namespace pcpp
 
 			PCPP_LOG_DEBUG("Begin periodic statistics update procedure");
 
+			constexpr auto maxWakeupInterval = std::chrono::milliseconds(500);
+			const auto wakeupInterval = std::min(context.updateInterval, maxWakeupInterval);
+
+			auto nextActionTime = std::chrono::steady_clock::now();
+
 			PcapStats stats;
 			while (!stopFlag.load())
 			{
+				nextActionTime += context.updateInterval;
+
 				try
 				{
 					pcapDescriptor.getStatistics(stats);
@@ -388,7 +397,25 @@ namespace pcpp
 					PCPP_LOG_ERROR("Unknown exception occurred while invoking statistics update callback");
 					break;
 				}
-				std::this_thread::sleep_for(context.updateInterval);
+
+				auto currentTime = std::chrono::steady_clock::now();
+
+				if (currentTime >= nextActionTime)
+				{
+					PCPP_LOG_WARN("Statistics update callback execution is taking longer than the update interval!");
+					nextActionTime = currentTime + context.updateInterval;
+				}
+
+				while (!stopFlag.load())
+				{
+					currentTime = std::chrono::steady_clock::now();
+
+					if (currentTime >= nextActionTime)
+						break;
+
+					auto nextWakeupTime = std::min(nextActionTime, currentTime + wakeupInterval);
+					std::this_thread::sleep_until(nextWakeupTime);
+				}
 			}
 			PCPP_LOG_DEBUG("Ended periodic statistics update procedure");
 		}


### PR DESCRIPTION
Addresses #2089,

The PR adds wakeups to the statistics thread of a `PcapLiveDevice` to query the stop flag, independently of the statistics update interval. This mitigates the behavior where a `stopCapture` can block for an entire statistics update interval and brings it down to a fixed constant time (currently 500ms).