### PR TITLE
Replace Logger TLS std::string `m_LastError` to std::array.

### DIFF
--- a/Common++/header/Logger.h
+++ b/Common++/header/Logger.h
@@ -311,7 +311,7 @@ namespace pcpp
 		/// @return Get the last error message
 		std::string getLastError() const
 		{
-			return m_LastError;
+			return { m_LastError.data() };
 		}
 
 		/// Suppress logs in all PcapPlusPlus modules
@@ -394,7 +394,9 @@ namespace pcpp
 		std::array<LogLevel, NumOfLogModules> m_LogModulesArray{};
 		LogPrinter m_LogPrinter;
 
-		static thread_local std::string m_LastError;
+		// Using an array instead of std::string because MinGW has issues with TLS destruction.
+		// The array should be large enough to hold most PCPP errors without cutoffs.
+		static thread_local std::array<char, 255> m_LastError;
 
 		bool m_UseContextPooling = true;
 		// Keep a maximum of 10 LogContext objects in the pool.

--- a/Common++/src/Logger.cpp
+++ b/Common++/src/Logger.cpp
@@ -50,11 +50,7 @@ namespace pcpp
 #endif
 	}
 
-	thread_local std::string Logger::m_LastError = [] {
-		std::string str;
-		str.reserve(200);
-		return str;
-	}();
+	thread_local std::array<char, 255> Logger::m_LastError = { 0 };
 
 	Logger::Logger() : m_LogsEnabled(true), m_LogPrinter(&printToCerr)
 	{
@@ -115,7 +111,13 @@ namespace pcpp
 		// If the log level is an error, save the error to the last error message variable.
 		if (logLevel == LogLevel::Error)
 		{
-			m_LastError = message;
+			static_assert(m_LastError.size() >= 1,
+			              "Last error buffer size must be at least 1 to hold a null terminator");
+
+			// Copy the message to the last error buffer, leaving space for null terminator
+			message.copy(m_LastError.data(), m_LastError.size() - 1);
+			auto termPos = std::min(message.size(), m_LastError.size() - 1);
+			m_LastError[termPos] = '\0';
 		}
 		if (m_LogsEnabled)
 		{

--- a/Common++/src/Logger.cpp
+++ b/Common++/src/Logger.cpp
@@ -115,9 +115,8 @@ namespace pcpp
 			              "Last error buffer size must be at least 1 to hold a null terminator");
 
 			// Copy the message to the last error buffer, leaving space for null terminator
-			message.copy(m_LastError.data(), m_LastError.size() - 1);
-			auto termPos = std::min(message.size(), m_LastError.size() - 1);
-			m_LastError[termPos] = '\0';
+			auto const copied = message.copy(m_LastError.data(), m_LastError.size() - 1);
+			m_LastError[copied] = '\0';
 		}
 		if (m_LogsEnabled)
 		{


### PR DESCRIPTION
## Bug

The replacement is due to an issue on MinGW with TLS variables that have non-trivial destructors. This causes crashes when threads that have initialized their thread local instance of the `m_LastError` variable attempt to finalize and exit.

The issue was discovered in the course of development of #2087.

## Proposed fix

The proposed fix replaces the last error std::string with a C-string array buffer. Due to std::array having trivial destructor semantics, the issues present with std::string do not materialize.

The length of the buffer of 255 was chosen from the previous reservation buffer to hopefully catch the majority of error messages without truncating the messages.