### PR TITLE
Reorder logging tests to be last.

### DIFF
--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -331,6 +331,7 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(TestWinDivertNetworkInterfaces, "windivert");
 
 	// Ordered last since they mutate the logger configuration and do not restore it perfectly.
+	// See issue: https://github.com/seladb/PcapPlusPlus/issues/2083
 	PTF_RUN_TEST(TestLogger, "no_network;logger");
 	PTF_RUN_TEST(TestLoggerMultiThread, "no_network;logger;skip_mem_leak_check");
 

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -223,8 +223,6 @@ int main(int argc, char* argv[])
 
 	PTF_RUN_TEST(TestObjectPool, "no_network");
 
-	PTF_RUN_TEST(TestLogger, "no_network;logger");
-	PTF_RUN_TEST(TestLoggerMultiThread, "no_network;logger;skip_mem_leak_check");
 
 	PTF_RUN_TEST(TestPcapFileReadWrite, "no_network;pcap");
 	PTF_RUN_TEST(TestPcapFileMicroPrecision, "no_network;pcap");
@@ -331,6 +329,10 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(TestWinDivertSendPackets, "windivert");
 	PTF_RUN_TEST(TestWinDivertParams, "windivert");
 	PTF_RUN_TEST(TestWinDivertNetworkInterfaces, "windivert");
+
+	// Ordered last since they mutate the logger configuration and do not restore it perfectly.
+	PTF_RUN_TEST(TestLogger, "no_network;logger");
+	PTF_RUN_TEST(TestLoggerMultiThread, "no_network;logger;skip_mem_leak_check");
 
 	PTF_END_RUNNING_TESTS;
 }

--- a/Tests/Pcap++Test/main.cpp
+++ b/Tests/Pcap++Test/main.cpp
@@ -223,7 +223,6 @@ int main(int argc, char* argv[])
 
 	PTF_RUN_TEST(TestObjectPool, "no_network");
 
-
 	PTF_RUN_TEST(TestPcapFileReadWrite, "no_network;pcap");
 	PTF_RUN_TEST(TestPcapFileMicroPrecision, "no_network;pcap");
 	PTF_RUN_TEST(TestPcapFileNanoPrecision, "no_network;pcap");


### PR DESCRIPTION
Mitigates #2083 

The PR mitigates the issue of logging tests not restoring the original configuration perfectly by running them last.