### PR TITLE
Update examples and benchmarks to use `IFileReaderDevice::tryCreateReader`.

### DIFF
--- a/Examples/HttpAnalyzer/main.cpp
+++ b/Examples/HttpAnalyzer/main.cpp
@@ -403,9 +403,9 @@ void onApplicationInterrupted(void* cookie)
 void analyzeHttpFromPcapFile(const std::string& pcapFileName, uint16_t dstPort)
 {
 	// open input file (pcap or pcapng file)
-	std::unique_ptr<pcpp::IFileReaderDevice> reader(pcpp::IFileReaderDevice::getReader(pcapFileName));
+	std::unique_ptr<pcpp::IFileReaderDevice> reader = pcpp::IFileReaderDevice::tryCreateReader(pcapFileName);
 
-	if (!reader->open())
+	if (!reader || !reader->open())
 		EXIT_WITH_ERROR("Could not open input pcap file");
 
 	// set a port  filter on the reader device to process only HTTP packets

--- a/Examples/IPDefragUtil/main.cpp
+++ b/Examples/IPDefragUtil/main.cpp
@@ -400,7 +400,8 @@ int main(int argc, char* argv[])
 
 	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader.get()) != nullptr)
 	{
-		writer = std::make_unique<pcpp::PcapFileWriterDevice>(outputFile, ((pcpp::PcapFileReaderDevice*)reader.get())->getLinkLayerType());
+		writer = std::make_unique<pcpp::PcapFileWriterDevice>(
+		    outputFile, ((pcpp::PcapFileReaderDevice*)reader.get())->getLinkLayerType());
 	}
 	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader.get()) != nullptr)
 	{
@@ -418,8 +419,8 @@ int main(int argc, char* argv[])
 
 	// run the de-fragmentation process
 	DefragStats stats;
-	processPackets(reader.get(), writer.get(), filterByBpfFilter, bpfFilter, filterByFragID, fragIDMap, copyAllPacketsToOutputFile,
-	               stats);
+	processPackets(reader.get(), writer.get(), filterByBpfFilter, bpfFilter, filterByFragID, fragIDMap,
+	               copyAllPacketsToOutputFile, stats);
 
 	// close files
 	reader->close();

--- a/Examples/IPDefragUtil/main.cpp
+++ b/Examples/IPDefragUtil/main.cpp
@@ -388,23 +388,23 @@ int main(int argc, char* argv[])
 	}
 
 	// create a reader device from input file
-	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader(inputFile);
+	std::unique_ptr<pcpp::IFileReaderDevice> reader = pcpp::IFileReaderDevice::tryCreateReader(inputFile);
 
-	if (!reader->open())
+	if (reader == nullptr || !reader->open())
 	{
 		EXIT_WITH_ERROR("Error opening input file");
 	}
 
 	// create a writer device for output file in the same file type as input file
-	pcpp::IFileWriterDevice* writer = nullptr;
+	std::unique_ptr<pcpp::IFileWriterDevice> writer = nullptr;
 
-	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != nullptr)
+	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader.get()) != nullptr)
 	{
-		writer = new pcpp::PcapFileWriterDevice(outputFile, ((pcpp::PcapFileReaderDevice*)reader)->getLinkLayerType());
+		writer = std::make_unique<pcpp::PcapFileWriterDevice>(outputFile, ((pcpp::PcapFileReaderDevice*)reader.get())->getLinkLayerType());
 	}
-	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != nullptr)
+	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader.get()) != nullptr)
 	{
-		writer = new pcpp::PcapNgFileWriterDevice(outputFile);
+		writer = std::make_unique<pcpp::PcapNgFileWriterDevice>(outputFile);
 	}
 	else
 	{
@@ -418,7 +418,7 @@ int main(int argc, char* argv[])
 
 	// run the de-fragmentation process
 	DefragStats stats;
-	processPackets(reader, writer, filterByBpfFilter, bpfFilter, filterByFragID, fragIDMap, copyAllPacketsToOutputFile,
+	processPackets(reader.get(), writer.get(), filterByBpfFilter, bpfFilter, filterByFragID, fragIDMap, copyAllPacketsToOutputFile,
 	               stats);
 
 	// close files
@@ -427,7 +427,4 @@ int main(int argc, char* argv[])
 
 	// print summary stats to console
 	printStats(stats, filterByFragID, filterByBpfFilter);
-
-	delete reader;
-	delete writer;
 }

--- a/Examples/IPFragUtil/main.cpp
+++ b/Examples/IPFragUtil/main.cpp
@@ -498,23 +498,23 @@ int main(int argc, char* argv[])
 	}
 
 	// create a reader device from input file
-	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader(inputFile);
+	std::unique_ptr<pcpp::IFileReaderDevice> reader = pcpp::IFileReaderDevice::tryCreateReader(inputFile);
 
-	if (!reader->open())
+	if (reader == nullptr || !reader->open())
 	{
 		EXIT_WITH_ERROR("Error opening input file");
 	}
 
 	// create a writer device for output file in the same file type as input file
-	pcpp::IFileWriterDevice* writer = nullptr;
+	std::unique_ptr<pcpp::IFileWriterDevice> writer = nullptr;
 
-	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != nullptr)
+	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader.get()) != nullptr)
 	{
-		writer = new pcpp::PcapFileWriterDevice(outputFile, ((pcpp::PcapFileReaderDevice*)reader)->getLinkLayerType());
+		writer = std::make_unique<pcpp::PcapFileWriterDevice>(outputFile, ((pcpp::PcapFileReaderDevice*)reader.get())->getLinkLayerType());
 	}
-	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != nullptr)
+	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader.get()) != nullptr)
 	{
-		writer = new pcpp::PcapNgFileWriterDevice(outputFile);
+		writer = std::make_unique<pcpp::PcapNgFileWriterDevice>((outputFile));
 	}
 	else
 	{
@@ -528,7 +528,7 @@ int main(int argc, char* argv[])
 
 	// run the fragmentation process
 	FragStats stats;
-	processPackets(reader, writer, fragSize, filterByBpfFilter, bpfFilter, filterByIpID, ipIDMap,
+	processPackets(reader.get(), writer.get(), fragSize, filterByBpfFilter, bpfFilter, filterByIpID, ipIDMap,
 	               copyAllPacketsToOutputFile, stats);
 
 	// close files
@@ -537,7 +537,4 @@ int main(int argc, char* argv[])
 
 	// print summary stats to console
 	printStats(stats, filterByIpID, filterByBpfFilter);
-
-	delete reader;
-	delete writer;
 }

--- a/Examples/IPFragUtil/main.cpp
+++ b/Examples/IPFragUtil/main.cpp
@@ -510,7 +510,8 @@ int main(int argc, char* argv[])
 
 	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader.get()) != nullptr)
 	{
-		writer = std::make_unique<pcpp::PcapFileWriterDevice>(outputFile, ((pcpp::PcapFileReaderDevice*)reader.get())->getLinkLayerType());
+		writer = std::make_unique<pcpp::PcapFileWriterDevice>(
+		    outputFile, ((pcpp::PcapFileReaderDevice*)reader.get())->getLinkLayerType());
 	}
 	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader.get()) != nullptr)
 	{

--- a/Examples/PcapPlusPlus-benchmark/benchmark-google.cpp
+++ b/Examples/PcapPlusPlus-benchmark/benchmark-google.cpp
@@ -20,7 +20,7 @@ static void BM_FileRead(benchmark::State& state, std::string const& filepath)
 		return;
 	}
 
-	auto reader = std::unique_ptr<pcpp::IFileReaderDevice>(pcpp::IFileReaderDevice::getReader(filepath));
+	auto reader = pcpp::IFileReaderDevice::tryCreateReader(filepath);
 	if (reader == nullptr)
 	{
 		state.SkipWithError("Cannot create file reader for file: " + filepath);
@@ -155,7 +155,7 @@ static void BM_PacketParsing(benchmark::State& state, std::string const& filenam
 	}
 
 	// Open the pcap file for reading
-	auto reader = std::unique_ptr<pcpp::IFileReaderDevice>(pcpp::IFileReaderDevice::getReader(filename));
+	auto reader = pcpp::IFileReaderDevice::tryCreateReader(filename);
 	if (reader == nullptr)
 	{
 		state.SkipWithError("Cannot create file reader for file: " + filename);
@@ -215,7 +215,7 @@ static void BM_PacketPureParsing(benchmark::State& state, std::string const& fil
 	}
 
 	// Open the pcap file for reading
-	auto reader = std::unique_ptr<pcpp::IFileReaderDevice>(pcpp::IFileReaderDevice::getReader(filename));
+	auto reader = pcpp::IFileReaderDevice::tryCreateReader(filename);
 	if (reader == nullptr)
 	{
 		state.SkipWithError("Cannot create file reader for file: " + filename);

--- a/Examples/PcapPrinter/main.cpp
+++ b/Examples/PcapPrinter/main.cpp
@@ -266,11 +266,9 @@ int main(int argc, char* argv[])
 	}
 
 	// open a pcap/pcapng file for reading
-	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader(inputPcapFileName);
-
-	if (!reader->open())
+	std::unique_ptr<pcpp::IFileReaderDevice> reader = pcpp::IFileReaderDevice::tryCreateReader(inputPcapFileName);
+	if (reader == nullptr || !reader->open())
 	{
-		delete reader;
 		EXIT_WITH_ERROR("Error opening input pcap file\n");
 	}
 
@@ -279,41 +277,39 @@ int main(int argc, char* argv[])
 	{
 		if (!reader->setFilter(filter))
 		{
-			delete reader;
 			EXIT_WITH_ERROR("Couldn't set filter '" << filter << "'");
 		}
 	}
 
 	// print file summary
-	(*out) << printFileSummary(reader);
+	(*out) << printFileSummary(reader.get());
 
 	// if requested to print only file summary - exit
 	if (printOnlySummary)
 	{
-		delete reader;
 		exit(0);
 	}
 
 	int printedPacketCount = 0;
 
 	// if the file is a pcap file
-	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader) != nullptr)
+	if (dynamic_cast<pcpp::PcapFileReaderDevice*>(reader.get()) != nullptr)
 	{
 		// print all requested packets in the pcap file
-		pcpp::PcapFileReaderDevice* pcapReader = dynamic_cast<pcpp::PcapFileReaderDevice*>(reader);
+		pcpp::PcapFileReaderDevice* pcapReader = dynamic_cast<pcpp::PcapFileReaderDevice*>(reader.get());
 		printedPacketCount = printPcapPackets(pcapReader, out, packetCount);
 	}
-	else if (dynamic_cast<pcpp::SnoopFileReaderDevice*>(reader) != nullptr)
+	else if (dynamic_cast<pcpp::SnoopFileReaderDevice*>(reader.get()) != nullptr)
 	{
 		// print all requested packets in the pcap file
-		pcpp::SnoopFileReaderDevice* snoopReader = dynamic_cast<pcpp::SnoopFileReaderDevice*>(reader);
+		pcpp::SnoopFileReaderDevice* snoopReader = dynamic_cast<pcpp::SnoopFileReaderDevice*>(reader.get());
 		printedPacketCount = printPcapPackets(snoopReader, out, packetCount);
 	}
 	// if the file is a pcap-ng file
-	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader) != nullptr)
+	else if (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader.get()) != nullptr)
 	{
 		// print all requested packets in the pcap-ng file
-		pcpp::PcapNgFileReaderDevice* pcapNgReader = dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader);
+		pcpp::PcapNgFileReaderDevice* pcapNgReader = dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader.get());
 		printedPacketCount = printPcapNgPackets(pcapNgReader, out, packetCount);
 	}
 
@@ -321,9 +317,6 @@ int main(int argc, char* argv[])
 
 	// close the file
 	reader->close();
-
-	// free reader memory
-	delete reader;
 
 	return 0;
 }

--- a/Examples/PcapSearch/main.cpp
+++ b/Examples/PcapSearch/main.cpp
@@ -129,10 +129,10 @@ std::string getExtension(const std::string& fileName)
 int searchPcap(const std::string& pcapFilePath, std::string searchCriteria, std::ofstream* detailedReportFile)
 {
 	// create the pcap/pcap-ng reader
-	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader(pcapFilePath);
+	std::unique_ptr<pcpp::IFileReaderDevice> reader = pcpp::IFileReaderDevice::tryCreateReader(pcapFilePath);
 
 	// if the reader fails to open
-	if (!reader->open())
+	if (!reader || !reader->open())
 	{
 		if (detailedReportFile != nullptr)
 		{
@@ -142,16 +142,12 @@ int searchPcap(const std::string& pcapFilePath, std::string searchCriteria, std:
 			(*detailedReportFile) << pcpp::Logger::getInstance().getLastError() << std::endl;
 		}
 
-		// free the reader memory and return
-		delete reader;
 		return 0;
 	}
 
 	// set the filter for the file so only packets that match the search criteria will be read
 	if (!reader->setFilter(std::move(searchCriteria)))
 	{
-		// free the reader memory and return
-		delete reader;
 		return 0;
 	}
 
@@ -195,9 +191,6 @@ int searchPcap(const std::string& pcapFilePath, std::string searchCriteria, std:
 
 		(*detailedReportFile) << "    ----> Found " << packetCount << " packets" << std::endl << std::endl;
 	}
-
-	// free the reader memory
-	delete reader;
 
 	// return how many packets matched the search criteria
 	return packetCount;

--- a/Examples/PcapSplitter/main.cpp
+++ b/Examples/PcapSplitter/main.cpp
@@ -364,13 +364,13 @@ int main(int argc, char* argv[])
 	    outputPcapDir + std::string(1, SEPARATOR) + getFileNameWithoutExtension(inputPcapFileName) + "-";
 
 	// open a pcap file for reading
-	std::unique_ptr<pcpp::IFileReaderDevice> reader(pcpp::IFileReaderDevice::getReader(inputPcapFileName));
-	bool isReaderPcapng = (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader.get()) != nullptr);
-
+	std::unique_ptr<pcpp::IFileReaderDevice> reader = pcpp::IFileReaderDevice::tryCreateReader(inputPcapFileName);
 	if (reader == nullptr || !reader->open())
 	{
 		EXIT_WITH_ERROR("Error opening input pcap file");
 	}
+
+	bool isReaderPcapng = (dynamic_cast<pcpp::PcapNgFileReaderDevice*>(reader.get()) != nullptr);
 
 	// set a filter if provided
 	if (filter != "")

--- a/Examples/SSLAnalyzer/main.cpp
+++ b/Examples/SSLAnalyzer/main.cpp
@@ -360,9 +360,9 @@ void onApplicationInterrupted(void* cookie)
 void analyzeSSLFromPcapFile(const std::string& pcapFileName)
 {
 	// open input file (pcap or pcapng file)
-	std::unique_ptr<pcpp::IFileReaderDevice> reader(pcpp::IFileReaderDevice::getReader(pcapFileName));
+	std::unique_ptr<pcpp::IFileReaderDevice> reader = pcpp::IFileReaderDevice::tryCreateReader(pcapFileName);
 
-	if (!reader->open())
+	if (!reader || !reader->open())
 		EXIT_WITH_ERROR("Could not open input pcap file");
 
 	// read the input file packet by packet and give it to the SSLStatsCollector for collecting stats

--- a/Examples/TLSFingerprinting/main.cpp
+++ b/Examples/TLSFingerprinting/main.cpp
@@ -387,10 +387,10 @@ void doTlsFingerprintingOnPcapFile(const std::string& inputPcapFileName, std::st
                                    const std::string& separator, bool chFP, bool shFP, const std::string& bpfFilter)
 {
 	// open input file (pcap or pcapng file)
-	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader(inputPcapFileName.c_str());
+	std::unique_ptr<pcpp::IFileReaderDevice> reader = pcpp::IFileReaderDevice::tryCreateReader(inputPcapFileName);
 
 	// try to open the file device
-	if (!reader->open())
+	if (!reader || !reader->open())
 		EXIT_WITH_ERROR("Cannot open pcap/pcapng file");
 
 	// set output file name to input file name if not provided by the user
@@ -440,7 +440,6 @@ void doTlsFingerprintingOnPcapFile(const std::string& inputPcapFileName, std::st
 
 	// close the reader and free its memory
 	reader->close();
-	delete reader;
 
 	printStats(stats, chFP, shFP);
 

--- a/Examples/TcpReassembly/main.cpp
+++ b/Examples/TcpReassembly/main.cpp
@@ -520,10 +520,10 @@ void doTcpReassemblyOnPcapFile(const std::string& fileName, pcpp::TcpReassembly&
                                const std::string& bpfFilter = "")
 {
 	// open input file (pcap or pcapng file)
-	pcpp::IFileReaderDevice* reader = pcpp::IFileReaderDevice::getReader(fileName);
+	std::unique_ptr<pcpp::IFileReaderDevice> reader = pcpp::IFileReaderDevice::tryCreateReader(fileName);
 
 	// try to open the file device
-	if (!reader->open())
+	if (!reader || !reader->open())
 		EXIT_WITH_ERROR("Cannot open pcap/pcapng file");
 
 	// set BPF filter if set by the user
@@ -550,7 +550,6 @@ void doTcpReassemblyOnPcapFile(const std::string& fileName, pcpp::TcpReassembly&
 
 	// close the reader and free its memory
 	reader->close();
-	delete reader;
 
 	std::cout << "Done! processed " << numOfConnectionsProcessed << " connections" << std::endl;
 }

--- a/Examples/X509Toolkit/PcapExtract.h
+++ b/Examples/X509Toolkit/PcapExtract.h
@@ -47,7 +47,8 @@ public:
 			throw std::runtime_error("Task already ran");
 		}
 
-		std::unique_ptr<pcpp::IFileReaderDevice> reader(pcpp::IFileReaderDevice::getReader(m_PcapFileName));
+		// createReader throws if the file cannot be opened or is of unsupported format
+		std::unique_ptr<pcpp::IFileReaderDevice> reader = pcpp::IFileReaderDevice::createReader(m_PcapFileName);
 
 		if (!reader->open())
 		{


### PR DESCRIPTION
The PR replaces example usages of deprecated `IFileReaderDevice::getReader` with the new `IFileReaderDevice::createReader` API.

The majority of the replacements utilize the `tryCreateReader` to minimize the changes due to the non-throwning behaviour of `getReader`.