### PR TITLE
Fix silent cast of `ProtocolTypeFamily` to `ProtocolType` in Packet ctor.

### DIFF
--- a/Packet++/header/Packet.h
+++ b/Packet++/header/Packet.h
@@ -83,15 +83,16 @@ namespace pcpp
 		/// @param[in] rawPacket A pointer to the raw packet
 		/// @param[in] freeRawPacket Optional parameter. A flag indicating if the destructor should also call the raw
 		/// packet destructor or not. Default value is false
-		/// @param[in] parseUntil Optional parameter. Parse the packet until you reach a certain protocol (inclusive).
-		/// Can be useful for cases when you need to parse only up to a certain layer and want to avoid the performance
-		/// impact and memory consumption of parsing the whole packet. Default value is ::UnknownProtocol which means
-		/// don't take this parameter into account
+		/// @param[in] parseUntil Optional parameter. Parse the packet until you reach a certain protocol family
+		/// (inclusive). Can be useful for cases when you need to parse only up to a certain layer and want to avoid the
+		/// performance impact and memory consumption of parsing the whole packet. Default value is ::UnknownProtocol
+		/// which means don't take this parameter into account
 		/// @param[in] parseUntilLayer Optional parameter. Parse the packet until you reach a certain layer in the OSI
 		/// model (inclusive). Can be useful for cases when you need to parse only up to a certain OSI layer (for
 		/// example transport layer) and want to avoid the performance impact and memory consumption of parsing the
 		/// whole packet. Default value is ::OsiModelLayerUnknown which means don't take this parameter into account
-		explicit Packet(RawPacket* rawPacket, bool freeRawPacket = false, ProtocolType parseUntil = UnknownProtocol,
+		explicit Packet(RawPacket* rawPacket, bool freeRawPacket = false,
+		                ProtocolTypeFamily parseUntil = UnknownProtocol,
 		                OsiModelLayer parseUntilLayer = OsiModelLayerUnknown);
 
 		/// A constructor for creating a packet out of already allocated RawPacket. Very useful when parsing packets

--- a/Packet++/header/Packet.h
+++ b/Packet++/header/Packet.h
@@ -83,16 +83,19 @@ namespace pcpp
 		/// @param[in] rawPacket A pointer to the raw packet
 		/// @param[in] freeRawPacket Optional parameter. A flag indicating if the destructor should also call the raw
 		/// packet destructor or not. Default value is false
-		/// @param[in] parseUntil Optional parameter. Parse the packet until you reach a certain protocol family
-		/// (inclusive). Can be useful for cases when you need to parse only up to a certain layer and want to avoid the
-		/// performance impact and memory consumption of parsing the whole packet. Default value is ::UnknownProtocol
-		/// which means don't take this parameter into account
+		/// @param[in] parseUntil Optional parameter. Parse the packet until you reach a certain protocol (inclusive).
+		/// Can be useful for cases when you need to parse only up to a certain layer and want to avoid the performance
+		/// impact and memory consumption of parsing the whole packet. Default value is ::UnknownProtocol which means
+		/// don't take this parameter into account
 		/// @param[in] parseUntilLayer Optional parameter. Parse the packet until you reach a certain layer in the OSI
 		/// model (inclusive). Can be useful for cases when you need to parse only up to a certain OSI layer (for
 		/// example transport layer) and want to avoid the performance impact and memory consumption of parsing the
 		/// whole packet. Default value is ::OsiModelLayerUnknown which means don't take this parameter into account
-		explicit Packet(RawPacket* rawPacket, bool freeRawPacket = false,
-		                ProtocolTypeFamily parseUntil = UnknownProtocol,
+		explicit Packet(RawPacket* rawPacket, bool freeRawPacket = false, ProtocolType parseUntil = UnknownProtocol,
+		                OsiModelLayer parseUntilLayer = OsiModelLayerUnknown);
+
+		/// @copydoc Packet(RawPacket*, bool, ProtocolType, OsiModelLayer)
+		explicit Packet(RawPacket* rawPacket, bool freeRawPacket, ProtocolTypeFamily parseUntil,
 		                OsiModelLayer parseUntilLayer = OsiModelLayerUnknown);
 
 		/// A constructor for creating a packet out of already allocated RawPacket. Very useful when parsing packets

--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -195,7 +195,8 @@ namespace pcpp
 		}
 	}
 
-	Packet::Packet(RawPacket* rawPacket, bool freeRawPacket, ProtocolType parseUntil, OsiModelLayer parseUntilLayer)
+	Packet::Packet(RawPacket* rawPacket, bool freeRawPacket, ProtocolTypeFamily parseUntil,
+	               OsiModelLayer parseUntilLayer)
 	{
 		m_FreeRawPacket = false;
 		m_RawPacket = nullptr;

--- a/Packet++/src/Packet.cpp
+++ b/Packet++/src/Packet.cpp
@@ -195,6 +195,10 @@ namespace pcpp
 		}
 	}
 
+	Packet::Packet(RawPacket* rawPacket, bool freeRawPacket, ProtocolType parseUntil, OsiModelLayer parseUntilLayer)
+	    : Packet(rawPacket, freeRawPacket, static_cast<ProtocolTypeFamily>(parseUntil), parseUntilLayer)
+	{}
+
 	Packet::Packet(RawPacket* rawPacket, bool freeRawPacket, ProtocolTypeFamily parseUntil,
 	               OsiModelLayer parseUntilLayer)
 	{


### PR DESCRIPTION
This PR changes the signature of the full Packet parsing constructor to use `ProtocolTypeFamily` instead of `ProtocolType`.

This is done to allow protocol "family" constants to be used in the main signature. Previously used family constants (`uint32_t`) were silently narrowed to the first protocol of the family (`uint8_t`). (e.g "IP" family would be treated as only "IPv4") if used in the full constructor signature.