### PR TITLE
Cppcheck noExplicitConstructor fixes

### DIFF
--- a/Packet++/header/HttpLayer.h
+++ b/Packet++/header/HttpLayer.h
@@ -646,7 +646,7 @@ namespace pcpp
 		};
 
 	private:
-		HttpRequestFirstLine(HttpRequestLayer* httpRequest);
+		explicit HttpRequestFirstLine(HttpRequestLayer* httpRequest);
 		HttpRequestFirstLine(HttpRequestLayer* httpRequest, HttpRequestLayer::HttpMethod method, HttpVersion version,
 		                     const std::string& uri = "/");
 
@@ -767,7 +767,7 @@ namespace pcpp
 		};
 
 	private:
-		HttpResponseFirstLine(HttpResponseLayer* httpResponse);
+		explicit HttpResponseFirstLine(HttpResponseLayer* httpResponse);
 		HttpResponseFirstLine(HttpResponseLayer* httpResponse, HttpVersion version,
 		                      const HttpResponseStatusCode& statusCode);
 

--- a/Packet++/header/SipLayer.h
+++ b/Packet++/header/SipLayer.h
@@ -617,7 +617,7 @@ namespace pcpp
 		};
 
 	private:
-		SipRequestFirstLine(SipRequestLayer* sipRequest);
+		explicit SipRequestFirstLine(SipRequestLayer* sipRequest);
 		SipRequestFirstLine(SipRequestLayer* sipRequest, SipRequestLayer::SipMethod method, const std::string& version,
 		                    const std::string& uri);
 
@@ -742,7 +742,7 @@ namespace pcpp
 		};
 
 	private:
-		SipResponseFirstLine(SipResponseLayer* sipResponse);
+		explicit SipResponseFirstLine(SipResponseLayer* sipResponse);
 		SipResponseFirstLine(SipResponseLayer* sipResponse, const std::string& version,
 		                     SipResponseLayer::SipResponseStatusCode statusCode, std::string statusCodeString = "");
 

--- a/Packet++/header/X509Decoder.h
+++ b/Packet++/header/X509Decoder.h
@@ -524,7 +524,7 @@ namespace pcpp
 			int m_CriticalOffset = -1;
 			int m_ExtensionValueOffset = 1;
 
-			X509Extension(Asn1SequenceRecord* root);
+			explicit X509Extension(Asn1SequenceRecord* root);
 		};
 
 		/// @class X509Extensions
@@ -597,7 +597,7 @@ namespace pcpp
 			int m_SubjectUniqueID = -1;
 			int m_ExtensionsOffset = -1;
 
-			X509TBSCertificate(Asn1SequenceRecord* root);
+			explicit X509TBSCertificate(Asn1SequenceRecord* root);
 		};
 
 		/// @class X509Certificate
@@ -731,7 +731,7 @@ namespace pcpp
 		}
 
 	private:
-		X509Extension(const X509Internal::X509Extension& internalExtension);
+		explicit X509Extension(const X509Internal::X509Extension& internalExtension);
 
 		bool m_IsCritical;
 		X509ExtensionType m_Type;

--- a/Pcap++/header/PfRingDevice.h
+++ b/Pcap++/header/PfRingDevice.h
@@ -74,7 +74,7 @@ namespace pcpp
 		bool m_HwClockEnabled;
 		bool m_IsFilterCurrentlySet;
 
-		PfRingDevice(const char* deviceName);
+		explicit PfRingDevice(const char* deviceName);
 
 		bool initCoreConfigurationByCoreMask(CoreMask coreMask);
 		void captureThreadMain(std::shared_ptr<StartupBlock> startupBlock);


### PR DESCRIPTION
another set of fixes as a follow-on to #2244