### PR TITLE
Fix #1863: Heap-buffer-overflow in TLSECPointFormatExtension parsing

### DIFF
--- a/Packet++/src/SSLHandshake.cpp
+++ b/Packet++/src/SSLHandshake.cpp
@@ -1223,8 +1223,13 @@ namespace pcpp
 		std::vector<uint8_t> result;
 
 		uint16_t extensionLength = getLength();
+
+		if (extensionLength < 1)
+			return result;
+
 		uint8_t listLength = *getData();
-		if (listLength != static_cast<uint8_t>(extensionLength - 1))
+
+		if (extensionLength != static_cast<uint16_t>(listLength) + 1)
 			return result;  // bad extension data
 
 		uint8_t* dataPtr = getData() + sizeof(uint8_t);

--- a/Tests/Packet++Test/TestDefinition.h
+++ b/Tests/Packet++Test/TestDefinition.h
@@ -168,6 +168,7 @@ PTF_TEST_CASE(SSLMultipleRecordParsing5Test);
 PTF_TEST_CASE(SSLPartialCertificateParseTest);
 PTF_TEST_CASE(SSLNewSessionTicketParseTest);
 PTF_TEST_CASE(SSLMalformedPacketParsing);
+PTF_TEST_CASE(SSLECPointFormatExtensionZeroLengthTest);
 PTF_TEST_CASE(TLS1_3ParsingTest);
 PTF_TEST_CASE(TLSCipherSuiteTest);
 PTF_TEST_CASE(ClientHelloTLSFingerprintTest);

--- a/Tests/Packet++Test/Tests/SSLTests.cpp
+++ b/Tests/Packet++Test/Tests/SSLTests.cpp
@@ -563,6 +563,21 @@ PTF_TEST_CASE(SSLMalformedPacketParsing)
 	PTF_ASSERT_EQUAL(clientHelloMessage->getExtensionCount(), 1);
 }  // SSLMalformedPacketParsing
 
+PTF_TEST_CASE(SSLECPointFormatExtensionZeroLengthTest)
+{
+	// Malformed EC Point Formats extension data payload:
+	// Bytes 0-1: { 0x00, 0x0b } -> Extension Type = 11 (EC Point Formats)
+	// Bytes 2-3: { 0x00, 0x00 } -> Extension Length = 0
+	// (This is malformed because it lacks the mandatory 1-byte list length field.
+	// It intentionally triggers the integer underflow vulnerability.)
+	uint8_t malformedExtData[] = { 0x00, 0x0b, 0x00, 0x00 };
+
+	pcpp::TLSECPointFormatExtension ecPointExt(malformedExtData, sizeof(malformedExtData));
+	std::vector<uint8_t> ecPointFormatList = ecPointExt.getECPointFormatList();
+
+	PTF_ASSERT_TRUE(ecPointFormatList.empty());
+}  // SSLECPointFormatExtensionZeroLengthTest
+
 PTF_TEST_CASE(TLS1_3ParsingTest)
 {
 	timeval time;

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -253,6 +253,7 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(SSLPartialCertificateParseTest, "ssl");
 	PTF_RUN_TEST(SSLNewSessionTicketParseTest, "ssl");
 	PTF_RUN_TEST(SSLMalformedPacketParsing, "ssl");
+	PTF_RUN_TEST(SSLECPointFormatExtensionZeroLengthTest, "ssl");
 	PTF_RUN_TEST(TLS1_3ParsingTest, "ssl");
 	PTF_RUN_TEST(TLSCipherSuiteTest, "ssl");
 	PTF_RUN_TEST(ClientHelloTLSFingerprintTest, "ssl");


### PR DESCRIPTION
## Description
Fixes #1863.

This Pull Request addresses a heap-buffer-overflow vulnerability detected by AddressSanitizer (ASAN) during the parsing of malformed TLS Client Hello messages, specifically within `pcpp::TLSECPointFormatExtension::getECPointFormatList()`.

### Root Cause
When an EC Point Formats extension is crafted with an `extensionLength` of 0, the previous boundary check (`extensionLength - 1`) resulted in an integer underflow. This bypassed the validation, allowing the subsequent loop to read out of bounds based on a forged `listLength`.

### Proposed Fix
* **Memory Safety:** Added a minimum length check (`extensionLength < 1`) prior to pointer dereferencing to prevent illegal memory access.
* **Logic Refactoring:** Refactored the boundary validation to use addition (`extensionLength != static_cast<uint16_t>(listLength) + 1`), completely eliminating the integer underflow vector.
