### PR TITLE
Use heuristic SIP parser by default.

### DIFF
--- a/Packet++/header/SipLayer.h
+++ b/Packet++/header/SipLayer.h
@@ -115,10 +115,10 @@ namespace pcpp
 		}
 
 		/// A static factory method that attempts to create a SIP layer from existing packet raw data
-		/// 
+		///
 		/// The method uses heuristics to determine whether the data contains a SIP request or response message and
 		/// creates the relevant layer type. If no message type can be identified, the method returns nullptr.
-		/// 
+		///
 		/// @param[in] data A pointer to the raw data
 		/// @param[in] dataLen Size of the data in bytes
 		/// @param[in] prevLayer A pointer to the previous layer

--- a/Packet++/header/SipLayer.h
+++ b/Packet++/header/SipLayer.h
@@ -115,18 +115,6 @@ namespace pcpp
 		}
 
 		/// A static factory method that attempts to create a SIP layer from existing packet raw data
-		/// The method first checks whether the source or destination port matches the SIP protocol.
-		/// @param[in] data A pointer to the raw data
-		/// @param[in] dataLen Size of the data in bytes
-		/// @param[in] prevLayer A pointer to the previous layer
-		/// @param[in] packet A pointer to the Packet instance where layer will be stored in
-		/// @param[in] srcPort Source port number to check
-		/// @param[in] dstPort Dest port number to check
-		/// @return A newly allocated SIP layer of type request or response, or nullptr if parsing fails
-		static SipLayer* parseSipLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet,
-		                               uint16_t srcPort, uint16_t dstPort);
-
-		/// A static factory method that attempts to create a SIP layer from existing packet raw data
 		/// This method does not check source or destination ports. Instead, it uses heuristics
 		/// to determine whether the data represents a SIP request or response.
 		/// @param[in] data A pointer to the raw data

--- a/Packet++/header/SipLayer.h
+++ b/Packet++/header/SipLayer.h
@@ -115,8 +115,10 @@ namespace pcpp
 		}
 
 		/// A static factory method that attempts to create a SIP layer from existing packet raw data
-		/// This method does not check source or destination ports. Instead, it uses heuristics
-		/// to determine whether the data represents a SIP request or response.
+		/// 
+		/// The method uses heuristics to determine whether the data contains a SIP request or response message and
+		/// creates the relevant layer type. If no message type can be identified, the method returns nullptr.
+		/// 
 		/// @param[in] data A pointer to the raw data
 		/// @param[in] dataLen Size of the data in bytes
 		/// @param[in] prevLayer A pointer to the previous layer

--- a/Packet++/src/SipLayer.cpp
+++ b/Packet++/src/SipLayer.cpp
@@ -159,30 +159,6 @@ namespace pcpp
 		}
 	}
 
-	SipLayer* SipLayer::parseSipLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet, uint16_t srcPort,
-	                                  uint16_t dstPort)
-	{
-		if (!(SipLayer::isSipPort(srcPort) || SipLayer::isSipPort(dstPort)))
-		{
-			return nullptr;
-		}
-
-		if (SipRequestFirstLine::parseMethod(reinterpret_cast<char*>(data), dataLen) !=
-		    SipRequestLayer::SipMethodUnknown)
-		{
-			return new SipRequestLayer(data, dataLen, prevLayer, packet);
-		}
-
-		if (SipResponseFirstLine::parseStatusCode(reinterpret_cast<char*>(data), dataLen) !=
-		        SipResponseLayer::SipStatusCodeUnknown &&
-		    !SipResponseFirstLine::parseVersion(reinterpret_cast<char*>(data), dataLen).empty())
-		{
-			return new SipResponseLayer(data, dataLen, prevLayer, packet);
-		}
-
-		return nullptr;
-	}
-
 	SipLayer* SipLayer::parseSipLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
 	{
 		SipLayer::SipParseResult sipParseResult = detectSipMessageType(data, dataLen);

--- a/Packet++/src/UdpLayer.cpp
+++ b/Packet++/src/UdpLayer.cpp
@@ -116,9 +116,7 @@ namespace pcpp
 		}
 		else if (SipLayer::isSipPort(portDst) || SipLayer::isSipPort(portSrc))
 		{
-			// Resolves the overload of parseSipLayer, without static_casting a function pointer.
-			auto* (*fac)(uint8_t*, size_t, Layer*, Packet*, uint16_t, uint16_t) = SipLayer::parseSipLayer;
-			tryConstructNextLayerFromFactoryWithFallback<PayloadLayer>(fac, udpData, udpDataLen, portSrc, portDst);
+			tryConstructNextLayerFromFactoryWithFallback<PayloadLayer>(SipLayer::parseSipLayer, udpData, udpDataLen);
 		}
 		else if ((RadiusLayer::isRadiusPort(portDst) || RadiusLayer::isRadiusPort(portSrc)) &&
 		         RadiusLayer::isDataValid(udpData, udpDataLen))
@@ -173,9 +171,7 @@ namespace pcpp
 
 		// Here, heuristics for all protocols should be invoked to determine the correct layer
 		{
-			// Resolves the overload of parseSipLayer, without static_casting a function pointer.
-			auto* (*fac)(uint8_t*, size_t, Layer*, Packet*) = SipLayer::parseSipLayer;
-			tryConstructNextLayerFromFactoryWithFallback<PayloadLayer>(fac, udpData, udpDataLen);
+			tryConstructNextLayerFromFactoryWithFallback<PayloadLayer>(SipLayer::parseSipLayer, udpData, udpDataLen);
 		}
 
 		if (!hasNextLayer())


### PR DESCRIPTION
The PR deduplicates the `parseSipLayer` logic by removing the overload that takes a port src / dst pair.

The existing two parser overloads perform effectively identical, with the exception that the port based overload also requires a specific port combination. Port numbers by themselves should generally only be considered hints for the next layer type and not a parsing error by themselves. As such, they shouldn't be part of downstream parsers that validate the data contents. Instead they should only be used during parser dispatch to select the most likely parser candidate.

