### PR TITLE
Fix out-of-bounds read from a truncated IGMPv3 group record

### DIFF
--- a/Packet++/src/IgmpLayer.cpp
+++ b/Packet++/src/IgmpLayer.cpp
@@ -333,8 +333,9 @@ namespace pcpp
 
 	igmpv3_group_record* IgmpV3ReportLayer::getFirstGroupRecord() const
 	{
-		// check if there are group records at all
-		if (getHeaderLen() <= sizeof(igmpv3_report_header))
+		// a group record is only usable if its fixed part fits inside the layer, otherwise reading
+		// the record type, the source count or the multicast address runs past the end of the data
+		if (getHeaderLen() < sizeof(igmpv3_report_header) + sizeof(igmpv3_group_record))
 			return nullptr;
 
 		uint8_t* curGroupPtr = m_Data + sizeof(igmpv3_report_header);
@@ -346,15 +347,17 @@ namespace pcpp
 		if (groupRecord == nullptr)
 			return nullptr;
 
-		uint8_t* nextGroupRecordBegin = reinterpret_cast<uint8_t*>(groupRecord) + groupRecord->getRecordLen();
-		if (std::distance(m_Data, nextGroupRecordBegin) >= static_cast<std::ptrdiff_t>(getHeaderLen()))
+		size_t recordOffset = static_cast<size_t>(reinterpret_cast<uint8_t*>(groupRecord) - m_Data);
+		size_t nextOffset = recordOffset + groupRecord->getRecordLen();
+
+		// checking only that the next record starts inside the layer leaves a trailing partial
+		// record reachable, which the caller then reads in full
+		if (nextOffset + sizeof(igmpv3_group_record) > getHeaderLen())
 		{
 			return nullptr;
 		}
 
-		igmpv3_group_record* nextGroup = reinterpret_cast<igmpv3_group_record*>(nextGroupRecordBegin);
-
-		return nextGroup;
+		return reinterpret_cast<igmpv3_group_record*>(m_Data + nextOffset);
 	}
 
 	void IgmpV3ReportLayer::computeCalculateFields()

--- a/Tests/Packet++Test/Tests/IgmpTests.cpp
+++ b/Tests/Packet++Test/Tests/IgmpTests.cpp
@@ -148,6 +148,29 @@ PTF_TEST_CASE(Igmpv3ParsingTest)
 	curGroup = igmpv3ReportLayer->getNextGroupRecord(curGroup);
 	PTF_ASSERT_NULL(curGroup);
 	PTF_ASSERT_EQUAL(igmpv3ReportLayer->toString(), "IGMPv3 Layer, Membership Report message");
+
+	// A report layer that ends in the middle of a group record must not hand that record out.
+	// Only the start of a record was checked against the layer, so a truncated one was returned
+	// and its fields were then read past the end of the buffer.
+	{
+		uint8_t truncated[] = { // Ethernet
+			                    0x01, 0x00, 0x5e, 0x00, 0x00, 0x16, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x08, 0x00,
+			                    // IPv4, total length 32, protocol 2 (IGMP)
+			                    0x45, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x00, 0x00, 0x0a, 0x00,
+			                    0x00, 0x01, 0xe0, 0x00, 0x00, 0x16,
+			                    // IGMPv3 report: 8 byte header claiming one group record, then only 4 bytes of it
+			                    0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01
+		};
+
+		timeval truncatedTime = {};
+		pcpp::RawPacket truncatedRawPacket(truncated, sizeof(truncated), truncatedTime, false, pcpp::LINKTYPE_ETHERNET);
+		pcpp::Packet truncatedPacket(&truncatedRawPacket);
+
+		auto truncatedReportLayer = truncatedPacket.getLayerOfType<pcpp::IgmpV3ReportLayer>();
+		PTF_ASSERT_NOT_NULL(truncatedReportLayer);
+		PTF_ASSERT_EQUAL(truncatedReportLayer->getGroupRecordCount(), 1);
+		PTF_ASSERT_NULL(truncatedReportLayer->getFirstGroupRecord());
+	}
 }  // Igmpv3ParsingTest
 
 PTF_TEST_CASE(Igmpv3QueryCreateAndEditTest)


### PR DESCRIPTION
A truncated IGMPv3 report reads off the end of the buffer. On `dev`, taking the multicast address of the record `getFirstGroupRecord()` hands back:

```
ERROR: AddressSanitizer: stack-buffer-overflow
READ of size 4
    #0 pcpp::igmpv3_group_record::getMulticastAddress() const  IgmpLayer.h:85
SUMMARY: stack-buffer-overflow IgmpLayer.h:85 in getMulticastAddress
```

Both accessors check the wrong thing. `getFirstGroupRecord()` only asks whether anything at all follows the report header:

```cpp
if (getHeaderLen() <= sizeof(igmpv3_report_header))
    return nullptr;
```

and `getNextGroupRecord()` only asks where the next record starts. One byte past the header is enough to get a pointer back. But `igmpv3_group_record` is 8 bytes before its source list, so `recordType`, `numOfSources` and `getMulticastAddress()` all read past the end. `isDataValid()` does not catch it either. It validates the 8 byte report header and nothing more.

Both now require the fixed part of the record to fit.

The reproducer is a 46 byte Ethernet + IPv4 packet whose report claims one group record and carries 4 bytes of it. With the fix `getFirstGroupRecord()` returns null.

Added to `Igmpv3ParsingTest`. Packet++Test is 259 passed, 0 failed. The igmp tests are clean under ASAN.

Same shape as #2203. The query side already does this: `IgmpV3QueryLayer::getSourceAddressAtIndex()` checks the offset against `getDataLen()` before reading
