### PR TITLE
Fix build error #2097

### DIFF
--- a/Common++/src/OUILookup.cpp
+++ b/Common++/src/OUILookup.cpp
@@ -92,7 +92,7 @@ namespace pcpp
 		}
 
 		// Get MAC address
-		uint8_t buffArray[6];
+		uint8_t buffArray[6] = { 0 };
 		addr.copyTo(buffArray);
 
 		const uint64_t macAddr = (((uint64_t)((buffArray)[5]) << 0) + ((uint64_t)((buffArray)[4]) << 8) +

--- a/Packet++/src/StpLayer.cpp
+++ b/Packet++/src/StpLayer.cpp
@@ -20,7 +20,7 @@ namespace pcpp
 
 	uint64_t StpLayer::macAddressToID(const pcpp::MacAddress& addr)
 	{
-		uint8_t value[6];
+		uint8_t value[6] = { 0 };
 		addr.copyTo(value);
 		return ((uint64_t(value[0]) << 40) | (uint64_t(value[1]) << 32) | (uint64_t(value[2]) << 24) |
 		        (uint64_t(value[3]) << 16) | (uint64_t(value[4]) << 8) | (uint64_t(value[5])));


### PR DESCRIPTION
### Bug description

**Describe the bug**
/home/RabbitRemoteControl/build_linux/source/PcapPlusPlus/Common++/src/OUILookup.cpp: In member function ‘std::string pcpp::/home/RabbitRemoteControl/build_linux/source/PcapPlusPlus/Common++/src/OUILookup.cpp:100:105: error: ‘buffArray’ may be usedgmake[2]: *** [Common++/CMakeFiles/Common++.dir/build.make:163：Common++/CMakeFiles/Common++.dir/src/OUILookup.cpp.o] 错误 1

Detected OS:  Linux
Distribution:   deepin
Version:            23.1
Architecture:   x86_64

gcc (Deepin 12.3.0-17deepin12) 12.3.0


### PcapPlusPlus versions tested on

v25.05

### Other PcapPlusPlus version (if applicable)

_No response_

### Operating systems tested on

Linux

### Other operation systems (if applicable)

deepin 23.1

### Compiler version

gcc (Deepin 12.3.0-17deepin12) 12.3.0

### Packet capture backend (if applicable)

_No response_