### PR TITLE
Improve AF_XDP CI tests using veth interfaces

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -989,6 +989,14 @@ jobs:
       - name: Build PcapPlusPlus
         run: cmake --build $BUILD_DIR -j
 
+      - name: Setup veth pair
+        run: |
+          sudo ip link add veth0 type veth peer name veth1
+          sudo ip link set veth0 up
+          sudo ip link set veth1 up
+          sudo ip addr add 192.168.100.1/24 dev veth0
+          sudo ip addr add 192.168.100.2/24 dev veth1
+
       - name: Prepare environment for tests
         run: |
           python -m venv .venv
@@ -998,7 +1006,7 @@ jobs:
       - name: Test PcapPlusPlus
         run: |
           . .venv/bin/activate
-          python ci/run_tests/run_tests.py --interface eth0 --use-sudo --pcap-test-args="-t xdp" --build-dir "$BUILD_DIR"
+          python ci/run_tests/run_tests.py --interface eth0 --tcpreplay-interface veth1 --use-sudo --pcap-test-args "-e veth0 -t xdp" --build-dir "$BUILD_DIR"
 
       - name: Create Cobertura Report
         run: |

--- a/Tests/Pcap++Test/Common/GlobalTestArgs.h
+++ b/Tests/Pcap++Test/Common/GlobalTestArgs.h
@@ -13,4 +13,5 @@ struct PcapTestArgs
 	int dpdkPort;
 	std::vector<std::string> dpdkArgs;
 	std::string kniIp;
+	std::string xdpInterface;
 };

--- a/Tests/Pcap++Test/Tests/XdpTests.cpp
+++ b/Tests/Pcap++Test/Tests/XdpTests.cpp
@@ -57,7 +57,6 @@ PTF_TEST_CASE(TestXdpDeviceReceivePackets)
 {
 #ifdef USE_XDP
 	std::string devName = getDeviceName();
-	std::cout << "devName is: " << devName << std::endl;
 	PTF_ASSERT_FALSE(devName.empty());
 	pcpp::XdpDevice device(devName);
 
@@ -73,7 +72,6 @@ PTF_TEST_CASE(TestXdpDeviceReceivePackets)
 	auto onPacketsArrive = [](pcpp::RawPacket packets[], uint32_t packetCount, pcpp::XdpDevice* device,
 	                          void* userCookie) -> void {
 		auto packetData = static_cast<XdpPacketData*>(userCookie);
-		std::cout << "Received packets: " << packetCount << std::endl;
 
 		for (uint32_t i = 0; i < packetCount; i++)
 		{

--- a/Tests/Pcap++Test/Tests/XdpTests.cpp
+++ b/Tests/Pcap++Test/Tests/XdpTests.cpp
@@ -36,6 +36,11 @@ bool assertConfig(const pcpp::XdpDevice::XdpDeviceConfiguration* config,
 
 std::string getDeviceName()
 {
+	if (!PcapTestGlobalArgs.xdpInterface.empty())
+	{
+		return PcapTestGlobalArgs.xdpInterface;
+	}
+
 	auto pcapLiveDev =
 	    pcpp::PcapLiveDeviceList::getInstance().getDeviceByIp(PcapTestGlobalArgs.ipToSendReceivePackets.c_str());
 	if (pcapLiveDev)
@@ -52,6 +57,7 @@ PTF_TEST_CASE(TestXdpDeviceReceivePackets)
 {
 #ifdef USE_XDP
 	std::string devName = getDeviceName();
+	std::cout << "devName is: " << devName << std::endl;
 	PTF_ASSERT_FALSE(devName.empty());
 	pcpp::XdpDevice device(devName);
 
@@ -67,6 +73,7 @@ PTF_TEST_CASE(TestXdpDeviceReceivePackets)
 	auto onPacketsArrive = [](pcpp::RawPacket packets[], uint32_t packetCount, pcpp::XdpDevice* device,
 	                          void* userCookie) -> void {
 		auto packetData = static_cast<XdpPacketData*>(userCookie);
+		std::cout << "Received packets: " << packetCount << std::endl;
 
 		for (uint32_t i = 0; i < packetCount; i++)
 		{

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -30,28 +30,29 @@ static struct option PcapTestOptions[] = {
 
 void printUsage()
 {
-	std::cout << "Usage: Pcap++Test -i ip_to_use | [-n] [-b] [-s] [-m] [-r remote_ip_addr] [-p remote_port] [-d "
-	             "dpdk_port] [-a dpdk_args] [-e xdp_interface] [-k ip_addr] [-t tags] [-w] [-h]\n\n"
-	          << "Flags:\n"
-	          << "-i --use-ip              IP to use for sending and receiving packets\n"
-	          << "-b --debug-mode          Set log level to DEBUG\n"
-	          << "-r --remote-ip	          IP of remote machine running rpcapd to test remote capture\n"
-	          << "-p --remote-port         Port of remote machine running rpcapd to test remote capture\n"
-	          << "-d --dpdk-port           The DPDK NIC port to test. Required if compiling with DPDK\n"
-	          << "-a --dpdk-args           DPDK args to pass to tests\n"
-	          << "-e --xdp-interface       The interface to use for AF_XDP tests. If not specified the IP address in --use-ip is used\n"
-	          << "-n --no-networking       Do not run tests that requires networking\n"
-	          << "-v --verbose             Run in verbose mode (emits more output in several tests)\n"
-	          << "-m --mem-verbose         Output information about each memory allocation and deallocation\n"
-	          << "-s --skip-mem-leak-check Skip memory leak check\n"
-	          << "-k --kni-ip              IP address for KNI device tests to use must not be the same\n"
-	          << "                         as any of existing network interfaces in your system.\n"
-	          << "                         If this parameter is omitted KNI tests will be skipped. Must be an IPv4.\n"
-	          << "                         For Linux systems only\n"
-	          << "-t --include-tags        A list of semicolon separated tags for tests to run\n"
-	          << "-x --exclude-tags        A list of semicolon separated tags for tests to exclude\n"
-	          << "-w --show-skipped-tests  Show tests that are skipped. Default is to hide them in tests results\n"
-	          << "-h --help                Display this help message and exit\n";
+	std::cout
+	    << "Usage: Pcap++Test -i ip_to_use | [-n] [-b] [-s] [-m] [-r remote_ip_addr] [-p remote_port] [-d "
+	       "dpdk_port] [-a dpdk_args] [-e xdp_interface] [-k ip_addr] [-t tags] [-w] [-h]\n\n"
+	    << "Flags:\n"
+	    << "-i --use-ip              IP to use for sending and receiving packets\n"
+	    << "-b --debug-mode          Set log level to DEBUG\n"
+	    << "-r --remote-ip	          IP of remote machine running rpcapd to test remote capture\n"
+	    << "-p --remote-port         Port of remote machine running rpcapd to test remote capture\n"
+	    << "-d --dpdk-port           The DPDK NIC port to test. Required if compiling with DPDK\n"
+	    << "-a --dpdk-args           DPDK args to pass to tests\n"
+	    << "-e --xdp-interface       The interface to use for AF_XDP tests. If not specified the IP address in --use-ip is used\n"
+	    << "-n --no-networking       Do not run tests that requires networking\n"
+	    << "-v --verbose             Run in verbose mode (emits more output in several tests)\n"
+	    << "-m --mem-verbose         Output information about each memory allocation and deallocation\n"
+	    << "-s --skip-mem-leak-check Skip memory leak check\n"
+	    << "-k --kni-ip              IP address for KNI device tests to use must not be the same\n"
+	    << "                         as any of existing network interfaces in your system.\n"
+	    << "                         If this parameter is omitted KNI tests will be skipped. Must be an IPv4.\n"
+	    << "                         For Linux systems only\n"
+	    << "-t --include-tags        A list of semicolon separated tags for tests to run\n"
+	    << "-x --exclude-tags        A list of semicolon separated tags for tests to exclude\n"
+	    << "-w --show-skipped-tests  Show tests that are skipped. Default is to hide them in tests results\n"
+	    << "-h --help                Display this help message and exit\n";
 }
 
 PcapTestArgs PcapTestGlobalArgs;

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -14,6 +14,7 @@ static struct option PcapTestOptions[] = {
 	{ "remote-port",         required_argument, nullptr, 'p' },
 	{ "dpdk-port",           required_argument, nullptr, 'd' },
 	{ "dpdk-args",           required_argument, nullptr, 'a' },
+	{ "xdp-interface",       required_argument, nullptr, 'e' },
 	{ "no-networking",       no_argument,       nullptr, 'n' },
 	{ "verbose",             no_argument,       nullptr, 'v' },
 	{ "mem-verbose",         no_argument,       nullptr, 'm' },
@@ -30,7 +31,7 @@ static struct option PcapTestOptions[] = {
 void printUsage()
 {
 	std::cout << "Usage: Pcap++Test -i ip_to_use | [-n] [-b] [-s] [-m] [-r remote_ip_addr] [-p remote_port] [-d "
-	             "dpdk_port] [-k ip_addr] [-t tags] [-w] [-h]\n\n"
+	             "dpdk_port] [-a dpdk_args] [-e xdp_interface] [-k ip_addr] [-t tags] [-w] [-h]\n\n"
 	          << "Flags:\n"
 	          << "-i --use-ip              IP to use for sending and receiving packets\n"
 	          << "-b --debug-mode          Set log level to DEBUG\n"
@@ -38,6 +39,7 @@ void printUsage()
 	          << "-p --remote-port         Port of remote machine running rpcapd to test remote capture\n"
 	          << "-d --dpdk-port           The DPDK NIC port to test. Required if compiling with DPDK\n"
 	          << "-a --dpdk-args           DPDK args to pass to tests\n"
+	          << "-e --xdp-interface       The interface to use for AF_XDP tests. If not specified the IP address in --use-ip is used\n"
 	          << "-n --no-networking       Do not run tests that requires networking\n"
 	          << "-v --verbose             Run in verbose mode (emits more output in several tests)\n"
 	          << "-m --mem-verbose         Output information about each memory allocation and deallocation\n"
@@ -68,7 +70,7 @@ int main(int argc, char* argv[])
 
 	int optionIndex = 0;
 	int opt = 0;
-	while ((opt = getopt_long(argc, argv, "k:i:br:p:d:a:nvt:x:smw", PcapTestOptions, &optionIndex)) != -1)
+	while ((opt = getopt_long(argc, argv, "k:i:br:p:d:a:e:nvt:x:smw", PcapTestOptions, &optionIndex)) != -1)
 	{
 		switch (opt)
 		{
@@ -94,6 +96,9 @@ int main(int argc, char* argv[])
 			break;
 		case 'a':
 			PcapTestGlobalArgs.dpdkArgs.push_back(optarg);
+			break;
+		case 'e':
+			PcapTestGlobalArgs.xdpInterface = optarg;
 			break;
 		case 'n':
 			runWithNetworking = false;


### PR DESCRIPTION
AF_XDP tests are [very flaky](https://github.com/seladb/PcapPlusPlus/actions/runs/25093206821/job/73523840137) because the AF_XDP socket doesn't capture the packets replayed by tcpreplay to the same interface.

The solution is similar to what we do in [DPDK CI tests](https://github.com/seladb/PcapPlusPlus/pull/2106) which is create 2 veth interfaces, run tcpreplay on `veth1` and capture packets with AF_XDP on `veth0`.