### PR TITLE
Fix deprecation warnings in DPDK module code.

### DIFF
--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -149,11 +149,12 @@ namespace pcpp
 		SystemCore getDpdkMasterCore() const;
 
 		/// Change the log level of all modules of DPDK
-		/// @param[in] logLevel The log level to set. LogLevel#Info is RTE_LOG_NOTICE and LogLevel#Debug is RTE_LOG_DEBUG
+		/// @param[in] logLevel The log level to set. LogLevel#Info is RTE_LOG_NOTICE and LogLevel#Debug is
+		/// RTE_LOG_DEBUG
 		void setDpdkLogLevel(LogLevel logLevel);
 
-		/// @return The current DPDK log level. RTE_LOG_NOTICE and lower are considered as LogLevel#Info. RTE_LOG_INFO or
-		/// RTE_LOG_DEBUG are considered as LogLevel#Debug
+		/// @return The current DPDK log level. RTE_LOG_NOTICE and lower are considered as LogLevel#Info. RTE_LOG_INFO
+		/// or RTE_LOG_DEBUG are considered as LogLevel#Debug
 		LogLevel getDpdkLogLevel() const;
 
 		/// Order DPDK to write all its logs to a file

--- a/Pcap++/header/DpdkDeviceList.h
+++ b/Pcap++/header/DpdkDeviceList.h
@@ -149,12 +149,12 @@ namespace pcpp
 		SystemCore getDpdkMasterCore() const;
 
 		/// Change the log level of all modules of DPDK
-		/// @param[in] logLevel The log level to set. Logger#Info is RTE_LOG_NOTICE and Logger#Debug is RTE_LOG_DEBUG
-		void setDpdkLogLevel(Logger::LogLevel logLevel);
+		/// @param[in] logLevel The log level to set. LogLevel#Info is RTE_LOG_NOTICE and LogLevel#Debug is RTE_LOG_DEBUG
+		void setDpdkLogLevel(LogLevel logLevel);
 
-		/// @return The current DPDK log level. RTE_LOG_NOTICE and lower are considered as Logger#Info. RTE_LOG_INFO or
-		/// RTE_LOG_DEBUG are considered as Logger#Debug
-		Logger::LogLevel getDpdkLogLevel() const;
+		/// @return The current DPDK log level. RTE_LOG_NOTICE and lower are considered as LogLevel#Info. RTE_LOG_INFO or
+		/// RTE_LOG_DEBUG are considered as LogLevel#Debug
+		LogLevel getDpdkLogLevel() const;
 
 		/// Order DPDK to write all its logs to a file
 		/// @param[in] logFile The file to write to

--- a/Pcap++/src/DpdkDeviceList.cpp
+++ b/Pcap++/src/DpdkDeviceList.cpp
@@ -165,7 +165,7 @@ namespace pcpp
 
 		m_MBufPoolSizePerDevice = mBufPoolSizePerDevice;
 		m_MBufDataSize = mBufDataSize;
-		DpdkDeviceList::getInstance().setDpdkLogLevel(Logger::Info);
+		DpdkDeviceList::getInstance().setDpdkLogLevel(LogLevel::Info);
 		return DpdkDeviceList::getInstance().initDpdkDevices(m_MBufPoolSizePerDevice, m_MBufDataSize);
 	}
 
@@ -307,28 +307,28 @@ namespace pcpp
 	void DpdkDeviceList::setDpdkLogLevel(Logger::LogLevel logLevel)
 	{
 #if (RTE_VER_YEAR > 17) || (RTE_VER_YEAR == 17 && RTE_VER_MONTH >= 11)
-		if (logLevel == Logger::Info)
+		if (logLevel == LogLevel::Info)
 			rte_log_set_global_level(RTE_LOG_NOTICE);
-		else  // logLevel == Logger::Debug
+		else  // logLevel == LogLevel::Debug
 			rte_log_set_global_level(RTE_LOG_DEBUG);
 #else
-		if (logLevel == Logger::Info)
+		if (logLevel == LogLevel::Info)
 			rte_set_log_level(RTE_LOG_NOTICE);
-		else  // logLevel == Logger::Debug
+		else  // logLevel == LogLevel::Debug
 			rte_set_log_level(RTE_LOG_DEBUG);
 #endif
 	}
 
-	Logger::LogLevel DpdkDeviceList::getDpdkLogLevel() const
+	LogLevel DpdkDeviceList::getDpdkLogLevel() const
 	{
 #if (RTE_VER_YEAR > 17) || (RTE_VER_YEAR == 17 && RTE_VER_MONTH >= 11)
 		if (rte_log_get_global_level() <= RTE_LOG_NOTICE)
 #else
 		if (rte_get_log_level() <= RTE_LOG_NOTICE)
 #endif
-			return Logger::Info;
+			return LogLevel::Info;
 		else
-			return Logger::Debug;
+			return LogLevel::Debug;
 	}
 
 	bool DpdkDeviceList::writeDpdkLogToFile(FILE* logFile)

--- a/Pcap++/src/MBufRawPacket.cpp
+++ b/Pcap++/src/MBufRawPacket.cpp
@@ -340,7 +340,7 @@ namespace pcpp
 		m_MbufDataSize = mBufDataSize;
 		auto mBufDataLen = rte_pktmbuf_pkt_len(mBuf);
 		m_RawDataLen = mBufDataLen;
-		RawPacket::setRawData(rte_pktmbuf_mtod(mBuf, const uint8_t*), mBufDataLen, timestamp, LINKTYPE_ETHERNET);
+		RawPacket::setRawData(rte_pktmbuf_mtod(mBuf, const uint8_t*), mBufDataLen, false, timestamp, LINKTYPE_ETHERNET);
 	}
 
 }  // namespace pcpp


### PR DESCRIPTION
The PR fixes deprecation warnings in `DpdkDevice` and `MBufRawPacket` that used old signatured of:
- `setRawData` - without the take ownership param.
- `pcpp::Logger::LogLevel` instead of `pcpp::LogLevel`.