### PR TITLE
Fix DpdkDeviceList not publicly inheriting DeviceListBase.

### DIFF
--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -55,7 +55,7 @@ namespace pcpp
 	///      once in every application at its startup process
 	///    - it contains the list of DpdkDevice instances and enables access to them
 	///    - it has methods to start and stop worker threads. See more details in startDpdkWorkerThreads()
-	class DpdkDeviceList : internal::DeviceListBase<DpdkDevice>
+	class DpdkDeviceList : public internal::DeviceListBase<DpdkDevice>
 	{
 		friend class KniDeviceList;
 


### PR DESCRIPTION
Fixes `DpdkDeviceList` not publicly inheriting `DeviceListBase` like other device list classes to allow common device list functionalities like iteration over all devices.