### PR TITLE
Fix out-of-bounds read in NDP layers parsed from a truncated ICMPv6 message

### DIFF
--- a/Packet++/header/NdpLayer.h
+++ b/Packet++/header/NdpLayer.h
@@ -177,6 +177,15 @@ namespace pcpp
 		    : NDPLayerBase(data, dataLen, prevLayer, packet)
 		{}
 
+		/// Checks whether the data is large enough to be parsed as a neighbor solicitation message
+		/// @param[in] data A pointer to the raw data
+		/// @param[in] dataLen Size of the data in bytes
+		/// @return True if the data is at least the size of the neighbor solicitation header
+		static bool isDataValid(const uint8_t* data, size_t dataLen)
+		{
+			return data != nullptr && dataLen >= sizeof(ndpneighborsolicitationhdr);
+		}
+
 		/// A constructor for a new NDPNeighborSolicitationLayer object
 		/// @param[in] code Code field
 		/// @param[in] targetIP Target IP address for which the solicitation shall be created
@@ -266,6 +275,15 @@ namespace pcpp
 		NDPNeighborAdvertisementLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
 		    : NDPLayerBase(data, dataLen, prevLayer, packet)
 		{}
+
+		/// Checks whether the data is large enough to be parsed as a neighbor advertisement message
+		/// @param[in] data A pointer to the raw data
+		/// @param[in] dataLen Size of the data in bytes
+		/// @return True if the data is at least the size of the neighbor advertisement header
+		static bool isDataValid(const uint8_t* data, size_t dataLen)
+		{
+			return data != nullptr && dataLen >= sizeof(ndpneighboradvertisementhdr);
+		}
 
 		/// A constructor that allocates a new NDP Advertisement Layer with target link-layer address option
 		/// @param[in] code Code field

--- a/Packet++/src/IcmpV6Layer.cpp
+++ b/Packet++/src/IcmpV6Layer.cpp
@@ -28,8 +28,12 @@ namespace pcpp
 		case ICMPv6MessageType::ICMPv6_ECHO_REPLY:
 			return new ICMPv6EchoLayer(data, dataLen, prevLayer, packet);
 		case ICMPv6MessageType::ICMPv6_NEIGHBOR_SOLICITATION:
+			if (!NDPNeighborSolicitationLayer::isDataValid(data, dataLen))
+				return new IcmpV6Layer(data, dataLen, prevLayer, packet);
 			return new NDPNeighborSolicitationLayer(data, dataLen, prevLayer, packet);
 		case ICMPv6MessageType::ICMPv6_NEIGHBOR_ADVERTISEMENT:
+			if (!NDPNeighborAdvertisementLayer::isDataValid(data, dataLen))
+				return new IcmpV6Layer(data, dataLen, prevLayer, packet);
 			return new NDPNeighborAdvertisementLayer(data, dataLen, prevLayer, packet);
 		case ICMPv6MessageType::ICMPv6_UNKNOWN_MESSAGE:
 			return new PayloadLayer(data, dataLen, prevLayer, packet);

--- a/Tests/Packet++Test/Tests/IcmpV6Tests.cpp
+++ b/Tests/Packet++Test/Tests/IcmpV6Tests.cpp
@@ -156,6 +156,29 @@ PTF_TEST_CASE(IcmpV6ParsingTest)
 	    "0000000204000000ff05000000000000000000000001000304000000ff020000000000000000000000010002";
 	PTF_ASSERT_EQUAL(pcpp::byteArrayToHexString(icmpV6Layer->getDataPtr(4), icmpV6Layer->getDataLen() - 4),
 	                 expectedPayloadString);
+
+	// A neighbor solicitation/advertisement message shorter than its 24-byte header must be rejected.
+	// Otherwise getTargetIP() reads the 16-byte target address past the buffer, and the NDP option walk
+	// computes getHeaderLen() - getNdpHeaderLen() which underflows below the header size.
+	{
+		// type 135 (neighbor solicitation), only 8 bytes: icmpv6 header + reserved, missing the 16-byte target IP
+		const uint8_t truncatedNeighborSolicitation[] = { 0x87, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+		PTF_ASSERT_FALSE(pcpp::NDPNeighborSolicitationLayer::isDataValid(truncatedNeighborSolicitation,
+		                                                                 sizeof(truncatedNeighborSolicitation)));
+
+		// type 136 (neighbor advertisement), same truncation
+		const uint8_t truncatedNeighborAdvertisement[] = { 0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+		PTF_ASSERT_FALSE(pcpp::NDPNeighborAdvertisementLayer::isDataValid(truncatedNeighborAdvertisement,
+		                                                                  sizeof(truncatedNeighborAdvertisement)));
+
+		// a full 24-byte header (icmpv6 header + reserved/flags + 16-byte target IP) is accepted
+		const uint8_t fullNeighborSolicitation[24] = { 0x87, 0x00, 0x00, 0x00 };
+		PTF_ASSERT_TRUE(pcpp::NDPNeighborSolicitationLayer::isDataValid(fullNeighborSolicitation,
+		                                                                sizeof(fullNeighborSolicitation)));
+		const uint8_t fullNeighborAdvertisement[24] = { 0x88, 0x00, 0x00, 0x00 };
+		PTF_ASSERT_TRUE(pcpp::NDPNeighborAdvertisementLayer::isDataValid(fullNeighborAdvertisement,
+		                                                                 sizeof(fullNeighborAdvertisement)));
+	}
 }
 
 PTF_TEST_CASE(IcmpV6CreationTest)


### PR DESCRIPTION
`parseIcmpV6Layer` builds an NDP neighbor solicitation/advertisement layer for ICMPv6 types 135/136 after only checking `dataLen >= sizeof(icmpv6hdr)` (4 bytes), but both NDP headers are 24 bytes. So a 4-23 byte type 135/136 message still gets parsed as NDP, and `getTargetIP()` reads the 16-byte target address at offset 8 past the end of the buffer. The option walk hits the same thing: `getHeaderLen() - getNdpHeaderLen()` is `dataLen - 24`, which underflows for a short packet. Both are reachable from `toString()`.

Fix adds `isDataValid()` to the two NDP layers (require the full 24 bytes) and falls back to a plain `IcmpV6Layer` when the message is too short, same as the GtpV2 guard in #2181.

## Testing

Added truncated type 135/136 messages to `IcmpV6ParsingTest` (rejected by `isDataValid`, full 24-byte headers still accepted). icmpv6 tests pass.
