### PR TITLE
Parse the malformed type packet in its own test

### DIFF
--- a/Tests/Packet++Test/Tests/SSHTests.cpp
+++ b/Tests/Packet++Test/Tests/SSHTests.cpp
@@ -135,7 +135,7 @@ PTF_TEST_CASE(SSHMalformedParsingTest)
 
 	// SSH message with unknown message type
 	auto rawPacket4 = createPacketFromHexResource("PacketExamples/SSHMessage_MalformedType.dat");
-	pcpp::Packet sshMessageMalformedTypePacket(rawPacket3.get());
+	pcpp::Packet sshMessageMalformedTypePacket(rawPacket4.get());
 	PTF_ASSERT_TRUE(sshMessageMalformedTypePacket.isPacketOfType(pcpp::SSH));
 	PTF_ASSERT_NULL(sshMessageMalformedTypePacket.getLayerOfType<pcpp::SSHHandshakeMessage>());
 	PTF_ASSERT_NOT_NULL(sshMessageMalformedTypePacket.getLayerOfType<pcpp::SSHEncryptedMessage>());


### PR DESCRIPTION
`SSHMalformedParsingTest` loads `SSHMessage_MalformedType.dat` but builds the packet from the previous raw packet:

```cpp
auto rawPacket4 = createPacketFromHexResource("PacketExamples/SSHMessage_MalformedType.dat");
pcpp::Packet sshMessageMalformedTypePacket(rawPacket3.get());
```

`rawPacket3` is the malformed padding length file, so the malformed type case runs against the wrong packet and `SSHMessage_MalformedType.dat` is never parsed by the suite.

The asserts pass either way, since both packets are expected to fall back to an encrypted message, which is why it went unnoticed.

Spotted while working on #2220, opened separately at @egecetin's suggestion. Packet++Test is 259 passed, 0 failed
