### PR TITLE
Cppcheck operatorEqToSelf fixes

### DIFF
--- a/Packet++/src/DnsResourceData.cpp
+++ b/Packet++/src/DnsResourceData.cpp
@@ -173,6 +173,11 @@ namespace pcpp
 
 	GenericDnsResourceData& GenericDnsResourceData::operator=(const GenericDnsResourceData& other)
 	{
+		if (this == &other)
+		{
+			return *this;
+		}
+
 		if (m_Data != nullptr)
 			delete[] m_Data;
 

--- a/Packet++/src/HttpLayer.cpp
+++ b/Packet++/src/HttpLayer.cpp
@@ -81,6 +81,11 @@ namespace pcpp
 
 	HttpRequestLayer& HttpRequestLayer::operator=(const HttpRequestLayer& other)
 	{
+		if (this == &other)
+		{
+			return *this;
+		}
+
 		HttpMessage::operator=(other);
 
 		if (m_FirstLine != nullptr)
@@ -698,6 +703,11 @@ namespace pcpp
 
 	HttpResponseLayer& HttpResponseLayer::operator=(const HttpResponseLayer& other)
 	{
+		if (this == &other)
+		{
+			return *this;
+		}
+
 		HttpMessage::operator=(other);
 
 		if (m_FirstLine != nullptr)

--- a/Packet++/src/SipLayer.cpp
+++ b/Packet++/src/SipLayer.cpp
@@ -553,6 +553,11 @@ namespace pcpp
 
 	SipRequestLayer& SipRequestLayer::operator=(const SipRequestLayer& other)
 	{
+		if (this == &other)
+		{
+			return *this;
+		}
+
 		SipLayer::operator=(other);
 
 		if (m_FirstLine != nullptr)
@@ -900,6 +905,11 @@ namespace pcpp
 
 	SipResponseLayer& SipResponseLayer::operator=(const SipResponseLayer& other)
 	{
+		if (this == &other)
+		{
+			return *this;
+		}
+
 		SipLayer::operator=(other);
 
 		if (m_FirstLine != nullptr)

--- a/Packet++/src/TLVData.cpp
+++ b/Packet++/src/TLVData.cpp
@@ -81,6 +81,11 @@ namespace pcpp
 
 	TLVRecordBuilder& TLVRecordBuilder::operator=(const TLVRecordBuilder& other)
 	{
+		if (this == &other)
+		{
+			return *this;
+		}
+
 		if (m_RecValue != nullptr)
 		{
 			delete[] m_RecValue;


### PR DESCRIPTION
This PR contains fixes for cppcheck operatorEqToSelf defects that would appear if `-IPacket++/header -IPcap++/header` were to be added to the cppcheck command. 

This a follow-on ticket from #2244 