### PR TITLE
Replace safe Packet++ option macros with constexpr constants

### DIFF
--- a/Packet++/src/CiscoHdlcLayer.cpp
+++ b/Packet++/src/CiscoHdlcLayer.cpp
@@ -10,8 +10,8 @@ namespace pcpp
 {
 
 // Protocol types for Cisco HDLC
-#define CISCO_HDLC_TYPE_IP 0x0800
-#define CISCO_HDLC_TYPE_IPV6 0x86DD
+constexpr uint16_t CiscoHdlcTypeIp = 0x0800;
+constexpr uint16_t CiscoHdlcTypeIpv6 = 0x86DD;
 
 	CiscoHdlcLayer::CiscoHdlcLayer(AddressType address)
 	{
@@ -30,12 +30,12 @@ namespace pcpp
 			{
 			case IPv4:
 			{
-				setNextProtocol(CISCO_HDLC_TYPE_IP);
+				setNextProtocol(CiscoHdlcTypeIp);
 				break;
 			}
 			case IPv6:
 			{
-				setNextProtocol(CISCO_HDLC_TYPE_IPV6);
+				setNextProtocol(CiscoHdlcTypeIpv6);
 				break;
 			}
 			}
@@ -51,12 +51,12 @@ namespace pcpp
 
 		switch (nextProtocol)
 		{
-		case CISCO_HDLC_TYPE_IP:
+		case CiscoHdlcTypeIp:
 		{
 			tryConstructNextLayerWithFallback<IPv4Layer, PayloadLayer>(payload, payloadLen);
 			break;
 		}
-		case CISCO_HDLC_TYPE_IPV6:
+		case CiscoHdlcTypeIpv6:
 		{
 			tryConstructNextLayerWithFallback<IPv6Layer, PayloadLayer>(payload, payloadLen);
 			break;

--- a/Packet++/src/DhcpLayer.cpp
+++ b/Packet++/src/DhcpLayer.cpp
@@ -6,7 +6,7 @@
 namespace pcpp
 {
 
-#define DHCP_MAGIC_NUMBER 0x63538263
+constexpr uint32_t DhcpMagicNumber = 0x63538263;
 
 	DhcpOption DhcpOptionBuilder::build() const
 	{
@@ -93,7 +93,7 @@ namespace pcpp
 	{
 		dhcp_header* hdr = getDhcpHeader();
 
-		hdr->magicNumber = DHCP_MAGIC_NUMBER;
+		hdr->magicNumber = DhcpMagicNumber;
 
 		DhcpMessageType msgType = getMessageType();
 		switch (msgType)

--- a/Packet++/src/GtpLayer.cpp
+++ b/Packet++/src/GtpLayer.cpp
@@ -12,7 +12,7 @@
 namespace pcpp
 {
 
-#define PCPP_GTP_V1_GPDU_MESSAGE_TYPE 0xff
+constexpr uint8_t GtpV1GpduMessageType = 0xff;
 
 	/// ==================
 	/// GtpExtension class
@@ -543,7 +543,7 @@ namespace pcpp
 			return false;
 		}
 
-		return header->messageType == PCPP_GTP_V1_GPDU_MESSAGE_TYPE;
+		return header->messageType == GtpV1GpduMessageType;
 	}
 
 	bool GtpV1Layer::isGTPCMessage() const
@@ -554,7 +554,7 @@ namespace pcpp
 			return false;
 		}
 
-		return header->messageType != PCPP_GTP_V1_GPDU_MESSAGE_TYPE;
+		return header->messageType != GtpV1GpduMessageType;
 	}
 
 	void GtpV1Layer::parseNextLayer()
@@ -567,7 +567,7 @@ namespace pcpp
 		}
 
 		gtpv1_header* header = getHeader();
-		if (header->messageType != PCPP_GTP_V1_GPDU_MESSAGE_TYPE)
+		if (header->messageType != GtpV1GpduMessageType)
 		{
 			// this is a GTP-C message, hence it is the last layer
 			return;
@@ -609,7 +609,7 @@ namespace pcpp
 
 		size_t res = sizeof(gtpv1_header);
 
-		if (header->messageType != PCPP_GTP_V1_GPDU_MESSAGE_TYPE)
+		if (header->messageType != GtpV1GpduMessageType)
 		{
 			size_t msgLen = be16toh(header->messageLength);
 			res += (msgLen > m_DataLen - sizeof(gtpv1_header) ? m_DataLen - sizeof(gtpv1_header) : msgLen);
@@ -644,7 +644,7 @@ namespace pcpp
 			teidStream << be32toh(header->teid);
 
 			std::string gtpu_gtpc;
-			if (header->messageType == PCPP_GTP_V1_GPDU_MESSAGE_TYPE)
+			if (header->messageType == GtpV1GpduMessageType)
 			{
 				gtpu_gtpc = "GTP-U message";
 			}

--- a/Packet++/src/IPv4Layer.cpp
+++ b/Packet++/src/IPv4Layer.cpp
@@ -19,8 +19,8 @@
 namespace pcpp
 {
 
-#define IPV4OPT_DUMMY 0xff
-#define IPV4_MAX_OPT_SIZE 40
+constexpr uint8_t IPv4OptionDummy = 0xff;
+constexpr size_t IPv4MaxOptionSize = 40;
 
 	/// ~~~~~~~~~~~~~~~~~
 	/// IPv4OptionBuilder
@@ -494,7 +494,7 @@ namespace pcpp
 		m_NumOfTrailingBytes = newNumberOfTrailingBytes;
 
 		for (int i = 0; i < m_NumOfTrailingBytes; i++)
-			m_Data[ipHdrSize + totalOptSize + i] = IPV4OPT_DUMMY;
+			m_Data[ipHdrSize + totalOptSize + i] = IPv4OptionDummy;
 
 		m_TempHeaderExtension = 0;
 		getIPv4Header()->internetHeaderLength = ((ipHdrSize + totalOptSize + m_NumOfTrailingBytes) / 4 & 0x0f);
@@ -510,10 +510,10 @@ namespace pcpp
 
 		size_t totalOptSize = getHeaderLen() - sizeof(iphdr) - m_NumOfTrailingBytes + sizeToExtend;
 
-		if (totalOptSize > IPV4_MAX_OPT_SIZE)
+		if (totalOptSize > IPv4MaxOptionSize)
 		{
 			PCPP_LOG_ERROR("Cannot add option - adding this option will exceed IPv4 total option size which is "
-			               << IPV4_MAX_OPT_SIZE);
+			               << IPv4MaxOptionSize);
 			newOption.purgeRecordData();
 			return IPv4Option(nullptr);
 		}

--- a/Packet++/src/NflogLayer.cpp
+++ b/Packet++/src/NflogLayer.cpp
@@ -10,9 +10,9 @@
 namespace pcpp
 {
 /// IPv4 protocol
-#define PCPP_WS_NFPROTO_IPV4 2
+constexpr uint8_t NflogFamilyIpv4 = 2;
 /// IPv6 protocol
-#define PCPP_WS_NFPROTO_IPV6 10
+constexpr uint8_t NflogFamilyIpv6 = 10;
 
 	uint8_t NflogLayer::getFamily()
 	{
@@ -56,12 +56,12 @@ namespace pcpp
 
 		switch (family)
 		{
-		case PCPP_WS_NFPROTO_IPV4:
+		case NflogFamilyIpv4:
 		{
 			tryConstructNextLayerWithFallback<IPv4Layer, PayloadLayer>(payload, payloadLen);
 			break;
 		}
-		case PCPP_WS_NFPROTO_IPV6:
+		case NflogFamilyIpv6:
 		{
 			tryConstructNextLayerWithFallback<IPv6Layer, PayloadLayer>(payload, payloadLen);
 			break;

--- a/Packet++/src/NtpLayer.cpp
+++ b/Packet++/src/NtpLayer.cpp
@@ -6,15 +6,14 @@
 #include "GeneralUtils.h"
 #include <cmath>
 
-/// 2^16 as a double
-#define NTP_FRIC 65536.
-/// 2^32 as a double
-#define NTP_FRAC 4294967296.
-/// Epoch offset between Unix time and NTP
-#define EPOCH_OFFSET 2208988800ULL
-
 namespace pcpp
 {
+	/// 2^16 as a double
+	constexpr double NtpFraction16Scale = 65536.;
+	/// 2^32 as a double
+	constexpr double NtpFraction32Scale = 4294967296.;
+	/// Epoch offset between Unix time and NTP
+	constexpr uint64_t NtpEpochOffset = 2208988800ULL;
 	NtpLayer::NtpLayer()
 	{
 		allocData(sizeof(ntp_header));
@@ -539,7 +538,7 @@ namespace pcpp
 	double NtpLayer::convertFromShortFormat(const uint32_t val)
 	{
 		double integerPart = netToHost16(val & 0xFFFF);
-		double fractionPart = netToHost16(((val & 0xFFFF0000) >> 16)) / NTP_FRIC;
+		double fractionPart = netToHost16(((val & 0xFFFF0000) >> 16)) / NtpFraction16Scale;
 
 		return integerPart + fractionPart;
 	}
@@ -547,11 +546,11 @@ namespace pcpp
 	double NtpLayer::convertFromTimestampFormat(const uint64_t val)
 	{
 		double integerPart = netToHost32(val & 0xFFFFFFFF);
-		double fractionPart = netToHost32(((val & 0xFFFFFFFF00000000) >> 32)) / NTP_FRAC;
+		double fractionPart = netToHost32(((val & 0xFFFFFFFF00000000) >> 32)) / NtpFraction32Scale;
 
 		// TODO: Return integer and fraction parts as struct to increase precision
 		// Offset change should be done here because of overflow
-		return integerPart + fractionPart - EPOCH_OFFSET;
+		return integerPart + fractionPart - NtpEpochOffset;
 	}
 
 	uint32_t NtpLayer::convertToShortFormat(const double val)
@@ -561,7 +560,7 @@ namespace pcpp
 
 		// Cast values to 16bit
 		uint32_t integerPartInt = hostToNet16(integerPart);
-		uint32_t fractionPartInt = hostToNet16(fractionPart * NTP_FRIC);
+		uint32_t fractionPartInt = hostToNet16(fractionPart * NtpFraction16Scale);
 
 		return integerPartInt | (fractionPartInt << 16);
 	}
@@ -572,8 +571,8 @@ namespace pcpp
 		double fractionPart = modf(val, &integerPart);
 
 		// Cast values to 32bit
-		uint64_t integerPartInt = hostToNet32(integerPart + EPOCH_OFFSET);
-		uint64_t fractionPartInt = hostToNet32(fractionPart * NTP_FRAC);
+		uint64_t integerPartInt = hostToNet32(integerPart + NtpEpochOffset);
+		uint64_t fractionPartInt = hostToNet32(fractionPart * NtpFraction32Scale);
 
 		return integerPartInt | (fractionPartInt << 32);
 	}

--- a/Packet++/src/NullLoopbackLayer.cpp
+++ b/Packet++/src/NullLoopbackLayer.cpp
@@ -10,7 +10,7 @@ namespace pcpp
 #define BSWAP16(x) (((x) >> 8) | ((x) << 8))
 #define BSWAP32(x) (((x) >> 24) | (((x) & 0x00FF'0000) >> 8) | (((x) & 0x0000'FF00) << 8) | ((x) << 24))
 
-#define IEEE_802_3_MAX_LEN 0x5dc
+constexpr uint32_t Ieee8023MaxLength = 0x5dc;
 
 	NullLoopbackLayer::NullLoopbackLayer(uint32_t family)
 	{
@@ -53,7 +53,7 @@ namespace pcpp
 		size_t payloadLen = m_DataLen - sizeof(uint32_t);
 
 		uint32_t family = getFamily();
-		if (family > IEEE_802_3_MAX_LEN)
+		if (family > Ieee8023MaxLength)
 		{
 			uint16_t ethType = static_cast<uint16_t>(family);
 			switch (ethType)

--- a/Packet++/src/SSHLayer.cpp
+++ b/Packet++/src/SSHLayer.cpp
@@ -9,7 +9,7 @@
 namespace pcpp
 {
 
-#define SSH_LAYER_BASE_STRING "SSH Layer"
+constexpr char SshLayerBaseString[] = "SSH Layer";
 
 	// ----------------
 	// SSHLayer methods
@@ -64,7 +64,7 @@ namespace pcpp
 
 	std::string SSHIdentificationMessage::toString() const
 	{
-		return std::string(SSH_LAYER_BASE_STRING) + ", " + "Identification message";
+		return std::string(SshLayerBaseString) + ", " + "Identification message";
 	}
 
 	// ---------------------------
@@ -125,7 +125,7 @@ namespace pcpp
 
 	std::string SSHHandshakeMessage::toString() const
 	{
-		return std::string(SSH_LAYER_BASE_STRING) + ", " + "Handshake Message: " + getMessageTypeStr();
+		return std::string(SshLayerBaseString) + ", " + "Handshake Message: " + getMessageTypeStr();
 	}
 
 	SSHHandshakeMessage* SSHHandshakeMessage::tryParse(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
@@ -254,7 +254,7 @@ namespace pcpp
 
 	std::string SSHEncryptedMessage::toString() const
 	{
-		return std::string(SSH_LAYER_BASE_STRING) + ", " + "Encrypted Message";
+		return std::string(SshLayerBaseString) + ", " + "Encrypted Message";
 	}
 
 }  // namespace pcpp

--- a/Packet++/src/SSLHandshake.cpp
+++ b/Packet++/src/SSLHandshake.cpp
@@ -685,17 +685,17 @@ namespace pcpp
 		return result;
 	}
 
-#define A 54059        ///< a prime
-#define B 76963        ///< another prime
-#define C 86969        ///< yet another prime
-#define FIRST_HASH 37  ///< also prime
+constexpr unsigned SslHashMultiplierA = 54059;  ///< a prime
+constexpr unsigned SslHashMultiplierB = 76963;  ///< another prime
+constexpr unsigned SslHashMultiplierC = 86969;  ///< yet another prime
+constexpr unsigned SslHashInitialValue = 37;    ///< also prime
 
 	static uint32_t hashString(std::string str)
 	{
-		unsigned h = FIRST_HASH;
+		unsigned h = SslHashInitialValue;
 		for (auto i = 0u; i < str.size(); ++i)
 		{
-			h = (h * A) ^ (str[i] * B);
+			h = (h * SslHashMultiplierA) ^ (str[i] * SslHashMultiplierB);
 		}
 		return h;
 	}

--- a/Packet++/src/SingleCommandTextProtocol.cpp
+++ b/Packet++/src/SingleCommandTextProtocol.cpp
@@ -3,21 +3,20 @@
 #include <algorithm>
 #include <vector>
 
-#define ASCII_HYPHEN 0x2d
-#define ASCII_SPACE 0x20
-#define MAX_COMMAND_LENGTH 9  // From SMTP command "STARTTLS" + 1 byte hyphen or space
-#define MIN_PACKET_LENGTH 2   // CRLF
-
 namespace pcpp
 {
+	constexpr char AsciiHyphen = 0x2d;
+	constexpr char AsciiSpace = 0x20;
+	constexpr size_t MaxCommandLength = 9;  // From SMTP command "STARTTLS" + 1 byte hyphen or space
+	constexpr size_t MinPacketLength = 2;   // CRLF
 
 	size_t SingleCommandTextProtocol::getArgumentFieldOffset() const
 	{
 		size_t maxLen;
-		if (m_DataLen < MAX_COMMAND_LENGTH)
+		if (m_DataLen < MaxCommandLength)
 			maxLen = m_DataLen;
 		else
-			maxLen = MAX_COMMAND_LENGTH;
+			maxLen = MaxCommandLength;
 
 		// To correctly detect multi-line packets with the option containing a space in
 		// the first MAX_CONTENT_LENGTH bytes, search the both of hyphen and space to take
@@ -25,8 +24,8 @@ namespace pcpp
 
 		std::string field(reinterpret_cast<char*>(m_Data), maxLen);
 
-		size_t posHyphen = field.find_first_of(ASCII_HYPHEN);
-		size_t posSpace = field.find_first_of(ASCII_SPACE);
+		size_t posHyphen = field.find_first_of(AsciiHyphen);
+		size_t posSpace = field.find_first_of(AsciiSpace);
 		size_t posCRLF = field.rfind("\r\n");
 
 		// No delimiter or packet end
@@ -45,9 +44,9 @@ namespace pcpp
 	void SingleCommandTextProtocol::setDelimiter(bool hyphen)
 	{
 		if (hyphen)
-			memset(&m_Data[getArgumentFieldOffset()], ASCII_HYPHEN, 1);
+			memset(&m_Data[getArgumentFieldOffset()], AsciiHyphen, 1);
 		else
-			memset(&m_Data[getArgumentFieldOffset()], ASCII_SPACE, 1);
+			memset(&m_Data[getArgumentFieldOffset()], AsciiSpace, 1);
 	}
 
 	bool SingleCommandTextProtocol::hyphenRequired(const std::string& value)
@@ -61,7 +60,7 @@ namespace pcpp
 	                                                     ProtocolType protocol)
 	{
 		m_Protocol = protocol;
-		allocData(MIN_PACKET_LENGTH);
+		allocData(MinPacketLength);
 		if (!command.empty())
 			setCommandInternal(command);
 		if (!option.empty())
@@ -163,12 +162,12 @@ namespace pcpp
 
 	bool SingleCommandTextProtocol::isMultiLine() const
 	{
-		return m_Data[getArgumentFieldOffset()] == ASCII_HYPHEN;
+		return m_Data[getArgumentFieldOffset()] == AsciiHyphen;
 	}
 
 	bool SingleCommandTextProtocol::isDataValid(const uint8_t* data, size_t dataSize)
 	{
-		if (data == nullptr || dataSize < MIN_PACKET_LENGTH)
+		if (data == nullptr || dataSize < MinPacketLength)
 			return false;
 
 		std::string payload = std::string(reinterpret_cast<const char*>(data), dataSize);

--- a/Packet++/src/TcpLayer.cpp
+++ b/Packet++/src/TcpLayer.cpp
@@ -30,7 +30,7 @@
 namespace pcpp
 {
 
-#define TCPOPT_DUMMY 0xff
+constexpr uint8_t TcpOptionDummy = 0xff;
 
 	/// ~~~~~~~~~~~~~~~~
 	/// TcpOptionBuilder
@@ -125,7 +125,7 @@ namespace pcpp
 	{
 		TcpOption nextOpt =
 		    m_OptionReader.getNextTLVRecord(tcpOption, getOptionsBasePtr(), getHeaderLen() - sizeof(tcphdr));
-		if (nextOpt.isNotNull() && nextOpt.getType() == TCPOPT_DUMMY)
+		if (nextOpt.isNotNull() && nextOpt.getType() == TcpOptionDummy)
 			return TcpOption(nullptr);
 
 		return nextOpt;
@@ -263,7 +263,7 @@ namespace pcpp
 		m_NumOfTrailingBytes = newNumberOfTrailingBytes;
 
 		for (int i = 0; i < m_NumOfTrailingBytes; i++)
-			m_Data[sizeof(tcphdr) + totalOptSize + i] = TCPOPT_DUMMY;
+			m_Data[sizeof(tcphdr) + totalOptSize + i] = TcpOptionDummy;
 
 		getTcpHeader()->dataOffset = (sizeof(tcphdr) + totalOptSize + m_NumOfTrailingBytes) / 4;
 	}

--- a/Packet++/src/TcpReassembly.cpp
+++ b/Packet++/src/TcpReassembly.cpp
@@ -13,8 +13,6 @@
 #	include <time.h>
 #endif
 
-#define PURGE_FREQ_SECS 1
-
 #define SEQ_LT(a, b) ((int32_t)((a) - (b)) < 0)
 #define SEQ_LEQ(a, b) ((int32_t)((a) - (b)) <= 0)
 #define SEQ_GT(a, b) ((int32_t)((a) - (b)) > 0)
@@ -22,6 +20,7 @@
 
 namespace pcpp
 {
+	constexpr int PurgeFrequencySeconds = 1;
 
 	static timeval timePointToTimeval(const std::chrono::time_point<std::chrono::high_resolution_clock>& in)
 	{
@@ -75,7 +74,7 @@ namespace pcpp
 		m_RemoveConnInfo = config.removeConnInfo;
 		m_MaxNumToClean = (config.removeConnInfo == true && config.maxNumToClean == 0) ? 30 : config.maxNumToClean;
 		m_MaxOutOfOrderFragments = config.maxOutOfOrderFragments;
-		m_PurgeTimepoint = time(nullptr) + PURGE_FREQ_SECS;
+		m_PurgeTimepoint = time(nullptr) + PurgeFrequencySeconds;
 		m_EnableBaseBufferClearCondition = config.enableBaseBufferClearCondition;
 	}
 
@@ -87,7 +86,7 @@ namespace pcpp
 			if (time(nullptr) >= m_PurgeTimepoint)
 			{
 				purgeClosedConnections();
-				m_PurgeTimepoint = time(nullptr) + PURGE_FREQ_SECS;
+				m_PurgeTimepoint = time(nullptr) + PurgeFrequencySeconds;
 			}
 		}
 

--- a/Packet++/src/VrrpLayer.cpp
+++ b/Packet++/src/VrrpLayer.cpp
@@ -11,31 +11,31 @@
 namespace pcpp
 {
 
-#define VRRP_PRIO_STOP 0     ///< priority to stop
-#define VRRP_PRIO_DEF 100    ///< default priority
-#define VRRP_PRIO_OWNER 255  ///< priority of the ip owner
+constexpr uint8_t VrrpPriorityStop = 0;       ///< priority to stop
+constexpr uint8_t VrrpPriorityDefault = 100;  ///< default priority
+constexpr uint8_t VrrpPriorityOwner = 255;    ///< priority of the IP owner
 
-#define VRRP_PACKET_FIX_LEN 8
-#define VRRP_PACKET_MAX_IP_ADDRESS_NUM 255
+constexpr uint8_t VrrpPacketFixedLength = 8;
+constexpr uint8_t VrrpPacketMaxIpAddressCount = 255;
 
-#define VRRP_V2_VERSION 2
-#define VRRP_V3_VERSION 3
+constexpr uint8_t VrrpVersion2 = 2;
+constexpr uint8_t VrrpVersion3 = 3;
 
 	// -------- Class VrrpLayer -----------------
 
 	VrrpLayer::VrrpLayer(ProtocolType subProtocol, uint8_t virtualRouterId, uint8_t priority)
 	{
-		allocData(VRRP_PACKET_FIX_LEN);
+		allocData(VrrpPacketFixedLength);
 		m_Protocol = subProtocol;
 		m_AddressType = IPAddress::IPv4AddressType;
 		auto vrrpHeader = getVrrpHeader();
 		if (subProtocol == VRRPv2)
 		{
-			vrrpHeader->version = VRRP_V2_VERSION;
+			vrrpHeader->version = VrrpVersion2;
 		}
 		else if (subProtocol == VRRPv3)
 		{
-			vrrpHeader->version = VRRP_V3_VERSION;
+			vrrpHeader->version = VrrpVersion3;
 		}
 		vrrpHeader->type = static_cast<uint8_t>(VrrpType::VrrpType_Advertisement);
 		setVirtualRouterID(virtualRouterId);
@@ -44,7 +44,7 @@ namespace pcpp
 
 	ProtocolType VrrpLayer::getVersionFromData(uint8_t* data, size_t dataLen)
 	{
-		if (!data || dataLen <= VRRP_PACKET_FIX_LEN)
+		if (!data || dataLen <= VrrpPacketFixedLength)
 		{
 			return UnknownProtocol;
 		}
@@ -53,9 +53,9 @@ namespace pcpp
 		uint8_t version = vrrpPacketCommon->version;
 		switch (version)
 		{
-		case VRRP_V2_VERSION:
+		case VrrpVersion2:
 			return VRRPv2;
-		case VRRP_V3_VERSION:
+		case VrrpVersion3:
 			return VRRPv3;
 		default:
 			return UnknownProtocol;
@@ -93,13 +93,13 @@ namespace pcpp
 	{
 		switch (getVrrpHeader()->priority)
 		{
-		case VRRP_PRIO_DEF:
+		case VrrpPriorityDefault:
 			return VrrpLayer::VrrpPriority::Default;
 
-		case VRRP_PRIO_STOP:
+		case VrrpPriorityStop:
 			return VrrpLayer::VrrpPriority::Stop;
 
-		case VRRP_PRIO_OWNER:
+		case VrrpPriorityOwner:
 			return VrrpLayer::VrrpPriority::Owner;
 
 		default:
@@ -183,12 +183,12 @@ namespace pcpp
 		size_t ipAddressLen = getIPAddressLen();
 
 		// check if there are virtual IP address at all
-		if (getHeaderLen() <= VRRP_PACKET_FIX_LEN + ipAddressLen)
+		if (getHeaderLen() <= VrrpPacketFixedLength + ipAddressLen)
 		{
 			return nullptr;
 		}
 
-		return (m_Data + VRRP_PACKET_FIX_LEN);
+		return (m_Data + VrrpPacketFixedLength);
 	}
 
 	uint8_t* VrrpLayer::getNextIPAddressPtr(uint8_t* ipAddressPtr) const
@@ -226,7 +226,7 @@ namespace pcpp
 			}
 		}
 
-		if (getIPAddressesCount() + ipAddresses.size() > VRRP_PACKET_MAX_IP_ADDRESS_NUM)
+		if (getIPAddressesCount() + ipAddresses.size() > VrrpPacketMaxIpAddressCount)
 		{
 			PCPP_LOG_ERROR("Cannot add virtual IP address, for virtual IP address has already exceed maximum.");
 			return false;
@@ -283,7 +283,7 @@ namespace pcpp
 
 		size_t ipAddressLen = getIPAddressLen();
 
-		size_t offset = VRRP_PACKET_FIX_LEN;
+		size_t offset = VrrpPacketFixedLength;
 		auto curIpAddressPtr = getFirstIPAddressPtr();
 		for (int i = 0; i < index; i++)
 		{
@@ -311,7 +311,7 @@ namespace pcpp
 
 	bool VrrpLayer::removeAllIPAddresses()
 	{
-		size_t offset = VRRP_PACKET_FIX_LEN;
+		size_t offset = VrrpPacketFixedLength;
 		size_t packetLen = getHeaderLen();
 		if (packetLen <= offset)
 		{


### PR DESCRIPTION
## Summary

- Replace safe internal Packet++ option macros with typed `constexpr` constants.
- Preserve the original values and behavior.
- Keep the changes limited to constants that can be converted without affecting conditional compilation or macro expansion.

Refs #1853

## Rationale

These macros represent fixed numeric values used by Packet++ option-processing code.

Replacing them with typed `constexpr` constants:

- provides explicit type information;
- avoids preprocessor text substitution;
- limits the constants to normal C++ scoping rules;
- makes their compile-time nature clear;
- preserves the existing runtime behavior.

For one-byte option values, `uint8_t` is used because the corresponding protocol field is eight bits wide. Byte order is not relevant for a single-byte value.

## Validation

- Built the `Packet++Test` target successfully.
- Ran the Packet++ test suite on this branch.
- Ran the same test suite on `master`.
- Confirmed that the same pre-existing tests fail on both branches.
- No additional test failures were introduced by these changes.

## Commit

`Replace safe Packet++ option macros with constexpr constants`