### PR TITLE
Update C-style casts

### DIFF
--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -177,10 +177,14 @@ namespace pcpp
 
 			// Release is called after the raw pointer is already inserted into the vector to prevent
 			// a memory leak if push_back throws.
-			// cppcheck-suppress danglingLifetime
+
+			// cppcheck-suppress-begin [danglingLifetime, ignoredReturnValue]
 			m_Vector.push_back(element.get());
 			element.release();
+			// cppcheck-suppress-end [danglingLifetime, ignoredReturnValue]
 		}
+
+		// cppcheck-suppress-begin danglingLifetime
 
 		/// Get the first element of the vector
 		/// @return An iterator object pointing to the first element of the vector
@@ -209,6 +213,8 @@ namespace pcpp
 		{
 			return m_Vector.end();
 		}
+
+		// cppcheck-suppress-end danglingLifetime
 
 		/// Get number of elements in the vector
 		/// @return The number of elements in the vector

--- a/Common++/header/PointerVector.h
+++ b/Common++/header/PointerVector.h
@@ -177,14 +177,10 @@ namespace pcpp
 
 			// Release is called after the raw pointer is already inserted into the vector to prevent
 			// a memory leak if push_back throws.
-
-			// cppcheck-suppress-begin [danglingLifetime, ignoredReturnValue]
+			// cppcheck-suppress danglingLifetime
 			m_Vector.push_back(element.get());
 			element.release();
-			// cppcheck-suppress-end [danglingLifetime, ignoredReturnValue]
 		}
-
-		// cppcheck-suppress-begin danglingLifetime
 
 		/// Get the first element of the vector
 		/// @return An iterator object pointing to the first element of the vector
@@ -213,8 +209,6 @@ namespace pcpp
 		{
 			return m_Vector.end();
 		}
-
-		// cppcheck-suppress-end danglingLifetime
 
 		/// Get number of elements in the vector
 		/// @return The number of elements in the vector

--- a/Examples/DpdkExample-FilterTraffic/main.cpp
+++ b/Examples/DpdkExample-FilterTraffic/main.cpp
@@ -159,8 +159,8 @@ void listDpdkPorts()
  * Prepare the configuration for each core. Configuration includes: which DpdkDevices and which RX queues to receive
  * packets from, where to send the matched packets, etc.
  */
-void prepareCoreConfiguration(std::vector<pcpp::DpdkDevice*>& dpdkDevicesToUse,
-                              std::vector<pcpp::SystemCore>& coresToUse, bool writePacketsToDisk,
+void prepareCoreConfiguration(std::vector<pcpp::DpdkDevice*> const& dpdkDevicesToUse,
+                              std::vector<pcpp::SystemCore> const& coresToUse, bool writePacketsToDisk,
                               const std::string& packetFilePath, pcpp::DpdkDevice* sendPacketsTo,
                               std::vector<AppWorkerConfig>& workerConfigArr, int workerConfigArrLen, uint16_t rxQueues)
 {
@@ -269,7 +269,7 @@ void printStats(const PacketStats& threadStats, const std::string& columnName)
  */
 void onApplicationInterrupted(void* cookie)
 {
-	FilterTrafficArgs* args = (FilterTrafficArgs*)cookie;
+	FilterTrafficArgs* args = static_cast<FilterTrafficArgs*>(cookie);
 
 	std::cout << std::endl << std::endl << "Application stopped" << std::endl;
 
@@ -281,7 +281,7 @@ void onApplicationInterrupted(void* cookie)
 	std::vector<PacketStats> threadStatsVec;
 	for (const auto& iter : *(args->workerThreadsVector))
 	{
-		AppWorkerThread* thread = (AppWorkerThread*)(iter);
+		AppWorkerThread* thread = static_cast<AppWorkerThread*>(iter);
 		PacketStats threadStats = thread->getStats();
 		aggregatedStats.collectStats(threadStats);
 		threadStatsVec.push_back(threadStats);
@@ -289,7 +289,7 @@ void onApplicationInterrupted(void* cookie)
 	}
 
 	// print stats for every worker threads
-	for (auto threadStats : threadStatsVec)
+	for (auto const& threadStats : threadStatsVec)
 	{
 		// no need to print table if no packets were received
 		if (threadStats.packetCount == 0)

--- a/Examples/IPFragUtil/main.cpp
+++ b/Examples/IPFragUtil/main.cpp
@@ -218,9 +218,13 @@ void splitIPPacketToFragmentsBySize(pcpp::RawPacket* rawPacket, size_t fragmentS
 
 		// set fragment parameters in IPv4/6 layer
 		if (ipProto == pcpp::IPv4)
-			setIPv4FragmentParams((pcpp::IPv4Layer*)fragIpLayer, curOffset, lastFrag);
+		{
+			setIPv4FragmentParams(static_cast<pcpp::IPv4Layer*>(fragIpLayer), curOffset, lastFrag);
+		}
 		else  // ipProto == IPv6
-			setIPv6FragmentParams((pcpp::IPv6Layer*)fragIpLayer, curOffset, lastFrag, randomNum);
+		{
+			setIPv6FragmentParams(static_cast<pcpp::IPv6Layer*>(fragIpLayer), curOffset, lastFrag, randomNum);
+		}
 
 		// compute all calculated fields of the new fragment
 		newFrag.computeCalculateFields();

--- a/Examples/KniPong/main.cpp
+++ b/Examples/KniPong/main.cpp
@@ -339,7 +339,7 @@ namespace
 		egress.sin_family = AF_INET;
 		egress.sin_addr.s_addr = inet_addr(args.kniIp.c_str());
 		egress.sin_port = pcpp::hostToNet16(args.kniPort);
-		if (bind(sock, (struct sockaddr*)&egress, sizeof(egress)) == -1)
+		if (bind(sock, reinterpret_cast<struct sockaddr*>(&egress), sizeof(egress)) == -1)
 		{
 			int old_errno = errno;
 			close(sock);
@@ -484,7 +484,7 @@ namespace
 		ingress.sin_family = AF_INET;
 		ingress.sin_addr.s_addr = inet_addr(args.outIp.c_str());
 		ingress.sin_port = pcpp::hostToNet16(args.kniPort);
-		if (connect(sock, (struct sockaddr*)&ingress, sizeof(ingress)) == -1)
+		if (connect(sock, reinterpret_cast<struct sockaddr*>(&ingress), sizeof(ingress)) == -1)
 		{
 			int old_errno = errno;
 			close(sock);

--- a/Packet++/header/IPv6Extensions.h
+++ b/Packet++/header/IPv6Extensions.h
@@ -85,7 +85,7 @@ namespace pcpp
 
 		ipv6_ext_base_header* getBaseHeader() const
 		{
-			return (ipv6_ext_base_header*)getDataPtr();
+			return reinterpret_cast<ipv6_ext_base_header*>(getDataPtr());
 		}
 
 		void setNextHeader(IPv6Extension* nextHeader)
@@ -136,7 +136,7 @@ namespace pcpp
 		/// @return A pointer to the @ref ipv6_frag_header
 		ipv6_frag_header* getFragHeader() const
 		{
-			return (ipv6_frag_header*)getDataPtr();
+			return reinterpret_cast<ipv6_frag_header*>(getDataPtr());
 		}
 
 		/// @return True if this is the first fragment (which usually contains the L4 header), false otherwise
@@ -191,7 +191,7 @@ namespace pcpp
 			/// @return True if data is valid and can be assigned
 			static bool canAssign(const uint8_t* recordRawData, size_t tlvDataLen)
 			{
-				auto data = (TLVRawData*)recordRawData;
+				auto data = reinterpret_cast<TLVRawData const*>(recordRawData);
 				if (data == nullptr)
 					return false;
 
@@ -389,7 +389,7 @@ namespace pcpp
 		/// @return A pointer to the @ref ipv6_routing_header
 		ipv6_routing_header* getRoutingHeader() const
 		{
-			return (ipv6_routing_header*)getDataPtr();
+			return reinterpret_cast<ipv6_routing_header*>(getDataPtr());
 		}
 
 		/// @return A pointer to the buffer containing the additional routing data for this extension. Notice that any
@@ -462,7 +462,7 @@ namespace pcpp
 		/// @return A pointer to the @ref ipv6_authentication_header
 		ipv6_authentication_header* getAuthHeader() const
 		{
-			return (ipv6_authentication_header*)getDataPtr();
+			return reinterpret_cast<ipv6_authentication_header*>(getDataPtr());
 		}
 
 		/// @return A pointer to the buffer containing the integrity check value (ICV) for this extension. Notice that

--- a/Packet++/src/IcmpV6Layer.cpp
+++ b/Packet++/src/IcmpV6Layer.cpp
@@ -87,6 +87,8 @@ namespace pcpp
 
 		if (m_PrevLayer != nullptr)
 		{
+			auto prevLayerAsIPv6 = static_cast<IPv6Layer*>(m_PrevLayer);
+
 			ScalarBuffer<uint16_t> vec[2];
 
 			vec[0].buffer = (uint16_t*)m_Data;
@@ -97,8 +99,8 @@ namespace pcpp
 			const unsigned int bigEndianNextHeader = htobe32(PACKETPP_IPPROTO_ICMPV6);
 
 			uint16_t pseudoHeader[pseudoHeaderLen / 2];
-			((IPv6Layer*)m_PrevLayer)->getSrcIPv6Address().copyTo((uint8_t*)pseudoHeader);
-			((IPv6Layer*)m_PrevLayer)->getDstIPv6Address().copyTo((uint8_t*)(pseudoHeader + 8));
+			prevLayerAsIPv6->getSrcIPv6Address().copyTo(reinterpret_cast<uint8_t*>(pseudoHeader));
+			prevLayerAsIPv6->getDstIPv6Address().copyTo(reinterpret_cast<uint8_t*>(pseudoHeader + 8));
 			memcpy(&pseudoHeader[16], &bigEndianLen, sizeof(uint32_t));
 			memcpy(&pseudoHeader[18], &bigEndianNextHeader, sizeof(uint32_t));
 			vec[1].buffer = pseudoHeader;

--- a/Packet++/src/IgmpLayer.cpp
+++ b/Packet++/src/IgmpLayer.cpp
@@ -339,7 +339,7 @@ namespace pcpp
 			return nullptr;
 
 		uint8_t* curGroupPtr = m_Data + sizeof(igmpv3_report_header);
-		return (igmpv3_group_record*)curGroupPtr;
+		return reinterpret_cast<igmpv3_group_record*>(curGroupPtr);
 	}
 
 	igmpv3_group_record* IgmpV3ReportLayer::getNextGroupRecord(igmpv3_group_record* groupRecord) const
@@ -387,7 +387,7 @@ namespace pcpp
 
 		uint8_t* groupRecordBuffer = new uint8_t[groupRecordSize];
 		memset(groupRecordBuffer, 0, groupRecordSize);
-		igmpv3_group_record* newGroupRecord = (igmpv3_group_record*)groupRecordBuffer;
+		igmpv3_group_record* newGroupRecord = reinterpret_cast<igmpv3_group_record*>(groupRecordBuffer);
 		newGroupRecord->multicastAddress = multicastAddress.toInt();
 		newGroupRecord->recordType = recordType;
 		newGroupRecord->auxDataLen = 0;

--- a/Packet++/src/SSLHandshake.cpp
+++ b/Packet++/src/SSLHandshake.cpp
@@ -1207,7 +1207,7 @@ namespace pcpp
 		uint8_t* dataPtr = getData() + sizeof(uint16_t);
 		for (int i = 0; i < listLength / 2; i++)
 		{
-			result.push_back(be16toh(*(uint16_t*)dataPtr));
+			result.push_back(be16toh(*reinterpret_cast<uint16_t*>(dataPtr)));
 			dataPtr += sizeof(uint16_t);
 		}
 
@@ -1540,7 +1540,7 @@ namespace pcpp
 			return 0;
 
 		uint8_t* extensionLengthPos = m_Data + extensionLengthOffset;
-		return be16toh(*(uint16_t*)extensionLengthPos);
+		return be16toh(*reinterpret_cast<uint16_t*>(extensionLengthPos));
 	}
 
 	SSLExtension* SSLClientHelloMessage::getExtension(int index) const
@@ -1965,7 +1965,7 @@ namespace pcpp
 		// read certificates length
 		// TODO: certificates length is 3B. Currently assuming the MSB is 0 and reading only 2 LSBs
 		uint8_t* curPos = data + sizeof(ssl_tls_handshake_layer) + sizeof(uint8_t);
-		uint16_t certificatesLength = be16toh(*(uint16_t*)(curPos));
+		uint16_t certificatesLength = be16toh(*reinterpret_cast<uint16_t*>(curPos));
 		if (certificatesLength == 0)
 			return;
 
@@ -1981,7 +1981,7 @@ namespace pcpp
 
 			// read certificate length
 			curPos += sizeof(uint8_t);
-			uint16_t certificateLength = be16toh(*(uint16_t*)(curPos));
+			uint16_t certificateLength = be16toh(*reinterpret_cast<uint16_t*>(curPos));
 
 			// advance to start position of certificate
 			curPos += sizeof(uint16_t);

--- a/Packet++/src/SomeIpSdLayer.cpp
+++ b/Packet++/src/SomeIpSdLayer.cpp
@@ -31,7 +31,7 @@ namespace pcpp
 
 	SomeIpSdOption::someipsdhdroptionsbase* SomeIpSdOption::getSomeIpSdOptionHeader() const
 	{
-		return (someipsdhdroptionsbase*)getDataPtr();
+		return reinterpret_cast<someipsdhdroptionsbase*>(getDataPtr());
 	}
 
 	void SomeIpSdOption::initStdFields(OptionType type)
@@ -65,7 +65,7 @@ namespace pcpp
 			break;
 		}
 
-		someipsdhdroptionsipv4* hdr = (someipsdhdroptionsipv4*)getDataPtr();
+		someipsdhdroptionsipv4* hdr = reinterpret_cast<someipsdhdroptionsipv4*>(getDataPtr());
 		hdr->ipv4Address = ipAddress.toInt();
 		hdr->portNumber = htobe16(port);
 		hdr->l4Protocol = l4Protocol;
@@ -79,7 +79,7 @@ namespace pcpp
 
 	IPv4Address SomeIpSdIPv4Option::getIpAddress() const
 	{
-		someipsdhdroptionsipv4* hdr = (someipsdhdroptionsipv4*)getDataPtr();
+		someipsdhdroptionsipv4* hdr = reinterpret_cast<someipsdhdroptionsipv4*>(getDataPtr());
 		IPv4Address ipAddr(hdr->ipv4Address);
 
 		return ipAddr;
@@ -87,13 +87,13 @@ namespace pcpp
 
 	uint16_t SomeIpSdIPv4Option::getPort() const
 	{
-		someipsdhdroptionsipv4* hdr = (someipsdhdroptionsipv4*)getDataPtr();
+		someipsdhdroptionsipv4* hdr = reinterpret_cast<someipsdhdroptionsipv4*>(getDataPtr());
 		return be16toh(hdr->portNumber);
 	}
 
 	SomeIpSdProtocolType SomeIpSdIPv4Option::getProtocol() const
 	{
-		someipsdhdroptionsipv4* hdr = (someipsdhdroptionsipv4*)getDataPtr();
+		someipsdhdroptionsipv4* hdr = reinterpret_cast<someipsdhdroptionsipv4*>(getDataPtr());
 		return hdr->l4Protocol;
 	}
 
@@ -119,7 +119,7 @@ namespace pcpp
 			break;
 		}
 
-		someipsdhdroptionsipv6* hdr = (someipsdhdroptionsipv6*)getDataPtr();
+		someipsdhdroptionsipv6* hdr = reinterpret_cast<someipsdhdroptionsipv6*>(getDataPtr());
 		std::memcpy(hdr->ipv6Address, ipAddress.toBytes(), 16);
 		hdr->portNumber = htobe16(port);
 		hdr->l4Protocol = l4Protocol;
@@ -133,7 +133,7 @@ namespace pcpp
 
 	IPv6Address SomeIpSdIPv6Option::getIpAddress() const
 	{
-		someipsdhdroptionsipv6* hdr = (someipsdhdroptionsipv6*)getDataPtr();
+		someipsdhdroptionsipv6* hdr = reinterpret_cast<someipsdhdroptionsipv6*>(getDataPtr());
 		IPv6Address ipAddr(hdr->ipv6Address);
 
 		return ipAddr;
@@ -141,13 +141,13 @@ namespace pcpp
 
 	uint16_t SomeIpSdIPv6Option::getPort() const
 	{
-		someipsdhdroptionsipv6* hdr = (someipsdhdroptionsipv6*)getDataPtr();
+		someipsdhdroptionsipv6* hdr = reinterpret_cast<someipsdhdroptionsipv6*>(getDataPtr());
 		return be16toh(hdr->portNumber);
 	}
 
 	SomeIpSdProtocolType SomeIpSdIPv6Option::getProtocol() const
 	{
-		someipsdhdroptionsipv6* hdr = (someipsdhdroptionsipv6*)getDataPtr();
+		someipsdhdroptionsipv6* hdr = reinterpret_cast<someipsdhdroptionsipv6*>(getDataPtr());
 		return hdr->l4Protocol;
 	}
 
@@ -186,7 +186,7 @@ namespace pcpp
 
 		initStdFields(OptionType::LoadBalancing);
 
-		someipsdhdroptionsload* hdr = (someipsdhdroptionsload*)getDataPtr();
+		someipsdhdroptionsload* hdr = reinterpret_cast<someipsdhdroptionsload*>(getDataPtr());
 		hdr->priority = htobe16(priority);
 		hdr->weight = htobe16(weight);
 	}
@@ -199,13 +199,13 @@ namespace pcpp
 
 	uint16_t SomeIpSdLoadBalancingOption::getPriority() const
 	{
-		someipsdhdroptionsload* hdr = (someipsdhdroptionsload*)getDataPtr();
+		someipsdhdroptionsload* hdr = reinterpret_cast<someipsdhdroptionsload*>(getDataPtr());
 		return be16toh(hdr->priority);
 	}
 
 	uint16_t SomeIpSdLoadBalancingOption::getWeight() const
 	{
-		someipsdhdroptionsload* hdr = (someipsdhdroptionsload*)getDataPtr();
+		someipsdhdroptionsload* hdr = reinterpret_cast<someipsdhdroptionsload*>(getDataPtr());
 		return be16toh(hdr->weight);
 	}
 
@@ -294,7 +294,7 @@ namespace pcpp
 
 	SomeIpSdEntry::someipsdhdrentry* SomeIpSdEntry::getSomeIpSdEntryHeader() const
 	{
-		return (someipsdhdrentry*)getDataPtr();
+		return reinterpret_cast<someipsdhdrentry*>(getDataPtr());
 	}
 
 	uint32_t SomeIpSdEntry::getNumOptions() const
@@ -360,7 +360,7 @@ namespace pcpp
 
 	uint8_t SomeIpSdEntry::getCounter() const
 	{
-		return (uint8_t)((be32toh(getSomeIpSdEntryHeader()->data) >> 16) & 0x0F);
+		return static_cast<uint8_t>((be32toh(getSomeIpSdEntryHeader()->data) >> 16) & 0x0F);
 	}
 
 	void SomeIpSdEntry::setCounter(uint8_t counter)
@@ -371,7 +371,7 @@ namespace pcpp
 
 	uint16_t SomeIpSdEntry::getEventgroupId() const
 	{
-		return (uint16_t)(be32toh(getSomeIpSdEntryHeader()->data) & 0x0000FFFF);
+		return static_cast<uint16_t>(be32toh(getSomeIpSdEntryHeader()->data) & 0x0000FFFF);
 	}
 
 	void SomeIpSdEntry::setEventgroupId(uint16_t eventgroupID)
@@ -457,19 +457,19 @@ namespace pcpp
 
 	uint8_t SomeIpSdLayer::getFlags() const
 	{
-		someipsdhdr* hdr = (someipsdhdr*)m_Data;
+		someipsdhdr* hdr = reinterpret_cast<someipsdhdr*>(m_Data);
 		return hdr->flags;
 	}
 
 	void SomeIpSdLayer::setFlags(uint8_t flags)
 	{
-		someipsdhdr* hdr = (someipsdhdr*)m_Data;
+		someipsdhdr* hdr = reinterpret_cast<someipsdhdr*>(m_Data);
 		hdr->flags = flags;
 	}
 
 	uint32_t SomeIpSdLayer::getNumEntries() const
 	{
-		return (uint32_t)(getLenEntries() / sizeof(SomeIpSdEntry::someipsdhdrentry));
+		return static_cast<uint32_t>(getLenEntries() / sizeof(SomeIpSdEntry::someipsdhdrentry));
 	}
 
 	uint32_t SomeIpSdLayer::getNumOptions() const
@@ -514,7 +514,8 @@ namespace pcpp
 
 		while (remainingLen > 0)
 		{
-			SomeIpSdOption::someipsdhdroptionsbase* hdr = (SomeIpSdOption::someipsdhdroptionsbase*)(m_Data + offset);
+			SomeIpSdOption::someipsdhdroptionsbase* hdr =
+			    reinterpret_cast<SomeIpSdOption::someipsdhdroptionsbase*>(m_Data + offset);
 			SomeIpSdOption::OptionType optionType = static_cast<SomeIpSdOption::OptionType>(hdr->type);
 
 			option = parseOption(optionType, offset, remainingLen);
@@ -544,7 +545,8 @@ namespace pcpp
 		size_t offset = sizeof(someipsdhdr) + sizeof(uint32_t) + getLenEntries() + sizeof(uint32_t);
 
 		size_t offsetToEntry = sizeof(someipsdhdr) + sizeof(uint32_t) + index * sizeof(SomeIpSdEntry::someipsdhdrentry);
-		SomeIpSdEntry::someipsdhdrentry* hdrEntry = (SomeIpSdEntry::someipsdhdrentry*)(m_Data + offsetToEntry);
+		SomeIpSdEntry::someipsdhdrentry* hdrEntry =
+		    reinterpret_cast<SomeIpSdEntry::someipsdhdrentry*>(m_Data + offsetToEntry);
 		uint8_t startIdxRun1 = hdrEntry->indexFirstOption;
 		uint8_t lenRun1 = hdrEntry->nrOpt1;
 		uint8_t startIdxRun2 = hdrEntry->indexSecondOption;
@@ -555,7 +557,7 @@ namespace pcpp
 		while (remainingLen > 0)
 		{
 			SomeIpSdOption::someipsdhdroptionsbase* hdrOption =
-			    (SomeIpSdOption::someipsdhdroptionsbase*)(m_Data + offset);
+			    reinterpret_cast<SomeIpSdOption::someipsdhdroptionsbase*>(m_Data + offset);
 
 			if (((idx >= startIdxRun1) && (idx < (startIdxRun1 + lenRun1))) ||
 			    ((idx >= startIdxRun2) && (idx < (startIdxRun2 + lenRun2))))
@@ -655,7 +657,8 @@ namespace pcpp
 			if (len + sizeof(uint16_t) + 3 * sizeof(uint8_t) > lenOptions)
 				return false;
 
-			uint32_t lenOption = be16toh(*((uint16_t*)(data + offsetOption + len))) + 3 * sizeof(uint8_t);
+			uint32_t lenOption =
+			    be16toh(*(reinterpret_cast<uint16_t const*>(data + offsetOption + len))) + 3 * sizeof(uint8_t);
 			len += lenOption;
 			if (len > lenOptions)  // the last one must be equal to lenOptions
 				return false;
@@ -672,7 +675,7 @@ namespace pcpp
 		uint32_t i = 0;
 		while (i < m_NumOptions)
 		{
-			uint32_t lenOption = be16toh(*((uint16_t*)(m_Data + offsetOption))) + 3 * sizeof(uint8_t);
+			uint32_t lenOption = be16toh(*(reinterpret_cast<uint16_t*>(m_Data + offsetOption))) + 3 * sizeof(uint8_t);
 
 			if (option.getLength() == lenOption)
 			{
@@ -717,7 +720,7 @@ namespace pcpp
 
 		const size_t someipsdhdrentrySize = sizeof(SomeIpSdEntry::someipsdhdrentry);
 		size_t offsetToAddAt = sizeof(someipsdhdr) + sizeof(uint32_t) + indexEntry * someipsdhdrentrySize;
-		auto hdrEntry = (SomeIpSdEntry::someipsdhdrentry*)(m_Data + offsetToAddAt);
+		auto hdrEntry = reinterpret_cast<SomeIpSdEntry::someipsdhdrentry*>(m_Data + offsetToAddAt);
 
 		uint8_t indexFirstOption = hdrEntry->indexFirstOption;
 		uint8_t lenFirstOption = hdrEntry->nrOpt1;
@@ -808,7 +811,7 @@ namespace pcpp
 
 	size_t SomeIpSdLayer::getLenEntries(const uint8_t* data)
 	{
-		return be32toh(*((uint32_t*)(data + sizeof(someipsdhdr))));
+		return be32toh(*(reinterpret_cast<const uint32_t*>(data + sizeof(someipsdhdr))));
 	}
 
 	size_t SomeIpSdLayer::getLenOptions() const
@@ -818,16 +821,18 @@ namespace pcpp
 
 	size_t SomeIpSdLayer::getLenOptions(const uint8_t* data)
 	{
-		return be32toh(*((uint32_t*)(data + sizeof(someipsdhdr) + sizeof(uint32_t) + getLenEntries(data))));
+		return be32toh(
+		    *(reinterpret_cast<const uint32_t*>(data + sizeof(someipsdhdr) + sizeof(uint32_t) + getLenEntries(data))));
 	}
 
 	void SomeIpSdLayer::setLenEntries(uint32_t length)
 	{
-		*((uint32_t*)(m_Data + sizeof(someipsdhdr))) = htobe32(length);
+		*(reinterpret_cast<uint32_t*>(m_Data + sizeof(someipsdhdr))) = htobe32(length);
 	}
 
 	void SomeIpSdLayer::setLenOptions(uint32_t length)
 	{
-		*((uint32_t*)(m_Data + sizeof(someipsdhdr) + sizeof(uint32_t) + getLenEntries())) = htobe32(length);
+		*(reinterpret_cast<uint32_t*>(m_Data + sizeof(someipsdhdr) + sizeof(uint32_t) + getLenEntries())) =
+		    htobe32(length);
 	}
 }  // namespace pcpp

--- a/Packet++/src/UdpLayer.cpp
+++ b/Packet++/src/UdpLayer.cpp
@@ -60,8 +60,9 @@ namespace pcpp
 				IPv4Address srcIP = static_cast<IPv4Layer*>(m_PrevLayer)->getSrcIPv4Address();
 				IPv4Address dstIP = static_cast<IPv4Layer*>(m_PrevLayer)->getDstIPv4Address();
 
-				checksumRes = pcpp::computePseudoHdrChecksum((uint8_t*)udpHdr, getDataLen(), IPAddress::IPv4AddressType,
-				                                             PACKETPP_IPPROTO_UDP, srcIP, dstIP);
+				checksumRes =
+				    pcpp::computePseudoHdrChecksum(reinterpret_cast<uint8_t*>(udpHdr), getDataLen(),
+				                                   IPAddress::IPv4AddressType, PACKETPP_IPPROTO_UDP, srcIP, dstIP);
 
 				PCPP_LOG_DEBUG("calculated IPv4 UDP checksum = 0x" << std::uppercase << std::hex << checksumRes);
 			}
@@ -70,8 +71,8 @@ namespace pcpp
 				IPv6Address srcIP = static_cast<IPv6Layer*>(m_PrevLayer)->getSrcIPv6Address();
 				IPv6Address dstIP = static_cast<IPv6Layer*>(m_PrevLayer)->getDstIPv6Address();
 
-				checksumRes = computePseudoHdrChecksum((uint8_t*)udpHdr, getDataLen(), IPAddress::IPv6AddressType,
-				                                       PACKETPP_IPPROTO_UDP, srcIP, dstIP);
+				checksumRes = computePseudoHdrChecksum(reinterpret_cast<uint8_t*>(udpHdr), getDataLen(),
+				                                       IPAddress::IPv6AddressType, PACKETPP_IPPROTO_UDP, srcIP, dstIP);
 
 				PCPP_LOG_DEBUG("calculated IPv6 UDP checksum = 0xX" << std::uppercase << std::hex << checksumRes);
 			}

--- a/Packet++/src/VrrpLayer.cpp
+++ b/Packet++/src/VrrpLayer.cpp
@@ -405,26 +405,26 @@ namespace pcpp
 	uint8_t VrrpV2Layer::getAdvInt() const
 	{
 		uint16_t authAdvInt = getVrrpHeader()->authTypeAdvInt;
-		auto authAdvIntPtr = (vrrpv2_auth_adv*)(&authAdvInt);
+		auto authAdvIntPtr = reinterpret_cast<vrrpv2_auth_adv*>(&authAdvInt);
 		return authAdvIntPtr->advInt;
 	}
 
 	void VrrpV2Layer::setAdvInt(uint8_t advInt)
 	{
-		auto authAdvIntPtr = (vrrpv2_auth_adv*)&getVrrpHeader()->authTypeAdvInt;
+		auto authAdvIntPtr = reinterpret_cast<vrrpv2_auth_adv*>(&getVrrpHeader()->authTypeAdvInt);
 		authAdvIntPtr->advInt = advInt;
 	}
 
 	uint8_t VrrpV2Layer::getAuthType() const
 	{
 		uint16_t authAdvInt = getVrrpHeader()->authTypeAdvInt;
-		auto* authAdvIntPtr = (vrrpv2_auth_adv*)(&authAdvInt);
+		auto* authAdvIntPtr = reinterpret_cast<vrrpv2_auth_adv*>(&authAdvInt);
 		return authAdvIntPtr->authType;
 	}
 
 	void VrrpV2Layer::setAuthType(uint8_t authType)
 	{
-		auto authAdvIntPtr = (vrrpv2_auth_adv*)&getVrrpHeader()->authTypeAdvInt;
+		auto authAdvIntPtr = reinterpret_cast<vrrpv2_auth_adv*>(&getVrrpHeader()->authTypeAdvInt);
 		authAdvIntPtr->authType = authType;
 	}
 
@@ -461,7 +461,7 @@ namespace pcpp
 	uint16_t VrrpV3Layer::getMaxAdvInt() const
 	{
 		uint16_t authAdvInt = getVrrpHeader()->authTypeAdvInt;
-		auto rsvdAdv = (vrrpv3_rsvd_adv*)(&authAdvInt);
+		auto rsvdAdv = reinterpret_cast<vrrpv3_rsvd_adv*>(&authAdvInt);
 		return be16toh(rsvdAdv->maxAdvInt);
 	}
 
@@ -471,7 +471,7 @@ namespace pcpp
 		{
 			throw std::invalid_argument("maxAdvInt must not exceed 12 bits length");
 		}
-		auto rsvdAdv = (vrrpv3_rsvd_adv*)&getVrrpHeader()->authTypeAdvInt;
+		auto rsvdAdv = reinterpret_cast<vrrpv3_rsvd_adv*>(&getVrrpHeader()->authTypeAdvInt);
 		rsvdAdv->maxAdvInt = htobe16(maxAdvInt);
 	}
 

--- a/Pcap++/src/PcapLiveDevice.cpp
+++ b/Pcap++/src/PcapLiveDevice.cpp
@@ -1565,9 +1565,9 @@ namespace pcpp
 			return;
 		}
 
-		struct if_msghdr* ifm = (struct if_msghdr*)buf.data();
-		struct sockaddr_dl* sdl = (struct sockaddr_dl*)(ifm + 1);
-		uint8_t* ptr = (uint8_t*)LLADDR(sdl);
+		struct if_msghdr* ifm = reinterpret_cast<struct if_msghdr*>(buf.data());
+		struct sockaddr_dl* sdl = reinterpret_cast<struct sockaddr_dl*>(ifm + 1);
+		uint8_t* ptr = reinterpret_cast<uint8_t*>(LLADDR(sdl));
 		m_MacAddress = MacAddress(ptr[0], ptr[1], ptr[2], ptr[3], ptr[4], ptr[5]);
 #endif
 	}

--- a/Tests/Packet++Test/Tests/SllNullLoopbackTests.cpp
+++ b/Tests/Packet++Test/Tests/SllNullLoopbackTests.cpp
@@ -118,7 +118,7 @@ PTF_TEST_CASE(NullLoopbackTest)
 	nextLayer = nullLoopbackLayer->getNextLayer();
 	PTF_ASSERT_NOT_NULL(nextLayer);
 	PTF_ASSERT_EQUAL(nextLayer->getProtocol(), pcpp::IPv4, enum);
-	PTF_ASSERT_EQUAL(((pcpp::IPv4Layer*)nextLayer)->getSrcIPAddress(), pcpp::IPv4Address("172.16.1.117"));
+	PTF_ASSERT_EQUAL(static_cast<pcpp::IPv4Layer*>(nextLayer)->getSrcIPAddress(), pcpp::IPv4Address("172.16.1.117"));
 	PTF_ASSERT_EQUAL(nullLoopbackLayer->getFamily(), PCPP_BSD_AF_INET);
 
 	PTF_ASSERT_TRUE(nullPacket3.isPacketOfType(pcpp::NULL_LOOPBACK));

--- a/Tests/Packet++Test/Tests/SomeIpSdTests.cpp
+++ b/Tests/Packet++Test/Tests/SomeIpSdTests.cpp
@@ -64,7 +64,8 @@ PTF_TEST_CASE(SomeIpSdParsingTest)
 	PTF_ASSERT_EQUAL((uint8_t)option->getType(), (uint8_t)pcpp::SomeIpSdOption::OptionType::IPv4Endpoint);
 	PTF_ASSERT_EQUAL(option->getDataPtr()[1], 0x09);
 
-	pcpp::SomeIpSdIPv4Option* ipv4Option = (pcpp::SomeIpSdIPv4Option*)option;
+	pcpp::SomeIpSdIPv4Option* ipv4Option = dynamic_cast<pcpp::SomeIpSdIPv4Option*>(option);
+	PTF_ASSERT_NOT_NULL(ipv4Option);
 	PTF_ASSERT_EQUAL(ipv4Option->getIpAddress(), pcpp::IPv4Address("160.48.199.28"));
 	PTF_ASSERT_EQUAL(ipv4Option->getProtocol(), pcpp::SomeIpSdProtocolType::SD_UDP);
 	PTF_ASSERT_EQUAL(ipv4Option->getPort(), 30502);
@@ -112,7 +113,8 @@ PTF_TEST_CASE(SomeIpSdParsingTest)
 	PTF_ASSERT_EQUAL((uint8_t)option2_1->getType(), (uint8_t)pcpp::SomeIpSdOption::OptionType::IPv6Endpoint);
 	PTF_ASSERT_EQUAL(option2_1->getDataPtr()[1], 0x15);
 
-	pcpp::SomeIpSdIPv6Option* ipv6Option2_1 = (pcpp::SomeIpSdIPv6Option*)option2_1;
+	pcpp::SomeIpSdIPv6Option* ipv6Option2_1 = dynamic_cast<pcpp::SomeIpSdIPv6Option*>(option2_1);
+	PTF_ASSERT_NOT_NULL(ipv6Option2_1);
 	PTF_ASSERT_EQUAL(ipv6Option2_1->getIpAddress(), pcpp::IPv6Address("fd53:7cb8:383:4::1:1e5"));
 	PTF_ASSERT_EQUAL(ipv6Option2_1->getProtocol(), pcpp::SomeIpSdProtocolType::SD_TCP);
 	PTF_ASSERT_EQUAL(ipv6Option2_1->getPort(), 29769);
@@ -122,7 +124,9 @@ PTF_TEST_CASE(SomeIpSdParsingTest)
 	PTF_ASSERT_EQUAL((uint8_t)option2_2->getType(), (uint8_t)pcpp::SomeIpSdOption::OptionType::ConfigurationString);
 	PTF_ASSERT_EQUAL(option2_2->getDataPtr()[5], 0x63);
 
-	pcpp::SomeIpSdConfigurationOption* configurationOption = (pcpp::SomeIpSdConfigurationOption*)option2_2;
+	pcpp::SomeIpSdConfigurationOption* configurationOption =
+	    dynamic_cast<pcpp::SomeIpSdConfigurationOption*>(option2_2);
+	PTF_ASSERT_NOT_NULL(configurationOption);
 	for (int i = 0; i < 89; i++)
 	{
 		PTF_ASSERT_EQUAL(configurationOption->getConfigurationString()[i],

--- a/Tests/Pcap++Test/Common/TestUtils.h
+++ b/Tests/Pcap++Test/Common/TestUtils.h
@@ -20,6 +20,9 @@ public:
 	    : m_Device(device), m_CancelTeardown(false), m_DeleteDevice(deleteDevice)
 	{}
 
+	DeviceTeardown(DeviceTeardown const&) = delete;
+	DeviceTeardown& operator=(DeviceTeardown const&) = delete;
+
 	~DeviceTeardown()
 	{
 		if (!m_CancelTeardown && m_Device != nullptr && m_Device->isOpened())
@@ -115,7 +118,7 @@ public:
 		return *this;
 	}
 
-	std::string getFileName() const
+	std::string const& getFileName() const
 	{
 		return m_Filename;
 	}

--- a/Tests/Pcap++Test/Common/TestUtils.h
+++ b/Tests/Pcap++Test/Common/TestUtils.h
@@ -21,10 +21,41 @@ public:
 	{}
 
 	DeviceTeardown(DeviceTeardown const&) = delete;
+	DeviceTeardown(DeviceTeardown&& other) noexcept
+	    : m_Device(other.m_Device), m_CancelTeardown(other.m_CancelTeardown), m_DeleteDevice(other.m_DeleteDevice)
+	{
+		other.m_Device = nullptr;
+	}
 	DeviceTeardown& operator=(DeviceTeardown const&) = delete;
+	DeviceTeardown& operator=(DeviceTeardown&& other) noexcept
+	{
+		if (this != &other)
+		{
+			doTeardown();
+			m_Device = other.m_Device;
+			m_CancelTeardown = other.m_CancelTeardown;
+			m_DeleteDevice = other.m_DeleteDevice;
+			other.m_Device = nullptr;
+		}
+		return *this;
+	}
 
 	~DeviceTeardown()
 	{
+		doTeardown();
+	}
+
+	void cancelTeardown()
+	{
+		m_CancelTeardown = true;
+	}
+
+private:
+	void doTeardown() noexcept
+	{
+		if (m_Device == nullptr)
+			return;
+
 		if (!m_CancelTeardown && m_Device != nullptr && m_Device->isOpened())
 		{
 			m_Device->close();
@@ -33,11 +64,6 @@ public:
 		{
 			delete m_Device;
 		}
-	}
-
-	void cancelTeardown()
-	{
-		m_CancelTeardown = true;
 	}
 };
 

--- a/Tests/Pcap++Test/Tests/DpdkTests.cpp
+++ b/Tests/Pcap++Test/Tests/DpdkTests.cpp
@@ -780,7 +780,7 @@ PTF_TEST_CASE(TestDpdkDeviceWorkerThreads)
 		int queueId = core.Id % numOfRxQueues;
 		PTF_PRINT_VERBOSE("Assigning queue #" << queueId << " to core " << core.Id);
 		newWorkerThread->init(dev, queueId, &queueMutexArr[queueId]);
-		workerThreadVec.push_back((pcpp::DpdkWorkerThread*)newWorkerThread);
+		workerThreadVec.push_back(newWorkerThread);
 		workerThreadCoreMask |= core.Mask;
 	}
 	PTF_PRINT_VERBOSE("Initiating " << workerThreadVec.size() << " worker threads");
@@ -832,7 +832,7 @@ PTF_TEST_CASE(TestDpdkDeviceWorkerThreads)
 	int packetCount = 0;
 	for (auto& iter : workerThreadVec)
 	{
-		DpdkTestWorkerThread* thread = (DpdkTestWorkerThread*)iter;
+		DpdkTestWorkerThread* thread = static_cast<DpdkTestWorkerThread*>(iter);
 		PTF_ASSERT_TRUE(thread->threadRanAndStopped());
 		packetCount += thread->getPacketCount();
 		PTF_PRINT_VERBOSE("Worker thread on core " << thread->getCoreId() << " captured " << thread->getPacketCount()


### PR DESCRIPTION
The PR contains cherrypicked changes from #2199 which update C-style casts.
This is done to consolidate the changes into discrete PRs, as #2199 contains quite a lot of fixes.

The updates are achieved by the following changes:
- converting to a narrower Cpp style cast.
- removing the cast due to being unneeded (`DpdkTests.cpp`)


Some unrelated changes are also included as they were part of the cherripicked commits:
- `DeviceTeardown` has also been updated by removing the copy constructor and adding a move constructor.
- `prepareCoreConfiguration` vector parameters changed to `const&`
- range-for loop variable updated to `auto const&`
- SuppressLogs `getFilename` return value changed to `std::string const&`.

---
Cherrypicked from #2199 