### PR TITLE
Update Arm and ICPX images to Ubuntu 26.04

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -63,17 +63,20 @@ jobs:
           - runner: ubuntu-latest
             image: ubuntu2604
             config-zstd: OFF
+          - runner: ubuntu-26.04-arm
+            image: ubuntu2604-arm64
+            config-zstd: OFF
+          - runner: ubuntu-latest
+            image: ubuntu2604-icpx
+            config-zstd: OFF
+            additional-flags: -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx
+            additional-gcov-flags: --gcov-executable "llvm-cov gcov"
           - runner: ubuntu-latest
             image: ubuntu2404
             config-zstd: OFF
           - runner: ubuntu-latest
             image: ubuntu2204
             config-zstd: OFF
-          - runner: ubuntu-latest
-            image: ubuntu2204-icpx
-            config-zstd: OFF
-            additional-flags: -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx
-            additional-gcov-flags: --gcov-executable "llvm-cov gcov"
           - runner: ubuntu-latest
             image: rhel94
             config-zstd: OFF
@@ -87,9 +90,6 @@ jobs:
             additional-gcov-flags: --gcov-ignore-errors
           - runner: ubuntu-latest
             image: alpine320
-            config-zstd: OFF
-          - runner: ubuntu-24.04-arm
-            image: ubuntu2404-arm64
             config-zstd: OFF
 
     steps:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,19 +31,19 @@ jobs:
           - runner: ubuntu-latest
             image: ubuntu2604
             config-zstd: OFF
+          - runner: ubuntu-26.04-arm
+            image: ubuntu2604-arm64
+            config-zstd: OFF
+          - runner: ubuntu-latest
+            image: ubuntu2604-icpx
+            config-zstd: OFF
+            additional-flags: -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx
           - runner: ubuntu-latest
             image: ubuntu2404
-            config-zstd: OFF
-          - runner: ubuntu-24.04-arm
-            image: ubuntu2404-arm64
             config-zstd: OFF
           - runner: ubuntu-latest
             image: ubuntu2204
             config-zstd: OFF
-          - runner: ubuntu-latest
-            image: ubuntu2204-icpx
-            config-zstd: OFF
-            additional-flags: -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx
           - runner: ubuntu-latest
             image: rhel94
             config-zstd: OFF

--- a/Examples/PcapPlusPlus-benchmark/CMakeLists.txt
+++ b/Examples/PcapPlusPlus-benchmark/CMakeLists.txt
@@ -13,7 +13,7 @@ if("cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
     include(FetchContent)
 
     # Fetch Google Benchmark
-    FetchContent_Declare(benchmark GIT_REPOSITORY https://github.com/google/benchmark.git GIT_TAG v1.9.0)
+    FetchContent_Declare(benchmark GIT_REPOSITORY https://github.com/google/benchmark.git GIT_TAG v1.9.5)
 
     # Disable testing and installation for Google Benchmark
     set(BENCHMARK_ENABLE_TESTING OFF)

--- a/Examples/PcapPlusPlus-benchmark/CMakeLists.txt
+++ b/Examples/PcapPlusPlus-benchmark/CMakeLists.txt
@@ -22,6 +22,8 @@ if("cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
 
     add_executable(BenchmarkExampleGoogle benchmark-google.cpp)
 
+    target_compile_definitions(BenchmarkExampleGoogle PRIVATE NOMINMAX)
+
     target_link_libraries(BenchmarkExampleGoogle PUBLIC PcapPlusPlus::Pcap++ benchmark::benchmark)
 
     set_target_properties(BenchmarkExampleGoogle PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PCAPPP_BINARY_EXAMPLES_DIR}")


### PR DESCRIPTION
Changes the images being used for ICPX and Arm to images based on Ubuntu 26.04