### PR TITLE
Utilize string literal concatenation for build time.

### DIFF
--- a/Common++/header/PcapPlusPlusVersion.h
+++ b/Common++/header/PcapPlusPlusVersion.h
@@ -37,7 +37,7 @@ namespace pcpp
 #else
 	inline std::string getBuildDateTime()
 	{
-		return std::string(__DATE__) + " " + std::string(__TIME__);
+		return __DATE__ " " __TIME__;
 	}
 #endif
 


### PR DESCRIPTION
Given that `__DATE__` and `__TIME__` expand to string literals, the entire segment could be evaluated at compile time by utilizing the string literal concatenation feature of the C / C++ compiler performed at translation phase 6. [Link](https://en.cppreference.com/cpp/language/string_literal#:~:text=Concatenation,(after%20preprocessing)%3A)