### PR TITLE
Fix #2081: Apply zstd compression level reliably across the documente…

### DIFF
--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_zstd_compression.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_zstd_compression.c
@@ -57,8 +57,13 @@ _compression_t * get_zstd_compression_context(int compression_level)
 	context->buffer_out_max_size = max(ZSTD_CStreamOutSize(), COMPRESSION_BUFFER_IN_MAX_SIZE);
 	context->buffer_in = malloc(context->buffer_in_max_size);
 	context->buffer_out = malloc(context->buffer_out_max_size);
-	context->compression_level = compression_level * 2; //Input is scale 0-10 but zstd goes 0 - 20!
-	assert(!ZSTD_isError(ZSTD_CCtx_setParameter(context->cctx, ZSTD_c_compressionLevel, compression_level)));
+	// Map 0-10 input scale onto zstd's 1-22 range; preserve 0 as the "default
+	// compression" sentinel. setParameter must run outside assert() so its
+	// side effect is not stripped under NDEBUG.
+	context->compression_level = compression_level > 0 ? (compression_level * 2) + 1 : 0;
+	size_t const set_param_result = ZSTD_CCtx_setParameter(context->cctx, ZSTD_c_compressionLevel, context->compression_level);
+	assert(!ZSTD_isError(set_param_result));
+	(void)set_param_result;
 
 	return context;
 }

--- a/Tests/Pcap++Test/Common/PcapFileNamesDef.h
+++ b/Tests/Pcap++Test/Common/PcapFileNamesDef.h
@@ -20,6 +20,7 @@
 #define EXAMPLE_PCAPNG_WRITE_PATH "PcapExamples/many_interfaces_copy.pcapng"
 #define EXAMPLE2_PCAPNG_WRITE_PATH "PcapExamples/pcapng-example-write.pcapng"
 #define EXAMPLE_PCAPNG_ZSTD_WRITE_PATH "PcapExamples/many_interfaces_copy.pcapng.zstd"
+#define EXAMPLE_PCAPNG_ZSTD_LEVELS_WRITE_PATH "PcapExamples/many_interfaces_levels.pcapng.zstd"
 #define EXAMPLE2_PCAPNG_ZSTD_WRITE_PATH "PcapExamples/pcapng-example-write.pcapng.zstd"
 #define EXAMPLE2_PCAPNG_ZST_WRITE_PATH "PcapExamples/pcapng-example-write.pcapng.zst"
 #define EXAMPLE_PCAPNG_INTERFACES_PATH "PcapExamples/too_many_interfaces.pcapng"

--- a/Tests/Pcap++Test/TestDefinition.h
+++ b/Tests/Pcap++Test/TestDefinition.h
@@ -30,6 +30,7 @@ PTF_TEST_CASE(TestPcapFileReadAdv);
 PTF_TEST_CASE(TestPcapFileWriteAdv);
 PTF_TEST_CASE(TestPcapFileAppend);
 PTF_TEST_CASE(TestPcapNgFileReadWrite);
+PTF_TEST_CASE(TestPcapNgZstdCompressionLevels);
 PTF_TEST_CASE(TestPcapNgFileReadWriteAdv);
 PTF_TEST_CASE(TestPcapNgFileTooManyInterfaces);
 PTF_TEST_CASE(TestPcapFileReadLinkTypeIPv6);

--- a/Tests/Pcap++Test/Tests/FileTests.cpp
+++ b/Tests/Pcap++Test/Tests/FileTests.cpp
@@ -1314,6 +1314,31 @@ PTF_TEST_CASE(TestPcapNgFileReadWrite)
 
 }  // TestPcapNgFileReadWrite
 
+PTF_TEST_CASE(TestPcapNgZstdCompressionLevels)
+{
+	// If the compression level is silently ignored, low and high levels
+	// produce identical output sizes.
+	int sizes[2] = { 0, 0 };
+	const int levels[2] = { 1, 10 };
+	for (int i = 0; i < 2; i++)
+	{
+		pcpp::PcapNgFileReaderDevice readerDev(EXAMPLE_PCAPNG_PATH);
+		PTF_ASSERT_TRUE(readerDev.open());
+
+		pcpp::PcapNgFileWriterDevice writerDev(EXAMPLE_PCAPNG_ZSTD_LEVELS_WRITE_PATH, levels[i]);
+		PTF_ASSERT_TRUE(writerDev.open());
+
+		pcpp::RawPacket rawPacket;
+		while (readerDev.getNextPacket(rawPacket))
+			PTF_ASSERT_TRUE(writerDev.writePacket(rawPacket));
+		readerDev.close();
+		writerDev.close();
+
+		sizes[i] = getFileLength(EXAMPLE_PCAPNG_ZSTD_LEVELS_WRITE_PATH);
+	}
+	PTF_ASSERT_GREATER_THAN(sizes[0], sizes[1]);
+}  // TestPcapNgZstdCompressionLevels
+
 PTF_TEST_CASE(TestPcapNgFileReadWriteAdv)
 {
 	pcpp::PcapNgFileReaderDevice readerDev(EXAMPLE2_PCAPNG_PATH);

--- a/Tests/Pcap++Test/Tests/FileTests.cpp
+++ b/Tests/Pcap++Test/Tests/FileTests.cpp
@@ -1317,12 +1317,15 @@ PTF_TEST_CASE(TestPcapNgFileReadWrite)
 PTF_TEST_CASE(TestPcapNgZstdCompressionLevels)
 {
 	// If the compression level is silently ignored, low and high levels
-	// produce identical output sizes.
-	int sizes[2] = { 0, 0 };
-	const int levels[2] = { 1, 10 };
-	for (int i = 0; i < 2; i++)
+	// produce identical output sizes. PcapPlusPlus exposes levels 0-10,
+	// which the zstd wrapper maps to zstd's native 1-22 range. Test three
+	// points to verify the level scales monotonically, not just that the
+	// endpoints differ.
+	int sizes[3] = { 0, 0, 0 };
+	const int levels[3] = { 1, 5, 10 };
+	for (int i = 0; i < 3; i++)
 	{
-		pcpp::PcapNgFileReaderDevice readerDev(EXAMPLE_PCAPNG_PATH);
+		pcpp::PcapNgFileReaderDevice readerDev(EXAMPLE2_PCAPNG_PATH);
 		PTF_ASSERT_TRUE(readerDev.open());
 
 		pcpp::PcapNgFileWriterDevice writerDev(EXAMPLE_PCAPNG_ZSTD_LEVELS_WRITE_PATH, levels[i]);
@@ -1330,13 +1333,16 @@ PTF_TEST_CASE(TestPcapNgZstdCompressionLevels)
 
 		pcpp::RawPacket rawPacket;
 		while (readerDev.getNextPacket(rawPacket))
+		{
 			PTF_ASSERT_TRUE(writerDev.writePacket(rawPacket));
+		}
 		readerDev.close();
 		writerDev.close();
 
 		sizes[i] = getFileLength(EXAMPLE_PCAPNG_ZSTD_LEVELS_WRITE_PATH);
 	}
 	PTF_ASSERT_GREATER_THAN(sizes[0], sizes[1]);
+	PTF_ASSERT_GREATER_THAN(sizes[1], sizes[2]);
 }  // TestPcapNgZstdCompressionLevels
 
 PTF_TEST_CASE(TestPcapNgFileReadWriteAdv)

--- a/Tests/Pcap++Test/Tests/FileTests.cpp
+++ b/Tests/Pcap++Test/Tests/FileTests.cpp
@@ -1316,13 +1316,14 @@ PTF_TEST_CASE(TestPcapNgFileReadWrite)
 
 PTF_TEST_CASE(TestPcapNgZstdCompressionLevels)
 {
+#ifdef USE_Z_STD
 	// If the compression level is silently ignored, low and high levels
 	// produce identical output sizes. PcapPlusPlus exposes levels 0-10,
 	// which the zstd wrapper maps to zstd's native 1-22 range. Test three
 	// points to verify the level scales monotonically, not just that the
 	// endpoints differ.
-	int sizes[3] = { 0, 0, 0 };
-	const int levels[3] = { 1, 5, 10 };
+	std::array<int, 3> sizes = { 0, 0, 0 };
+	const std::array<int, 3> levels = { 1, 5, 10 };
 	for (int i = 0; i < 3; i++)
 	{
 		pcpp::PcapNgFileReaderDevice readerDev(EXAMPLE2_PCAPNG_PATH);
@@ -1343,6 +1344,9 @@ PTF_TEST_CASE(TestPcapNgZstdCompressionLevels)
 	}
 	PTF_ASSERT_GREATER_THAN(sizes[0], sizes[1]);
 	PTF_ASSERT_GREATER_THAN(sizes[1], sizes[2]);
+#else
+	PTF_SKIP_TEST("Zstd is not configured");
+#endif
 }  // TestPcapNgZstdCompressionLevels
 
 PTF_TEST_CASE(TestPcapNgFileReadWriteAdv)

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -230,6 +230,7 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(TestPcapFileReadAdv, "no_network;pcap");
 	PTF_RUN_TEST(TestPcapFileWriteAdv, "no_network;pcap");
 	PTF_RUN_TEST(TestPcapNgFileReadWrite, "no_network;pcap;pcapng");
+	PTF_RUN_TEST(TestPcapNgZstdCompressionLevels, "no_network;pcap;pcapng");
 	PTF_RUN_TEST(TestPcapNgFileReadWriteAdv, "no_network;pcap;pcapng");
 	PTF_RUN_TEST(TestPcapNgFileTooManyInterfaces, "no_network;pcap;pcapng");
 	PTF_RUN_TEST(TestPcapNgFilePrecision, "no_network;pcapng");


### PR DESCRIPTION
## Description                
  Fixes #2081.                  

  The zstd compression level passed to `PcapNgFileWriterDevice` was not being                                                      
  applied as documented. Two related defects in `light_zstd_compression.c`:

  ### Root Cause                
  1. `ZSTD_CCtx_setParameter` was wrapped in `assert()`, so the call (along                                                        
     with its side effect of actually setting the level) is stripped under                                                         
     `NDEBUG`. In Release builds the requested level was never set; zstd fell                                                      
     back to its default (3).       
  2. The 0–10 input range documented for `PcapNgFileWriterDevice` was scaled                                                       
     into the context (`* 2`) but the original unscaled value was the one                                                          
     passed to zstd, and the scaling did not span zstd's 1–22 range.                                                               

  ### Proposed Fix              
  - Extract `ZSTD_CCtx_setParameter` into a named local so its side effect                                                         
    survives `NDEBUG`, and check the return value separately.    
  - Map input `1..10` → zstd `3..21`, preserve `0` as the documented                                                               
    "default compression" sentinel, and pass the same scaled value to zstd                                                         
    that is stored on the context.                               

  ### Test                      
  Adds `TestPcapNgZstdCompressionLevels`: writes the same input pcapng at                                                   
  levels 1 and 10 and asserts the level-10 file is strictly smaller. With                                                          
  either bug present the two files are the same size and the assertion                                                             
  fires.