### PR TITLE
More release notes fixes

### DIFF
--- a/cmake/package/READMEs/README.release.freebsd
+++ b/cmake/package/READMEs/README.release.freebsd
@@ -41,5 +41,5 @@ Using PcapPlusPlus in your project:
 Running the examples:
 ---------------------
 
- - Make sure you have libpcap developer pack installed (or run `pkg install libpcap` to install it)
+ - Make sure you have libpcap developer pack installed (or run `pkg install libpcap` to install it). It's not needed by every example individually, but the examples are built with libpcap support by default, so it's required for the standard build
  - You may need to run the executables as sudo

--- a/cmake/package/READMEs/README.release.linux
+++ b/cmake/package/READMEs/README.release.linux
@@ -21,6 +21,7 @@ This package contains:
 Using PcapPlusPlus in your project:
 -----------------------------------
 
+ - Make sure you have libpcap-dev package installed
  - If your application uses CMake, you can add `PcapPlusPlus_ROOT=<PACKAGE_DIR>` when running CMake, for example:
    `cmake -S . -B build -DPcapPlusPlus_ROOT=<PACKAGE_DIR>`
  - If your application uses Makefiles, you can use pkg-config with `PcapPlusPlus.pc`:
@@ -39,7 +40,5 @@ Using PcapPlusPlus in your project:
 Running the examples:
 ---------------------
 
- - Make sure you have libpcap installed (it should come built-in with most Linux distributions). It's not needed by
-   every example individually, but the examples are built with libpcap support by default, so it's required for the
-   standard build
+ - Make sure you have libpcap installed (it should come built-in with most Linux distributions). It's not needed by every example individually, but the examples are built with libpcap support by default, so it's required for the standard build
  - You may need to run the executables as sudo

--- a/cmake/package/READMEs/README.release.macos
+++ b/cmake/package/READMEs/README.release.macos
@@ -41,7 +41,5 @@ Using PcapPlusPlus in your project:
 Running the examples:
 ---------------------
 
- - Make sure you have libpcap installed (or install it with Homebrew: https://formulae.brew.sh/formula/libpcap). It's
-   not needed by every example individually, but the examples are built with libpcap support by default, so it's
-   required for the standard build
+ - Make sure you have libpcap installed (or install it with Homebrew: https://formulae.brew.sh/formula/libpcap). It's not needed by every example individually, but the examples are built with libpcap support by default, so it's required for the standard build
  - You may need to run the executables as sudo

--- a/cmake/package/READMEs/README.release.win.mingw
+++ b/cmake/package/READMEs/README.release.win.mingw
@@ -47,5 +47,4 @@ Using PcapPlusPlus in your project:
 Running the examples:
 ---------------------
 
- - Make sure you have WinPcap, Npcap or Wireshark installed. It's not needed by every example individually, but the
-   examples are built with WinPcap/Npcap support by default, so it's required for the standard build
+ - Make sure you have WinPcap, Npcap or Wireshark installed. It's not needed by every example individually, but the examples are built with WinPcap/Npcap support by default, so it's required for the standard build

--- a/cmake/package/READMEs/README.release.win.vs
+++ b/cmake/package/READMEs/README.release.win.vs
@@ -32,7 +32,6 @@ In order to compile your application with these binaries you need to:
 Running the examples:
 ---------------------
 
- - Make sure you have WinPcap, Npcap or Wireshark installed. It's not needed by every example individually, but the
-   examples are built with WinPcap/Npcap support by default, so it's required for the standard build
+ - Make sure you have WinPcap, Npcap or Wireshark installed. It's not needed by every example individually, but the examples are built with WinPcap/Npcap support by default, so it's required for the standard build
  - Make sure you have Visual C++ Redistributable for Visual Studio installed
  - If examples still don't run, install Visual C++ Redistributable for Visual Studio 2010 also

--- a/cmake/package/READMEs/release_notes.txt
+++ b/cmake/package/READMEs/release_notes.txt
@@ -2,6 +2,7 @@ Release notes (changes from v25.05)
 -----------------------------------
 
 - libpcap / WinPcap / Npcap is now optional. `Pcap++` no longer has a hard dependency on a packet-capture engine. Separately, `Common++`/`Packet++` can now be built entirely on their own, without `Pcap++`. As part of this work, PcapPlusPlus can now read and write `.pcap` files without libpcap (thanks @Dimi1010 for the follow-up performance fixes and keeping this working across build configs!)
+  * Note that the official pre-built packages are still built with libpcap / WinPcap / Npcap support enabled, so if you're using those you'll still need it installed. This change is primarily relevant if you're building PcapPlusPlus from source
 - Bumped the minimum required C++ standard to C++14 (thanks @Dimi1010 !)
 - Protocol support:
   * Added Modbus protocol (thanks @yahyayozo !)


### PR DESCRIPTION
- Add a better explanation about libpcap being optional
- Remove line breaks in `README_release*`
- Add a requirement to have libpcap-dev installed on Linux