### PR TITLE
Fix out-of-bounds read from a trailing partial VRRP virtual IP address

### DIFF
--- a/Packet++/src/VrrpLayer.cpp
+++ b/Packet++/src/VrrpLayer.cpp
@@ -199,14 +199,17 @@ namespace pcpp
 		}
 
 		size_t ipAddressLen = getIPAddressLen();
+		size_t nextOffset = static_cast<size_t>(ipAddressPtr - m_Data) + ipAddressLen;
 
-		// prev virtual IP address was the last virtual IP address
-		if (ipAddressPtr + ipAddressLen - m_Data >= (int)getHeaderLen())
+		// The next virtual IP address must fit entirely inside the layer. Checking only that the current
+		// address ends inside it leaves a trailing partial address reachable, which the caller then reads
+		// in full and runs past the end of the buffer.
+		if (nextOffset + ipAddressLen > getHeaderLen())
 		{
 			return nullptr;
 		}
 
-		return (ipAddressPtr + ipAddressLen);
+		return (m_Data + nextOffset);
 	}
 
 	bool VrrpLayer::addIPAddressesAt(const std::vector<IPAddress>& ipAddresses, int offset)

--- a/Tests/Packet++Test/Tests/VrrpTest.cpp
+++ b/Tests/Packet++Test/Tests/VrrpTest.cpp
@@ -91,6 +91,29 @@ PTF_TEST_CASE(VrrpParsingTest)
 	expectedIpAddressVec = { pcpp::IPAddress("fe80::254"), pcpp::IPAddress("2001:db8::1"),
 		                     pcpp::IPAddress("2001:db8::2") };
 	PTF_ASSERT_TRUE(ipAddressVec == expectedIpAddressVec)
+
+	// A VRRP layer whose length leaves a partial virtual IP address at the end must stop before it.
+	// getNextIPAddressPtr() only checked that the current address ends inside the layer, so it handed
+	// back a pointer to a trailing partial address that getIPAddresses() then read in full, running
+	// past the end of the buffer.
+	{
+		uint8_t truncated[] = { // Ethernet
+			                    0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x08, 0x00,
+			                    // IPv4, total length 33, protocol 112 (VRRP)
+			                    0x45, 0x00, 0x00, 0x21, 0x00, 0x00, 0x00, 0x00, 0xff, 0x70, 0x00, 0x00, 0x0a, 0x00,
+			                    0x00, 0x01, 0xe0, 0x00, 0x00, 0x12,
+			                    // VRRP v2: 8-byte header, one full IPv4 address, then a single trailing byte
+			                    0x21, 0x01, 0x64, 0x01, 0x00, 0x01, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x01, 0xff
+		};
+
+		timeval truncatedTime = {};
+		pcpp::RawPacket truncatedRawPacket(truncated, sizeof(truncated), truncatedTime, false, pcpp::LINKTYPE_ETHERNET);
+		pcpp::Packet truncatedPacket(&truncatedRawPacket);
+
+		auto truncatedVrrpLayer = truncatedPacket.getLayerOfType<pcpp::VrrpV2Layer>();
+		PTF_ASSERT_NOT_NULL(truncatedVrrpLayer);
+		PTF_ASSERT_EQUAL(truncatedVrrpLayer->getIPAddresses().size(), 1);
+	}
 }  // VrrpParsingTest
 
 PTF_TEST_CASE(VrrpCreateAndEditTest)


### PR DESCRIPTION
`VrrpLayer::getNextIPAddressPtr()` decides whether another virtual IP address follows by checking that the *current* one ends inside the layer:

```cpp
if (ipAddressPtr + ipAddressLen - m_Data >= (int)getHeaderLen())
    return nullptr;
```

That still returns a pointer when the layer ends with a partial address. `getIPAddresses()` then reads the full 4 or 16 bytes at that pointer through `getIPAddressFromData()` and runs past the end of the buffer.

The fix requires the next address to fit entirely inside the layer before returning it.

## Reproducing

A 47 byte Ethernet + IPv4 (protocol 112) packet whose VRRPv2 layer holds an 8 byte header, one complete IPv4 address and a single trailing byte. Under AddressSanitizer on `dev`:

```
ERROR: AddressSanitizer: stack-buffer-overflow
READ of size 4
    #1 pcpp::VrrpLayer::getIPAddresses() const  VrrpLayer.cpp:173
SUMMARY: stack-buffer-overflow VrrpLayer.cpp:350 in getIPAddressFromData
```

With the fix the trailing byte is ignored and the layer reports its one complete address.

The case is added to `VrrpParsingTest`. Full Packet++Test is 259 passed, 0 failed, and `VrrpParsingTest` is clean under ASAN.

`VrrpCreateAndEditTest` does trip a stack-use-after-scope under ASAN, but that is pre-existing test code that outlives its stack layers and it fails the same way on dev, same shape as `DoIpRoutActReqCreation`
