### PR TITLE
Fix out-of-bounds read in GreLayer optional-field getters on truncated packets

### DIFF
--- a/Packet++/header/GreLayer.h
+++ b/Packet++/header/GreLayer.h
@@ -246,7 +246,25 @@ namespace pcpp
 		/// @return True if the data is valid and can represent an GREv0 layer
 		static inline bool isDataValid(const uint8_t* data, size_t dataLen)
 		{
-			return data && dataLen >= sizeof(gre_basic_header);
+			if (!data || dataLen < sizeof(gre_basic_header))
+				return false;
+
+			// The optional fields (checksum/routing, key, sequence number, ack sequence number) each add 4 bytes
+			// to the header if their respective bit is set. Mirrors the length calculation in GreLayer::getHeaderLen()
+			// so that isDataValid() rejects truncated packets before any optional-field getter tries to read past the
+			// end of the buffer
+			auto* header = reinterpret_cast<const gre_basic_header*>(data);
+			size_t requiredLen = sizeof(gre_basic_header);
+			if (header->checksumBit == 1 || header->routingBit == 1)
+				requiredLen += sizeof(uint32_t);
+			if (header->keyBit == 1)
+				requiredLen += sizeof(uint32_t);
+			if (header->sequenceNumBit == 1)
+				requiredLen += sizeof(uint32_t);
+			if (header->ackSequenceNumBit == 1)
+				requiredLen += sizeof(uint32_t);
+
+			return dataLen >= requiredLen;
 		}
 
 		// implement abstract methods
@@ -316,7 +334,23 @@ namespace pcpp
 		/// @return True if the data is valid and can represent an GREv1 layer
 		static inline bool isDataValid(const uint8_t* data, size_t dataLen)
 		{
-			return data && dataLen >= sizeof(gre1_header);
+			if (!data || dataLen < sizeof(gre1_header))
+				return false;
+
+			// sizeof(gre1_header) already accounts for the mandatory key field (payload length + call ID), so only
+			// the remaining optional fields (checksum/routing, sequence number, ack sequence number) can add 4 more
+			// bytes each. Mirrors the length calculation in GreLayer::getHeaderLen() so that isDataValid() rejects
+			// truncated packets before any optional-field getter tries to read past the end of the buffer
+			auto* header = reinterpret_cast<const gre_basic_header*>(data);
+			size_t requiredLen = sizeof(gre1_header);
+			if (header->checksumBit == 1 || header->routingBit == 1)
+				requiredLen += sizeof(uint32_t);
+			if (header->sequenceNumBit == 1)
+				requiredLen += sizeof(uint32_t);
+			if (header->ackSequenceNumBit == 1)
+				requiredLen += sizeof(uint32_t);
+
+			return dataLen >= requiredLen;
 		}
 
 		// implement abstract methods


### PR DESCRIPTION
## Problem

`GREv0Layer::isDataValid()` and `GREv1Layer::isDataValid()` only check the
data length against the fixed base header size (`sizeof(gre_basic_header)`
for v0, `sizeof(gre1_header)` for v1), regardless of which optional fields
(checksum/routing, key, sequence number, ack sequence number) the packet's
own bit flags claim are present.

`GreLayer::getFieldValue()` computes each optional field's offset purely
from those bit flags, with no check against the actual buffer length. So a
truncated GRE packet that has an optional bit set but not enough trailing
bytes causes `getChecksum()` / `getKey()` / `getSequenceNumber()` /
`getAcknowledgmentNum()` / `getOffset()` to read past the end of the
buffer.

This is reachable through ordinary packet parsing, not just direct API
misuse: `IPv4Layer::parseNextLayer()` dispatches protocol-47 payloads into
`tryConstructNextLayerWithFallback<GREv0Layer/GREv1Layer, PayloadLayer>`,
which gates construction solely on `isDataValid()`. A short/truncated
capture (or a crafted packet) is enough to get a `GreLayer` constructed
over a buffer too small for the fields it claims to contain, and the next
call to one of the getters above reads out of bounds.

I verified this empirically (VirtualAlloc guard page + AddVectoredExceptionHandler,
since ASan isn't available in this toolchain) by building the real,
unmodified `Packet++` library and:
- confirming `GREv0Layer::isDataValid()` accepts a 4-byte buffer with
  `checksumBit` set, and that the subsequent `getChecksum()`/`getKey()`
  call reads past the end of the allocation
- confirming `GREv1Layer::isDataValid()` accepts an 8-byte buffer with
  `keyBit` and `sequenceNumBit` both set even though the sequence-number
  field it computes sits one byte past the 8-byte allocation
- building a truncated IPv4-in-GRE packet and confirming the real
  `IPv4Layer::parseNextLayer()` → `tryConstructNextLayerWithFallback`
  chain constructs an (unsafe) `GREv0Layer` instead of falling back to
  `PayloadLayer`

## Fix

Both `isDataValid()` implementations now sum the required buffer length
from the same optional-field bits that `GreLayer::getHeaderLen()` already
uses, so a truncated packet is correctly rejected (falling back to
`PayloadLayer` during parsing) instead of allowing a `GreLayer` to be
constructed over an undersized buffer.

After the fix, the same harness confirms:
- `GREv0Layer::isDataValid()` now rejects the 4-byte/`checksumBit`-set case
- `GREv1Layer::isDataValid()` now rejects the 8-byte/`keyBit`+`sequenceNumBit`-set case
- the truncated IPv4-in-GRE packet no longer constructs a `GREv0Layer` (falls back to `PayloadLayer`)
- well-formed GRE packets (v0 and v1, with every optional field actually
  present at its correct offset) still parse correctly and all getters
  still return the correct values, so this doesn't regress the normal
  parsing path

Only `Packet++/header/GreLayer.h` is touched; no behavior changes for
correctly-sized packets.