### PR TITLE
Fix uninitialized member variables.

### DIFF
--- a/Common++/src/PcapPlusPlusVersion.cpp
+++ b/Common++/src/PcapPlusPlusVersion.cpp
@@ -7,16 +7,18 @@ namespace pcpp
 	{
 #ifdef GIT_COMMIT
 		return GIT_COMMIT;
-#endif
+#else
 		return "unavailable";
+#endif
 	}
 
 	std::string getGitBranch()
 	{
 #ifdef GIT_BRANCH
 		return GIT_BRANCH;
-#endif
+#else
 		return "unavailable";
+#endif
 	}
 
 	std::string getGitInfo()

--- a/Examples/SSLAnalyzer/SSLStatsCollector.h
+++ b/Examples/SSLAnalyzer/SSLStatsCollector.h
@@ -15,9 +15,9 @@
 struct Rate
 {
 	// periodic rate
-	double currentRate;
+	double currentRate = 0;
 	// overall rate
-	double totalRate;
+	double totalRate = 0;
 };
 
 /**
@@ -26,27 +26,27 @@ struct Rate
 struct SSLGeneralStats
 {
 	// total number of SSL flows
-	int numOfSSLFlows;
+	int numOfSSLFlows = 0;
 	// rate of SSL flows
 	Rate sslFlowRate;
 	// total number of SSL packets
-	int numOfSSLPackets;
+	int numOfSSLPackets = 0;
 	// rate of SSL packets
 	Rate sslPacketRate;
 	// average number of SSL packets per flow
-	double averageNumOfPacketsPerFlow;
+	double averageNumOfPacketsPerFlow = 0;
 	// total SSL traffic in bytes
-	int amountOfSSLTraffic;
+	int amountOfSSLTraffic = 0;
 	// average number of SSL traffic per flow
-	double averageAmountOfDataPerFlow;
+	double averageAmountOfDataPerFlow = 0;
 	// rate of SSL traffic
 	Rate sslTrafficRate;
 	// total stats collection time
-	double sampleTime;
+	double sampleTime = 0;
 	// number of flows which handshake was complete
-	int numOfHandshakeCompleteFlows;
+	int numOfHandshakeCompleteFlows = 0;
 	// number of flows that were terminated because of SSL/TLS alert
-	int numOfFlowsWithAlerts;
+	int numOfFlowsWithAlerts = 0;
 	// number of flows per SSL/TLS version
 	std::unordered_map<uint16_t, int> sslVersionCount;
 	// number of flows per TCP port
@@ -79,7 +79,7 @@ struct SSLGeneralStats
 struct ClientHelloStats
 {
 	// total number of client-hello messages
-	int numOfMessages;
+	int numOfMessages = 0;
 	// rate of client-hello messages
 	Rate messageRate;
 	// a map for counting the server names seen in traffic
@@ -103,7 +103,7 @@ struct ClientHelloStats
 struct ServerHelloStats
 {
 	// total number of server-hello messages
-	int numOfMessages;
+	int numOfMessages = 0;
 	// rate of server-hello messages
 	Rate messageRate;
 	// count of the different chosen cipher-suites

--- a/Packet++/header/DnsResourceData.h
+++ b/Packet++/header/DnsResourceData.h
@@ -235,7 +235,7 @@ namespace pcpp
 		struct MxData
 		{
 			/// Preference value
-			uint16_t preference;
+			uint16_t preference = 0;
 			/// Mail exchange hostname
 			std::string mailExchange;
 		};

--- a/Packet++/header/DnsResourceData.h
+++ b/Packet++/header/DnsResourceData.h
@@ -255,7 +255,7 @@ namespace pcpp
 		/// the offset from the start of the DNS layer. For example: if the string 'yahoo.com' already appears in offset
 		/// 12 in the packet and you want to set the DNS RR data as 'my.subdomain.yahoo.com' you may use the following
 		/// string: 'my.subdomain.#12'. This will result in writing 'my.subdomain' and a pointer to offset 12
-		MxDnsResourceData(const uint16_t& preference, const std::string& mailExchange);
+		MxDnsResourceData(uint16_t preference, const std::string& mailExchange);
 
 		~MxDnsResourceData() override = default;
 

--- a/Packet++/header/PostgresLayer.h
+++ b/Packet++/header/PostgresLayer.h
@@ -349,17 +349,17 @@ namespace pcpp
 			/// Column name
 			std::string name;
 			/// Table OID (0 if not from a table column)
-			uint32_t tableOID;
+			uint32_t tableOID = 0;
 			/// Column index within the table
-			uint16_t columnIndex;
+			uint16_t columnIndex = 0;
 			/// Data type OID
-			uint32_t typeOID;
+			uint32_t typeOID = 0;
 			/// Type size (-1 for variable length)
-			int16_t typeSize;
+			int16_t typeSize = 0;
 			/// Type modifier (-1 if none)
-			int32_t typeModifier;
+			int32_t typeModifier = -1;
 			/// Format
-			PostgresColumnFormat format;
+			PostgresColumnFormat format = PostgresColumnFormat::Unknown;
 		};
 
 		/// A constructor that creates the layer from an existing packet raw data

--- a/Packet++/header/SipLayer.h
+++ b/Packet++/header/SipLayer.h
@@ -653,7 +653,7 @@ namespace pcpp
 			/// @brief The SIP protocol version (e.g., SIP/2.0)
 			std::string version;
 			/// @brief The response status code number (e.g., 200, 100)
-			SipResponseLayer::SipResponseStatusCode statusCode;
+			SipResponseLayer::SipResponseStatusCode statusCode = SipResponseLayer::SipStatusCodeUnknown;
 		};
 
 		/// @return The status code as SipResponseLayer#SipResponseStatusCode enum

--- a/Packet++/header/TLVData.h
+++ b/Packet++/header/TLVData.h
@@ -229,6 +229,7 @@ namespace pcpp
 			return *this;
 		}
 
+		// cppcheck-suppress functionStatic
 		/// Get the first TLV record out of a byte stream
 		/// @param[in] tlvDataBasePtr A pointer to the TLV data byte stream
 		/// @param[in] tlvDataLen The TLV data byte stream length
@@ -253,6 +254,7 @@ namespace pcpp
 			return resRec;
 		}
 
+		// cppcheck-suppress [constParameterReference, functionStatic]
 		/// Get a TLV record that follows a given TLV record in a byte stream
 		/// @param[in] record A given TLV record
 		/// @param[in] tlvDataBasePtr A pointer to the TLV data byte stream

--- a/Packet++/src/DnsResourceData.cpp
+++ b/Packet++/src/DnsResourceData.cpp
@@ -102,7 +102,7 @@ namespace pcpp
 			PCPP_LOG_ERROR("Cannot decode name, dataPtr is nullptr or length is 0");
 	}
 
-	MxDnsResourceData::MxDnsResourceData(const uint16_t& preference, const std::string& mailExchange)
+	MxDnsResourceData::MxDnsResourceData(uint16_t preference, const std::string& mailExchange)
 	{
 		m_Data.preference = preference;
 		m_Data.mailExchange = mailExchange;

--- a/Packet++/src/GreLayer.cpp
+++ b/Packet++/src/GreLayer.cpp
@@ -238,7 +238,7 @@ namespace pcpp
 	{
 		size_t result = sizeof(gre_basic_header);
 
-		gre_basic_header* header = (gre_basic_header*)m_Data;
+		gre_basic_header const* header = reinterpret_cast<gre_basic_header const*>(m_Data);
 
 		if (header->checksumBit == 1 || header->routingBit == 1)
 			result += 4;

--- a/Tests/Pcap++Test/Common/GlobalTestArgs.h
+++ b/Tests/Pcap++Test/Common/GlobalTestArgs.h
@@ -7,10 +7,10 @@
 struct PcapTestArgs
 {
 	std::string ipToSendReceivePackets;
-	bool debugMode;
+	bool debugMode = false;
 	std::string remoteIp;
-	uint16_t remotePort;
-	int dpdkPort;
+	uint16_t remotePort = 0;
+	int dpdkPort = 0;
 	std::vector<std::string> dpdkArgs;
 	std::string kniIp;
 	std::string xdpInterface;


### PR DESCRIPTION
This PR contains cherrypicked commits from #2199 focusing on fixing uninitialized member variable warnings. Most member variables are initialized to 0 where possible.

Some other changes include:
- `GreLayer`: C-cast -> Cpp cast
- `MxDnsResourceData`: Constructor parameter `uint16 const&` changed to `uint16_t`. 
Passing values of size <= 8 bytes by reference is detrimental, unless needed.
- `TLVData`: Added cppcheck suppressions.