### PR TITLE
Fix out-of-bounds read in GtpV2Layer for short TEID-present headers (#2171)

### DIFF
--- a/Packet++/src/GtpLayer.cpp
+++ b/Packet++/src/GtpLayer.cpp
@@ -1031,6 +1031,16 @@ namespace pcpp
 			return false;
 		}
 
+		// The mandatory fixed header always contains the sequence-number/spare word
+		// (sizeof(uint32_t), already required above). When the TEID-present bit is set
+		// the 4-byte TEID precedes that word, so an additional uint32_t must be present.
+		// Without this check accessors such as getSequenceNumber()/getMessagePriority()
+		// would read past the end of the supplied buffer (out-of-bounds read).
+		if (header->teidPresent && dataSize < sizeof(gtpv2_basic_header) + 2 * sizeof(uint32_t))
+		{
+			return false;
+		}
+
 		return true;
 	}
 

--- a/Tests/Packet++Test/TestDefinition.h
+++ b/Tests/Packet++Test/TestDefinition.h
@@ -209,6 +209,7 @@ PTF_TEST_CASE(GtpV1LayerParsingTest);
 PTF_TEST_CASE(GtpV1LayerCreationTest);
 PTF_TEST_CASE(GtpV1LayerEditTest);
 PTF_TEST_CASE(GtpV2LayerParsingTest);
+PTF_TEST_CASE(GtpV2LayerInvalidDataTest);
 PTF_TEST_CASE(GtpV2LayerCreationTest);
 PTF_TEST_CASE(GtpV2LayerEditTest);
 

--- a/Tests/Packet++Test/Tests/GtpTests.cpp
+++ b/Tests/Packet++Test/Tests/GtpTests.cpp
@@ -423,6 +423,26 @@ PTF_TEST_CASE(GtpV2LayerParsingTest)
 	}
 }  // GtpV2LayerParsingTest
 
+PTF_TEST_CASE(GtpV2LayerInvalidDataTest)
+{
+	// A GTPv2 packet whose TEID-present (T) bit is set must carry, in its fixed header,
+	// the 4-byte TEID *and* the 4-byte sequence-number/spare word that follows it.
+	// A buffer that only holds the basic header + TEID (8 bytes) must be rejected,
+	// otherwise getSequenceNumber()/getMessagePriority() read out of bounds (issue #2171).
+	// byte 0 = 0x48 -> version 2, T bit set.
+	const uint8_t shortTeidPresent[] = { 0x48, 0x20, 0x00, 0x08, 0xde, 0xad, 0xbe, 0xef };
+	PTF_ASSERT_FALSE(pcpp::GtpV2Layer::isDataValid(shortTeidPresent, sizeof(shortTeidPresent)));
+
+	// The full TEID-present fixed header (basic header + TEID + sequence/spare = 12 bytes) is valid.
+	const uint8_t fullTeidPresent[] = { 0x48, 0x20, 0x00, 0x0c, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x12, 0x34, 0x00 };
+	PTF_ASSERT_TRUE(pcpp::GtpV2Layer::isDataValid(fullTeidPresent, sizeof(fullTeidPresent)));
+
+	// When the TEID-present bit is clear, the sequence/spare word directly follows the basic
+	// header, so 8 bytes is the valid minimum (byte 0 = 0x40 -> version 2, T bit clear).
+	const uint8_t noTeid[] = { 0x40, 0x20, 0x00, 0x08, 0x00, 0x12, 0x34, 0x00 };
+	PTF_ASSERT_TRUE(pcpp::GtpV2Layer::isDataValid(noTeid, sizeof(noTeid)));
+}  // GtpV2LayerInvalidDataTest
+
 PTF_TEST_CASE(GtpV2LayerCreationTest)
 {
 	timeval time{};

--- a/Tests/Packet++Test/main.cpp
+++ b/Tests/Packet++Test/main.cpp
@@ -304,6 +304,7 @@ int main(int argc, char* argv[])
 	PTF_RUN_TEST(GtpV1LayerCreationTest, "gtp");
 	PTF_RUN_TEST(GtpV1LayerEditTest, "gtp");
 	PTF_RUN_TEST(GtpV2LayerParsingTest, "gtp");
+	PTF_RUN_TEST(GtpV2LayerInvalidDataTest, "gtp");
 	PTF_RUN_TEST(GtpV2LayerCreationTest, "gtp");
 	PTF_RUN_TEST(GtpV2LayerEditTest, "gtp");
 


### PR DESCRIPTION
## Summary

Fixes #2171 — an out-of-bounds read in `GtpV2Layer` when parsing a truncated GTPv2 packet whose **TEID-present (T) bit** is set.

## Root cause

`GtpV2Layer::isDataValid` required only `sizeof(gtpv2_basic_header) + sizeof(uint32_t)` (8) bytes regardless of the T bit:

```cpp
if (!data || dataSize < sizeof(gtpv2_basic_header) + sizeof(uint32_t))
    return false;
```

In the GTPv2 fixed header, the 4-byte sequence-number/spare word always follows the basic header, **but when the T bit is set the 4-byte TEID sits in between**. So a TEID-present header needs 12 bytes (`basic header + TEID + sequence/spare`), not 8.

Because the validator accepted the 8-byte buffer, `getSequenceNumber()` (and `getMessagePriority()`) then advanced past the TEID and dereferenced a 32-bit word that lies beyond the caller-supplied buffer:

```cpp
auto* sequencePos = m_Data + sizeof(gtpv2_basic_header);
if (getHeader()->teidPresent)
    sequencePos += sizeof(uint32_t);
return be32toh(*reinterpret_cast<uint32_t*>(sequencePos)) >> 8;  // OOB read
```

This is the same partial-frame validation pattern as CVE-2025-7485.

## Fix

Require the extra `uint32_t` in `isDataValid` when the T bit is set, so a truncated TEID-present header is rejected before any accessor can run:

```cpp
if (header->teidPresent && dataSize < sizeof(gtpv2_basic_header) + 2 * sizeof(uint32_t))
    return false;
```

The no-TEID minimum (8 bytes) and all valid headers are unaffected.

## Verification

**AddressSanitizer reproduction** (PoC buffer from the issue, `48 20 00 08 de ad be ef`, T bit set, 8 bytes) confirms the over-read on the unguarded accessor before the validation guard:

```
==ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 4
    #0 pcpp::GtpV2Layer::getSequenceNumber() const Packet++/src/GtpLayer.cpp:1127
0x... is located 0 bytes after 8-byte region [...]
```

With the fix, `isDataValid` returns `false` for that buffer, so the layer is never constructed via the parsing path and the accessor is unreachable.

- Added regression test `GtpV2LayerInvalidDataTest` (rejects the short TEID-present buffer; accepts the valid 12-byte TEID-present header and the 8-byte no-TEID header).
- Built with `-DPCAPPP_USE_SANITIZER=AddressSanitizer` and ran the full `Packet++Test` suite: **258 passed, 0 failed**.
- `clang-format` reports no diffs on the changed files.