### PR TITLE
Removed the blank issue template as github already provides a stock t…

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank.md
+++ b/.github/ISSUE_TEMPLATE/blank.md
@@ -1,6 +1,0 @@
----
-name: Blank issue
-about: Report a issue with no specific category
----
-
-(A clear and concise description of the issue.)


### PR DESCRIPTION
Github already provides a blank issue template by default. By having an additional template, the template selector menu ends up with duplicate "blank" templates. The one marked with red arrow is the custom one from the template, the one with a yellow arrow is the stock one provided by Github.

<img width="854" height="542" alt="image" src="https://github.com/user-attachments/assets/65635851-8822-48e3-abe5-f5cc60391df8" />
