### PR TITLE
Add runtime flag for zstd compression support.

### DIFF
--- a/Pcap++/CMakeLists.txt
+++ b/Pcap++/CMakeLists.txt
@@ -109,6 +109,7 @@ target_link_libraries(
 )
 
 if(LIGHT_PCAPNG_ZSTD)
+  target_compile_definitions(Pcap++ PRIVATE PCPP_PCAPNG_ZSTD_SUPPORT)
   target_link_libraries(Pcap++ PRIVATE light_pcapng)
 endif()
 

--- a/Pcap++/header/PcapFileDevice.h
+++ b/Pcap++/header/PcapFileDevice.h
@@ -324,6 +324,10 @@ namespace pcpp
 		internal::LightPcapNgHandle* m_LightPcapNg;
 
 	public:
+		/// @brief A static method that checks if the device was built with zstd compression support
+		/// @return True if zstd compression is supported, false otherwise.
+		static bool isZstdSupported();
+
 		/// A constructor for this class that gets the pcap-ng full path file name to open. Notice that after calling
 		/// this constructor the file isn't opened yet, so reading packets will fail. For opening the file call open()
 		/// @param[in] fileName The full path of the file to read
@@ -409,6 +413,10 @@ namespace pcpp
 		int m_CompressionLevel;
 
 	public:
+		/// @brief A static method that checks if the device was built with zstd compression support
+		/// @return True if zstd compression is supported, false otherwise.
+		static bool isZstdSupported();
+
 		/// A constructor for this class that gets the pcap-ng full path file name to open for writing or create. Notice
 		/// that after calling this constructor the file isn't opened yet, so writing packets will fail. For opening the
 		/// file call open()

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -12,6 +12,15 @@ namespace pcpp
 {
 	namespace
 	{
+		constexpr bool checkZstdSupport()
+		{
+#ifdef PCPP_PCAPNG_ZSTD_SUPPORT
+			return true;
+#else
+			return false;
+#endif
+		}
+
 		/// @brief Converts a light_pcapng_t* to an opaque LightPcapNgHandle*.
 		/// @param pcapngHandle The light_pcapng_t* to convert.
 		/// @return An pointer to the opaque handle.
@@ -830,6 +839,11 @@ namespace pcpp
 	// PcapNgFileReaderDevice members
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+	bool PcapNgFileReaderDevice::isZstdSupported()
+	{
+		return checkZstdSupport();
+	}
+
 	PcapNgFileReaderDevice::PcapNgFileReaderDevice(const std::string& fileName) : IFileReaderDevice(fileName)
 	{
 		m_LightPcapNg = nullptr;
@@ -997,6 +1011,11 @@ namespace pcpp
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// PcapNgFileWriterDevice members
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+	bool PcapNgFileWriterDevice::isZstdSupported()
+	{
+		return checkZstdSupport();
+	}
 
 	PcapNgFileWriterDevice::PcapNgFileWriterDevice(const std::string& fileName, int compressionLevel)
 	    : IFileWriterDevice(fileName)


### PR DESCRIPTION
Fixes #1973

Extracted functionality from #1962

Adds a static method that returns `true` or `false` depending on runtime support of zstd compression.