### PR TITLE
Simplify TcpReassembly connection purge to use multimap.

### DIFF
--- a/Packet++/header/TcpReassembly.h
+++ b/Packet++/header/TcpReassembly.h
@@ -483,7 +483,7 @@ namespace pcpp
 
 		void closeConnectionInternal(uint32_t flowKey, ConnectionEndReason reason);
 
-		void insertIntoCleanupList(uint32_t flowKey);
+		void scheduleCleanup(uint32_t flowKey);
 	};
 
 }  // namespace pcpp

--- a/Packet++/header/TcpReassembly.h
+++ b/Packet++/header/TcpReassembly.h
@@ -460,7 +460,7 @@ namespace pcpp
 		};
 
 		using ConnectionList = std::unordered_map<uint32_t, TcpReassemblyData>;
-		using CleanupList = std::map<time_t, std::list<uint32_t>>;
+		using CleanupList = std::multimap<time_t, uint32_t>;
 
 		OnTcpMessageReady m_OnMessageReadyCallback;
 		OnTcpConnectionStart m_OnConnStart;

--- a/Packet++/header/TcpReassembly.h
+++ b/Packet++/header/TcpReassembly.h
@@ -460,7 +460,7 @@ namespace pcpp
 		};
 
 		using ConnectionList = std::unordered_map<uint32_t, TcpReassemblyData>;
-		using CleanupList = std::multimap<time_t, uint32_t>;
+		using CleanupMultiMap = std::multimap<time_t, uint32_t>;
 
 		OnTcpMessageReady m_OnMessageReadyCallback;
 		OnTcpConnectionStart m_OnConnStart;
@@ -468,7 +468,7 @@ namespace pcpp
 		void* m_UserCookie;
 		ConnectionList m_ConnectionList;
 		ConnectionInfoList m_ConnectionInfo;
-		CleanupList m_CleanupList;
+		CleanupMultiMap m_CleanupMultimap;
 		bool m_RemoveConnInfo;
 		uint32_t m_ClosedConnectionDelay;
 		uint32_t m_MaxNumToClean;

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -798,14 +798,14 @@ namespace pcpp
 
 	void TcpReassembly::insertIntoCleanupList(uint32_t flowKey)
 	{
-		// m_CleanupList is a multimap with key of type time_t (expiration time) and a value type uint32_t (flow key).
+		// m_CleanupMultimap is a multimap with key of type time_t (expiration time) and a value type uint32_t (flow key).
 		// Due to being a multimap, multiple flow keys can have the same expiration time.
 		//
 		// During purge, up to 'maxNumToClean' entries with expiration time smaller than the current time will be
 		// removed from storage.
 
 		auto expireTime = time(nullptr) + m_ClosedConnectionDelay;
-		m_CleanupList.insert(std::make_pair(expireTime, flowKey));
+		m_CleanupMultimap.insert(std::make_pair(expireTime, flowKey));
 	}
 
 	uint32_t TcpReassembly::purgeClosedConnections(uint32_t maxNumToClean)
@@ -815,8 +815,8 @@ namespace pcpp
 		if (maxNumToClean == 0)
 			maxNumToClean = m_MaxNumToClean;
 
-		auto it = m_CleanupList.begin();
-		auto itEnd = m_CleanupList.upper_bound(time(nullptr));
+		auto it = m_CleanupMultimap.begin();
+		auto itEnd = m_CleanupMultimap.upper_bound(time(nullptr));
 
 		for (; it != itEnd && count < maxNumToClean; ++it, ++count)
 		{
@@ -825,7 +825,7 @@ namespace pcpp
 			m_ConnectionList.erase(flowKey);
 		}
 
-		m_CleanupList.erase(m_CleanupList.begin(), it);
+		m_CleanupMultimap.erase(m_CleanupMultimap.begin(), it);
 
 		return count;
 	}

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -805,7 +805,7 @@ namespace pcpp
 		// removed from storage.
 
 		auto expireTime = time(nullptr) + m_ClosedConnectionDelay;
-		m_CleanupMultimap.insert(std::make_pair(expireTime, flowKey));
+		m_CleanupMultimap.emplace(expireTime, flowKey);
 	}
 
 	uint32_t TcpReassembly::purgeClosedConnections(uint32_t maxNumToClean)

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -798,16 +798,14 @@ namespace pcpp
 
 	void TcpReassembly::insertIntoCleanupList(uint32_t flowKey)
 	{
-		// m_CleanupList is a map with key of type time_t (expiration time). The mapped type is a list that stores the
-		// flow keys to be cleared in certain point of time. m_CleanupList.insert inserts an empty list if the container
-		// does not already contain an element with an equivalent key, otherwise this method returns an iterator to the
-		// element that prevents insertion.
-		std::pair<CleanupList::iterator, bool> pair =
-		    m_CleanupList.insert(std::make_pair(time(nullptr) + m_ClosedConnectionDelay, CleanupList::mapped_type()));
+		// m_CleanupList is a multimap with key of type time_t (expiration time) and a value type uint32_t (flow key).
+		// Due to being a multimap, multiple flow keys can have the same expiration time.
+		//
+		// During purge, up to 'maxNumToClean' entries with expiration time smaller than the current time will be
+		// removed from storage.
 
-		// getting the reference to list
-		CleanupList::mapped_type& keysList = pair.first->second;
-		keysList.push_front(flowKey);
+		auto expireTime = time(nullptr) + m_ClosedConnectionDelay;
+		m_CleanupList.insert(std::make_pair(expireTime, flowKey));
 	}
 
 	uint32_t TcpReassembly::purgeClosedConnections(uint32_t maxNumToClean)
@@ -817,24 +815,17 @@ namespace pcpp
 		if (maxNumToClean == 0)
 			maxNumToClean = m_MaxNumToClean;
 
-		CleanupList::iterator iterTime = m_CleanupList.begin(), iterTimeEnd = m_CleanupList.upper_bound(time(nullptr));
-		while (iterTime != iterTimeEnd && count < maxNumToClean)
+		auto it = m_CleanupList.begin();
+		auto itEnd = m_CleanupList.upper_bound(time(nullptr));
+
+		for (; it != itEnd && count < maxNumToClean; ++it, ++count)
 		{
-			CleanupList::mapped_type& keysList = iterTime->second;
-
-			for (; !keysList.empty() && count < maxNumToClean; ++count)
-			{
-				CleanupList::mapped_type::const_reference key = keysList.front();
-				m_ConnectionInfo.erase(key);
-				m_ConnectionList.erase(key);
-				keysList.pop_front();
-			}
-
-			if (keysList.empty())
-				m_CleanupList.erase(iterTime++);
-			else
-				++iterTime;
+			auto flowKey = it->second;
+			m_ConnectionInfo.erase(flowKey);
+			m_ConnectionList.erase(flowKey);
 		}
+
+		m_CleanupList.erase(m_CleanupList.begin(), it);
 
 		return count;
 	}

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -798,8 +798,8 @@ namespace pcpp
 
 	void TcpReassembly::scheduleCleanup(uint32_t flowKey)
 	{
-		// m_CleanupMultimap is a multimap with key of type time_t (expiration time) and a value type uint32_t (flow key).
-		// Due to being a multimap, multiple flow keys can have the same expiration time.
+		// m_CleanupMultimap is a multimap with key of type time_t (expiration time) and a value type uint32_t (flow
+		// key). Due to being a multimap, multiple flow keys can have the same expiration time.
 		//
 		// During purge, up to 'maxNumToClean' entries with expiration time smaller than the current time will be
 		// removed from storage.

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -751,7 +751,7 @@ namespace pcpp
 			m_OnConnEnd(tcpReassemblyData.connData, reason, m_UserCookie);
 
 		tcpReassemblyData.closed = true;  // mark the connection as closed
-		insertIntoCleanupList(flowKey);
+		scheduleCleanup(flowKey);
 
 		PCPP_LOG_DEBUG("Connection with flow key 0x" << std::hex << flowKey << " is closed");
 	}
@@ -781,7 +781,7 @@ namespace pcpp
 				m_OnConnEnd(tcpReassemblyData.connData, TcpReassemblyConnectionClosedManually, m_UserCookie);
 
 			tcpReassemblyData.closed = true;  // mark the connection as closed
-			insertIntoCleanupList(flowKey);
+			scheduleCleanup(flowKey);
 
 			PCPP_LOG_DEBUG("Connection with flow key 0x" << std::hex << flowKey << " is closed");
 		}
@@ -796,7 +796,7 @@ namespace pcpp
 		return -1;
 	}
 
-	void TcpReassembly::insertIntoCleanupList(uint32_t flowKey)
+	void TcpReassembly::scheduleCleanup(uint32_t flowKey)
 	{
 		// m_CleanupMultimap is a multimap with key of type time_t (expiration time) and a value type uint32_t (flow key).
 		// Due to being a multimap, multiple flow keys can have the same expiration time.


### PR DESCRIPTION
The change removes the need to create a list for situations where only 1 connection will be purged at time T.
Instead the additional flow keys at time T will be directly inserted into the multimap as additional nodes.

The change also simplifies the purge code down to a single loop over the range of nodes `[beginIt, upperBound(T))`.
Since `multimap<K, V>` is an ordered container, the connections are purged in the order: oldest expire time -> oldest insertion.