### PR TITLE
Modernize internal `TcpReassembly` structs to Cpp11.

### DIFF
--- a/Packet++/header/TcpReassembly.h
+++ b/Packet++/header/TcpReassembly.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <list>
 #include <time.h>
+#include <array>
 #include <functional>
 
 /// @file
@@ -401,13 +402,11 @@ namespace pcpp
 	private:
 		struct TcpFragment
 		{
-			uint32_t sequence;
-			size_t dataLength;
-			uint8_t* data;
+			uint32_t sequence = 0;
+			size_t dataLength = 0;
+			uint8_t* data = nullptr;
 			std::chrono::time_point<std::chrono::high_resolution_clock> timestamp;
 
-			TcpFragment() : sequence(0), dataLength(0), data(nullptr)
-			{}
 			~TcpFragment()
 			{
 				delete[] data;
@@ -416,26 +415,20 @@ namespace pcpp
 
 		struct TcpOneSideData
 		{
-			IPAddress srcIP;
-			uint16_t srcPort;
-			uint32_t sequence;
 			PointerVector<TcpFragment> tcpFragmentList;
-			bool gotFinOrRst;
-
-			TcpOneSideData() : srcPort(0), sequence(0), gotFinOrRst(false)
-			{}
+			uint32_t sequence = 0;
+			uint16_t srcPort = 0;
+			IPAddress srcIP;
+			bool gotFinOrRst = false;
 		};
 
 		struct TcpReassemblyData
 		{
-			bool closed;
-			int8_t numOfSides;
-			int8_t prevSide;
-			TcpOneSideData twoSides[2];
+			bool closed = false;
+			int8_t numOfSides = 0;
+			int8_t prevSide = -1;
+			std::array<TcpOneSideData, 2> twoSides;
 			ConnectionData connData;
-
-			TcpReassemblyData() : closed(false), numOfSides(0), prevSide(-1)
-			{}
 		};
 
 		class OutOfOrderProcessingGuard


### PR DESCRIPTION
This PR updates the internal helper structs of `TcpReassembly` to utilize default member initializers.

It also optimizes `TcpOneSideData` size (64 bytes -> 56 bytes in Release) by reordering some members to reduce internal padding due to alignment requirements.