### PR TITLE
Fix TLVRecord type safety in getValueAs() and setValue() (#2237)

### DIFF
--- a/Packet++/header/TLVData.h
+++ b/Packet++/header/TLVData.h
@@ -155,20 +155,24 @@ namespace pcpp
 		/// A templated method to retrieve the record data as a certain type T. For example, if record data is 4B long
 		/// (integer) then this method should be used as getValueAs<int>() and it will return the record data as an
 		/// integer.<BR> Notice this return value is a copy of the data, not a pointer to the actual data
-		/// @tparam T A non-pointer, trivially copyable type
+		/// @tparam T A non-pointer, default-constructible, trivially copyable type
 		/// @param[in] offset The offset in the record data to start reading the value from. Useful for cases when you
 		/// want to read some of the data that doesn't start at offset 0. This is an optional parameter and the default
 		/// value is 0, meaning start reading the value at the beginning of the record data
 		/// @return The record data as type T
 		template <typename T> T getValueAs(size_t offset = 0) const
 		{
-			static_assert(std::is_trivially_copyable<T>::value && !std::is_pointer<T>::value,
-			              "TLVRecord::getValueAs<T>() requires T to be a non-pointer, trivially copyable type");
+			static_assert(std::is_trivially_copyable<T>::value && std::is_default_constructible<T>::value &&
+			                  !std::is_pointer<T>::value,
+			              "TLVRecord::getValueAs<T>() requires T to be a non-pointer, "
+			              "default-constructible, trivially copyable type");
 
 			if (getDataSize() < sizeof(T) + offset)
+			{
 				return T{};
+			}
 
-			T result{};
+			T result;
 			memcpy(&result, m_Data->recordValue + getValueOffset() + offset, sizeof(T));
 			return result;
 		}
@@ -187,7 +191,9 @@ namespace pcpp
 			              "TLVRecord::setValue<T>() requires T to be a non-pointer, trivially copyable type");
 
 			if (getDataSize() < sizeof(T))
+			{
 				return false;
+			}
 
 			memcpy(m_Data->recordValue + getValueOffset() + valueOffset, &newValue, sizeof(T));
 			return true;

--- a/Packet++/header/TLVData.h
+++ b/Packet++/header/TLVData.h
@@ -3,6 +3,7 @@
 #include "Layer.h"
 #include "IpAddress.h"
 #include <string.h>
+#include <type_traits>
 
 /// @file
 
@@ -154,22 +155,27 @@ namespace pcpp
 		/// A templated method to retrieve the record data as a certain type T. For example, if record data is 4B long
 		/// (integer) then this method should be used as getValueAs<int>() and it will return the record data as an
 		/// integer.<BR> Notice this return value is a copy of the data, not a pointer to the actual data
+		/// @tparam T A non-pointer, trivially copyable type
 		/// @param[in] offset The offset in the record data to start reading the value from. Useful for cases when you
 		/// want to read some of the data that doesn't start at offset 0. This is an optional parameter and the default
 		/// value is 0, meaning start reading the value at the beginning of the record data
 		/// @return The record data as type T
 		template <typename T> T getValueAs(size_t offset = 0) const
 		{
-			if (getDataSize() < sizeof(T) + offset)
-				return 0;
+			static_assert(std::is_trivially_copyable<T>::value && !std::is_pointer<T>::value,
+			              "TLVRecord::getValueAs<T>() requires T to be a non-pointer, trivially copyable type");
 
-			T result;
+			if (getDataSize() < sizeof(T) + offset)
+				return T{};
+
+			T result{};
 			memcpy(&result, m_Data->recordValue + getValueOffset() + offset, sizeof(T));
 			return result;
 		}
 
 		/// A templated method to copy data of type T into the TLV record data. For example: if record data is 4[Bytes]
 		/// long use this method with \<int\> to set an integer value into the record data: setValue<int>(num)
+		/// @tparam T A non-pointer, trivially copyable type
 		/// @param[in] newValue The value of type T to copy to the record data
 		/// @param[in] valueOffset An optional parameter that specifies where to start setting the record data (default
 		/// set to 0). For example: if record data is 20 bytes long and you only need to set the 4 last bytes as integer
@@ -177,6 +183,9 @@ namespace pcpp
 		/// @return True if value was set successfully or false if the size of T is larger than the record data size
 		template <typename T> bool setValue(T newValue, int valueOffset = 0)
 		{
+			static_assert(std::is_trivially_copyable<T>::value && !std::is_pointer<T>::value,
+			              "TLVRecord::setValue<T>() requires T to be a non-pointer, trivially copyable type");
+
 			if (getDataSize() < sizeof(T))
 				return false;
 


### PR DESCRIPTION
## Summary

Fixes #2237.

`TLVRecord::getValueAs<T>()` and `setValue<T>()` use `memcpy` to copy raw bytes to and from objects, but previously accepted arbitrary types.

This could lead to undefined behavior when non-trivially copyable types such as `std::string` were used.

### Changes

- Add a `static_assert` to `getValueAs<T>()` and `setValue<T>()` to require `T` to be trivially copyable and non-pointer.
- Change the insufficient-data return path in `getValueAs<T>()` from `return 0;` to `return T{};`.

### Rationale

Since these APIs rely on raw `memcpy` of the object representation, accepting non-trivially copyable types is unsafe.

Using `static_assert` makes this requirement explicit and provides a direct compile-time diagnostic at the call site instead of allowing invalid types to compile and fail at runtime.

For valid trivially copyable types, `return T{};` also provides the intended value-initialized result when the record does not contain enough data.