### PR TITLE
Update deprecated file reader API in tutorials

### DIFF
--- a/Examples/Tutorials/Tutorial-PacketCraftAndEdit/main.cpp
+++ b/Examples/Tutorials/Tutorial-PacketCraftAndEdit/main.cpp
@@ -18,7 +18,7 @@ int main(int argc, char* argv[])
 
 	// use the IFileReaderDevice interface to automatically identify file type (pcap/pcap-ng)
 	// and create an interface instance that both readers implement
-	std::unique_ptr<pcpp::IFileReaderDevice> reader(pcpp::IFileReaderDevice::getReader("1_http_packet.pcap"));
+	auto reader = pcpp::IFileReaderDevice::tryCreateReader("1_http_packet.pcap");
 
 	// verify that a reader interface was indeed created
 	if (reader == nullptr)

--- a/Examples/Tutorials/Tutorial-PacketParsing/main.cpp
+++ b/Examples/Tutorials/Tutorial-PacketParsing/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char* argv[])
 {
 	// use the IFileReaderDevice interface to automatically identify file type (pcap/pcap-ng)
 	// and create an interface instance that both readers implement
-	std::unique_ptr<pcpp::IFileReaderDevice> reader(pcpp::IFileReaderDevice::getReader("1_http_packet.pcap"));
+	auto reader = pcpp::IFileReaderDevice::tryCreateReader("1_http_packet.pcap");
 
 	// verify that a reader interface was indeed created
 	if (reader == nullptr)

--- a/Examples/Tutorials/Tutorial-PcapFiles/main.cpp
+++ b/Examples/Tutorials/Tutorial-PcapFiles/main.cpp
@@ -9,7 +9,7 @@ int main(int argc, char* argv[])
 {
 	// use the IFileReaderDevice interface to automatically identify file type (pcap/pcap-ng)
 	// and create an interface instance that both readers implement
-	std::unique_ptr<pcpp::IFileReaderDevice> reader(pcpp::IFileReaderDevice::getReader("input.pcap"));
+	auto reader = pcpp::IFileReaderDevice::tryCreateReader("input.pcap");
 
 	// verify that a reader interface was indeed created
 	if (reader == nullptr)


### PR DESCRIPTION
Update tutorial examples to replace the deprecated `IFileReaderDevice::getReader()` API with `tryCreateReader()`.

Updated tutorials:

- `Tutorial-PcapFiles`
- `Tutorial-PacketParsing`
- `Tutorial-PacketCraftAndEdit`

Hi! I was following the tutorial examples and noticed that the compiler generated deprecation warnings for the `getReader()` API. I wanted to make a contribution -- this is my first time contributing to an open-source project, so any guidance would be appreciated.

I also noticed that the [website tutorial walkthrough](https://pcapplusplus.github.io/docs/tutorials) is not fully up to date, and some code snippets still contain outdated usages such as `pcpp::multiPlatformSleep`. I'd be happy to update the website as well so that the snippets reflect the current tutorial code, but I wanted to check first whether that would be welcomed.

Thanks!