### PR TITLE
Fix parameter names shadowing functions.

### DIFF
--- a/Common++/header/ObjectPool.h
+++ b/Common++/header/ObjectPool.h
@@ -139,10 +139,10 @@ namespace pcpp
 			}
 
 			/// @brief Sets the maximum number of objects in the pool.
-			void setMaxSize(std::size_t maxSize)
+			void setMaxSize(std::size_t newMaxSize)
 			{
 				std::lock_guard<std::mutex> lock(m_Mutex);
-				m_MaxPoolSize = maxSize;
+				m_MaxPoolSize = newMaxSize;
 
 				// If the new max size is less than the current size, we need to remove some objects from the pool.
 				while (m_Pool.size() > m_MaxPoolSize)

--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -225,12 +225,12 @@ namespace pcpp
 		}
 
 		/// @brief Reserve storage for the vector.
-		/// @param[in] size The number of elements to reserve space for.
+		/// @param[in] newSize The number of elements to reserve space for.
 		/// @remarks This method ensures that the vector can hold at least the specified number of elements
 		/// without requiring a reallocation.
-		void reserve(size_t size)
+		void reserve(size_t newSize)
 		{
-			m_Vector.reserve(size);
+			m_Vector.reserve(newSize);
 		}
 
 		/// @return A pointer of the first element in the vector


### PR DESCRIPTION
PR fixes parameter names shadowing existing functions names by renaming the parameters.

Affected changes:
- `ObjectPool::setMaxSize(size_t maxSize)` shadows `ObjectPool::maxSize()` inside the function scope. Param `maxSize` renamed to `newMaxSize`.
- `PointerVector::reserve(size_t size)` shadows `PointerVector::size()` inside the function scope. Param `size` has been renamed to `newSize`,

---
Cherrypicked from #2199 