### PR TITLE
Add standard upgrade path for `enum` to `enum class` transition.

### DIFF
--- a/Common++/header/DeprecationUtils.h
+++ b/Common++/header/DeprecationUtils.h
@@ -9,7 +9,7 @@
 // Provides backwards compatibility for enum class types that have been upgraded.
 //
 // This macro should be once used in the header file of the upgraded enum class type with each enum value.
-// This will define the enum value as a const auto with the same name, mimicing the old enum value, but
+// This will define the enum value as a const auto with the same name, mimicking the old enum value, but
 // with a deprecation warning to encourage users to switch to the new enum class value.
 //
 #define PCPP_ENUM_CLASS_UPGRADE_COMPAT(cls, val)                                                                       \

--- a/Common++/header/DeprecationUtils.h
+++ b/Common++/header/DeprecationUtils.h
@@ -6,6 +6,16 @@
 #	define PCPP_DEPRECATED(msg) [[deprecated(msg)]]
 #endif
 
+// Provides backwards compatibility for enum class types that have been upgraded..
+//
+// This macro should be once used in the header file of the upgraded enum class type with each enum value.
+// This will define the enum value as a const auto with the same name, mimicing the old enum value, but
+// with a deprecation warning to encourage users to switch to the new enum class value.
+//
+#define PCPP_ENUM_CLASS_UPGRADE_COMPAT(cls, val)                                                                       \
+	PCPP_DEPRECATED("Enum class upgrade: Use " #cls "::" #val " instead.")                                             \
+	const auto val = cls::val
+
 #if !defined(DISABLE_WARNING_PUSH) || !defined(DISABLE_WARNING_POP)
 #	if defined(_MSC_VER)
 #		define DISABLE_WARNING_PUSH __pragma(warning(push))

--- a/Common++/header/DeprecationUtils.h
+++ b/Common++/header/DeprecationUtils.h
@@ -6,7 +6,7 @@
 #	define PCPP_DEPRECATED(msg) [[deprecated(msg)]]
 #endif
 
-// Provides backwards compatibility for enum class types that have been upgraded..
+// Provides backwards compatibility for enum class types that have been upgraded.
 //
 // This macro should be once used in the header file of the upgraded enum class type with each enum value.
 // This will define the enum value as a const auto with the same name, mimicing the old enum value, but

--- a/Common++/header/DeprecationUtils.h
+++ b/Common++/header/DeprecationUtils.h
@@ -14,7 +14,7 @@
 //
 #define PCPP_ENUM_CLASS_UPGRADE_COMPAT(cls, val)                                                                       \
 	PCPP_DEPRECATED("Enum class upgrade: Use " #cls "::" #val " instead.")                                             \
-	const auto val = cls::val
+	const static auto val = cls::val
 
 #if !defined(DISABLE_WARNING_PUSH) || !defined(DISABLE_WARNING_POP)
 #	if defined(_MSC_VER)

--- a/Pcap++/header/DpdkDevice.h
+++ b/Pcap++/header/DpdkDevice.h
@@ -8,6 +8,7 @@
 #include "SystemUtils.h"
 #include "Device.h"
 #include "MBufRawPacket.h"
+#include "DeprecationUtils.h"
 
 /// @file
 /// This file and DpdkDeviceList.h provide PcapPlusPlus C++ wrapper for DPDK (stands for data-plan development kit).
@@ -74,7 +75,7 @@ namespace pcpp
 
 	/// An enum describing all PMD (poll mode driver) types supported by DPDK. For more info about these PMDs please
 	/// visit the DPDK web-site
-	enum DpdkPMDType
+	enum class DpdkPMDType
 	{
 		/// Unknown PMD type
 		PMD_UNKNOWN,
@@ -116,6 +117,26 @@ namespace pcpp
 		/// AF_PACKET PMD
 		PMD_AF_PACKET
 	};
+
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_UNKNOWN);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_BOND);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_E1000EM);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_IGB);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_IGBVF);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_ENIC);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_FM10K);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_I40E);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_I40EVF);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_IXGBE);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_IXGBEVF);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_MLX4);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_NULL);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_PCAP);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_RING);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_VIRTIO);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_VMXNET3);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_XENVIRT);
+	PCPP_ENUM_CLASS_UPGRADE_COMPAT(DpdkPMDType, PMD_AF_PACKET);
 
 	/// @typedef OnDpdkPacketsArriveCallback
 	/// A callback that is called when a burst of packets are captured by DpdkDevice

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -243,9 +243,6 @@ namespace pcpp
 			PCPP_OUT
 		};
 
-		// const static auto PCPP_INOUT = PcapDirection::PCPP_INOUT;
-		// const static auto PCPP_IN = PcapDirection::PCPP_IN;
-		// const static auto PCPP_OUT = PcapDirection::PCPP_OUT;
 		PCPP_ENUM_CLASS_UPGRADE_COMPAT(PcapDirection, PCPP_INOUT);
 		PCPP_ENUM_CLASS_UPGRADE_COMPAT(PcapDirection, PCPP_IN);
 		PCPP_ENUM_CLASS_UPGRADE_COMPAT(PcapDirection, PCPP_OUT);

--- a/Pcap++/header/PcapLiveDevice.h
+++ b/Pcap++/header/PcapLiveDevice.h
@@ -233,7 +233,7 @@ namespace pcpp
 
 		/// Set direction for capturing packets (you can read more here:
 		/// <https://www.tcpdump.org/manpages/pcap.3pcap.html#lbAI>)
-		enum PcapDirection
+		enum class PcapDirection
 		{
 			/// Capture traffics both incoming and outgoing
 			PCPP_INOUT = 0,
@@ -242,6 +242,13 @@ namespace pcpp
 			/// Only capture outgoing traffics
 			PCPP_OUT
 		};
+
+		// const static auto PCPP_INOUT = PcapDirection::PCPP_INOUT;
+		// const static auto PCPP_IN = PcapDirection::PCPP_IN;
+		// const static auto PCPP_OUT = PcapDirection::PCPP_OUT;
+		PCPP_ENUM_CLASS_UPGRADE_COMPAT(PcapDirection, PCPP_INOUT);
+		PCPP_ENUM_CLASS_UPGRADE_COMPAT(PcapDirection, PCPP_IN);
+		PCPP_ENUM_CLASS_UPGRADE_COMPAT(PcapDirection, PCPP_OUT);
 
 		/// Set which source provides timestamps associated to each captured packet
 		/// (you can read more here: <https://www.tcpdump.org/manpages/pcap-tstamp.7.html>)
@@ -339,7 +346,7 @@ namespace pcpp
 			/// @param[in] timestampPrecision The timestamp precision (not all platforms support this).
 			/// Default precision is Microseconds.
 			explicit DeviceConfiguration(DeviceMode mode = Promiscuous, int packetBufferTimeoutMs = 0,
-			                             int packetBufferSize = 0, PcapDirection direction = PCPP_INOUT,
+			                             int packetBufferSize = 0, PcapDirection direction = PcapDirection::PCPP_INOUT,
 			                             int snapshotLength = 0, unsigned int nflogGroup = 0, bool usePoll = false,
 			                             TimestampProvider timestampProvider = TimestampProvider::Host,
 			                             TimestampPrecision timestampPrecision = TimestampPrecision::Microseconds)

--- a/Pcap++/src/DpdkDevice.cpp
+++ b/Pcap++/src/DpdkDevice.cpp
@@ -203,7 +203,7 @@ namespace pcpp
 		// it's impossible to close it and open it again with a larger number of RX+TX queues. So for this
 		// PMD I made a patch to open the device in the first time with maximum RX & TX queue, close it
 		// immediately and open it again with number of queues the user wanted to
-		if (!m_WasOpened && m_PMDType == PMD_VMXNET3)
+		if (!m_WasOpened && m_PMDType == DpdkPMDType::PMD_VMXNET3)
 		{
 			m_WasOpened = true;
 			openMultiQueues(getTotalNumOfRxQueues(), getTotalNumOfTxQueues(), config);
@@ -533,41 +533,41 @@ namespace pcpp
 		m_PMDName = std::string(portInfo.driver_name);
 
 		if (m_PMDName == "eth_bond")
-			m_PMDType = PMD_BOND;
+			m_PMDType = DpdkPMDType::PMD_BOND;
 		else if (m_PMDName == "rte_em_pmd")
-			m_PMDType = PMD_E1000EM;
+			m_PMDType = DpdkPMDType::PMD_E1000EM;
 		else if (m_PMDName == "rte_igb_pmd")
-			m_PMDType = PMD_IGB;
+			m_PMDType = DpdkPMDType::PMD_IGB;
 		else if (m_PMDName == "rte_igbvf_pmd")
-			m_PMDType = PMD_IGBVF;
+			m_PMDType = DpdkPMDType::PMD_IGBVF;
 		else if (m_PMDName == "rte_enic_pmd")
-			m_PMDType = PMD_ENIC;
+			m_PMDType = DpdkPMDType::PMD_ENIC;
 		else if (m_PMDName == "rte_pmd_fm10k")
-			m_PMDType = PMD_FM10K;
+			m_PMDType = DpdkPMDType::PMD_FM10K;
 		else if (m_PMDName == "rte_i40e_pmd" || m_PMDName == "net_i40e")
-			m_PMDType = PMD_I40E;
+			m_PMDType = DpdkPMDType::PMD_I40E;
 		else if (m_PMDName == "rte_i40evf_pmd")
-			m_PMDType = PMD_I40EVF;
+			m_PMDType = DpdkPMDType::PMD_I40EVF;
 		else if (m_PMDName == "rte_ixgbe_pmd")
-			m_PMDType = PMD_IXGBE;
+			m_PMDType = DpdkPMDType::PMD_IXGBE;
 		else if (m_PMDName == "rte_ixgbevf_pmd")
-			m_PMDType = PMD_IXGBEVF;
+			m_PMDType = DpdkPMDType::PMD_IXGBEVF;
 		else if (m_PMDName == "librte_pmd_mlx4")
-			m_PMDType = PMD_MLX4;
+			m_PMDType = DpdkPMDType::PMD_MLX4;
 		else if (m_PMDName == "eth_null")
-			m_PMDType = PMD_NULL;
+			m_PMDType = DpdkPMDType::PMD_NULL;
 		else if (m_PMDName == "eth_pcap")
-			m_PMDType = PMD_PCAP;
+			m_PMDType = DpdkPMDType::PMD_PCAP;
 		else if (m_PMDName == "eth_ring")
-			m_PMDType = PMD_RING;
+			m_PMDType = DpdkPMDType::PMD_RING;
 		else if (m_PMDName == "rte_virtio_pmd")
-			m_PMDType = PMD_VIRTIO;
+			m_PMDType = DpdkPMDType::PMD_VIRTIO;
 		else if (m_PMDName == "rte_vmxnet3_pmd")
-			m_PMDType = PMD_VMXNET3;
+			m_PMDType = DpdkPMDType::PMD_VMXNET3;
 		else if (m_PMDName == "eth_xenvirt")
-			m_PMDType = PMD_XENVIRT;
+			m_PMDType = DpdkPMDType::PMD_XENVIRT;
 		else
-			m_PMDType = PMD_UNKNOWN;
+			m_PMDType = DpdkPMDType::PMD_UNKNOWN;
 
 #if (RTE_VER_YEAR < 18) || (RTE_VER_YEAR == 18 && RTE_VER_MONTH < 5)  // before 18.05
 		char pciName[30];
@@ -594,14 +594,14 @@ namespace pcpp
 	{
 		switch (m_PMDType)
 		{
-		case PMD_IGBVF:
-		case PMD_I40EVF:
-		case PMD_IXGBEVF:
-		case PMD_PCAP:
-		case PMD_RING:
-		case PMD_VIRTIO:
-		case PMD_VMXNET3:
-		case PMD_XENVIRT:
+		case DpdkPMDType::PMD_IGBVF:
+		case DpdkPMDType::PMD_I40EVF:
+		case DpdkPMDType::PMD_IXGBEVF:
+		case DpdkPMDType::PMD_PCAP:
+		case DpdkPMDType::PMD_RING:
+		case DpdkPMDType::PMD_VIRTIO:
+		case DpdkPMDType::PMD_VMXNET3:
+		case DpdkPMDType::PMD_XENVIRT:
 			return true;
 		default:
 			return false;
@@ -1474,7 +1474,7 @@ namespace pcpp
 	{
 		if (m_Config.rssHashFunction == static_cast<uint64_t>(RSS_DEFAULT))
 		{
-			if (m_PMDType == PMD_I40E || m_PMDType == PMD_I40EVF)
+			if (m_PMDType == DpdkPMDType::PMD_I40E || m_PMDType == DpdkPMDType::PMD_I40EVF)
 			{
 				return RSS_NONFRAG_IPV4_TCP | RSS_NONFRAG_IPV4_UDP | RSS_NONFRAG_IPV4_OTHER | RSS_FRAG_IPV4 |
 				       RSS_NONFRAG_IPV6_TCP | RSS_NONFRAG_IPV6_UDP | RSS_NONFRAG_IPV6_OTHER | RSS_FRAG_IPV6;

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -199,11 +199,11 @@ namespace pcpp
 	{
 		switch (direction)
 		{
-		case PcapLiveDevice::PCPP_IN:
+		case PcapLiveDevice::PcapDirection::PCPP_IN:
 			return PCAP_D_IN;
-		case PcapLiveDevice::PCPP_OUT:
+		case PcapLiveDevice::PcapDirection::PCPP_OUT:
 			return PCAP_D_OUT;
-		case PcapLiveDevice::PCPP_INOUT:
+		case PcapLiveDevice::PcapDirection::PCPP_INOUT:
 			return PCAP_D_INOUT;
 		default:
 			throw std::invalid_argument("Unknown direction type");
@@ -713,12 +713,12 @@ namespace pcpp
 
 		switch (config.direction)
 		{
-		case PCPP_IN:
+		case PcapDirection::PCPP_IN:
 		{
 			PCPP_LOG_DEBUG("Only incoming traffics will be captured");
 			break;
 		}
-		case PCPP_OUT:
+		case PcapDirection::PCPP_OUT:
 		{
 			PCPP_LOG_DEBUG("Only outgoing traffics will be captured");
 			break;

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -700,7 +700,7 @@ namespace pcpp
 			throw std::runtime_error("Cannot activate the device, error was: " + std::string(pcap.getLastError()));
 		}
 
-		if (config.direction != PCPP_INOUT)
+		if (config.direction != PcapDirection::PCPP_INOUT)
 		{
 			pcap_direction_t directionToSet = directionTypeMap(config.direction);
 			ret = pcap_setdirection(pcap.get(), directionToSet);

--- a/Tests/Pcap++Test/Tests/DpdkTests.cpp
+++ b/Tests/Pcap++Test/Tests/DpdkTests.cpp
@@ -306,7 +306,7 @@ PTF_TEST_CASE(TestDpdkDevice)
 	}
 
 	uint64_t configuredRssHF = pcpp::DpdkDevice::RSS_IPV4 | pcpp::DpdkDevice::RSS_IPV6;
-	if (dev->getPMDType() == pcpp::PMD_I40E || dev->getPMDType() == pcpp::PMD_I40EVF)
+	if (dev->getPMDType() == pcpp::DpdkPMDType::PMD_I40E || dev->getPMDType() == pcpp::DpdkPMDType::PMD_I40EVF)
 	{
 		configuredRssHF = pcpp::DpdkDevice::RSS_NONFRAG_IPV4_TCP | pcpp::DpdkDevice::RSS_NONFRAG_IPV4_UDP |
 		                  pcpp::DpdkDevice::RSS_NONFRAG_IPV4_OTHER | pcpp::DpdkDevice::RSS_FRAG_IPV4 |

--- a/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
+++ b/Tests/Pcap++Test/Tests/LiveDeviceTests.cpp
@@ -739,8 +739,8 @@ PTF_TEST_CASE(TestPcapLiveDeviceSpecialCfg)
 
 	// create a non-default configuration with a snapshot length of 10 bytes
 	int snaplen = 20;
-	pcpp::PcapLiveDevice::DeviceConfiguration devConfigWithSnaplen(pcpp::PcapLiveDevice::Promiscuous, 0, 0,
-	                                                               pcpp::PcapLiveDevice::PCPP_INOUT, snaplen);
+	pcpp::PcapLiveDevice::DeviceConfiguration devConfigWithSnaplen(
+	    pcpp::PcapLiveDevice::Promiscuous, 0, 0, pcpp::PcapLiveDevice::PcapDirection::PCPP_INOUT, snaplen);
 
 	liveDev->open(devConfigWithSnaplen);
 


### PR DESCRIPTION
## Description

Add a standardized backwards compatible upgrade path from `enum` to `enum class` via macro.

Upgrades the following enums to `enum class` as proof of concept:
- `DpdkPMDType`
- `PcapLiveDevice::PcapDirection`

## Rationale

Generally `enum class` enumerator types are preferred in modern post C++11 code, due to better scoping mechanics and less pollution of the parent scope. However, the changes in the scoping mechanics introduce a backwards incompatible change when updating existing `enum` types to `enum class`.

## Proposal

A proposed solution to preserve backwards compatibility is to define `const auto Value = EnumT::Value;`. This effectively mimics the old behaviour of spilling the enum values. These constant values are additionally flagged with a `[[deprecated]]` attribute to encourage users to transition to the new `enum class` value definitions.

To reduce the required boilerplate the PR adds a new macro `PCPP_ENUM_CLASS_UPGRADE_COMPAT(cls, val)` that defines the a constant `val` to the value `cls::val`, along with an appropriate deprecation message.

The PR additionally updates the enums `DpdkPMDType` and `PcapDirection` as a proof of concept.
