### PR TITLE
Fix TestSystemCoreUtils failing on machines with more than 32 cores

### DIFF
--- a/Common++/header/SystemUtils.h
+++ b/Common++/header/SystemUtils.h
@@ -125,8 +125,10 @@ namespace pcpp
 	/// @return Total number of CPU cores on device
 	int getNumOfCores();
 
-	/// Create a core mask for all cores available on machine
-	/// @return A core mask for all cores available on machine
+	/// Create a core mask for all cores available on machine. Since CoreMask is a 32-bit
+	/// value, on machines with more than MAX_NUM_OF_CORES (32) cores only the first 32
+	/// cores are represented in the returned mask
+	/// @return A core mask for all cores available on machine, capped at MAX_NUM_OF_CORES
 	CoreMask getCoreMaskForAllMachineCores();
 
 	/// Create a core mask from a vector of system cores

--- a/Tests/Pcap++Test/Tests/SystemUtilsTests.cpp
+++ b/Tests/Pcap++Test/Tests/SystemUtilsTests.cpp
@@ -1,5 +1,6 @@
 #include "../TestDefinition.h"
 #include "SystemUtils.h"
+#include <algorithm>
 #include <bitset>
 
 PTF_TEST_CASE(TestSystemCoreUtils)
@@ -7,8 +8,10 @@ PTF_TEST_CASE(TestSystemCoreUtils)
 	auto numOfCores = pcpp::getNumOfCores();
 	PTF_ASSERT_GREATER_THAN(numOfCores, 1);
 
+	// getCoreMaskForAllMachineCores() returns a 32-bit mask, so on machines with more than
+	// MAX_NUM_OF_CORES (32) cores it can only represent the first 32 of them
 	std::bitset<32> bs(pcpp::getCoreMaskForAllMachineCores());
-	PTF_ASSERT_EQUAL(bs.count(), numOfCores);
+	PTF_ASSERT_EQUAL(bs.count(), std::min(numOfCores, static_cast<int>(MAX_NUM_OF_CORES)));
 
 	auto coreVector =
 	    std::vector<pcpp::SystemCore>{ pcpp::SystemCores::Core0, pcpp::SystemCores::Core2, pcpp::SystemCores::Core4 };


### PR DESCRIPTION
## Summary
- `TestSystemCoreUtils` asserted that `getCoreMaskForAllMachineCores()`'s bit count equals the raw core count returned by `getNumOfCores()`.
- `CoreMask` is a 32-bit value, so `getCoreMaskForAllMachineCores()` can only ever represent the first `MAX_NUM_OF_CORES` (32) cores by design — the test's expectation was simply wrong on any host with more than 32 logical cores (e.g. large cloud/CI instances).
- This is a test-only fix; no production behavior changes. `getCoreMaskForAllMachineCores()`'s 32-core cap is pre-existing, intentional behavior.

## Changes
- `Tests/Pcap++Test/Tests/SystemUtilsTests.cpp`: assert against `std::min(numOfCores, MAX_NUM_OF_CORES)` instead of the unclamped core count.
- `Common++/header/SystemUtils.h`: clarified `getCoreMaskForAllMachineCores()`'s doc comment to mention the 32-core cap (doc-only change).

## Test plan
- [x] `Bin/Pcap++Test -n -t TestSystemCoreUtils` passes on a 96-core machine (previously failed with `Actual: 32, Expected: 96`)
- [x] Full `Pcap++Test -n` suite passes

Made with [Cursor](https://cursor.com)