### PR TITLE
Update CI jobs that use Windows Server 2025 to use Visual Studio 2026.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -706,11 +706,11 @@ jobs:
       matrix:
         include:
           - os: windows-2025
-            platform: "Visual Studio 17 2022"
+            platform: "Visual Studio 18 2026"
             arch: Win32
             pcap_lib: "winpcap"
           - os: windows-2025
-            platform: "Visual Studio 17 2022"
+            platform: "Visual Studio 18 2026"
             arch: "x64"
             pcap_lib: ${{ needs.define-windows-pcap-backend-matrix.outputs.npcap-or-default }}
           - os: windows-2022
@@ -813,7 +813,7 @@ jobs:
         # The visual studio generator is a multi-config generator. This means that the executable will be in a configuration subfolder (e.g., Debug or Release),
         # relative to the target folder. Example: $(BuildDir)/Test/Packet++Test/Debug/Packet++Test.exe
       - name: Configure PcapPlusPlus (WinDivert)
-        run: cmake -A x64 -G "Visual Studio 17 2022" -DPCAP_ROOT=${{ env.PCAP_SDK_DIR }} -DPCAPPP_USE_WINDIVERT=ON -DWinDivert_ROOT=${{ env.WINDIVERT_DIR }} -S . -B "$env:BUILD_DIR"
+        run: cmake -A x64 -G "Visual Studio 18 2026" -DPCAP_ROOT=${{ env.PCAP_SDK_DIR }} -DPCAPPP_USE_WINDIVERT=ON -DWinDivert_ROOT=${{ env.WINDIVERT_DIR }} -S . -B "$env:BUILD_DIR"
 
       - name: Build PcapPlusPlus
         run: cmake --build $env:BUILD_DIR -j


### PR DESCRIPTION
As per https://github.com/actions/runner-images/issues/14017 the Windows Server 2025 image now ships with VS 2026 instead of VS 2022.