### PR TITLE
Refactor `S7CommLayer` to use unique pointer.

### DIFF
--- a/Packet++/header/S7CommLayer.h
+++ b/Packet++/header/S7CommLayer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include "EthLayer.h"
 #include "Layer.h"
 
@@ -92,15 +93,9 @@ namespace pcpp
 		/// @param[in] packet A pointer to the Packet instance where layer will be stored in
 		S7CommLayer(uint8_t* data, size_t dataLen, Layer* prevLayer, Packet* packet)
 		    : Layer(data, dataLen, prevLayer, packet, S7COMM)
-		{
-			m_Parameter = nullptr;
-		}
+		{}
 
-		~S7CommLayer() override
-		{
-			if (m_Parameter)
-				delete m_Parameter;
-		}
+		~S7CommLayer() override = default;
 
 		/// @return S7comm protocol id
 		uint8_t getProtocolId() const;
@@ -185,7 +180,7 @@ namespace pcpp
 
 		size_t getS7commHeaderLength() const;
 
-		S7CommParameter* m_Parameter;
+		std::unique_ptr<S7CommParameter> m_Parameter;
 	};
 
 }  // namespace pcpp

--- a/Packet++/src/S7CommLayer.cpp
+++ b/Packet++/src/S7CommLayer.cpp
@@ -136,10 +136,10 @@ namespace pcpp
 		if (!m_Parameter)
 		{
 			uint8_t* payload = m_Data + getS7commHeaderLength();
-			m_Parameter = new S7CommParameter(payload, getParamLength());
+			m_Parameter = std::unique_ptr<S7CommParameter>(new S7CommParameter(payload, getParamLength()));
 		}
 
-		return m_Parameter;
+		return m_Parameter.get();
 	}
 
 	size_t S7CommLayer::getS7commHeaderLength() const


### PR DESCRIPTION
Refactors `S7CommLayer` to utilize smart pointers for lifetime management of `S7CommParameter` lazy object.

---
Cherrypicked from #2199 