### PR TITLE
Add basic tool to dump pcap to test dat resource format.

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -5,6 +5,7 @@ if(PCAPPP_BUILD_TESTS)
 
   if(PCAPPP_BUILD_PCAPPP)
     add_subdirectory(Pcap++Test)
+    add_subdirectory(Tools/ResourceDumper)
   endif()
 endif()
 

--- a/Tests/Tools/ResourceDumper/CMakeLists.txt
+++ b/Tests/Tools/ResourceDumper/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(ResourceDumper ResourceDumper.cpp)
+target_link_libraries(ResourceDumper PcppTestUtilities Pcap++)

--- a/Tests/Tools/ResourceDumper/ResourceDumper.cpp
+++ b/Tests/Tools/ResourceDumper/ResourceDumper.cpp
@@ -1,0 +1,70 @@
+#include <iostream>
+
+#include "PcapFileDevice.h"
+#include "Resources.h"
+
+int main(int argc, char* argv[])
+{
+	if (argc != 5)
+	{
+		std::cerr << "Usage: " << argv[0] << " <pcap file> <packet num> <resource type [hex]> <output file>"
+		          << std::endl;
+		return 1;
+	}
+
+	std::string pcapFile = argv[1];
+	int packetNum = std::stoi(argv[2]);
+	std::string resourceType = argv[3];
+	std::string outputFile = argv[4];
+
+	if (resourceType != "hex")
+	{
+		std::cerr << "Unsupported resource type: " << resourceType << std::endl;
+		return 1;
+	}
+
+	auto dev = pcpp::IFileReaderDevice::getReader(pcapFile);
+	if (!dev->open())
+	{
+		std::cerr << "Error opening the pcap file" << std::endl;
+		return 1;
+	}
+
+	pcpp_tests::utils::ResourceProvider resourceProvider(".", false /* unfreeze the provider */);
+
+	// Skip packets until we reach the packet we want to dump.
+	pcpp::RawPacket rawPacket;
+	for (int i = 0; i < packetNum; i++)
+	{
+		if (!dev->getNextPacket(rawPacket))
+		{
+			std::cerr << "Error reading packet number " << i << std::endl;
+			return 1;
+		}
+	}
+
+	// Read the actual packet we want to dump
+	if (!dev->getNextPacket(rawPacket))
+	{
+		std::cerr << "Error reading packet number " << packetNum << std::endl;
+		return 1;
+	}
+
+	using pcpp_tests::utils::ResourceType;
+	resourceProvider.saveResource(ResourceType::HexData, outputFile.c_str(), rawPacket.getRawData(),
+	                              rawPacket.getRawDataLen());
+
+	// Test loading the resource back to ensure it was saved correctly
+	auto res = resourceProvider.loadResourceToVector(outputFile.c_str(), ResourceType::HexData);
+	for (size_t i = 0; i < res.size(); ++i)
+	{
+		if (res[i] != rawPacket.getRawData()[i])
+		{
+			std::cerr << "Error: loaded resource does not match original packet data at byte " << i << std::endl;
+			return 1;
+		}
+	}
+
+	dev->close();
+	return 0;
+}


### PR DESCRIPTION
This PR adds a test tool for dumping a packet to the test hex .dat format using the resource utility.

Since are mostly using the hex format to store packet samples for tests, I think it would be useful to have a standard tool to generate them.

PS: I think we don't have such a tool yet? Or at least I haven't found it?