### PR TITLE
Fix invalid deletes in XdpExample-FilterTraffic

### DIFF
--- a/Examples/XdpExample-FilterTraffic/main.cpp
+++ b/Examples/XdpExample-FilterTraffic/main.cpp
@@ -272,13 +272,15 @@ void collectStats(std::future<void> futureObj, PacketStats* packetStats, pcpp::X
 		auto rxStats = dev->getStatistics();
 
 		pcpp::XdpDevice::XdpDeviceStats* txStats = nullptr;
+		pcpp::XdpDevice::XdpDeviceStats txStatsValue;
 
 		if (sendDev)
 		{
 			// if send socket is different from receive socket, collect stats from the send socket
 			if (sendDev != dev)
 			{
-				txStats = new pcpp::XdpDevice::XdpDeviceStats(sendDev->getStatistics());
+				txStatsValue = sendDev->getStatistics();
+				txStats = &txStatsValue;
 			}
 			else  // send and receive sockets are the same
 			{
@@ -288,11 +290,6 @@ void collectStats(std::future<void> futureObj, PacketStats* packetStats, pcpp::X
 
 		// print RX and (maybe) TX stats in a table
 		printStats(packetStats, &rxStats, txStats);
-
-		if (txStats != &rxStats)
-		{
-			delete txStats;
-		}
 	}
 }
 
@@ -518,6 +515,8 @@ int main(int argc, char* argv[])
 
 	// open the XDP device to send packets if needed
 	pcpp::XdpDevice* sendDev = nullptr;
+	std::unique_ptr<pcpp::XdpDevice> sendDevOwner;
+
 	if (!sendInterfaceName.empty())
 	{
 		// send and receive devices might be the same
@@ -528,7 +527,9 @@ int main(int argc, char* argv[])
 		else
 		{
 			// if they are not the same, open another AF_XDP socket for the send device
-			sendDev = new pcpp::XdpDevice(sendInterfaceName);
+			sendDevOwner = make_unique<pcpp::XdpDevice>(sendInterfaceName);
+			sendDev = sendDevOwner.get();
+
 			if (!sendDev->open())
 			{
 				dev.close();
@@ -582,18 +583,19 @@ int main(int argc, char* argv[])
 	}
 
 	pcpp::XdpDevice::XdpDeviceStats* txStats = nullptr;
+	pcpp::XdpDevice::XdpDeviceStats txStatsValue;
 
 	// close the send XDP device if needed
 	if (sendDev != nullptr)
 	{
 		// collect final TX stats
-		txStats = new pcpp::XdpDevice::XdpDeviceStats(sendDev->getStatistics());
+		txStatsValue = sendDev->getStatistics();
+		txStats = &txStatsValue;
 
 		// if the send and receive devices are the same - no need to close the device again
 		if (sendInterfaceName != interfaceName)
 		{
 			sendDev->close();
-			delete sendDev;
 		}
 	}
 
@@ -605,7 +607,6 @@ int main(int argc, char* argv[])
 
 	// print final stats
 	printStats(&packetStats, &rxStats, txStats);
-	delete txStats;
 
 	for (const auto& additionalStat : additionalStats)
 	{

--- a/Examples/XdpExample-FilterTraffic/main.cpp
+++ b/Examples/XdpExample-FilterTraffic/main.cpp
@@ -527,7 +527,7 @@ int main(int argc, char* argv[])
 		else
 		{
 			// if they are not the same, open another AF_XDP socket for the send device
-			sendDevOwner = make_unique<pcpp::XdpDevice>(sendInterfaceName);
+			sendDevOwner = std::make_unique<pcpp::XdpDevice>(sendInterfaceName);
 			sendDev = sendDevOwner.get();
 
 			if (!sendDev->open())


### PR DESCRIPTION
## Notes

I found these cppcheck errors while setting up the project locally and running `pre-commit run --all-files` on the current `dev` branch. I did not find an existing issue for this, so this PR is not linked to an issue number.

## Summary

This PR fixes invalid delete patterns in `Examples/XdpExample-FilterTraffic/main.cpp`.

The example previously used raw pointers that could either point to stack objects or heap-allocated objects. This caused cppcheck to report `autovarInvalidDeallocation` warnings for:

- `delete txStats`
- `delete sendDev`

The fix removes the unclear ownership by:

- using stack storage for temporary TX stats instead of allocating with `new`
- using `std::unique_ptr<pcpp::XdpDevice>` to own a separately-created send device
- keeping `sendDev` as a non-owning pointer to either the receive device or the owned send device