### PR TITLE
Fix truncated Telnet and TLS hello reads

### DIFF
--- a/Packet++/src/SSLHandshake.cpp
+++ b/Packet++/src/SSLHandshake.cpp
@@ -1450,6 +1450,9 @@ namespace pcpp
 
 	SSLVersion SSLClientHelloMessage::getHandshakeVersion() const
 	{
+		if (m_DataLen < sizeof(ssl_tls_handshake_layer) + sizeof(uint16_t))
+			return SSLVersion(0);
+
 		uint16_t handshakeVersion = be16toh(getClientHelloHeader()->handshakeVersion);
 		return SSLVersion(handshakeVersion);
 	}
@@ -1778,6 +1781,9 @@ namespace pcpp
 			if (supportedVersions.size() == 1)
 				return supportedVersions[0];
 		}
+
+		if (m_DataLen < sizeof(ssl_tls_handshake_layer) + sizeof(uint16_t))
+			return SSLVersion(0);
 
 		uint16_t handshakeVersion = be16toh(getServerHelloHeader()->handshakeVersion);
 		return SSLVersion(handshakeVersion);

--- a/Packet++/src/TelnetLayer.cpp
+++ b/Packet++/src/TelnetLayer.cpp
@@ -116,6 +116,9 @@ namespace pcpp
 
 	size_t TelnetLayer::distanceToNextIAC(uint8_t* startPos, size_t maxLength)
 	{
+		if (startPos == nullptr || maxLength == 0)
+			return 0;
+
 		auto beginIt = startPos;
 		auto endIt = startPos + maxLength;
 		auto nextIacIt = findNextIAC(beginIt, endIt);
@@ -124,8 +127,11 @@ namespace pcpp
 
 	size_t TelnetLayer::getFieldLen(uint8_t* startPos, size_t maxLength)
 	{
+		if (startPos == nullptr || maxLength == 0)
+			return 0;
+
 		// Check first byte is IAC
-		if (startPos && (startPos[0] == static_cast<int>(TelnetCommand::InterpretAsCommand)) && (maxLength >= 2))
+		if ((startPos[0] == static_cast<int>(TelnetCommand::InterpretAsCommand)) && (maxLength >= 2))
 		{
 			// If subnegotiation parse until next IAC
 			if (startPos[1] == static_cast<int>(TelnetCommand::Subnegotiation))
@@ -133,7 +139,7 @@ namespace pcpp
 			// Only WILL, WONT, DO, DONT have option. Ref http://pcmicro.com/netfoss/telnet.html
 			else if (startPos[1] >= static_cast<int>(TelnetCommand::WillPerform) &&
 			         startPos[1] <= static_cast<int>(TelnetCommand::DontPerform))
-				return 3;
+				return std::min<size_t>(3, maxLength);
 			return 2;
 		}
 		return distanceToNextIAC(startPos, maxLength);
@@ -205,13 +211,19 @@ namespace pcpp
 
 	int16_t TelnetLayer::getSubCommand(uint8_t* pos, size_t len)
 	{
-		if (len < 3 || pos[1] < static_cast<int>(TelnetCommand::Subnegotiation))
+		if (pos == nullptr || len < 3 || pos[1] < static_cast<int>(TelnetCommand::Subnegotiation))
 			return static_cast<int>(TelnetOption::TelnetOptionNoOption);
 		return pos[2];
 	}
 
 	uint8_t* TelnetLayer::getCommandData(uint8_t* pos, size_t& len)
 	{
+		if (pos == nullptr || len < 2)
+		{
+			len = 0;
+			return nullptr;
+		}
+
 		if (pos[1] == static_cast<int>(TelnetCommand::Subnegotiation) && len > 3)
 		{
 			len -= 3;

--- a/Packet++/src/TelnetLayer.cpp
+++ b/Packet++/src/TelnetLayer.cpp
@@ -116,9 +116,6 @@ namespace pcpp
 
 	size_t TelnetLayer::distanceToNextIAC(uint8_t* startPos, size_t maxLength)
 	{
-		if (startPos == nullptr || maxLength == 0)
-			return 0;
-
 		auto beginIt = startPos;
 		auto endIt = startPos + maxLength;
 		auto nextIacIt = findNextIAC(beginIt, endIt);
@@ -127,11 +124,8 @@ namespace pcpp
 
 	size_t TelnetLayer::getFieldLen(uint8_t* startPos, size_t maxLength)
 	{
-		if (startPos == nullptr || maxLength == 0)
-			return 0;
-
 		// Check first byte is IAC
-		if ((startPos[0] == static_cast<int>(TelnetCommand::InterpretAsCommand)) && (maxLength >= 2))
+		if (startPos && (startPos[0] == static_cast<int>(TelnetCommand::InterpretAsCommand)) && (maxLength >= 2))
 		{
 			// If subnegotiation parse until next IAC
 			if (startPos[1] == static_cast<int>(TelnetCommand::Subnegotiation))
@@ -211,19 +205,13 @@ namespace pcpp
 
 	int16_t TelnetLayer::getSubCommand(uint8_t* pos, size_t len)
 	{
-		if (pos == nullptr || len < 3 || pos[1] < static_cast<int>(TelnetCommand::Subnegotiation))
+		if (len < 3 || pos[1] < static_cast<int>(TelnetCommand::Subnegotiation))
 			return static_cast<int>(TelnetOption::TelnetOptionNoOption);
 		return pos[2];
 	}
 
 	uint8_t* TelnetLayer::getCommandData(uint8_t* pos, size_t& len)
 	{
-		if (pos == nullptr || len < 2)
-		{
-			len = 0;
-			return nullptr;
-		}
-
 		if (pos[1] == static_cast<int>(TelnetCommand::Subnegotiation) && len > 3)
 		{
 			len -= 3;

--- a/Tests/Packet++Test/TestDefinition.h
+++ b/Tests/Packet++Test/TestDefinition.h
@@ -158,6 +158,7 @@ PTF_TEST_CASE(DhcpEditTest);
 
 // Implemented in SSLTests.cpp
 PTF_TEST_CASE(SSLClientHelloParsingTest);
+PTF_TEST_CASE(SSLHelloTruncatedVersionTest);
 PTF_TEST_CASE(SSLExtensionWithZeroSizeTest);
 PTF_TEST_CASE(SSLAppDataParsingTest);
 PTF_TEST_CASE(SSLAlertParsingTest);
@@ -238,6 +239,7 @@ PTF_TEST_CASE(NtpCreationTests);
 // Implemented in TelnetTests.cpp
 PTF_TEST_CASE(TelnetCommandParsingTests);
 PTF_TEST_CASE(TelentCommandInvalidDataTests);
+PTF_TEST_CASE(TelnetCommandTruncatedOptionTest);
 PTF_TEST_CASE(TelnetDataParsingTests);
 
 // Implemented in IcmpV6Tests.cpp

--- a/Tests/Packet++Test/Tests/SSLTests.cpp
+++ b/Tests/Packet++Test/Tests/SSLTests.cpp
@@ -141,6 +141,25 @@ PTF_TEST_CASE(SSLClientHelloParsingTest)
 	}
 }  // SSLClientHelloParsingTest
 
+PTF_TEST_CASE(SSLHelloTruncatedVersionTest)
+{
+	uint8_t clientHelloData[sizeof(pcpp::ssl_tls_handshake_layer)] = {};
+	clientHelloData[0] = pcpp::SSL_CLIENT_HELLO;
+	pcpp::SSLClientHelloMessage clientHelloMessage(clientHelloData, sizeof(clientHelloData), nullptr);
+
+	PTF_ASSERT_EQUAL(clientHelloMessage.getHandshakeVersion().asUInt(), 0);
+	auto clientFingerprint = clientHelloMessage.generateTLSFingerprint();
+	PTF_ASSERT_EQUAL(clientFingerprint.tlsVersion, 0);
+
+	uint8_t serverHelloData[sizeof(pcpp::ssl_tls_handshake_layer)] = {};
+	serverHelloData[0] = pcpp::SSL_SERVER_HELLO;
+	pcpp::SSLServerHelloMessage serverHelloMessage(serverHelloData, sizeof(serverHelloData), nullptr);
+
+	PTF_ASSERT_EQUAL(serverHelloMessage.getHandshakeVersion().asUInt(), 0);
+	auto serverFingerprint = serverHelloMessage.generateTLSFingerprint();
+	PTF_ASSERT_EQUAL(serverFingerprint.tlsVersion, 0);
+}  // SSLHelloTruncatedVersionTest
+
 PTF_TEST_CASE(SSLExtensionWithZeroSizeTest)
 {
 	timeval time;

--- a/Tests/Packet++Test/Tests/TelnetTests.cpp
+++ b/Tests/Packet++Test/Tests/TelnetTests.cpp
@@ -289,6 +289,23 @@ PTF_TEST_CASE(TelentCommandInvalidDataTests)
 	                 pcpp::TelnetLayer::TelnetOption::TelnetOptionNoOption, enumclass);
 }
 
+PTF_TEST_CASE(TelnetCommandTruncatedOptionTest)
+{
+	auto* truncatedWill = new uint8_t[2]{ static_cast<uint8_t>(pcpp::TelnetLayer::TelnetCommand::InterpretAsCommand),
+		                                  static_cast<uint8_t>(pcpp::TelnetLayer::TelnetCommand::WillPerform) };
+	pcpp::TelnetLayer telnetLayer(truncatedWill, 2, nullptr, nullptr);
+
+	PTF_ASSERT_EQUAL(telnetLayer.getTotalNumberOfCommands(), 1);
+	PTF_ASSERT_EQUAL(telnetLayer.getNextCommand(), pcpp::TelnetLayer::TelnetCommand::WillPerform, enumclass);
+	PTF_ASSERT_EQUAL(telnetLayer.getOption(), pcpp::TelnetLayer::TelnetOption::TelnetOptionNoOption, enumclass);
+
+	size_t length = 42;
+	PTF_ASSERT_NULL(telnetLayer.getOptionData(length));
+	PTF_ASSERT_EQUAL(length, 0);
+	PTF_ASSERT_EQUAL(telnetLayer.getOption(pcpp::TelnetLayer::TelnetCommand::WillPerform),
+	                 pcpp::TelnetLayer::TelnetOption::TelnetOptionNoOption, enumclass);
+}
+
 PTF_TEST_CASE(TelnetDataParsingTests)
 {
 

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -242,6 +242,7 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(GreEditTest, "gre");
 
 	PTF_RUN_TEST(SSLClientHelloParsingTest, "ssl");
+	PTF_RUN_TEST(SSLHelloTruncatedVersionTest, "ssl");
 	PTF_RUN_TEST(SSLExtensionWithZeroSizeTest, "ssl");
 	PTF_RUN_TEST(SSLAppDataParsingTest, "ssl");
 	PTF_RUN_TEST(SSLAlertParsingTest, "ssl");
@@ -327,6 +328,7 @@ int main(int argc, char* argv[])
 
 	PTF_RUN_TEST(TelnetCommandParsingTests, "telnet");
 	PTF_RUN_TEST(TelentCommandInvalidDataTests, "telnet");
+	PTF_RUN_TEST(TelnetCommandTruncatedOptionTest, "telnet");
 	PTF_RUN_TEST(TelnetDataParsingTests, "telnet");
 
 	PTF_RUN_TEST(TpktLayerTest, "tpkt");


### PR DESCRIPTION
## Summary

Two parser accessors assumed optional bytes were present after the minimal message header:

- SSL ClientHello version access read the hello version even when the message only contained the handshake header. I added the same short-buffer guard to the server-hello path as well.
- Telnet field sizing returned 3 bytes for WILL/WONT/DO/DONT even if the packet ended after the command byte. The option helpers now treat that as a truncated command with no option.

The valid-packet path is unchanged. Truncated inputs now return the existing fallback values instead of reading past the available data.

Fixes #2151.
Fixes #2152.

## Testing

- cmake -S . -B build-asan -DPCAPPP_BUILD_PCAPPP=OFF -DPCAPPP_BUILD_EXAMPLES=OFF -DPCAPPP_BUILD_TESTS=ON -DPCAPPP_BUILD_FUZZERS=OFF -DPCAPPP_USE_SANITIZER=AddressSanitizer -DCMAKE_BUILD_TYPE=Debug
- cmake --build build-asan --target Packet++Test -j 2
- env ASAN_OPTIONS=detect_leaks=0 ./Packet++Test -t "ssl;telnet"
- env ASAN_OPTIONS=detect_leaks=0 ./Packet++Test

I disabled LSAN for these runs because the test binary uses MemPlumber/backtrace allocation tracking; with leak detection enabled the tests themselves pass, then LSAN reports allocations from that tracking path at process exit.
