### PR TITLE
cppcheck virtualCallInConstructor fixes

### DIFF
--- a/Packet++/src/RawPacket.cpp
+++ b/Packet++/src/RawPacket.cpp
@@ -20,7 +20,7 @@ namespace pcpp
 
 	RawPacket::~RawPacket()
 	{
-		clear();
+		RawPacket::clear();
 	}
 
 	RawPacket::RawPacket(const RawPacket& other)

--- a/Pcap++/src/RawSocketDevice.cpp
+++ b/Pcap++/src/RawSocketDevice.cpp
@@ -97,7 +97,7 @@ namespace pcpp
 
 	RawSocketDevice::~RawSocketDevice()
 	{
-		close();
+		RawSocketDevice::close();
 	}
 
 	RawSocketDevice::RecvPacketResult RawSocketDevice::receivePacket(RawPacket& rawPacket, bool blocking,

--- a/Pcap++/src/XdpDevice.cpp
+++ b/Pcap++/src/XdpDevice.cpp
@@ -130,7 +130,7 @@ namespace pcpp
 
 	XdpDevice::~XdpDevice()
 	{
-		close();
+		XdpDevice::close();
 	}
 
 	bool XdpDevice::receivePackets(OnPacketsArrive onPacketsArrive, void* onPacketsArriveUserCookie, int timeoutMS)


### PR DESCRIPTION
another set of cppcheck fixes as a follow-on to #2244 