### PR TITLE
Fix use-of-uninitialized-value in PcapNgFileReaderDevice::getNextPacketInternal

### DIFF
--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
@@ -461,6 +461,8 @@ int light_get_next_packet(light_pcapng_t *pcapng, light_packet_header *packet_he
 		packet_header->timestamp.tv_nsec = 0;
 		if (pcapng->file_info->interface_block_count > 0)
 			packet_header->data_link = pcapng->file_info->link_types[0];
+		else
+			packet_header->data_link = 0xFFFF;
 
 		*packet_data = (uint8_t*)spb->packet_data;
 	}

--- a/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
+++ b/3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c
@@ -462,7 +462,7 @@ int light_get_next_packet(light_pcapng_t *pcapng, light_packet_header *packet_he
 		if (pcapng->file_info->interface_block_count > 0)
 			packet_header->data_link = pcapng->file_info->link_types[0];
 		else
-			packet_header->data_link = 0xFFFF;
+			packet_header->data_link = 0xFFFF; /* unknown/invalid link type sentinel (no interface block present) */
 
 		*packet_data = (uint8_t*)spb->packet_data;
 	}

--- a/Pcap++/src/PcapFileDevice.cpp
+++ b/Pcap++/src/PcapFileDevice.cpp
@@ -874,7 +874,7 @@ namespace pcpp
 			return false;
 		}
 
-		light_packet_header pktHeader;
+		light_packet_header pktHeader{};
 		const uint8_t* pktData = nullptr;
 
 		if (!light_get_next_packet(toLightPcapNgT(m_LightPcapNg), &pktHeader, &pktData))


### PR DESCRIPTION
## Summary

Fixes the MSAN-reported `Use-of-uninitialized-value` in `pcpp::PcapNgFileReaderDevice::getNextPacketInternal` (OSS-Fuzz issue, crash type reported in `FuzzWriterNg`).

issue:  https://issues.oss-fuzz.com/issues/479882050

## Root Cause

In `light_get_next_packet` (`light_pcapng_ext.c`), the `LIGHT_SIMPLE_PACKET_BLOCK` branch sets `packet_header->data_link` **only** when `interface_block_count > 0`:

```c
if (pcapng->file_info->interface_block_count > 0)
    packet_header->data_link = pcapng->file_info->link_types[0];
// else: data_link left UNINITIALIZED
```

When a pcapng file contains a Simple Packet Block without any preceding Interface Description Block, `data_link` is never written. Back in `getNextPacketInternal`, the uninitialized `pktHeader.data_link` value is then read by `m_BpfWrapper.matches()` and `RawPacket::setRawData()`, triggering MSAN.

## Changes

### `3rdParty/LightPcapNg/LightPcapNg/src/light_pcapng_ext.c`
Added an `else` clause in the SPB path of `light_get_next_packet` to always assign `data_link`. Uses the same `0xFFFF` sentinel already used in the EPB "out-of-range interface_id" case, meaning unknown/invalid link type.

### `Pcap++/src/PcapFileDevice.cpp`
Zero-initialized `light_packet_header pktHeader{}` in `getNextPacketInternal` as defense-in-depth, ensuring no field is ever read uninitialized regardless of which code path `light_get_next_packet` takes.
